### PR TITLE
feature/addtional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adds supports for additional properties in models
+
 ## [0.0.2] - 2021-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2021-04-25
+
 ### Added
 
 - Adds supports for additional properties in models

--- a/abstractions/dotnet/src/KiotaAbstractions.csproj
+++ b/abstractions/dotnet/src/KiotaAbstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 
 </Project>

--- a/abstractions/dotnet/src/serialization/IParsable.cs
+++ b/abstractions/dotnet/src/serialization/IParsable.cs
@@ -9,5 +9,7 @@ namespace Kiota.Abstractions.Serialization {
         }
 
         void Serialize(ISerializationWriter writer);
+
+        IDictionary<string, object> AdditionalData { get; }
     }
 }

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -15,6 +15,7 @@ namespace Kiota.Abstractions.Serialization {
         void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : class, IParsable<T>, new();
         void WriteObjectValue<T>(string key, T value) where T : class, IParsable<T>, new();
         void WriteEnumValue<T>(string key, T? value) where T : struct, Enum;
+        void WriteAdditionalData(IDictionary<string, object> value);
         Stream GetSerializedContent();
     }
 }

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -44,7 +44,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.7'
+            version '1.0.8'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
@@ -10,4 +10,6 @@ public interface Parsable {
     @Nonnull
     <T> Map<String, BiConsumer<T, ParseNode>> getDeserializeFields();
     void serialize(@Nonnull final SerializationWriter writer);
+    @Nonnull
+    Map<String, Object> getAdditionalData();
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
@@ -3,6 +3,7 @@ package com.microsoft.kiota.serialization;
 import java.io.Closeable;
 import java.io.InputStream;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.UUID;
 import java.util.EnumSet;
 import java.lang.Enum;
@@ -25,4 +26,5 @@ public interface SerializationWriter extends Closeable {
     InputStream getSerializedContent();
     <T extends Enum<T>> void writeEnumSetValue(@Nullable final String key, @Nullable final EnumSet<T> values);
     <T extends Enum<T>> void writeEnumValue(@Nullable final String key, @Nullable final T value);
+    void writeAdditionalData(@Nonnull final Map<String, Object> value);
 }

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/src/serialization/parsable.ts
+++ b/abstractions/typescript/src/serialization/parsable.ts
@@ -4,4 +4,5 @@ import { SerializationWriter } from './serializationWriter';
 export interface Parsable<T> {
     deserializeFields(): Map<string, (item: T, node: ParseNode) => void>;
     serialize(writer: SerializationWriter): void;
+    additionalData: Map<string, unknown>;
 }

--- a/abstractions/typescript/src/serialization/serializationWriter.ts
+++ b/abstractions/typescript/src/serialization/serializationWriter.ts
@@ -12,4 +12,5 @@ export interface SerializationWriter {
     writeObjectValue<T extends Parsable<T>>(key?: string | undefined, value?: T | undefined): void;
     writeEnumValue<T>(key?: string | undefined, ...values: (T | undefined)[]): void;
     getSerializedContent(): ReadableStream;
+    writeAdditionalData(value: Map<string, unknown>): void;
 }

--- a/core/dotnet/src/KiotaCore.csproj
+++ b/core/dotnet/src/KiotaCore.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="KiotaAbstractions" Version="1.0.7" />
+    <PackageReference Include="KiotaAbstractions" Version="1.0.8" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
@@ -10,7 +10,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/core/dotnet/src/serialization/JsonSerializationWriter.cs
+++ b/core/dotnet/src/serialization/JsonSerializationWriter.cs
@@ -108,6 +108,11 @@ namespace KiotaCore.Serialization {
             writer.WriteEndObject();
         }
         private void WriteAnyValue<T>(string key, T value) {
+            if(value == null) {
+                if(!string.IsNullOrEmpty(key))
+                    this.writer.WritePropertyName(key);
+                this.writer.WriteNullValue();
+            }
             switch(value) {
                 case string s:
                     WriteStringValue(key, s);

--- a/core/dotnet/src/serialization/JsonSerializationWriter.cs
+++ b/core/dotnet/src/serialization/JsonSerializationWriter.cs
@@ -117,6 +117,38 @@ namespace KiotaCore.Serialization {
                 writer.WriteEndObject();
             }
         }
+        public void WriteAdditionalData(IDictionary<string, object> value) {
+            if(value == null) return;
+            
+            foreach(var dataValue in value) {
+                switch(dataValue.Value) {
+                    case string s:
+                        WriteStringValue(dataValue.Key, s);
+                    break;
+                    case bool b:
+                        WriteBoolValue(dataValue.Key, b);
+                    break;
+                    case int i:
+                        WriteIntValue(dataValue.Key, i);
+                    break;
+                    case float f:
+                        WriteFloatValue(dataValue.Key, f);
+                    break;
+                    case double d:
+                        WriteDoubleValue(dataValue.Key, d);
+                    break;
+                    case Guid g:
+                        WriteGuidValue(dataValue.Key, g);
+                    break;
+                    case DateTimeOffset dto:
+                        WriteDateTimeOffsetValue(dataValue.Key, dto);
+                    break;
+                    default:
+                        throw new InvalidOperationException($"error serialization additional data value with key {dataValue.Key}, unknown type {dataValue.Value?.GetType()}");
+                }
+            }
+        }
+
         public void Dispose()
         {
             writer.Dispose();

--- a/core/java/.project
+++ b/core/java/.project
@@ -16,7 +16,7 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1615408842209</id>
+			<id>0</id>
 			<name></name>
 			<type>30</type>
 			<matcher>

--- a/core/java/lib/.classpath
+++ b/core/java/lib/.classpath
@@ -6,20 +6,7 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="bin/main" path="src/main/resources">
-		<attributes>
-			<attribute name="gradle_scope" value="main"/>
-			<attribute name="gradle_used_by_scope" value="main,test"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="bin/test" path="src/test/java">
-		<attributes>
-			<attribute name="gradle_scope" value="test"/>
-			<attribute name="gradle_used_by_scope" value="test"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="bin/test" path="src/test/resources">
 		<attributes>
 			<attribute name="gradle_scope" value="test"/>
 			<attribute name="gradle_used_by_scope" value="test"/>

--- a/core/java/lib/build.gradle
+++ b/core/java/lib/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     api 'com.azure:azure-identity:1.2.5'
     api 'com.google.code.gson:gson:2.8.6'
 
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.7'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.8'
 }
 
 publishing {
@@ -57,7 +57,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-core'
-            version '1.0.0'
+            version '1.0.2'
             from(components.java)
         }
     }

--- a/core/typescript/package.json
+++ b/core/typescript/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@azure/identity": "^1.3.0",
-    "@microsoft/kiota-abstractions": "^1.0.7",
+    "@microsoft/kiota-abstractions": "^1.0.8",
     "cross-fetch": "^3.1.4",
     "web-streams-polyfill": "^3.0.3"
   }

