### PR TITLE
feature/request path

### DIFF
--- a/src/kiota.core/CodeDOM/AccessModifier.cs
+++ b/src/kiota.core/CodeDOM/AccessModifier.cs
@@ -1,0 +1,7 @@
+namespace kiota.core {
+        public enum AccessModifier {
+        Public,
+        Protected,
+        Private
+    }
+}

--- a/src/kiota.core/CodeDOM/CodeMethod.cs
+++ b/src/kiota.core/CodeDOM/CodeMethod.cs
@@ -17,6 +17,7 @@ namespace kiota.core
             
         }
         public CodeMethodKind MethodKind = CodeMethodKind.Custom;
+        public AccessModifier Access = AccessModifier.Public;
         public CodeType ReturnType;
         public List<CodeParameter> Parameters = new List<CodeParameter>();
         public bool IsStatic = false;

--- a/src/kiota.core/CodeDOM/CodeMethod.cs
+++ b/src/kiota.core/CodeDOM/CodeMethod.cs
@@ -7,7 +7,8 @@ namespace kiota.core
     public enum CodeMethodKind
     {
         Custom,
-        ResponseHandler
+        ResponseHandler,
+        IndexerBackwardCompatibility
     }
 
     public class CodeMethod : CodeTerminal, ICloneable

--- a/src/kiota.core/CodeDOM/CodeProperty.cs
+++ b/src/kiota.core/CodeDOM/CodeProperty.cs
@@ -19,6 +19,7 @@
             get; set;
         }
         public bool ReadOnly = false;
+        public AccessModifier Access = AccessModifier.Public;
         public CodeType Type;
         public string DefaultValue;
     }

--- a/src/kiota.core/CodeDOM/CodeProperty.cs
+++ b/src/kiota.core/CodeDOM/CodeProperty.cs
@@ -3,7 +3,8 @@
     public enum CodePropertyKind
     {
         Custom,
-        ResponseHandler
+        ResponseHandler,
+        RequestBuilder
     }
 
     public class CodeProperty : CodeTerminal

--- a/src/kiota.core/CodeDOM/CodeType.cs
+++ b/src/kiota.core/CodeDOM/CodeType.cs
@@ -20,6 +20,7 @@ namespace kiota.core
         }
 
         public bool ActionOf = false;
+        public bool IsNullable = true;
 
         public OpenApiSchema Schema;
 

--- a/src/kiota.core/GenerationConfiguration.cs
+++ b/src/kiota.core/GenerationConfiguration.cs
@@ -6,5 +6,6 @@
         public string ClientNamespaceName { get; set; } = "GraphClient";
         public string SchemaRootNamespaceName { get; set; } = "microsoft.graph";
         public GenerationLanguage Language { get; set; } = GenerationLanguage.CSharp;
+        public string ApiRootUrl { get; set; } = "https://graph.microsoft.com/v1.0";
     }
 }

--- a/src/kiota.core/KiotaBuilder.cs
+++ b/src/kiota.core/KiotaBuilder.cs
@@ -207,7 +207,7 @@ namespace kiota.core
                 }
                 else
                 {
-                    var prop = CreateProperty(propIdentifier, propType, codeClass); // we should add the type definition here but we can't as it might not have been generated yet
+                    var prop = CreateProperty(propIdentifier, propType, codeClass, kind: CodePropertyKind.RequestBuilder); // we should add the type definition here but we can't as it might not have been generated yet
                     codeClass.AddProperty(prop);
                 }
             }
@@ -306,12 +306,13 @@ namespace kiota.core
             return prop;
         }
 
-        private CodeProperty CreateProperty(string childIdentifier, string childType, CodeClass codeClass, string defaultValue = null, OpenApiSchema typeSchema = null, CodeClass typeDefinition = null)
+        private CodeProperty CreateProperty(string childIdentifier, string childType, CodeClass codeClass, string defaultValue = null, OpenApiSchema typeSchema = null, CodeClass typeDefinition = null, CodePropertyKind kind = CodePropertyKind.Custom)
         {
             var prop = new CodeProperty(codeClass)
             {
                 Name = childIdentifier,
-                DefaultValue = defaultValue
+                DefaultValue = defaultValue,
+                PropertyKind = kind,
             };
             prop.Type = new CodeType(prop) { Name = childType, Schema = typeSchema, TypeDefinition = typeDefinition };
             logger.LogDebug("Creating property {name} of {type}", prop.Name, prop.Type.Name);

--- a/src/kiota.core/KiotaBuilder.cs
+++ b/src/kiota.core/KiotaBuilder.cs
@@ -226,7 +226,7 @@ namespace kiota.core
 
                 CreateResponseHandler(codeClass);
             }
