### PR TITLE
feature/documentation

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -13,7 +13,7 @@ namespace Kiota.Builder
     /// <summary>
     /// CodeClass represents an instance of a Class to be generated in source code
     /// </summary>
-    public class CodeClass : CodeBlock
+    public class CodeClass : CodeBlock, IDocumentedElement
     {
         private string name;
 
@@ -24,6 +24,7 @@ namespace Kiota.Builder
         }
         public CodeClassKind ClassKind { get; set; } = CodeClassKind.Custom;
 
+        public string Description {get; set;}
         /// <summary>
         /// Name of Class
         /// </summary>

--- a/src/Kiota.Builder/CodeDOM/CodeEnum.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeEnum.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Kiota.Builder
 {
-    public class CodeEnum : CodeElement {
+    public class CodeEnum : CodeElement, IDocumentedElement {
         public CodeEnum(CodeElement parent) : base(parent)
         {
             
@@ -15,5 +15,6 @@ namespace Kiota.Builder
         }
         public List<string> Options { get; set; } = new List<string>();
         public bool Flags { get; set; }
+        public string Description {get; set;}
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeIndexer.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeIndexer.cs
@@ -1,11 +1,12 @@
 ﻿namespace Kiota.Builder
 {
-    public class CodeIndexer : CodeTerminal
+    public class CodeIndexer : CodeTerminal, IDocumentedElement
     {
         public CodeIndexer(CodeElement parent): base(parent) {
             
         }
         public CodeTypeBase IndexType {get; set;}
         public CodeTypeBase ReturnType {get; set;}
+        public string Description {get; set;}
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -25,7 +25,7 @@ namespace Kiota.Builder
         Trace
     }
 
-    public class CodeMethod : CodeTerminal, ICloneable
+    public class CodeMethod : CodeTerminal, ICloneable, IDocumentedElement
     {
         public CodeMethod(CodeElement parent): base(parent)
         {
@@ -38,6 +38,8 @@ namespace Kiota.Builder
         public List<CodeParameter> Parameters {get;set;} = new List<CodeParameter>();
         public bool IsStatic {get;set;} = false;
         public bool IsAsync {get;set;} = true;
+        public string Description {get; set;}
+
 
         public object Clone()
         {
@@ -50,6 +52,7 @@ namespace Kiota.Builder
                 IsAsync = IsAsync,
                 Access = Access,
                 IsStatic = IsStatic,
+                Description = Description.Clone() as string,
                 GenerationProperties = new (GenerationProperties),
             };
         }

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -52,7 +52,7 @@ namespace Kiota.Builder
                 IsAsync = IsAsync,
                 Access = Access,
                 IsStatic = IsStatic,
-                Description = Description.Clone() as string,
+                Description = Description?.Clone() as string,
                 GenerationProperties = new (GenerationProperties),
             };
         }

--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -11,7 +11,7 @@ namespace Kiota.Builder
         RequestBody
     }
 
-    public class CodeParameter : CodeTerminal, ICloneable
+    public class CodeParameter : CodeTerminal, ICloneable, IDocumentedElement
     {
         public CodeParameter(CodeElement parent): base(parent)
         {
@@ -20,7 +20,7 @@ namespace Kiota.Builder
         public CodeParameterKind ParameterKind {get;set;}= CodeParameterKind.Custom;
         public CodeTypeBase Type {get;set;}
         public bool Optional {get;set;}= false;
-
+        public string Description {get; set;}
         public object Clone()
         {
             return new CodeParameter(Parent) {
@@ -28,6 +28,7 @@ namespace Kiota.Builder
                 ParameterKind = ParameterKind,
                 Name = Name.Clone() as string,
                 Type = Type.Clone() as CodeTypeBase,
+                Description = Description.Clone() as string,
             };
         }
     }

--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -28,7 +28,7 @@ namespace Kiota.Builder
                 ParameterKind = ParameterKind,
                 Name = Name.Clone() as string,
                 Type = Type.Clone() as CodeTypeBase,
-                Description = Description.Clone() as string,
+                Description = Description?.Clone() as string,
             };
         }
     }

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -9,7 +9,7 @@ namespace Kiota.Builder
         Deserializer
     }
 
