### PR TITLE
adds automatic github release on tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,56 @@
+name: Create GitHub release
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish_binaries:
+    name: Publish binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture:
+          - win-x64
+          - win-x86
+          - linux-x64
+          - osx-x64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Publish ${{ matrix.architecture }}
+        run: dotnet publish ./src/kiota/kiota.csproj -c Release -p:PublishSingleFile=true -r ${{ matrix.architecture }} -o ./${{ matrix.architecture }}
+      - name: Archive Release ${{ matrix.architecture }}
+        uses: thedoctor0/zip-release@master
+        with:
+          filename: './${{ matrix.architecture }}.zip'
+          path: './${{ matrix.architecture }}'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binaries-${{ matrix.architecture }}
+          path: ./${{ matrix.architecture }}.zip
+  create_release:
+    name: Create Release
+    needs: [publish_binaries]
+    environment:
+      name: gh_releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          path: output
+      - name: Release
+        uses: anton-yurchenko/git-release@v3.4.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "false"
+          PRE_RELEASE: "false"
+          CHANGELOG_FILE: "CHANGELOG.md"
+          ALLOW_EMPTY_CHANGELOG: "true"
+          ALLOW_TAG_PREFIX: "true"
+        with:
+          args: |
+              output/binaries-*/*.zip

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches: [main]
+    tags: ['v*']
     paths: ['src/**', '.github/workflows/**']
 jobs:
   push_to_registry:
@@ -18,8 +19,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-      - name: Push to GitHub Packages
+      - run: |
+          $version = $Env:BRANCH_NAME -replace "refs/tags/v",""
+          echo "::set-output name=version::${version}"
+        shell: pwsh
+        id: getversion
+        if: contains(github.ref, 'refs/tags/v')
+        env:
+          BRANCH_NAME: ${{ github.ref }}
+      - name: Push to GitHub Packages - Nightly
+        if: contains(github.ref, 'refs/head/main')
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: docker.pkg.github.com/microsoft/kiota/generator:latest
+          tags: docker.pkg.github.com/microsoft/kiota/generator:nightly
+      - name: Push to GitHub Packages - Release
+        if: contains(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: docker.pkg.github.com/microsoft/kiota/generator:latest,docker.pkg.github.com/microsoft/kiota/generator:${{ steps.getversion.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2021-04-20
+
+### Added
+
+- Initial GitHub release

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 WORKDIR /app
 
 COPY ./src ./kiota/src
-COPY ./tests ./kiota/tests
-COPY ./kiota.sln ./kiota
 WORKDIR /app/kiota
 RUN dotnet publish ./src/kiota/kiota.csproj -c Release
 
@@ -15,3 +13,6 @@ COPY --from=build-env /app/kiota/src/kiota/bin/Release/net5.0 ./
 VOLUME /app/output
 VOLUME /app/openapi.yml
 ENTRYPOINT ["dotnet", "kiota.dll"]
+LABEL description="# Welcome to Kiota Generator \
+To start generating SDKs checkout [the getting started documentation](https://github.com/microsoft/kiota/#running-kiota-with-docker)  \
+[Source dockerfile](https://github.com/microsoft/kiota/blob/main/releases/Dockerfile)"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ No additional tools are required for dotnet projects.
 
 ### Generating SDKs
 
-Installing the tools and cloning this repository, you can either build Kiota or use it with docker.
+You can either clone the repository and build Kiota locally, download and run binaries or run the docker image.
 
 #### Running Kiota with Docker
 
@@ -68,6 +68,8 @@ dotnet publish ./src/kiota/kiota.csproj -c Release -p:PublishSingleFile=true -r 
 Navigate to the output directory (usually under `src/kiota/bin/Release/net5.0`) and start generating SDKs by running Kiota.
 
 #### Running Kiota from binaries
+
+If you haven't built kiota locally, select the appropriate version from the [releases page](https://github.com/microsoft/kiota/releases).
 
 ```Shell
 kiota.exe --openapi ../msgraph-sdk-powershell/openApiDocs/v1.0/mail.yml --language csharp -o ../somepath -n samespaceprefix


### PR DESCRIPTION
## Summary

- adds a workflow to automate github releases on tags - updates docker workflow to support nightly and releases - adds a changelog file - adds a description to the docker file
- updates readme to include a link to the releases page

Fixes #98

This pull request adds a workflow to create GitHub releases on tags

1. Make your changes
1. (optional) Update the csproj to bump the version number
1. Update the changelog
1. `git tag vX.X.X` && `git push --tags`

This will [create a release](https://github.com/microsoft/kiota/releases)

This PR also updates the docker workflow to publish multiple tags (nigthly on main, latest + version on tag) [see here](https://github.com/microsoft/kiota/packages/740417/versions)

## Generation changes

Note applicable