--- a/core/typescript/src/serialization/jsonParseNode.ts
+++ b/core/typescript/src/serialization/jsonParseNode.ts
@@ -59,7 +59,10 @@ export class JsonParseNode implements ParseNode {
         const fields = item.deserializeFields();
         Object.entries(this._jsonNode as any).forEach(([k, v]) => {
             const deserializer = fields.get(k);
-            deserializer && deserializer(item, new JsonParseNode(v));
+            if(deserializer)
+                deserializer(item, new JsonParseNode(v));
+            else
+                item.additionalData.set(k, v);
         });
     }
 }

--- a/src/Kiota.Builder/CodeDOM/AccessModifier.cs
+++ b/src/Kiota.Builder/CodeDOM/AccessModifier.cs
@@ -1,7 +1,7 @@
 namespace Kiota.Builder {
         public enum AccessModifier {
-        Public,
-        Protected,
-        Private
+        Public = 2,
+        Protected = 1,
+        Private = 0
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -77,13 +77,13 @@ namespace Kiota.Builder
             else return null;
         }
         
-        public CodeClass GetUpperMostInheritanceParent(CodeClass startClassToSkip = null) {
+        public CodeClass GetGreatestGrandparent(CodeClass startClassToSkip = null) {
             var parentClass = GetParentClass();
             if(parentClass == null)
                 return startClassToSkip != null && startClassToSkip == this ? null : this;
             // we don't want to return the current class if this is the start node in the inheritance tree and doesn't have parent
             else
-                return parentClass.GetUpperMostInheritanceParent(startClassToSkip);
+                return parentClass.GetGreatestGrandparent(startClassToSkip);
         }
 
         public class Declaration : BlockDeclaration

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -71,6 +71,20 @@ namespace Kiota.Builder
             AddMissingParent(codeClasses);
             this.InnerChildElements.AddRange(codeClasses);
         }
+        public CodeClass GetParentClass() {
+            if(StartBlock is Declaration declaration)
+                return declaration.Inherits?.TypeDefinition as CodeClass;
+            else return null;
+        }
+        
+        public CodeClass GetUpperMostInheritanceParent(CodeClass startClassToSkip = null) {
+            var parentClass = GetParentClass();
+            if(parentClass == null)
+                return startClassToSkip != null && startClassToSkip == this ? null : this;
+            // we don't want to return the current class if this is the start node in the inheritance tree and doesn't have parent
+            else
+                return parentClass.GetUpperMostInheritanceParent(startClassToSkip);
+        }
 
         public class Declaration : BlockDeclaration
         {

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -11,7 +11,8 @@ namespace Kiota.Builder
         RequestExecutor,
         RequestGenerator,
         Serializer,
-        DeserializerBackwardCompatibility
+        DeserializerBackwardCompatibility,
+        AdditionalDataAccessor
     }
     public enum HttpMethod {
         Get,

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -6,7 +6,8 @@ namespace Kiota.Builder
     {
         Custom,
         RequestBuilder,
-        Deserializer
+        Deserializer,
+        AdditionalData
     }
 
     public class CodeProperty : CodeTerminal, IDocumentedElement

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -682,7 +682,7 @@ namespace Kiota.Builder
             }
             if(!model.ContainsMember(additionalDataPropName) &&
                 includeAdditionalProperties && 
-                !(model.GetUpperMostInheritanceParent(model)?.ContainsMember(additionalDataPropName) ?? false)) {
+                !(model.GetGreatestGrandparent(model)?.ContainsMember(additionalDataPropName) ?? false)) {
                 // we don't want to add the property if the parent already has it
                 var additionalDataProp = new CodeProperty(model) {
                     Name = additionalDataPropName,

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -642,7 +642,7 @@ namespace Kiota.Builder
             }
             else if(schema?.AllOf?.Any(x => x?.Type?.Equals(OpenApiObjectType) ?? false) ?? false)
                 CreatePropertiesForModelClass(rootNode, currentNode, schema.AllOf.Last(x => x.Type.Equals(OpenApiObjectType)), operation, ns, model, parent);
-            AddSerializationMembers(model, schema.AdditionalPropertiesAllowed);
+            AddSerializationMembers(model, schema?.AdditionalPropertiesAllowed ?? false);
         }
         private const string deserializeFieldsPropName = "DeserializeFields";
         private const string serializeMethodName = "Serialize";

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -642,11 +642,12 @@ namespace Kiota.Builder
             }
             else if(schema?.AllOf?.Any(x => x?.Type?.Equals(OpenApiObjectType) ?? false) ?? false)
                 CreatePropertiesForModelClass(rootNode, currentNode, schema.AllOf.Last(x => x.Type.Equals(OpenApiObjectType)), operation, ns, model, parent);
