### PR TITLE
feature/shorter indexer path java ts

### DIFF
--- a/src/kiota.core/CodeDOM/CodeElement.cs
+++ b/src/kiota.core/CodeDOM/CodeElement.cs
@@ -9,6 +9,7 @@ namespace kiota.core
     /// </summary>
     public abstract class CodeElement
     {
+        public Dictionary<string, object> GenerationProperties { get; set; } = new Dictionary<string, object>();
         public CodeElement(CodeElement parent)
         {
             if(parent == null && !(this is CodeNamespace))

--- a/src/kiota.core/CodeDOM/CodeType.cs
+++ b/src/kiota.core/CodeDOM/CodeType.cs
@@ -31,6 +31,7 @@ namespace kiota.core
                 Name = Name.Clone() as string,
                 Schema = Schema,
                 TypeDefinition = TypeDefinition,
+                IsNullable = IsNullable
             };
         }
     }

--- a/src/kiota.core/Refiners/CommonLanaguageRefiner.cs
+++ b/src/kiota.core/Refiners/CommonLanaguageRefiner.cs
@@ -6,6 +6,55 @@ namespace kiota.core {
     {
         public abstract void Refine(CodeNamespace generatedCode);
 
+        private const string pathSegmentPropertyName = "pathSegment";
+        protected void ReplaceIndexersByMethodsWithParameter(CodeElement currentElement, string methodNameSuffix = default) {
+            if(currentElement is CodeIndexer currentIndexer) {
+                var currentParentClass = currentElement.Parent as CodeClass;
+                currentParentClass.InnerChildElements.Remove(currentElement);
+                var pathSegment = currentParentClass
+                                    .GetChildElements()
+                                    .OfType<CodeProperty>()
+                                    .FirstOrDefault(x => x.Name.Equals(pathSegmentPropertyName, StringComparison.InvariantCultureIgnoreCase))
+                                    ?.DefaultValue;
+                if(!string.IsNullOrEmpty(pathSegment))
+                    AddIndexerMethod(currentElement.GetImmediateParentOfType<CodeNamespace>().GetRootNamespace(), 
+                                    currentParentClass,
+                                    currentIndexer.ReturnType.TypeDefinition,
+                                    pathSegment.Trim('\"').TrimStart('/'),
+                                    methodNameSuffix);
+            }
+            CrawlTree(currentElement, c => ReplaceIndexersByMethodsWithParameter(c, methodNameSuffix));
+        }
+        protected void AddIndexerMethod(CodeElement currentElement, CodeClass targetClass, CodeClass indexerClass, string pathSegment, string methodNameSuffix) {
+            if(currentElement is CodeProperty currentProperty && currentProperty.Type.TypeDefinition == targetClass) {
+                var parentClass = currentElement.Parent as CodeClass;
+                var method = new CodeMethod(parentClass) {
+                    IsAsync = false,
+                    IsStatic = false,
+                    Access = AccessModifier.Public,
+                    MethodKind = CodeMethodKind.IndexerBackwardCompatibility,
+                    Name = pathSegment + methodNameSuffix,
+                };
+                method.ReturnType = new CodeType(method) {
+                    IsNullable = false,
+                    TypeDefinition = indexerClass,
+                    Name = indexerClass.Name,
+                };
+                method.GenerationProperties.Add(pathSegmentPropertyName, pathSegment);
+                var parameter = new CodeParameter(method) {
+                    Name = "id",
+                    Optional = false,
+                    ParameterKind = CodeParameterKind.Custom
+                };
+                parameter.Type = new CodeType(parameter) {
+                    Name = "String",
+                    IsNullable = false,
+                };
+                method.Parameters.Add(parameter);
+                parentClass.AddMethod(method);
+            }
+            CrawlTree(currentElement, c => AddIndexerMethod(c, targetClass, indexerClass, pathSegment, methodNameSuffix));
+        }
         internal void AddInnerClasses(CodeElement current) {
             if(current is CodeClass currentClass) {
                 foreach(var parameter in current.GetChildElements().OfType<CodeMethod>().SelectMany(x =>x.Parameters).Where(x => x.Type.ActionOf))

--- a/src/kiota.core/Refiners/TypeScriptRefiner.cs
+++ b/src/kiota.core/Refiners/TypeScriptRefiner.cs
@@ -8,6 +8,7 @@ namespace kiota.core {
         public override void Refine(CodeNamespace generatedCode)
         {
             PatchResponseHandlerType(generatedCode);
+            ReplaceIndexersByMethodsWithParameter(generatedCode, "ById");
             AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
         }
         private void PatchResponseHandlerType(CodeElement current) {


### PR DESCRIPTION
- shortens the code path for indexers in java - adds defensive programming for method parameters in java
- adds shorter path for indexers in typescript

```java
// old
client.users().get("john").mailFolders().get("inbox").childFolders().get("sub").messages().get("id")

//new
client.users("john").mailFolders("inbox").childFolders("sub").messages("id")
```

```TypeScript
//old
client.users.item("john").mailFolders.item("inbox").childFolders.item("sub").messages.item("id")

// new
client.usersById("john").mailFoldersById("inbox").childFoldersById("sub").messagesById("id")
```