-            CreatePathBuilder(codeClass, currentNode, isRootClientClass);
+            CreatePathManagement(codeClass, currentNode, isRootClientClass);
            
 
             (currentNode.DoesNodeBelongToItemSubnamespace() ? codeNamespace.EnsureItemNamespace() : codeNamespace).AddClass(codeClass);
@@ -240,7 +240,7 @@ namespace kiota.core
             }
         }
 
-        private void CreatePathBuilder(CodeClass currentClass, OpenApiUrlSpaceNode currentNode, bool isRootClientClass) {
+        private void CreatePathManagement(CodeClass currentClass, OpenApiUrlSpaceNode currentNode, bool isRootClientClass) {
             var pathProperty = new CodeProperty(currentClass) {
                 Access = AccessModifier.Private,
                 Name = "pathSegment",
@@ -253,13 +253,13 @@ namespace kiota.core
             };
             currentClass.AddProperty(pathProperty);
 
-            var pathBuilderProperty = new CodeProperty(currentClass) {
-                Name = "pathBuilder"
+            var currentPathProperty = new CodeProperty(currentClass) {
+                Name = "currentPath"
             };
-            pathBuilderProperty.Type = new CodeType(pathBuilderProperty) {
+            currentPathProperty.Type = new CodeType(currentPathProperty) {
                 Name = "string"
             };
-            currentClass.AddProperty(pathBuilderProperty);
+            currentClass.AddProperty(currentPathProperty);
         }
 
         /// <summary>

--- a/src/kiota.core/Refiners/CommonLanaguageRefiner.cs
+++ b/src/kiota.core/Refiners/CommonLanaguageRefiner.cs
@@ -21,13 +21,13 @@ namespace kiota.core {
                 var propertiesTypes = currentClass
                                     .InnerChildElements
                                     .OfType<CodeProperty>()
-                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                    .Where(x => x.PropertyKind != CodePropertyKind.ResponseHandler)
                                     .Select(x => x.Type)
                                     .Distinct();
                 var methods = currentClass
                                     .InnerChildElements
                                     .OfType<CodeMethod>()
-                                    .Where(x => x.MethodKind == CodeMethodKind.Custom);
+                                    .Where(x => x.MethodKind != CodeMethodKind.ResponseHandler);
                 var methodsReturnTypes = methods
                                     .Select(x => x.ReturnType)
                                     .Distinct();

--- a/src/kiota.core/Refiners/JavaRefiner.cs
+++ b/src/kiota.core/Refiners/JavaRefiner.cs
@@ -39,16 +39,11 @@ namespace kiota.core {
             else return null;
         }
         private void PatchResponseHandlerType(CodeElement current) {
-            var properties = current.GetChildElements()
-                .OfType<CodeProperty>();
-            properties
-                .Where(x => x.PropertyKind == CodePropertyKind.ResponseHandler)
-                .ToList()
-                .ForEach(x => x.Type.Name = "java.util.function.Function<Object,Object>");
-            current.GetChildElements()
-                .Except(properties)
-                .ToList()
-                .ForEach(x => PatchResponseHandlerType(x));
+            if(current is CodeProperty currentProperty && currentProperty.PropertyKind == CodePropertyKind.ResponseHandler) {
+                currentProperty.Type.Name = "java.util.function.Function<Object,java.util.concurrent.CompletableFuture<Object>>";
+                currentProperty.DefaultValue = "x -> defaultResponseHandler(x)";
+            }
+            CrawlTree(current, PatchResponseHandlerType);
         }
     }
 }

--- a/src/kiota.core/Refiners/TypeScriptRefiner.cs
+++ b/src/kiota.core/Refiners/TypeScriptRefiner.cs
@@ -11,16 +11,11 @@ namespace kiota.core {
             AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
         }
         private void PatchResponseHandlerType(CodeElement current) {
-            var properties = current.GetChildElements()
-                .OfType<CodeProperty>();
-            properties
-                .Where(x => x.PropertyKind == CodePropertyKind.ResponseHandler)
-                .ToList()
-                .ForEach(x => x.Type.Name = "(input: object) => object");
-            current.GetChildElements()
-                .Except(properties)
-                .ToList()
-                .ForEach(x => PatchResponseHandlerType(x));
+            if(current is CodeProperty currentProperty && currentProperty.PropertyKind == CodePropertyKind.ResponseHandler) {
+                currentProperty.Type.Name = "(input: object) => Promise<object>";
+                currentProperty.DefaultValue = "this.defaultResponseHandler";
+            }
+            CrawlTree(current, PatchResponseHandlerType);
         }
     }
 }

