### PR TITLE
feature/union types

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -19,11 +19,6 @@ namespace Kiota.Builder
             EndBlock = new BlockEnd(this);
         }
 
-        public override string Name
-        {
-            get;set;
-        }
-
         public override IList<CodeElement> GetChildElements()
         {
             var elements = new List<CodeElement>(InnerChildElements);
@@ -55,7 +50,6 @@ namespace Kiota.Builder
         }
         public class BlockDeclaration : CodeTerminal
         {
-            public override string Name { get; set; }
             public List<CodeUsing> Usings = new List<CodeUsing>();
             public BlockDeclaration(CodeElement parent): base(parent)
             {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -27,7 +27,7 @@ namespace Kiota.Builder
         /// <summary>
         /// Name of Class
         /// </summary>
-        public new string Name
+        public override string Name
         {
             get => name;
             set

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -27,7 +27,7 @@ namespace Kiota.Builder
         /// <summary>
         /// Name of Class
         /// </summary>
-        public override string Name
+        public new string Name
         {
             get => name;
             set
@@ -76,13 +76,6 @@ namespace Kiota.Builder
             public Declaration(CodeElement parent):base(parent)
             {
                 
-            }
-            /// <summary>
-            /// Class name
-            /// </summary>
-            public override string Name
-            {
-                get; set;
             }
             public CodeType Inherits { get; set; }
             public List<CodeType> Implements { get; set; } = new List<CodeType>();

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -19,7 +19,7 @@ namespace Kiota.Builder
         public CodeElement Parent { get; set; }
         public abstract IList<CodeElement> GetChildElements();
 
-        public abstract string Name
+        public string Name
         {
             get; set;
         }

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -19,7 +19,7 @@ namespace Kiota.Builder
         public CodeElement Parent { get; set; }
         public abstract IList<CodeElement> GetChildElements();
 
-        public string Name
+        public virtual string Name
         {
             get; set;
         }

--- a/src/Kiota.Builder/CodeDOM/CodeIndexer.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeIndexer.cs
@@ -2,11 +2,10 @@
 {
     public class CodeIndexer : CodeTerminal
     {
-        public CodeIndexer(CodeElement parent): base(parent)
-        {
+        public CodeIndexer(CodeElement parent): base(parent) {
             
         }
-        public CodeType IndexType;
-        public CodeType ReturnType;
+        public CodeTypeBase IndexType;
+        public CodeTypeBase ReturnType;
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -19,7 +19,7 @@ namespace Kiota.Builder
         }
         public CodeMethodKind MethodKind = CodeMethodKind.Custom;
         public AccessModifier Access = AccessModifier.Public;
-        public CodeType ReturnType;
+        public CodeTypeBase ReturnType;
         public List<CodeParameter> Parameters = new List<CodeParameter>();
         public bool IsStatic = false;
         public bool IsAsync = true;
@@ -28,7 +28,7 @@ namespace Kiota.Builder
         {
             return new CodeMethod(Parent) {
                 MethodKind = MethodKind,
-                ReturnType = ReturnType.Clone() as CodeType,
+                ReturnType = ReturnType.Clone() as CodeTypeBase,
                 Parameters = Parameters.Select(x => x.Clone() as CodeParameter).ToList(),
                 Name = Name.Clone() as string,
             };

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -17,7 +17,7 @@ namespace Kiota.Builder
             return new CodeNamespace(null);
         }
         private string name;
-        public new string Name
+        public override string Name
         {
             get { return name;
             }

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -17,7 +17,7 @@ namespace Kiota.Builder
             return new CodeNamespace(null);
         }
         private string name;
-        public override string Name
+        public new string Name
         {
             get { return name;
             }

--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -17,7 +17,7 @@ namespace Kiota.Builder
             
         }
         public CodeParameterKind ParameterKind = CodeParameterKind.Custom;
-        public CodeType Type;
+        public CodeTypeBase Type;
         public bool Optional = false;
 
         public object Clone()
@@ -26,7 +26,7 @@ namespace Kiota.Builder
                 Optional = Optional,
                 ParameterKind = ParameterKind,
                 Name = Name.Clone() as string,
-                Type = Type.Clone() as CodeType,
+                Type = Type.Clone() as CodeTypeBase,
             };
         }
     }

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -15,11 +15,6 @@ namespace Kiota.Builder
             
         }
         public CodePropertyKind PropertyKind = CodePropertyKind.Custom;
-
-        public override string Name
-        {
-            get; set;
-        }
         public bool ReadOnly = false;
         public AccessModifier Access = AccessModifier.Public;
         public CodeTypeBase Type;

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -22,7 +22,7 @@ namespace Kiota.Builder
         }
         public bool ReadOnly = false;
         public AccessModifier Access = AccessModifier.Public;
-        public CodeType Type;
+        public CodeTypeBase Type;
         public string DefaultValue;
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeTerminal.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeTerminal.cs
@@ -2,17 +2,12 @@
 
 namespace Kiota.Builder
 {
-    public class CodeTerminal : CodeElement
+    public abstract class CodeTerminal : CodeElement
     {
         public CodeTerminal(CodeElement parent): base(parent)
         {
             
         }
-        public override string Name
-        {
-            get;set;
-        }
-
         public override IList<CodeElement> GetChildElements()
         {
             return new List<CodeElement>();

--- a/src/Kiota.Builder/CodeDOM/CodeType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeType.cs
@@ -17,7 +17,6 @@ namespace Kiota.Builder
         public override object Clone()
         {
             return new CodeType(this.Parent){
-                Name = Name.Clone() as string,
                 TypeDefinition = TypeDefinition,
                 IsExternal = IsExternal
             }.BaseClone<CodeType>(this);

--- a/src/Kiota.Builder/CodeDOM/CodeType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeType.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
@@ -15,14 +14,10 @@ namespace Kiota.Builder
         }
         public bool IsExternal = false;
 
-        [Obsolete]
-        public OpenApiSchema Schema;
-
         public override object Clone()
         {
             return new CodeType(this.Parent){
                 Name = Name.Clone() as string,
-                Schema = Schema,
                 TypeDefinition = TypeDefinition,
                 IsExternal = IsExternal
             }.BaseClone<CodeType>(this);

--- a/src/Kiota.Builder/CodeDOM/CodeType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeType.cs
@@ -3,16 +3,12 @@ using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
-    public class CodeType : CodeTerminal, ICloneable
+    public class CodeType : CodeTypeBase, ICloneable
     {
-        public enum CodeTypeCollectionKind {
-            None,
-            Array,
-            Complex
-        }
-        public CodeType(CodeElement parent): base(parent)
-        {
+        public CodeType(CodeElement parent): base(parent){
             
+        }
+        public CodeType(CodeTypeBase ancestor): base(ancestor) {
         }
         public override string Name
         {
@@ -23,22 +19,17 @@ namespace Kiota.Builder
             get;
             set;
         }
-
-        public bool ActionOf = false;
-        public bool IsNullable = true;
         public bool IsExternal = false;
-        public CodeTypeCollectionKind CollectionKind = CodeTypeCollectionKind.None;
 
+        [Obsolete]
         public OpenApiSchema Schema;
 
-        public object Clone()
+        public new object Clone()
         {
-            return new CodeType(Parent){
-                ActionOf = ActionOf,
+            return new CodeType(base.Clone() as CodeTypeBase){
                 Name = Name.Clone() as string,
                 Schema = Schema,
                 TypeDefinition = TypeDefinition,
-                IsNullable = IsNullable,
                 IsExternal = IsExternal
             };
         }

--- a/src/Kiota.Builder/CodeDOM/CodeType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeType.cs
@@ -8,12 +8,6 @@ namespace Kiota.Builder
         public CodeType(CodeElement parent): base(parent){
             
         }
-        public CodeType(CodeTypeBase ancestor): base(ancestor) {
-        }
-        public override string Name
-        {
-            get; set;
-        }
         public CodeClass TypeDefinition
         {
             get;
@@ -24,14 +18,14 @@ namespace Kiota.Builder
         [Obsolete]
         public OpenApiSchema Schema;
 
-        public new object Clone()
+        public override object Clone()
         {
-            return new CodeType(base.Clone() as CodeTypeBase){
+            return new CodeType(this.Parent){
                 Name = Name.Clone() as string,
                 Schema = Schema,
                 TypeDefinition = TypeDefinition,
                 IsExternal = IsExternal
-            };
+            }.BaseClone<CodeType>(this);
         }
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kiota.Builder {
+    public class CodeTypeBase: CodeTerminal, ICloneable {
+        public enum CodeTypeCollectionKind {
+            None,
+            Array,
+            Complex
+        }
+        public CodeTypeBase(CodeElement parent) : base(parent) {
+            
+        }
+        public CodeTypeBase(CodeTypeBase ancestor): base(ancestor.Parent)
+        {
+            ActionOf = ancestor.ActionOf;
+            IsNullable = ancestor.IsNullable;
+            CollectionKind = ancestor.CollectionKind;
+        }
+        public bool ActionOf = false;
+        public bool IsNullable = true;
+        public CodeTypeCollectionKind CollectionKind = CodeTypeCollectionKind.None;
+
+        public object Clone()
+        {
+            return new CodeTypeBase(this);
+        }
+        public IEnumerable<CodeType> AllTypes {
+            get {
+                if(this is CodeType currentType)
+                    return new CodeType[] { currentType };
+                else if (this is CodeUnionType currentUnion)
+                    return currentUnion.Types;
+                else
+                    return Enumerable.Empty<CodeType>();
+            }
+        }
+    }
+}

--- a/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace Kiota.Builder {
-    public class CodeTypeBase: CodeTerminal, ICloneable {
+    public abstract class CodeTypeBase: CodeTerminal, ICloneable {
         public enum CodeTypeCollectionKind {
             None,
             Array,
@@ -12,20 +12,21 @@ namespace Kiota.Builder {
         public CodeTypeBase(CodeElement parent) : base(parent) {
             
         }
-        public CodeTypeBase(CodeTypeBase ancestor): base(ancestor.Parent)
-        {
-            ActionOf = ancestor.ActionOf;
-            IsNullable = ancestor.IsNullable;
-            CollectionKind = ancestor.CollectionKind;
-        }
         public bool ActionOf = false;
         public bool IsNullable = true;
         public CodeTypeCollectionKind CollectionKind = CodeTypeCollectionKind.None;
 
-        public object Clone()
+        public ChildType BaseClone<ChildType>(CodeTypeBase source) where ChildType : CodeTypeBase
         {
-            return new CodeTypeBase(this);
+            ActionOf = source.ActionOf;
+            IsNullable = source.IsNullable;
+            CollectionKind = source.CollectionKind;
+            Name = source.Name.Clone() as string;
+            return this as ChildType;
         }
+
+        public abstract object Clone();
+
         public IEnumerable<CodeType> AllTypes {
             get {
                 if(this is CodeType currentType)

--- a/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kiota.Builder
+{
+    public class CodeUnionType : CodeTypeBase, ICloneable {
+        public CodeUnionType(CodeElement parent) : base(parent) {
+            
+        }
+        public CodeUnionType(CodeTypeBase ancestor) : base(ancestor) {
+            
+        }
+        public void AddType(params CodeType[] codeTypes) {
+            foreach(var codeType in codeTypes.Where(x => x != null && !Types.Contains(x)))
+                Types.Add(codeType);
+        }
+        public List<CodeType> Types { get; private set; } = new List<CodeType>();
+
+        public new object Clone() {
+            return new CodeUnionType(base.Clone() as CodeTypeBase){
+                Name = Name.Clone() as string,
+                Types = new List<CodeType>(Types),
+            };
+        }
+    }
+}

--- a/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
@@ -8,20 +8,17 @@ namespace Kiota.Builder
         public CodeUnionType(CodeElement parent) : base(parent) {
             
         }
-        public CodeUnionType(CodeTypeBase ancestor) : base(ancestor) {
-            
-        }
         public void AddType(params CodeType[] codeTypes) {
             foreach(var codeType in codeTypes.Where(x => x != null && !Types.Contains(x)))
                 Types.Add(codeType);
         }
         public List<CodeType> Types { get; private set; } = new List<CodeType>();
 
-        public new object Clone() {
-            return new CodeUnionType(base.Clone() as CodeTypeBase){
+        public override object Clone() {
+            return new CodeUnionType(this.Parent){
                 Name = Name.Clone() as string,
                 Types = new List<CodeType>(Types),
-            };
+            }.BaseClone<CodeUnionType>(this);
         }
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUnionType.cs
@@ -16,7 +16,6 @@ namespace Kiota.Builder
 
         public override object Clone() {
             return new CodeUnionType(this.Parent){
-                Name = Name.Clone() as string,
                 Types = new List<CodeType>(Types),
             }.BaseClone<CodeUnionType>(this);
         }

--- a/src/Kiota.Builder/CodeDOM/CodeUsing.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUsing.cs
@@ -8,10 +8,6 @@ namespace Kiota.Builder
         {
             
         }
-        public override string Name
-        {
-            get; set;
-        }
         public CodeType Declaration { get; set; }
 
         public override IList<CodeElement> GetChildElements()

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -333,7 +333,6 @@ namespace Kiota.Builder
             };
             prop.Type = new CodeType(prop) {
                 Name = isCollection ? typeSchema?.Items?.Reference?.GetClassName() : childType,
-                Schema = typeSchema,
                 TypeDefinition = typeDefinition,
                 CollectionKind = isCollection ? CodeType.CodeTypeCollectionKind.Complex : default
             };
@@ -478,7 +477,6 @@ namespace Kiota.Builder
                 return new CodeType(parentElement) {
                     TypeDefinition = codeClass,
                     Name = className,
-                    Schema = schema
                 };
             } else if(schema?.AllOf?.Any() ?? false) {
                 var lastSchema = schema.AllOf.Last();
@@ -497,7 +495,6 @@ namespace Kiota.Builder
                 return new CodeType(parentElement) {
                     TypeDefinition = codeClass,
                     Name = className,
-                    Schema = lastSchema
                 };
             } else if((schema?.AnyOf?.Any() ?? false) || (schema?.OneOf?.Any() ?? false)) {
                 var schemas = schema.AnyOf.Union(schema.OneOf);
@@ -514,7 +511,6 @@ namespace Kiota.Builder
                     unionType.AddType(new CodeType(unionType) {
                         TypeDefinition = codeClass,
                         Name = className,
-                        Schema = schema
                     });
                 }
                 return unionType;
@@ -589,7 +585,6 @@ namespace Kiota.Builder
                     prop.Type = new CodeType(prop)
                     {
                         Name = parameter.Schema.Items?.Type ?? parameter.Schema.Type,
-                        Schema = parameter.Schema,
                         CollectionKind = parameter.Schema.Type.Equals("array", StringComparison.InvariantCultureIgnoreCase) ? CodeType.CodeTypeCollectionKind.Array : default
                     };
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -462,7 +462,7 @@ namespace Kiota.Builder
             } else 
                 throw new InvalidOperationException($"could not find a shortest namespace name for reference id {referenceId}");
         }
-        private CodeType CreateModelClasses(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeElement parentElement)
+        private CodeTypeBase CreateModelClasses(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeElement parentElement)
         {
             var originalReference = schema?.Reference;
             var originalReferenceId = originalReference?.Id;
@@ -480,47 +480,45 @@ namespace Kiota.Builder
                     Name = className,
                     Schema = schema
                 };
-            } else { // Reused schema from components
-                // object type
-                // array of object
-                // all of object
-                // one of object
-                // any of object
-
-                if(schema?.AllOf?.Any() ?? false) {
-                    var lastSchema = schema.AllOf.Last();
-                    CodeClass codeClass = null;
-                    string className = string.Empty;
-                    foreach(var currentSchema in schema.AllOf) {
-                        var isLastSchema = currentSchema == lastSchema;
-                        var shortestNamespaceName = currentSchema.Reference == null ? GetNamespaceNameForModelByOperationId(operation.OperationId) : GetShortestNamespaceNameForModelByReferenceId(rootNode, currentSchema.Reference.Id);
-                        var shortestNamespace = codeNamespace.GetRootNamespace().GetNamespace(shortestNamespaceName);
-                        if(shortestNamespace == null)
-                            shortestNamespace = codeNamespace.AddNamespace(shortestNamespaceName);
-                        className = isLastSchema ? currentNode.GetClassName(operation: operation) : currentSchema.GetClassName();
-                        codeClass = AddModelClassIfDoesntExit(rootNode, currentNode, currentSchema, operation, className, shortestNamespace, parentElement, codeClass, true);
-                    }
-
-                    return new CodeType(parentElement) {
-                        TypeDefinition = codeClass,
-                        Name = className,
-                        Schema = lastSchema
-                    };
-                } else {
-                    //TODO anyOf & oneOf
-                    var shortestNamespaceName = GetShortestNamespaceNameForModelByReferenceId(rootNode, originalReferenceId);
+            } else if(schema?.AllOf?.Any() ?? false) {
+                var lastSchema = schema.AllOf.Last();
+                CodeClass codeClass = null;
+                string className = string.Empty;
+                foreach(var currentSchema in schema.AllOf) {
+                    var isLastSchema = currentSchema == lastSchema;
+                    var shortestNamespaceName = currentSchema.Reference == null ? GetNamespaceNameForModelByOperationId(operation.OperationId) : GetShortestNamespaceNameForModelByReferenceId(rootNode, currentSchema.Reference.Id);
                     var shortestNamespace = codeNamespace.GetRootNamespace().GetNamespace(shortestNamespaceName);
                     if(shortestNamespace == null)
                         shortestNamespace = codeNamespace.AddNamespace(shortestNamespaceName);
-                    var className = currentNode.GetClassName(operation: operation);
-                    var codeClass = AddModelClassIfDoesntExit(rootNode, currentNode, schema, operation, className, shortestNamespace, parentElement);
-                    return new CodeType(parentElement) {
+                    className = isLastSchema ? currentNode.GetClassName(operation: operation) : currentSchema.GetClassName();
+                    codeClass = AddModelClassIfDoesntExit(rootNode, currentNode, currentSchema, operation, className, shortestNamespace, parentElement, codeClass, true);
+                }
+
+                return new CodeType(parentElement) {
+                    TypeDefinition = codeClass,
+                    Name = className,
+                    Schema = lastSchema
+                };
+            } else if((schema?.AnyOf?.Any() ?? false) || (schema?.OneOf?.Any() ?? false)) {
+                var schemas = schema.AnyOf.Union(schema.OneOf);
+                var unionType = new CodeUnionType(parentElement);
+                foreach(var currentSchema in schemas) {
+                    var shortestNamespaceName = currentSchema.Reference == null ? GetNamespaceNameForModelByOperationId(operation.OperationId) : GetShortestNamespaceNameForModelByReferenceId(rootNode, currentSchema.Reference.Id);
+                    var shortestNamespace = codeNamespace.GetRootNamespace().GetNamespace(shortestNamespaceName);
+                    if(shortestNamespace == null)
+                        shortestNamespace = codeNamespace.AddNamespace(shortestNamespaceName);
+                    var className = currentSchema.GetClassName();
+                    var codeClass = AddModelClassIfDoesntExit(rootNode, currentNode, currentSchema, operation, className, shortestNamespace, parentElement);
+                    unionType.AddType(new CodeType(unionType) {
                         TypeDefinition = codeClass,
                         Name = className,
                         Schema = schema
-                    };
+                    });
                 }
+                return unionType;
             }
+            else throw new InvalidOperationException("un handled case, might be object type or array type");
+            // object type array of object are technically already handled in properties but if we have a root with those we might be missing some cases here
         }
         private CodeClass AddModelClassIfDoesntExit(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, string className, CodeNamespace currentNamespace, CodeElement parentElement, CodeClass inheritsFrom = null, bool checkInAllNamespaces = false) {
             var existingClass = checkInAllNamespaces ? 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -501,7 +501,9 @@ namespace Kiota.Builder
                 };
             } else if((schema?.AnyOf?.Any() ?? false) || (schema?.OneOf?.Any() ?? false)) {
                 var schemas = schema.AnyOf.Union(schema.OneOf);
-                var unionType = new CodeUnionType(parentElement);
+                var unionType = new CodeUnionType(parentElement) {
+                    Name = currentNode.GetClassName(operation: operation, suffix: "Response"),
+                };
                 foreach(var currentSchema in schemas) {
                     var shortestNamespaceName = currentSchema.Reference == null ? GetNamespaceNameForModelByOperationId(operation.OperationId) : GetShortestNamespaceNameForModelByReferenceId(rootNode, currentSchema.Reference.Id);
                     var shortestNamespace = codeNamespace.GetRootNamespace().GetNamespace(shortestNamespaceName);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -293,8 +293,12 @@ namespace Kiota.Builder
             foreach(var childElement in codeElement.GetChildElements())
                 MapTypeDefinitions(childElement);
         }
-        private void MapTypeDefinition(params CodeType[] currentTypes) {
-            foreach(var currentType in currentTypes.Where(x => x.TypeDefinition == null))
+        private void MapTypeDefinition(params CodeTypeBase[] currentTypes) {
+            foreach(var currentType in currentTypes.OfType<CodeType>()
+                                                    .Union(currentTypes
+                                                            .OfType<CodeUnionType>()
+                                                            .SelectMany(x => x.Types))
+                                                    .Where(x => x.TypeDefinition == null))
                 currentType.TypeDefinition = currentType
                         .GetImmediateParentOfType<CodeNamespace>()
                         .GetRootNamespace()

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -9,6 +9,7 @@ namespace Kiota.Builder {
         {
             AddDefaultImports(generatedCode);
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
+            ConvertUnionTypesToWrapper(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
             AddAsyncSuffix(generatedCode);
             AddInnerClasses(generatedCode);

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -11,6 +11,7 @@ namespace Kiota.Builder {
             AddInnerClasses(generatedCode);
             MakeQueryStringParametersNonOptionalAndInsertOverrideMethod(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode);
+            ConvertUnionTypesToWrapper(generatedCode);
             AddRequireNonNullImports(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
             AddDefaultImports(generatedCode);

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
@@ -139,7 +138,7 @@ namespace Kiota.Builder
             if(code is CodeUnionType) 
                 throw new InvalidOperationException($"CSharp does not support union types, the union type {code.Name} should have been filtered out by the refiner");
             else if (code is CodeType currentType) {
-                var typeName = TranslateType(currentType.Name, currentType.Schema);
+                var typeName = TranslateType(currentType.Name);
                 var collectionPrefix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? "List<" : string.Empty;
                 var collectionSuffix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? ">" : 
                                             (currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Array ? "[]" : string.Empty);
@@ -151,7 +150,7 @@ namespace Kiota.Builder
             else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
         }
 
-        public override string TranslateType(string typeName, OpenApiSchema schema)
+        public override string TranslateType(string typeName)
         {
             switch (typeName)
             {

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -20,20 +20,21 @@ namespace Kiota.Builder
             return $"@javax.annotation.{(parameter.Optional ? "Nullable" : "Nonnull")} final {GetTypeString(parameter.Type)} {parameter.Name}";
         }
 
-        public override string GetTypeString(CodeType code)
+        public override string GetTypeString(CodeTypeBase code)
         {
-            var typeName = TranslateType(code.Name, code.Schema);
-            var collectionPrefix = code.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? "List<" : string.Empty;
-            var collectionSuffix = code.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? ">" : 
-                                        (code.CollectionKind == CodeType.CodeTypeCollectionKind.Array ? "[]" : string.Empty);
-            if (code.ActionOf)
-            {
-                return $"java.util.function.Consumer<{collectionPrefix}{typeName}{collectionSuffix}>";
+            if(code is CodeUnionType) 
+                throw new InvalidOperationException($"Java does not support union types, the union type {code.Name} should have been filtered out by the refiner");
+            else if (code is CodeType currentType) {
+                var typeName = TranslateType(currentType.Name, currentType.Schema);
+                var collectionPrefix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? "List<" : string.Empty;
+                var collectionSuffix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? ">" : 
+                                            (currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Array ? "[]" : string.Empty);
+                if (currentType.ActionOf)
+                    return $"java.util.function.Consumer<{collectionPrefix}{typeName}{collectionSuffix}>";
+                else
+                    return $"{collectionPrefix}{typeName}{collectionSuffix}";
             }
-            else
-            {
-                return $"{collectionPrefix}{typeName}{collectionSuffix}";
-            }
+            else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
         }
 
         public override string TranslateType(string typeName, OpenApiSchema schema)

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
@@ -25,7 +24,7 @@ namespace Kiota.Builder
             if(code is CodeUnionType) 
                 throw new InvalidOperationException($"Java does not support union types, the union type {code.Name} should have been filtered out by the refiner");
             else if (code is CodeType currentType) {
-                var typeName = TranslateType(currentType.Name, currentType.Schema);
+                var typeName = TranslateType(currentType.Name);
                 var collectionPrefix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? "List<" : string.Empty;
                 var collectionSuffix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex ? ">" : 
                                             (currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Array ? "[]" : string.Empty);
@@ -37,7 +36,7 @@ namespace Kiota.Builder
             else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
         }
 
-        public override string TranslateType(string typeName, OpenApiSchema schema)
+        public override string TranslateType(string typeName)
         {
             switch (typeName)
             {//TODO we're probably missing a bunch of type mappings
@@ -45,7 +44,6 @@ namespace Kiota.Builder
                 case "boolean": return "Boolean";
                 case "string": return "String";
                 case "object": return "Object";
-                case "array": return $"{TranslateType(schema.Items.Type, schema.Items)}[]";
                 default: return typeName.ToFirstCharacterUpperCase() ?? "Object";
             }
         }

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -87,7 +87,7 @@ namespace Kiota.Builder
         }
 
         public abstract string GetParameterSignature(CodeParameter parameter);
-        public abstract string GetTypeString(CodeType code);
+        public abstract string GetTypeString(CodeTypeBase code);
         public abstract string TranslateType(string typeName, OpenApiSchema schema);
         public abstract void WriteProperty(CodeProperty code);
         public abstract void WriteIndexer(CodeIndexer code);

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
@@ -88,7 +87,7 @@ namespace Kiota.Builder
 
         public abstract string GetParameterSignature(CodeParameter parameter);
         public abstract string GetTypeString(CodeTypeBase code);
-        public abstract string TranslateType(string typeName, OpenApiSchema schema);
+        public abstract string TranslateType(string typeName);
         public abstract void WriteProperty(CodeProperty code);
         public abstract void WriteIndexer(CodeIndexer code);
         public abstract void WriteMethod(CodeMethod code);

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.OpenApi.Models;
 
 namespace Kiota.Builder
 {
@@ -25,7 +24,7 @@ namespace Kiota.Builder
             if(code is CodeUnionType currentUnion && currentUnion.Types.Any())
                 return currentUnion.Types.Select(x => GetTypeString(x)).Aggregate((x, y) => $"{x} | {y}") + collectionSuffix;
             else if(code is CodeType currentType) {
-                var typeName = TranslateType(currentType.Name, currentType.Schema);
+                var typeName = TranslateType(currentType.Name);
                 if (code.ActionOf)
                 {
                     IncreaseIndent(4);
@@ -51,12 +50,11 @@ namespace Kiota.Builder
             else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
         }
 
-        public override string TranslateType(string typeName, OpenApiSchema schema)
+        public override string TranslateType(string typeName)
         {
             switch (typeName)
             {//TODO we're probably missing a bunch of type mappings
                 case "integer": return "number";
-                case "array": return $"{TranslateType(schema.Items.Type, schema.Items)}[]";
                 case "string": // little casing hack
                 case "object":
                 case "boolean":


### PR DESCRIPTION
- adds the ability to express union types in code dom - adds support for union types in typescript
- adds support for inserting union types for any of or one of
- adds union types replacement for java and CSharp
- fixes cloning implementation - removes unecessary overrides for names
- removes openapi model contagion from codedom and writers
- fixes an issue where namespace names would be lost
- removes unecessary name cloning done by base

fixes #1