-    public class CodeProperty : CodeTerminal
+    public class CodeProperty : CodeTerminal, IDocumentedElement
     {
         public CodeProperty(CodeElement parent): base(parent)
         {
@@ -20,5 +20,6 @@ namespace Kiota.Builder
         public AccessModifier Access {get;set;} = AccessModifier.Public;
         public CodeTypeBase Type {get;set;}
         public string DefaultValue {get;set;}
+        public string Description {get; set;}
     }
 }

--- a/src/Kiota.Builder/CodeDOM/IDocumentedElement.cs
+++ b/src/Kiota.Builder/CodeDOM/IDocumentedElement.cs
@@ -1,0 +1,5 @@
+namespace Kiota.Builder {
+    public interface IDocumentedElement {
+        string Description {get; set;}
+    }
+}

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -173,7 +173,18 @@ namespace Kiota.Builder
         private const string StreamTypeName = "stream";
         private const string VoidTypeName = "void";
         private const string docCommentPrefix = "/// ";
-
+        private void WriteMethodDocumentation(CodeMethod code) {
+            var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
+            var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
+            if (isDescriptionPresent || parametersWithDescription.Any()) {
+                WriteLine($"{docCommentPrefix}<summary>");
+                if(isDescriptionPresent)
+                    WriteLine($"{docCommentPrefix}{code.Description}");
+                foreach(var paramWithDescription in parametersWithDescription)
+                    WriteLine($"{docCommentPrefix}<param name=\"{paramWithDescription.Name}\">{paramWithDescription.Description}</param>");
+                WriteLine($"{docCommentPrefix}</summary>");
+            }
+        }
         public override void WriteMethod(CodeMethod code)
         {
             var staticModifier = code.IsStatic ? "static " : string.Empty;
@@ -186,16 +197,7 @@ namespace Kiota.Builder
             var genericTypePrefix = isVoid ? string.Empty : "<";
             var genricTypeSuffix = code.IsAsync && !isVoid ? ">": string.Empty;
             var completeReturnType = $"{(code.IsAsync ? "async Task" + genericTypePrefix : string.Empty)}{(code.IsAsync && isVoid ? string.Empty : returnType)}{genricTypeSuffix}";
-            var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
-            var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
-            if (isDescriptionPresent || parametersWithDescription.Any()) {
-                WriteLine($"{docCommentPrefix}<summary>");
-                if(isDescriptionPresent)
-                    WriteLine($"{docCommentPrefix}{code.Description}");
-                foreach(var paramWithDescription in parametersWithDescription)
-                    WriteLine($"{docCommentPrefix}<param name=\"{paramWithDescription.Name}\">{paramWithDescription.Description}</param>");
-                WriteLine($"{docCommentPrefix}</summary>");
-            }
+            WriteMethodDocumentation(code);
             // Task type should be moved into the refiner
             WriteLine($"{GetAccessModifier(code.Access)} {staticModifier}{hideModifier}{completeReturnType} {code.Name}({string.Join(", ", code.Parameters.Select(p=> GetParameterSignature(p)).ToList())}) {{");
             IncreaseIndent();

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -99,7 +99,7 @@ namespace Kiota.Builder
                 WriteLine(docCommentEnd);
             }
         }
-        private string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
+        private static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
         private void WriteShortDescription(string description) {
             if(!string.IsNullOrEmpty(description))
                 WriteLine($"{docCommentStart} {RemoveInvalidDescriptionCharacters(description)} {docCommentEnd}");

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -62,7 +62,7 @@ namespace Kiota.Builder
             }
             var derivation = (code.Inherits == null ? string.Empty : $" extends {code.Inherits.Name.ToFirstCharacterUpperCase()}") +
                             (!code.Implements.Any() ? string.Empty : $" implements {code.Implements.Select(x => x.Name).Aggregate((x,y) => x + " ," + y)}");