--- a/src/kiota.core/Writers/CSharpWriter.cs
+++ b/src/kiota.core/Writers/CSharpWriter.cs
@@ -42,17 +42,25 @@ namespace kiota.core
 
         public override void WriteProperty(CodeProperty code)
         {
-            var simpleBody = " get;";
+            var simpleBody = "get;";
             if (!code.ReadOnly)
             {
-                simpleBody = " get; set; ";
+                simpleBody = "get; set;";
             }
             var defaultValue = string.Empty;
             if (code.DefaultValue != null)
             {
                 defaultValue = " = " + code.DefaultValue + ";";
             }
-            WriteLine($"{GetAccessModifier(code.Access)} {GetTypeString(code.Type)} {code.Name.ToFirstCharacterUpperCase()} {{{simpleBody}}}{defaultValue}");
+            var propertyType = GetTypeString(code.Type);
+            switch(code.PropertyKind) {
+                case CodePropertyKind.RequestBuilder:
+                    WriteLine($"{GetAccessModifier(code.Access)} {propertyType} {code.Name.ToFirstCharacterUpperCase()} {{ get => new {propertyType} {{ PathBuilder = PathBuilder + PathSegment }}; }}");
+                break;
+                default:
+                    WriteLine($"{GetAccessModifier(code.Access)} {propertyType} {code.Name.ToFirstCharacterUpperCase()} {{ {simpleBody} }}{defaultValue}");
+                break;
+            }
         }
 
         public override void WriteIndexer(CodeIndexer code)

--- a/src/kiota.core/Writers/CSharpWriter.cs
+++ b/src/kiota.core/Writers/CSharpWriter.cs
@@ -42,10 +42,10 @@ namespace kiota.core
 
         public override void WriteProperty(CodeProperty code)
         {
-            var simpleBody = "get;";
+            var simpleBody = " get;";
             if (!code.ReadOnly)
             {
-                simpleBody = "get;set;";
+                simpleBody = " get; set; ";
             }
             var defaultValue = string.Empty;
             if (code.DefaultValue != null)
@@ -57,7 +57,8 @@ namespace kiota.core
 
         public override void WriteIndexer(CodeIndexer code)
         {
-            WriteLine($"public {GetTypeString(code.ReturnType)} this[{GetTypeString(code.IndexType)} {code.Name}] {{get {{ return null; }} }}");
+            var returnType = GetTypeString(code.ReturnType);
+            WriteLine($"public {returnType} this[{GetTypeString(code.IndexType)} position] {{ get {{ return new {returnType} {{ PathBuilder = PathBuilder + PathSegment + \"/\" + position }}; }} }}");
         }
 
         public override void WriteMethod(CodeMethod code)

--- a/src/kiota.core/Writers/CSharpWriter.cs
+++ b/src/kiota.core/Writers/CSharpWriter.cs
@@ -52,7 +52,7 @@ namespace kiota.core
             {
                 defaultValue = " = " + code.DefaultValue + ";";
             }
-            WriteLine($"public {GetTypeString(code.Type)} {code.Name.ToFirstCharacterUpperCase()} {{{simpleBody}}}{defaultValue}");
+            WriteLine($"{GetAccessModifier(code.Access)} {GetTypeString(code.Type)} {code.Name.ToFirstCharacterUpperCase()} {{{simpleBody}}}{defaultValue}");
         }
 
         public override void WriteIndexer(CodeIndexer code)
