### PR TITLE
bugfix/http desc and simple schema

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -501,6 +501,18 @@ namespace Kiota.Builder
             } else 
                 throw new InvalidOperationException($"could not find a shortest namespace name for reference id {referenceId}");
         }
+        private CodeType CreateModelClassAndType(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeElement parentElement, CodeNamespace codeNamespace, string classNameSuffix = "") {
+            var namespaceName = currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName);
+            var ns = codeNamespace.GetRootNamespace().GetNamespace(namespaceName);
+            if(ns == null)
+                ns = codeNamespace.AddNamespace(namespaceName);
+            var className = currentNode.GetClassName(operation: operation, suffix: classNameSuffix);
+            var codeDeclaration = AddModelDeclarationIfDoesntExit(rootNode, currentNode, schema, operation, className, ns, parentElement);
+            return new CodeType(parentElement) {
+                TypeDefinition = codeDeclaration,
+                Name = className,
+            };
+        }
         private CodeTypeBase CreateModelClasses(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeElement parentElement)
         {
             var originalReference = schema?.Reference;
@@ -508,16 +520,7 @@ namespace Kiota.Builder
             var codeNamespace = parentElement.GetImmediateParentOfType<CodeNamespace>();
             
             if (originalReference == null) { // Inline schema, i.e. specific to the Operation
-                var namespaceName = currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName);
-                var ns = codeNamespace.GetRootNamespace().GetNamespace(namespaceName);
-                if(ns == null)
-                    ns = codeNamespace.AddNamespace(namespaceName);
-                var className = currentNode.GetClassName(operation: operation, suffix: "Response");
-                var codeDeclaration = AddModelDeclarationIfDoesntExit(rootNode, currentNode, schema, operation, className, ns, parentElement);
-                return new CodeType(parentElement) {
-                    TypeDefinition = codeDeclaration,
-                    Name = className,
-                };
+                return CreateModelClassAndType(rootNode, currentNode, schema, operation, parentElement, codeNamespace, "Response");
             } else if(schema?.AllOf?.Any() ?? false) {
                 var lastSchema = schema.AllOf.Last();
                 CodeElement codeDeclaration = null;
@@ -554,6 +557,9 @@ namespace Kiota.Builder
                     });
                 }
                 return unionType;
+            } else if((schema?.Type?.Equals("object") ?? false) && (schema?.Properties?.Any() ?? false)) {
+                // referenced schema, no inheritance or union type
+                return CreateModelClassAndType(rootNode, currentNode, schema, operation, parentElement, codeNamespace);
             }
             else throw new InvalidOperationException("un handled case, might be object type or array type");
             // object type array of object are technically already handled in properties but if we have a root with those we might be missing some cases here

--- a/src/kiota/Program.cs
+++ b/src/kiota/Program.cs
@@ -80,6 +80,6 @@ namespace kiota
             return configObject;
         }
 
-        private static string GetAbsolutePath(string source) => Path.IsPathRooted(source) ? source : Path.Combine(Directory.GetCurrentDirectory(), source);
+        private static string GetAbsolutePath(string source) => Path.IsPathRooted(source) || source.StartsWith("http") ? source : Path.Combine(Directory.GetCurrentDirectory(), source);
     }
 }


### PR DESCRIPTION
- fixes a bug where passing urls for open api descriptions would fail to load
- fixes #107 adds support for simple referenced schemas

## Summary

Passing a open API description with a URI as an arugment (starting with http/https, not a local file) would fail to load due to path management)
If an operation would reference a schema (not any/all/one of, but not an inline schema) the case was not handled properly.

## Generation diff

None for our test files, however [PetStore](https://petstore.swagger.io/v2/swagger.json) now works. @darrelmiller will soon add samples for pet store as well.