-            //TODO: missing javadoc
+            WriteShortDescription((code.Parent as CodeClass)?.Description);
             WriteLine($"public class {code.Name.ToFirstCharacterUpperCase()}{derivation} {{");
             IncreaseIndent();
         }
@@ -79,11 +79,36 @@ namespace Kiota.Builder
         }
         private const string serializerFactoryParamName = "serializerFactory";
         private const string streamType = "InputStream";
+        private const string docCommentStart = "/**";
+        private const string docCommentPrefix = " * ";
+        private const string docCommentEnd = " */";
+        private void WriteMethodDocumentation(CodeMethod code) {
+            var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
+            var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
+            if (isDescriptionPresent || parametersWithDescription.Any()) {
+                WriteLine(docCommentStart);
+                if(isDescriptionPresent)
+                    WriteLine($"{docCommentPrefix}{RemoveInvalidDescriptionCharacters(code.Description)}");
+                foreach(var paramWithDescription in parametersWithDescription)
+                    WriteLine($"{docCommentPrefix}@param {paramWithDescription.Name} {RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
+                
+                if(code.IsAsync)
+                    WriteLine($"{docCommentPrefix}@return a CompletableFuture of {code.ReturnType.Name}");
+                else
+                    WriteLine($"{docCommentPrefix}@return a {code.ReturnType.Name}");
+                WriteLine(docCommentEnd);
+            }
+        }
+        private string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
+        private void WriteShortDescription(string description) {
+            if(!string.IsNullOrEmpty(description))
+                WriteLine($"{docCommentStart} {RemoveInvalidDescriptionCharacters(description)} {docCommentEnd}");
+        }
         public override void WriteMethod(CodeMethod code)
         {
-            //TODO javadoc
             var returnType = GetTypeString(code.ReturnType);
             var parentClass = code.Parent as CodeClass;
+            WriteMethodDocumentation(code);
             if(returnType.Equals("void", StringComparison.InvariantCultureIgnoreCase))
             {
                 if(code.MethodKind == CodeMethodKind.RequestExecutor)
@@ -258,7 +283,7 @@ namespace Kiota.Builder
         }
         public override void WriteProperty(CodeProperty code)
         {
-            //TODO: missing javadoc
+            WriteShortDescription(code.Description);
             var returnType = GetTypeString(code.Type);
             switch(code.PropertyKind) {
                 case CodePropertyKind.RequestBuilder:
@@ -302,8 +327,9 @@ namespace Kiota.Builder
             WriteLines($"package {(code.Parent as CodeNamespace)?.Name};",
                 string.Empty,
                 "import com.microsoft.kiota.serialization.ValuedEnum;",
-                string.Empty,
-                $"public enum {enumName} implements ValuedEnum {{");
+                string.Empty);
+            WriteShortDescription(code.Description);
+            WriteLine($"public enum {enumName} implements ValuedEnum {{");
             IncreaseIndent();
             Write(code.Options
                         .Select(x => $"{x.ToFirstCharacterUpperCase()}(\"{x}\")")

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -247,7 +247,7 @@ namespace Kiota.Builder
                 WriteLine(docCommentEnd);
             }
         }
-        private string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
+        private static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
         private void WriteShortDescription(string description) {
             if(!string.IsNullOrEmpty(description))
                 WriteLine($"{docCommentStart} {RemoveInvalidDescriptionCharacters(description)} {docCommentEnd}");


### PR DESCRIPTION
- adds the infrastructure to support generating doc comment
- adds support for doc comments in dotnet
- adds doc comment support for java
- adds doc comment support for typescript

fixes #23
fixes #22
fixes #21

adds comments like these to improve the devolepment experience

## serialization
```TS
/**
     * Serialiazes information the current object
     * @param writer Serialization writer to use to serialize this model
     * @returns a void
     */
```

## deserialization 
```TS
/**
     * The serialization information for the current model
     * @returns a Map<string, (item: SingleValueLegacyExtendedProperty, node: ParseNode) => void>
     */
```

## a property
```TS
/** The message ID in the format specified by RFC2822.  */
```

## a class
```TS
/** Builds and executes requests for operations under /users/{user-id}  */
```