@@ -64,7 +64,7 @@ namespace kiota.core
         {
             var staticModifier = code.IsStatic ? "static " : string.Empty;
             // Task type should be moved into the refiner
-            WriteLine($"public {staticModifier}Task<{GetTypeString(code.ReturnType).ToFirstCharacterUpperCase()}> {code.Name}({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) {{ return null; }}");
+            WriteLine($"{GetAccessModifier(code.Access)} {staticModifier}Task<{GetTypeString(code.ReturnType).ToFirstCharacterUpperCase()}> {code.Name}({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) {{ return null; }}");
 
         }
 
@@ -102,6 +102,11 @@ namespace kiota.core
         {
             var parameterType = GetTypeString(parameter.Type);
             return $"{parameterType} {parameter.Name}{(parameter.Optional ? $" = default({parameterType})": string.Empty)}";
+        }
+
+        public override string GetAccessModifier(AccessModifier access)
+        {
+            return (access == AccessModifier.Public ? "public" : (access == AccessModifier.Protected ? "protected" : "private"));
         }
     }
 }

--- a/src/kiota.core/Writers/CSharpWriter.cs
+++ b/src/kiota.core/Writers/CSharpWriter.cs
@@ -55,7 +55,7 @@ namespace kiota.core
             var propertyType = GetTypeString(code.Type);
             switch(code.PropertyKind) {
                 case CodePropertyKind.RequestBuilder:
-                    WriteLine($"{GetAccessModifier(code.Access)} {propertyType} {code.Name.ToFirstCharacterUpperCase()} {{ get => new {propertyType} {{ PathBuilder = PathBuilder + PathSegment }}; }}");
+                    WriteLine($"{GetAccessModifier(code.Access)} {propertyType} {code.Name.ToFirstCharacterUpperCase()} {{ get => new {propertyType} {{ CurrentPath = CurrentPath + PathSegment }}; }}");
                 break;
                 default:
                     WriteLine($"{GetAccessModifier(code.Access)} {propertyType} {code.Name.ToFirstCharacterUpperCase()} {{ {simpleBody} }}{defaultValue}");
@@ -66,7 +66,7 @@ namespace kiota.core
         public override void WriteIndexer(CodeIndexer code)
         {
             var returnType = GetTypeString(code.ReturnType);
-            WriteLine($"public {returnType} this[{GetTypeString(code.IndexType)} position] {{ get {{ return new {returnType} {{ PathBuilder = PathBuilder + PathSegment + \"/\" + position }}; }} }}");
+            WriteLine($"public {returnType} this[{GetTypeString(code.IndexType)} position] {{ get {{ return new {returnType} {{ CurrentPath = CurrentPath + PathSegment + \"/\" + position }}; }} }}");
         }
 
         public override void WriteMethod(CodeMethod code)

--- a/src/kiota.core/Writers/JavaWriter.cs
+++ b/src/kiota.core/Writers/JavaWriter.cs
@@ -92,7 +92,7 @@ namespace kiota.core
             switch(code.MethodKind) {
                 case CodeMethodKind.IndexerBackwardCompatibility:
                     WriteLine($"final {code.ReturnType.Name} builder = new {code.ReturnType.Name}();");
-                    WriteLine("builder.pathBuilder = this.pathBuilder + this.pathSegment + \"/\" + position;");
+                    WriteLine("builder.currentPath = this.currentPath + this.pathSegment + \"/\" + position;");
                     WriteLine("return builder;");
                 break;
                 default:

--- a/src/kiota.core/Writers/JavaWriter.cs
+++ b/src/kiota.core/Writers/JavaWriter.cs
@@ -86,19 +86,23 @@ namespace kiota.core
         {
             //TODO javadoc
             WriteLine("@javax.annotation.Nonnull");
-            WriteLine($"public {(code.IsAsync ? "java.util.concurrent.Future<" : string.Empty)}{GetTypeString(code.ReturnType).ToFirstCharacterUpperCase()}{(code.IsAsync ? ">" : string.Empty)} {code.Name.ToFirstCharacterLowerCase()}({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) {{ return null; }}");
+            WriteLine($"{GetAccessModifier(code.Access)} {(code.IsAsync ? "java.util.concurrent.Future<" : string.Empty)}{GetTypeString(code.ReturnType).ToFirstCharacterUpperCase()}{(code.IsAsync ? ">" : string.Empty)} {code.Name.ToFirstCharacterLowerCase()}({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) {{ return null; }}");
         }
 
         public override void WriteProperty(CodeProperty code)
         {
             //TODO: missing javadoc
             WriteLine("@javax.annotation.Nullable");
-            WriteLine($"public {GetTypeString(code.Type)} {code.Name};");
+            WriteLine($"{GetAccessModifier(code.Access)} {GetTypeString(code.Type)} {code.Name};");
         }
 
         public override void WriteType(CodeType code)
         {
             Write(GetTypeString(code), includeIndent: false);
+        }
+        public override string GetAccessModifier(AccessModifier access)
+        {
+            return (access == AccessModifier.Public ? "public" : (access == AccessModifier.Protected ? "protected" : "private"));
         }
     }
 }