-            AddSerializationMembers(model);
+            AddSerializationMembers(model, schema.AdditionalPropertiesAllowed);
         }
         private const string deserializeFieldsPropName = "DeserializeFields";
         private const string serializeMethodName = "Serialize";
-        private static void AddSerializationMembers(CodeClass model) {
+        private const string additionalDataPropName = "AdditionalData";
+        private static void AddSerializationMembers(CodeClass model, bool includeAdditionalProperties) {
             var serializationPropsType = $"IDictionary<string, Action<{model.Name.ToFirstCharacterUpperCase()}, IParseNode>>";
             if(!model.ContainsMember(deserializeFieldsPropName)) {
                 var deserializeProp = new CodeProperty(model) {
@@ -678,6 +679,24 @@ namespace Kiota.Builder
                 serializeMethod.AddParameter(parameter);
                 
                 model.AddMethod(serializeMethod);
+            }
+            if(!model.ContainsMember(additionalDataPropName) &&
+                includeAdditionalProperties && 
+                !(model.GetUpperMostInheritanceParent(model)?.ContainsMember(additionalDataPropName) ?? false)) {
+                // we don't want to add the property if the parent already has it
+                var additionalDataProp = new CodeProperty(model) {
+                    Name = additionalDataPropName,
+                    Access = AccessModifier.Public,
+                    DefaultValue = "new Dictionary<string, object>()",
+                    PropertyKind = CodePropertyKind.AdditionalData,
+                    Description = "Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.",
+                    ReadOnly = true,
+                };
+                additionalDataProp.Type = new CodeType(additionalDataProp) {
+                    Name = "IDictionary<string, object>",
+                    IsNullable = false,
+                };
+                model.AddProperty(additionalDataProp);
             }
         }
         private CodeClass CreateOperationParameter(OpenApiUrlSpaceNode node, OperationType operationType, OpenApiOperation operation, CodeClass parentClass)

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Kiota.Builder.Extensions;
 
 namespace Kiota.Builder {
     public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
@@ -99,6 +100,20 @@ namespace Kiota.Builder {
                         Name = "OffsetDateTime"
                     };
                     (currentProperty.Parent as CodeClass).AddUsing(nUsing);
+                } else if (currentProperty.PropertyKind == CodePropertyKind.AdditionalData) {
+                    currentProperty.Access = AccessModifier.Private;
+                    currentProperty.DefaultValue = "new HashMap<>()";
+                    currentProperty.Type.Name = "Map<String, Object>";
+                    var parentClass = currentElement.Parent as CodeClass;
+                    parentClass.AddMethod(new CodeMethod(parentClass) {
+                        Name = $"get{currentProperty.Name.ToFirstCharacterUpperCase()}",
+                        Access = AccessModifier.Public,
+                        Description = currentProperty.Description,
+                        MethodKind = CodeMethodKind.AdditionalDataAccessor,
+                        IsAsync = false,
+                        IsStatic = false,
+                        ReturnType = currentProperty.Type,
+                    });
                 }
             }
             if (currentElement is CodeMethod currentMethod) {

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -52,6 +52,10 @@ namespace Kiota.Builder {
                     currentProperty.Type.Name = $"Map<string, (item: {currentProperty.Parent.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>";
                 else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.InvariantCultureIgnoreCase))
                     currentProperty.Type.Name = $"Date";
+                else if(currentProperty.PropertyKind == CodePropertyKind.AdditionalData) {
+                    currentProperty.Type.Name = "Map<string, unknown>";
+                    currentProperty.DefaultValue = "new Map<string, unknown>()";
+                }
             }
             if (currentElement is CodeMethod currentMethod) {
                 if(currentMethod.MethodKind == CodeMethodKind.RequestExecutor)

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -57,11 +57,8 @@ namespace Kiota.Builder
         private const string parseNodeInterfaceName = "IParseNode";
         public override void WriteProperty(CodeProperty code)
         {
-            var simpleBody = "get;";
-            if (!code.ReadOnly)
-            {
-                simpleBody = "get; set;";
-            }
+            var setterAccessModifier = code.ReadOnly && code.Access > AccessModifier.Private ? "private " : string.Empty;
+            var simpleBody = $"get; {setterAccessModifier}set;";
             var defaultValue = string.Empty;
             if (code.DefaultValue != null)
             {
@@ -217,6 +214,7 @@ namespace Kiota.Builder
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
+                        //TODO: call writer for additional properties
                     }
                 break;
                 case CodeMethodKind.RequestGenerator:

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -207,6 +207,7 @@ namespace Kiota.Builder
             var headersParam = code.Parameters.OfKind(CodeParameterKind.Headers);
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
+                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("base.Serialize(writer);");
                     foreach(var otherProp in parentClass
@@ -214,8 +215,9 @@ namespace Kiota.Builder
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
-                        //TODO: call writer for additional properties
                     }
+                    if(additionalDataProperty != null)
+                        WriteLine($"writer.WriteAdditionalData({additionalDataProperty.Name});");
                 break;
                 case CodeMethodKind.RequestGenerator:
                     var operationName = code.HttpMethod?.ToString();

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -135,6 +135,7 @@ namespace Kiota.Builder
             }
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
+                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if((parentClass.StartBlock as CodeClass.Declaration).Inherits != null)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
@@ -143,6 +144,8 @@ namespace Kiota.Builder
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterLowerCase()});");
                     }