--- a/src/kiota.core/Writers/LanguageWriter.cs
+++ b/src/kiota.core/Writers/LanguageWriter.cs
@@ -90,5 +90,6 @@ namespace kiota.core
         public abstract void WriteType(CodeType code);
         public abstract void WriteCodeClassDeclaration(CodeClass.Declaration code);
         public abstract void WriteCodeClassEnd(CodeClass.End code);
+        public abstract string GetAccessModifier(AccessModifier access);
     }
 }

--- a/src/kiota.core/Writers/TypeScriptWriter.cs
+++ b/src/kiota.core/Writers/TypeScriptWriter.cs
@@ -151,17 +151,22 @@ namespace kiota.core
 
         public override void WriteMethod(CodeMethod code)
         {
-            WriteLine($"public readonly {code.Name.ToFirstCharacterLowerCase()} = ({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) : {(code.IsAsync ? "Promise<": string.Empty)}{GetTypeString(code.ReturnType)}{(code.IsAsync ? ">": string.Empty)} => {{ return {(code.IsAsync ? "Promise.resolve(" : string.Empty)}{(code.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{(code.IsAsync ? ")" : string.Empty)}; }}");
+            WriteLine($"{GetAccessModifier(code.Access)} readonly {code.Name.ToFirstCharacterLowerCase()} = ({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) : {(code.IsAsync ? "Promise<": string.Empty)}{GetTypeString(code.ReturnType)}{(code.IsAsync ? ">": string.Empty)} => {{ return {(code.IsAsync ? "Promise.resolve(" : string.Empty)}{(code.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{(code.IsAsync ? ")" : string.Empty)}; }}");
         }
 
         public override void WriteProperty(CodeProperty code)
         {
-            WriteLine($"public {code.Name}?: {GetTypeString(code.Type)} | undefined;");
+            var defaultValue = string.IsNullOrEmpty(code.DefaultValue) ? string.Empty : $" = {code.DefaultValue}";
+            WriteLine($"{GetAccessModifier(code.Access)}{(code.ReadOnly ? " readonly ": " ")}{code.Name.ToFirstCharacterLowerCase()}?: {GetTypeString(code.Type)} | undefined{defaultValue};");
         }
 
         public override void WriteType(CodeType code)
         {
             Write(GetTypeString(code), includeIndent: false);
+        }
+        public override string GetAccessModifier(AccessModifier access)
+        {
+            return (access == AccessModifier.Public ? "public" : (access == AccessModifier.Protected ? "protected" : "private"));
         }
     }
 }

--- a/src/kiota.core/Writers/TypeScriptWriter.cs
+++ b/src/kiota.core/Writers/TypeScriptWriter.cs
@@ -157,7 +157,7 @@ namespace kiota.core
             switch(code.MethodKind) {
                 case CodeMethodKind.IndexerBackwardCompatibility:
                     WriteLine($"const builder = new {code.ReturnType.Name}();");
-                    WriteLine("builder.pathBuilder = this.pathBuilder && this.pathBuilder + this.pathSegment + \"/\" + position;");
+                    WriteLine("builder.currentPath = this.currentPath && this.currentPath + this.pathSegment + \"/\" + position;");
                     WriteLine("return builder;");
                     break;
                 default:

--- a/src/kiota.core/Writers/TypeScriptWriter.cs
+++ b/src/kiota.core/Writers/TypeScriptWriter.cs
@@ -139,6 +139,7 @@ namespace kiota.core
             var method = new CodeMethod(code) {
                 Name = "item",
                 ReturnType = code.ReturnType,
+                MethodKind = CodeMethodKind.IndexerBackwardCompatibility,
                 IsAsync = false,
             };
             method.AddParameter(new CodeParameter(method) {
@@ -151,13 +152,26 @@ namespace kiota.core
 
         public override void WriteMethod(CodeMethod code)
         {
-            WriteLine($"{GetAccessModifier(code.Access)} readonly {code.Name.ToFirstCharacterLowerCase()} = ({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) : {(code.IsAsync ? "Promise<": string.Empty)}{GetTypeString(code.ReturnType)}{(code.IsAsync ? ">": string.Empty)} => {{ return {(code.IsAsync ? "Promise.resolve(" : string.Empty)}{(code.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{(code.IsAsync ? ")" : string.Empty)}; }}");
+            WriteLine($"{GetAccessModifier(code.Access)} readonly {code.Name.ToFirstCharacterLowerCase()} = ({string.Join(',', code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) : {(code.IsAsync ? "Promise<": string.Empty)}{GetTypeString(code.ReturnType)}{(code.IsAsync ? ">": string.Empty)} => {{");
+            IncreaseIndent();
+            switch(code.MethodKind) {
+                case CodeMethodKind.IndexerBackwardCompatibility:
+                    WriteLine($"const builder = new {code.ReturnType.Name}();");
+                    WriteLine("builder.pathBuilder = this.pathBuilder && this.pathBuilder + this.pathSegment + \"/\" + position;");
+                    WriteLine("return builder;");
+                    break;
+                default:
+                    WriteLine($"return {(code.IsAsync ? "Promise.resolve(" : string.Empty)}{(code.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{(code.IsAsync ? ")" : string.Empty)};");
+                    break;
+            }
+            DecreaseIndent();
+            WriteLine("}");
         }
 
         public override void WriteProperty(CodeProperty code)
         {
             var defaultValue = string.IsNullOrEmpty(code.DefaultValue) ? string.Empty : $" = {code.DefaultValue}";
-            WriteLine($"{GetAccessModifier(code.Access)}{(code.ReadOnly ? " readonly ": " ")}{code.Name.ToFirstCharacterLowerCase()}?: {GetTypeString(code.Type)} | undefined{defaultValue};");
+            WriteLine($"{GetAccessModifier(code.Access)}{(code.ReadOnly ? " readonly ": " ")}{code.Name.ToFirstCharacterLowerCase()}{(code.Type.IsNullable ? "?" : string.Empty)}: {GetTypeString(code.Type)}{(code.Type.IsNullable ? " | undefined" : string.Empty)}{defaultValue};");
         }
 
         public override void WriteType(CodeType code)

--- a/tests/kiota.core.tests/CodeDomTests.cs
+++ b/tests/kiota.core.tests/CodeDomTests.cs
@@ -16,7 +16,7 @@ namespace kiota.core.tests
             var outputCode = CodeRenderer.RenderCodeAsString(new CSharpWriter(Path.GetRandomFileName(), "foo"),myNamespace);
 
             Assert.Equal(@"namespace foo {
-    public class bar {
+    public class Bar {
     }
 }
 ", outputCode);


### PR DESCRIPTION
- adds access modifier support for methods and properties - adds default value support for typescript properties
- fixes typescript response handler default value
- fixes default reesponse handler naming and type for java
- adds support for nullable type definition - adds indexers support for path building

fixes #30

TODO:
- [x] request builder properties needs to be assigned a value so the fluent API works and assign the pathBuilder