+                    if(additionalDataProperty != null)
+                        WriteLine($"writer.writeAdditionalData(this.{additionalDataProperty.Name.ToFirstCharacterLowerCase()});");
                 break;
                 case CodeMethodKind.DeserializerBackwardCompatibility:
                     var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
@@ -222,6 +225,9 @@ namespace Kiota.Builder
                     WriteLine("return java.util.concurrent.CompletableFuture.failedFuture(ex);");
                     DecreaseIndent();
                     WriteLine("}");
+                break;
+                case CodeMethodKind.AdditionalDataAccessor:
+                    WriteLine($"return {code.Name.Substring(3).ToFirstCharacterLowerCase()};"); // 3 -> get prefix
                 break;
                 default:
                     WriteLine("return null;");

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -293,6 +293,7 @@ namespace Kiota.Builder
                     WriteLine("]);");
                     break;
                 case CodeMethodKind.Serializer:
+                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
@@ -301,6 +302,8 @@ namespace Kiota.Builder
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", this.{otherProp.Name.ToFirstCharacterLowerCase()});");
                     }
+                    if(additionalDataProperty != null)
+                        WriteLine($"writer.writeAdditionalData(this.{additionalDataProperty.Name.ToFirstCharacterLowerCase()});");
                     break;
                 case CodeMethodKind.RequestGenerator:
                     WriteLines("const requestInfo = new RequestInfo();",
@@ -372,7 +375,7 @@ namespace Kiota.Builder
                 break;
                 default:
                     var defaultValue = string.IsNullOrEmpty(code.DefaultValue) ? string.Empty : $" = {code.DefaultValue}";
-                    var singleLiner = code.PropertyKind == CodePropertyKind.Custom;
+                    var singleLiner = code.PropertyKind == CodePropertyKind.Custom || code.PropertyKind == CodePropertyKind.AdditionalData;
                     WriteLine($"{GetAccessModifier(code.Access)}{(code.ReadOnly ? " readonly ": " ")}{code.Name.ToFirstCharacterLowerCase()}{(code.Type.IsNullable ? "?" : string.Empty)}: {returnType}{(isFlagEnum ? "[]" : string.Empty)}{(code.Type.IsNullable ? " | undefined" : string.Empty)}{defaultValue}{(singleLiner ? ";" : string.Empty)}");
                 break;
             }


### PR DESCRIPTION
- adds additional properties for dotnet
- adds additional data serialization/deserialization for dotnet
- adds support for scalar objects and collections for additional properties
- adds support for additional data for typescript
- adds support for additional data in java - fixes a java serialization bug where null values would be written
- updates samples reference

## Summary

This pull request adds support for additional properties that are not described in the openAPI documentation of the API.
This is usefull for things like oData anotations, etc.
Fixes #53

## Generation diff
https://github.com/microsoft/kiota-samples/pull/10
