### PR TITLE
bugfix/main graph gen tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2021-04-28
+
+### Changed
+
+- Multiple performance improvements for large descriptions
+- Deterministic ordering of properties/methods/indexers/subclasses
+- Deterministic import of sub path request builders
+- Stopped generating phantom indexer methods for TypeScript and Java
+
 ## [0.0.3] - 2021-04-25
 
 ### Added

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -9,8 +9,8 @@ namespace Kiota.Abstractions
     {
         public Uri URI { get; set; }
         public HttpMethod HttpMethod { get; set; }
-        public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+        public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public Stream Content { get; set; }
         private const string jsonContentType = "application/json";
         private const string binaryContentType = "application/octet-stream";

--- a/core/dotnet/src/HttpCore.cs
+++ b/core/dotnet/src/HttpCore.cs
@@ -131,7 +131,7 @@ namespace KiotaCore
                 
             };
             if(requestInfo.Headers?.Any() ?? false)
-                requestInfo.Headers.Where(x => !contentTypeHeaderName.Equals(x.Key, StringComparison.InvariantCultureIgnoreCase)).ToList().ForEach(x => message.Headers.Add(x.Key, x.Value));
+                requestInfo.Headers.Where(x => !contentTypeHeaderName.Equals(x.Key, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => message.Headers.Add(x.Key, x.Value));
             if(requestInfo.Content != null) {
                 message.Content = new StreamContent(requestInfo.Content);
                 if(requestInfo?.Headers?.ContainsKey(contentTypeHeaderName) ?? false)

--- a/core/dotnet/src/serialization/JsonParseNodeFactory.cs
+++ b/core/dotnet/src/serialization/JsonParseNodeFactory.cs
@@ -11,7 +11,7 @@ namespace KiotaCore.Serialization {
         {
             if(string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException(nameof(contentType));
-            else if(!validContentType.Equals(contentType, StringComparison.InvariantCultureIgnoreCase))
+            else if(!validContentType.Equals(contentType, StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentOutOfRangeException($"expected a {validContentType} content type");
             
             _ = content ?? throw new ArgumentNullException(nameof(content));

--- a/core/dotnet/src/serialization/JsonSerializationWriterFactory.cs
+++ b/core/dotnet/src/serialization/JsonSerializationWriterFactory.cs
@@ -7,7 +7,7 @@ namespace KiotaCore.Serialization {
         public ISerializationWriter GetSerializationWriter(string contentType) {
             if(string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException(nameof(contentType));
-            else if(!validContentType.Equals(contentType, StringComparison.InvariantCultureIgnoreCase))
+            else if(!validContentType.Equals(contentType, StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentOutOfRangeException($"expected a {validContentType} content type");
 
             return new JsonSerializationWriter();

--- a/docs/kiotaabstractions.md
+++ b/docs/kiotaabstractions.md
@@ -23,8 +23,8 @@ public class RequestInfo
     {
         public Uri URI { get; set; }
         public HttpMethod HttpMethod { get; set; }
-        public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+        public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public Stream Content { get; set; }
     }
 ```

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -36,11 +36,14 @@ namespace Kiota.Builder
             if(elements == null) return;
             
             foreach(var element in elements)
-                if(!InnerChildElements.TryAdd(element.Name, element))
+                try {
+                    InnerChildElements.Add(element.Name, element); //try add is not behaving like documented
+                } catch (ArgumentException) {
                     if(element is CodeMethod currentMethod) {// allows for methods overload
                         var methodOverloadNameSuffix = currentMethod.Parameters.Any() ? currentMethod.Parameters.Select(x => x.Name).OrderBy(x => x).Aggregate((x, y) => x + y) : "1";
                         InnerChildElements.Add($"{currentMethod.Name}-{methodOverloadNameSuffix}", currentMethod);
                     }
+                }
         }
         public T FindChildByName<T>(string childName, bool findInChildElements = true) where T: ICodeElement {
             if(string.IsNullOrEmpty(childName))

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -38,11 +38,9 @@ namespace Kiota.Builder
             foreach(var element in elements)
                 try {
                     InnerChildElements.Add(element.Name, element); //try add is not behaving like documented
-                } catch (ArgumentException) {
-                    if(element is CodeMethod currentMethod) {// allows for methods overload
-                        var methodOverloadNameSuffix = currentMethod.Parameters.Any() ? currentMethod.Parameters.Select(x => x.Name).OrderBy(x => x).Aggregate((x, y) => x + y) : "1";
-                        InnerChildElements.Add($"{currentMethod.Name}-{methodOverloadNameSuffix}", currentMethod);
-                    }
+                } catch (ArgumentException) when (element is CodeMethod currentMethod) { // allows for methods overload
+                    var methodOverloadNameSuffix = currentMethod.Parameters.Any() ? currentMethod.Parameters.Select(x => x.Name).OrderBy(x => x).Aggregate((x, y) => x + y) : "1";
+                    InnerChildElements.Add($"{currentMethod.Name}-{methodOverloadNameSuffix}", currentMethod);
                 }
         }
         public T FindChildByName<T>(string childName, bool findInChildElements = true) where T: ICodeElement {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -44,22 +44,22 @@ namespace Kiota.Builder
                         InnerChildElements.Add($"{currentMethod.Name}-{methodOverloadNameSuffix}", currentMethod);
                     }
         }
-        public T FindChildByName<T>(string childName, bool findInChildElements = true) where T: CodeElement {
+        public T FindChildByName<T>(string childName, bool findInChildElements = true) where T: ICodeElement {
             if(string.IsNullOrEmpty(childName))
                 throw new ArgumentNullException(nameof(childName));
             
             if(!InnerChildElements.Any())
-                return null;
+                return default(T);
 
             if(InnerChildElements.TryGetValue(childName, out var result) && result is T)
-                return (T)result;
+                return (T)(object)result;
             else if(findInChildElements)
                 foreach(var childElement in InnerChildElements.Values.OfType<CodeBlock>()) {
                     var childResult = childElement.FindChildByName<T>(childName, true);
                     if(childResult != null)
                         return childResult;
                 }
-            return null;
+            return default(T);
         }
         public class BlockDeclaration : CodeTerminal
         {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace Kiota.Builder
     public class CodeBlock : CodeElement
     {
         public BlockDeclaration StartBlock {get; set;}
-        public Dictionary<string, CodeElement> InnerChildElements {get; set;} = new(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, CodeElement> InnerChildElements {get; set;} = new ConcurrentDictionary<string, CodeElement>(StringComparer.OrdinalIgnoreCase);
         public BlockEnd EndBlock {get; set;}
         public CodeBlock(CodeElement parent):base(parent)
         {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -21,12 +21,9 @@ namespace Kiota.Builder
             EndBlock = new BlockEnd(this);
         }
 
-        public override IList<CodeElement> GetChildElements()
+        public override IEnumerable<CodeElement> GetChildElements()
         {
-            var elements = new List<CodeElement>(InnerChildElements.Values);
-            elements.Insert(0, StartBlock);
-            elements.Add(EndBlock);
-            return elements;
+            return new CodeElement[] { StartBlock, EndBlock }.Union(InnerChildElements.Values);
         }
         public void AddUsing(params CodeUsing[] codeUsings)
         {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -12,7 +12,7 @@ namespace Kiota.Builder
     public class CodeBlock : CodeElement
     {
         public BlockDeclaration StartBlock {get; set;}
-        public Dictionary<string, CodeElement> InnerChildElements {get; set;} = new();
+        public Dictionary<string, CodeElement> InnerChildElements {get; set;} = new(StringComparer.OrdinalIgnoreCase);
         public BlockEnd EndBlock {get; set;}
         public CodeBlock(CodeElement parent):base(parent)
         {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -13,7 +13,7 @@ namespace Kiota.Builder
     /// <summary>
     /// CodeClass represents an instance of a Class to be generated in source code
     /// </summary>
-    public class CodeClass : CodeBlock, IDocumentedElement
+    public class CodeClass : CodeBlock, IDocumentedElement, ITypeDefinition
     {
         private string name;
 

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -43,12 +43,11 @@ namespace Kiota.Builder
             AddRange(indexer);
         }
 
-        public void AddProperty(params CodeProperty[] properties)
+        public IEnumerable<CodeProperty> AddProperty(params CodeProperty[] properties)
         {
             if(!properties.Any() || properties.Any(x => x == null))
                 throw new ArgumentNullException(nameof(properties));
-            AddMissingParent(properties);
-            AddRange(properties);
+            return AddRange(properties);
         }
 
         public bool ContainsMember(string name)
@@ -56,20 +55,18 @@ namespace Kiota.Builder
             return this.InnerChildElements.ContainsKey(name);
         }
 
-        public void AddMethod(params CodeMethod[] methods)
+        public IEnumerable<CodeMethod> AddMethod(params CodeMethod[] methods)
         {
             if(!methods.Any() || methods.Any(x => x == null))
                 throw new ArgumentOutOfRangeException(nameof(methods));
-            AddMissingParent(methods);
-            AddRange(methods);
+            return AddRange(methods);
         }
 
-        public void AddInnerClass(params CodeClass[] codeClasses)
+        public IEnumerable<CodeClass> AddInnerClass(params CodeClass[] codeClasses)
         {
             if(!codeClasses.Any() || codeClasses.Any(x => x == null))
                 throw new ArgumentOutOfRangeException(nameof(codeClasses));
-            AddMissingParent(codeClasses);
-            AddRange(codeClasses);
+            return AddRange(codeClasses);
         }
         public CodeClass GetParentClass() {
             if(StartBlock is Declaration declaration)

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -40,7 +40,7 @@ namespace Kiota.Builder
 
         public void SetIndexer(CodeIndexer indexer)
         {
-            this.InnerChildElements.Add(indexer);
+            AddRange(indexer);
         }
 
         public void AddProperty(params CodeProperty[] properties)
@@ -48,12 +48,12 @@ namespace Kiota.Builder
             if(!properties.Any() || properties.Any(x => x == null))
                 throw new ArgumentNullException(nameof(properties));
             AddMissingParent(properties);
-            this.InnerChildElements.AddRange(properties);
+            AddRange(properties);
         }
 
         public bool ContainsMember(string name)
         {
-            return this.InnerChildElements.Any(e => e.Name == name);
+            return this.InnerChildElements.ContainsKey(name);
         }
 
         public void AddMethod(params CodeMethod[] methods)
@@ -61,7 +61,7 @@ namespace Kiota.Builder
             if(!methods.Any() || methods.Any(x => x == null))
                 throw new ArgumentOutOfRangeException(nameof(methods));
             AddMissingParent(methods);
-            this.InnerChildElements.AddRange(methods);
+            AddRange(methods);
         }
 
         public void AddInnerClass(params CodeClass[] codeClasses)
@@ -69,7 +69,7 @@ namespace Kiota.Builder
             if(!codeClasses.Any() || codeClasses.Any(x => x == null))
                 throw new ArgumentOutOfRangeException(nameof(codeClasses));
             AddMissingParent(codeClasses);
-            this.InnerChildElements.AddRange(codeClasses);
+            AddRange(codeClasses);
         }
         public CodeClass GetParentClass() {
             if(StartBlock is Declaration declaration)

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -7,7 +7,7 @@ namespace Kiota.Builder
     /// <summary>
     /// Abstract element of some piece of source code to be generated
     /// </summary>
-    public abstract class CodeElement
+    public abstract class CodeElement : ICodeElement
     {
         public Dictionary<string, object> GenerationProperties { get; set; } = new Dictionary<string, object>();
         protected CodeElement(CodeElement parent)

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -17,7 +17,7 @@ namespace Kiota.Builder
             Parent = parent;
         }
         public CodeElement Parent { get; set; }
-        public virtual IEnumerable<CodeElement> GetChildElements() => Enumerable.Empty<CodeElement>();
+        public virtual IEnumerable<CodeElement> GetChildElements(bool innerOnly = false) => Enumerable.Empty<CodeElement>();
 
         public virtual string Name
         {

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -9,7 +9,7 @@ namespace Kiota.Builder
     /// </summary>
     public abstract class CodeElement : ICodeElement
     {
-        public Dictionary<string, object> GenerationProperties { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> GenerationProperties { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         protected CodeElement(CodeElement parent)
         {
             if(parent == null && !(this is CodeNamespace))

--- a/src/Kiota.Builder/CodeDOM/CodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeElement.cs
@@ -17,7 +17,7 @@ namespace Kiota.Builder
             Parent = parent;
         }
         public CodeElement Parent { get; set; }
-        public abstract IList<CodeElement> GetChildElements();
+        public virtual IEnumerable<CodeElement> GetChildElements() => Enumerable.Empty<CodeElement>();
 
         public virtual string Name
         {

--- a/src/Kiota.Builder/CodeDOM/CodeEnum.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeEnum.cs
@@ -9,10 +9,6 @@ namespace Kiota.Builder
         {
             
         }
-        public override IList<CodeElement> GetChildElements()
-        {
-            return Enumerable.Empty<CodeElement>().ToList();
-        }
         public List<string> Options { get; set; } = new List<string>();
         public bool Flags { get; set; }
         public string Description {get; set;}

--- a/src/Kiota.Builder/CodeDOM/CodeEnum.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeEnum.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Kiota.Builder
 {
-    public class CodeEnum : CodeElement, IDocumentedElement {
+    public class CodeEnum : CodeElement, IDocumentedElement, ITypeDefinition {
         public CodeEnum(CodeElement parent) : base(parent)
         {
             

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Kiota.Builder

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -44,6 +44,16 @@ namespace Kiota.Builder
             if(Parent == null) return this;
             else return (this.Parent as CodeNamespace).GetRootNamespace();
         }
+        public CodeNamespace FindNamespaceByName(string nsName) {
+            var result = FindChildByName<CodeNamespace>(nsName, false);
+            if(result == null)
+                foreach(var childNS in InnerChildElements.Values.OfType<CodeNamespace>()) {
+                    result = childNS.FindNamespaceByName(nsName);
+                    if(result != null)
+                        break;
+                }
+            return result;
+        }
         public CodeNamespace AddNamespace(string namespaceName) {
             if(string.IsNullOrEmpty(namespaceName))
                 throw new ArgumentNullException(nameof(namespaceName));
@@ -51,7 +61,7 @@ namespace Kiota.Builder
             var lastPresentSegmentIndex = default(int);
             CodeNamespace lastPresentSegmentNamespace = Parent == null ? this : GetRootNamespace();
             while(lastPresentSegmentIndex < namespaceNameSegements.Length) {
-                var segmentNameSpace = lastPresentSegmentNamespace.FindChildByName<CodeNamespace>(namespaceNameSegements.Take(lastPresentSegmentIndex + 1).Aggregate((x, y) => $"{x}.{y}"));
+                var segmentNameSpace = lastPresentSegmentNamespace.FindNamespaceByName(namespaceNameSegements.Take(lastPresentSegmentIndex + 1).Aggregate((x, y) => $"{x}.{y}"));
                 if(segmentNameSpace == null)
                     break;
                 else {

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -35,13 +35,13 @@ namespace Kiota.Builder
             if(!codeClasses.Any() || codeClasses.Any( x=> x == null))
                 throw new ArgumentOutOfRangeException(nameof(codeClasses));
             AddMissingParent(codeClasses);
-            this.InnerChildElements.AddRange(codeClasses);
+            AddRange(codeClasses);
         }
         private void AddNamespace(params CodeNamespace[] codeNamespaces) {
             if(!codeNamespaces.Any() || codeNamespaces.Any(x => x == null))
                 throw new ArgumentOutOfRangeException(nameof(codeNamespaces));
             AddMissingParent(codeNamespaces);
-            this.InnerChildElements.AddRange(codeNamespaces);
+            AddRange(codeNamespaces);
         }
         private static readonly char namespaceNameSeparator = '.';
         public CodeNamespace AddNamespace(string namespaceName) {
@@ -78,7 +78,7 @@ namespace Kiota.Builder
                 throw new ArgumentException("ensuring item namespaces is only supported when passing the root namespace as a parameter", nameof(rootNamespace));
             if (IsItemNamespace) return this;
             else {
-                var childNamespace = this.InnerChildElements.OfType<CodeNamespace>().FirstOrDefault(x => x.IsItemNamespace);
+                var childNamespace = this.InnerChildElements.Values.OfType<CodeNamespace>().FirstOrDefault(x => x.IsItemNamespace);
                 if(childNamespace == null) {
                     childNamespace = rootNamespace.AddNamespace($"{this.Name}.item");
                     childNamespace.IsItemNamespace = true;
@@ -100,7 +100,7 @@ namespace Kiota.Builder
             if(!enumDeclarations.Any() || enumDeclarations.Any( x=> x == null))
                 throw new ArgumentOutOfRangeException(nameof(enumDeclarations));
             AddMissingParent(enumDeclarations);
-            this.InnerChildElements.AddRange(enumDeclarations);
+            AddRange(enumDeclarations);
         }
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeTerminal.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeTerminal.cs
@@ -8,9 +8,5 @@ namespace Kiota.Builder
         {
             
         }
-        public override IList<CodeElement> GetChildElements()
-        {
-            return new List<CodeElement>();
-        }
     }
 }

--- a/src/Kiota.Builder/CodeDOM/CodeUsing.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUsing.cs
@@ -9,10 +9,5 @@ namespace Kiota.Builder
             
         }
         public CodeType Declaration { get; set; }
-
-        public override IList<CodeElement> GetChildElements()
-        {
-            return new List<CodeElement>();
-        }
     }
 }

--- a/src/Kiota.Builder/CodeDOM/ICodeElement.cs
+++ b/src/Kiota.Builder/CodeDOM/ICodeElement.cs
@@ -1,0 +1,5 @@
+namespace Kiota.Builder {
+    public interface ICodeElement {
+        string Name { get; set; }
+    }
+}

--- a/src/Kiota.Builder/CodeDOM/ITypeDefinition.cs
+++ b/src/Kiota.Builder/CodeDOM/ITypeDefinition.cs
@@ -1,0 +1,5 @@
+namespace Kiota.Builder {
+    public interface ITypeDefinition : ICodeElement {
+
+    }
+}

--- a/src/Kiota.Builder/CodeElementOrderComparer.cs
+++ b/src/Kiota.Builder/CodeElementOrderComparer.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kiota.Builder {
+    public class CodeElementOrderComparer : IComparer<CodeElement>
+    {
+        public int Compare(CodeElement x, CodeElement y)
+        {
+            var isXNull = x == null;
+            var isYNull = y == null;
+            if(isXNull && isYNull) return 0;
+            else if (isXNull) return -1;
+            else if(isYNull) return 1;
+
+
+            return GetTypeFactor(x).CompareTo(GetTypeFactor(y)) * typeWeight + 
+                (x.Name?.CompareTo(y.Name) ?? 0) * nameWeight + 
+                GetParametersFactor(x).CompareTo(GetParametersFactor(y)) * parametersWeight;
+        }
+        private static readonly int nameWeight = 10;
+        private static readonly int typeWeight = 100;
+        private int GetTypeFactor(CodeElement element) {
+            switch(element) {
+                case CodeUsing:
+                    return 1;
+                case CodeClass.Declaration:
+                    return 2;
+                case CodeProperty:
+                    return 3;
+                case CodeIndexer:
+                    return 4;
+                case CodeMethod:
+                    return 5;
+                case CodeClass:
+                    return 6;
+                case CodeClass.End:
+                    return 7;
+                default:
+                    return 0;
+            }
+        }
+        private static readonly int parametersWeight = 1;
+        private int GetParametersFactor(CodeElement element) {
+            if(element is CodeMethod method && (method.Parameters?.Any() ?? false))
+                return method.Parameters.Count;
+            return 0;
+        }
+    }
+}

--- a/src/Kiota.Builder/CodeRenderer.cs
+++ b/src/Kiota.Builder/CodeRenderer.cs
@@ -40,11 +40,12 @@ namespace Kiota.Builder
                     await RenderCodeNamespaceToFilePerClassAsync(writer, codeNamespace);
             }
         }
-
+        private static readonly CodeElementOrderComparer rendererElementComparer = new CodeElementOrderComparer();
         private static void RenderCode(LanguageWriter writer, CodeElement element)
         {
             writer.Write(element);
-            foreach (var childElement in element.GetChildElements())
+            foreach (var childElement in element.GetChildElements()
+                                                .OrderBy(x => x, rendererElementComparer))
             {
                 RenderCode(writer, childElement);
             }

--- a/src/Kiota.Builder/CodeRenderer.cs
+++ b/src/Kiota.Builder/CodeRenderer.cs
@@ -30,7 +30,7 @@ namespace Kiota.Builder
 
         public static async Task RenderCodeNamespaceToFilePerClassAsync(LanguageWriter writer, CodeNamespace root)
         {
-            foreach (var codeElement in root.GetChildElements())
+            foreach (var codeElement in root.GetChildElements(true))
             {
                 if (codeElement is CodeClass codeClass)
                     await RenderCodeNamespaceToSingleFileAsync(writer, codeClass, writer.PathSegmenter.GetPath(root, codeClass));

--- a/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
@@ -28,22 +28,14 @@ namespace Kiota.Builder.Extensions {
                 var result = new List<string>();
                 if(!string.IsNullOrEmpty(schema.Reference?.Id))
                     result.Add(schema.Reference.Id);
-                if(schema.Properties != null) {
-                    schema.Properties.Values.ToList().ForEach(x => visitedSchemas.Add(x));
+                if(schema.Properties != null)
                     result.AddRange(schema.Properties.Values.SelectMany(x => x.GetSchemaReferenceIds(visitedSchemas)));
-                }
-                if(schema.AnyOf != null) {
-                    schema.AnyOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                if(schema.AnyOf != null)
                     result.AddRange(schema.AnyOf.SelectMany(x => x.GetSchemaReferenceIds(visitedSchemas)));
-                }
-                if(schema.AllOf != null) {
-                    schema.AllOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                if(schema.AllOf != null)
                     result.AddRange(schema.AllOf.SelectMany(x => x.GetSchemaReferenceIds(visitedSchemas)));
-                }
-                if(schema.OneOf != null) {
-                    schema.OneOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                if(schema.OneOf != null)
                     result.AddRange(schema.OneOf.SelectMany(x => x.GetSchemaReferenceIds(visitedSchemas)));
-                }
                 return result;
             } else 
                 return Enumerable.Empty<string>();

--- a/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
@@ -37,7 +37,7 @@ namespace Kiota.Builder.Extensions {
                 foreach(var child in currentNode.Children.Values)
                     AddAllPathsEntries(child, index);
         }
-        internal static string GetNodeNamespaceFromPath(this OpenApiUrlSpaceNode currentNode, string prefix = default) =>
+        internal static string GetNodeNamespaceFromPath(this OpenApiUrlSpaceNode currentNode, string prefix) =>
             prefix + 
                     ((currentNode?.Path?.Contains(pathNameSeparator) ?? false) ?
                         "." + currentNode?.Path

--- a/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
@@ -9,7 +9,7 @@ namespace Kiota.Builder.Extensions {
 
         // where component id and the value is the set of openapiurlNode referencing it
         public static Dictionary<string, HashSet<OpenApiUrlSpaceNode>> GetComponentsReferenceIndex(this OpenApiUrlSpaceNode rootNode) {
-            var result = new Dictionary<string, HashSet<OpenApiUrlSpaceNode>>();
+            var result = new Dictionary<string, HashSet<OpenApiUrlSpaceNode>>(StringComparer.OrdinalIgnoreCase);
             AddAllPathsEntries(rootNode, result);
             return result;
         }

--- a/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlSpaceNodeExtensions.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+
+namespace Kiota.Builder.Extensions {
+    public static class OpenApiUrlSpaceNodeExtensions {
+
+        // where component id and the value is the set of openapiurlNode referencing it
+        public static Dictionary<string, HashSet<OpenApiUrlSpaceNode>> GetComponentsReferenceIndex(this OpenApiUrlSpaceNode rootNode) {
+            var result = new Dictionary<string, HashSet<OpenApiUrlSpaceNode>>();
+            AddAllPathsEntries(rootNode, result);
+            return result;
+        }
+        private static void AddAllPathsEntries(OpenApiUrlSpaceNode currentNode, Dictionary<string, HashSet<OpenApiUrlSpaceNode>> index) {
+            if(currentNode == null)
+                return;
+            
+            if(currentNode.PathItem != null && currentNode.HasOperations()) {
+                var nodeOperations = currentNode.PathItem.Operations.Values;
+                var requestSchemasFirstLevel = nodeOperations.SelectMany(x => x.RequestBody?.Content?.Values?.Select(y => y.Schema) ?? Enumerable.Empty<OpenApiSchema>());
+                var responseSchemasFirstLevel = nodeOperations.SelectMany(x => 
+                                                    x?.Responses?.Values?.SelectMany(y => 
+                                                                    y?.Content?.Values?.Select(z => z.Schema) ?? Enumerable.Empty<OpenApiSchema>()) ?? Enumerable.Empty<OpenApiSchema>());
+                var operationFirstLevelSchemas = requestSchemasFirstLevel.Union(responseSchemasFirstLevel);
+
+                operationFirstLevelSchemas.SelectMany(x => GetSchemaReferenceIds(x)).ToList().ForEach(x => {
+                    if(index.TryGetValue(x, out var entry))
+                        entry.Add(currentNode);
+                    else
+                        index.Add(x, new(new [] { currentNode}));
+                });
+            }
+            
+            if(currentNode.Children != null)
+                foreach(var child in currentNode.Children.Values)
+                    AddAllPathsEntries(child, index);
+        }
+        private static IEnumerable<string> GetSchemaReferenceIds(OpenApiSchema schema, HashSet<OpenApiSchema> visitedSchemas = null) {
+            if(visitedSchemas == null)
+                visitedSchemas = new();            
+            if(!visitedSchemas.Contains(schema)) {
+                visitedSchemas.Add(schema);
+                var result = new List<string>();
+                if(!string.IsNullOrEmpty(schema.Reference?.Id))
+                    result.Add(schema.Reference.Id);
+                if(schema.Properties != null) {
+                    schema.Properties.Values.ToList().ForEach(x => visitedSchemas.Add(x));
+                    result.AddRange(schema.Properties.Values.SelectMany(x => GetSchemaReferenceIds(x, visitedSchemas)));
+                }
+                if(schema.AnyOf != null) {
+                    schema.AnyOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                    result.AddRange(schema.AnyOf.SelectMany(x => GetSchemaReferenceIds(x, visitedSchemas)));
+                }
+                if(schema.AllOf != null) {
+                    schema.AllOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                    result.AddRange(schema.AllOf.SelectMany(x => GetSchemaReferenceIds(x, visitedSchemas)));
+                }
+                if(schema.OneOf != null) {
+                    schema.OneOf.ToList().ForEach(x => visitedSchemas.Add(x));
+                    result.AddRange(schema.OneOf.SelectMany(x => GetSchemaReferenceIds(x, visitedSchemas)));
+                }
+                return result;
+            } else 
+                return Enumerable.Empty<string>();
+        }
+    }
+}

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -257,12 +257,12 @@ namespace Kiota.Builder
 
             (currentNode.DoesNodeBelongToItemSubnamespace() ? currentNamespace.EnsureItemNamespace() : currentNamespace).AddClass(codeClass);
 
-            foreach (var childNode in currentNode.Children.Values)
+            Parallel.ForEach(currentNode.Children.Values, childNode => 
             {
                 var targetNamespaceName = childNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName);
                 var targetNamespace = rootNamespace.FindChildByName<CodeNamespace>(targetNamespaceName) ?? rootNamespace.AddNamespace(targetNamespaceName);
                 CreateRequestBuilderClass(targetNamespace, childNode, rootNode);
-            }
+            });
         }
 
         private void CreatePathManagement(CodeClass currentClass, OpenApiUrlSpaceNode currentNode, bool isRootClientClass) {
@@ -317,12 +317,11 @@ namespace Kiota.Builder
         private void MapTypeDefinitions(CodeElement codeElement) {
             var unmappedTypes = GetUnmappedTypeDefinitions(codeElement).Distinct();
             
-            //TODO remove when missing names are fixed
             unmappedTypes.Where(x => string.IsNullOrEmpty(x.Name)).ToList().ForEach(x => {
                 Debug.WriteLine($"Type with empty name and parent {x.Parent.Name}");
             });
 
-            unmappedTypes.Where(x => !string.IsNullOrEmpty(x.Name)).GroupBy(x => x.Name).ToList().ForEach(x => {
+            Parallel.ForEach(unmappedTypes.Where(x => !string.IsNullOrEmpty(x.Name)).GroupBy(x => x.Name), x => {
                 var definition = rootNamespace.FindChildByName<ITypeDefinition>(x.First().Name) as CodeElement;
                 if(definition != null)
                     foreach(var type in x) {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -320,7 +320,7 @@ namespace Kiota.Builder
                 if(string.IsNullOrEmpty(currentType.Name))
                     Debug.WriteLine($"Type with empty name and parent {currentType.Parent.Name}");
                 else
-                    currentType.TypeDefinition = rootNamespace.FindChildByName<CodeClass>(currentType.Name) as CodeElement ?? rootNamespace.FindChildByName<CodeEnum>(currentType.Name);
+                    currentType.TypeDefinition = rootNamespace.FindChildByName<ITypeDefinition>(currentType.Name) as CodeElement;
         }
 
         private CodeIndexer CreateIndexer(string childIdentifier, string childType, CodeClass codeClass, OpenApiUrlSpaceNode currentNode)
@@ -552,8 +552,7 @@ namespace Kiota.Builder
         }
         private CodeElement GetExistingDeclaration(bool checkInAllNamespaces, CodeNamespace currentNamespace, OpenApiUrlSpaceNode currentNode, string declarationName) {
             var searchNameSpace = GetSearchNamespace(checkInAllNamespaces, currentNode, currentNamespace);
-            return (searchNameSpace.FindChildByName<CodeClass>(declarationName, checkInAllNamespaces) as CodeElement ?? 
-                    searchNameSpace.FindChildByName<CodeEnum>(declarationName, checkInAllNamespaces));
+            return searchNameSpace.FindChildByName<ITypeDefinition>(declarationName, checkInAllNamespaces) as CodeElement;
         }
         private CodeNamespace GetSearchNamespace(bool checkInAllNamespaces, OpenApiUrlSpaceNode currentNode, CodeNamespace currentNamespace) {
             if(checkInAllNamespaces) return rootNamespace;

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -379,13 +379,20 @@ namespace Kiota.Builder
                 PropertyKind = kind,
                 Description = typeSchema?.Description,
             };
-            var typeName = isCollection ? (typeSchema?.Items?.Reference?.GetClassName() ?? typeSchema?.Items?.Type) : childType;
-            if("string".Equals(typeName, StringComparison.InvariantCultureIgnoreCase) && "date-time".Equals(typeSchema?.Format, StringComparison.InvariantCultureIgnoreCase))
+            var typeName = childType;
+            var isExternal = false;
+            if("string".Equals(typeName, StringComparison.OrdinalIgnoreCase) && "date-time".Equals(typeSchema?.Format, StringComparison.OrdinalIgnoreCase)) {
+                isExternal = true;
                 typeName = "DateTimeOffset";
+            } else if ("double".Equals(typeSchema?.Format, StringComparison.OrdinalIgnoreCase)) {
+                isExternal = true;
+                typeName = "double";
+            }
             prop.Type = new CodeType(prop) {
                 Name = typeName,
                 TypeDefinition = typeDefinition,
                 CollectionKind = isCollection ? CodeType.CodeTypeCollectionKind.Complex : default,
+                IsExternal = isExternal,
             };
             logger.LogDebug("Creating property {name} of {type}", prop.Name, prop.Type.Name);
             return prop;
@@ -722,7 +729,7 @@ namespace Kiota.Builder
                     prop.Type = new CodeType(prop)
                     {
                         Name = parameter.Schema.Items?.Type ?? parameter.Schema.Type,
-                        CollectionKind = parameter.Schema.Type.Equals("array", StringComparison.InvariantCultureIgnoreCase) ? CodeType.CodeTypeCollectionKind.Array : default
+                        CollectionKind = parameter.Schema.Type.Equals("array", StringComparison.OrdinalIgnoreCase) ? CodeType.CodeTypeCollectionKind.Array : default
                     };
 
                     if (!parameterClass.ContainsMember(parameter.Name))

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -182,7 +182,7 @@ namespace Kiota.Builder
         {
             // Determine Class Name
             CodeClass codeClass;
-            var isRootClientClass = String.IsNullOrEmpty(currentNode.Identifier);
+            var isRootClientClass = String.IsNullOrEmpty(currentNode.GetIdentifier());
             if (isRootClientClass)
             {
                 codeClass = new CodeClass(codeNamespace) { 
@@ -504,10 +504,11 @@ namespace Kiota.Builder
             if (originalReference == null) { // Inline schema, i.e. specific to the Operation
                 return CreateModelClassAndType(rootNode, currentNode, schema, operation, parentElement, codeNamespace, "Response");
             } else if(schema?.AllOf?.Any() ?? false) {
-                var lastSchema = schema.AllOf.Last();
+                var allOfs = schema.FlattenEmptyAllOf();
+                var lastSchema = allOfs.Last();
                 CodeElement codeDeclaration = null;
                 string className = string.Empty;
-                foreach(var currentSchema in schema.AllOf) {
+                foreach(var currentSchema in allOfs) {
                     var isLastSchema = currentSchema == lastSchema;
                     var shortestNamespaceName = currentSchema.Reference == null ? currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName) : GetShortestNamespaceNameForModelByReferenceId(rootNode, currentSchema.Reference.Id);
                     var shortestNamespace = codeNamespace.GetRootNamespace().GetNamespace(shortestNamespaceName);
@@ -539,7 +540,7 @@ namespace Kiota.Builder
                     });
                 }
                 return unionType;
-            } else if((schema?.Type?.Equals("object") ?? false) && (schema?.Properties?.Any() ?? false)) {
+            } else if(schema?.Type?.Equals("object") ?? false) {
                 // referenced schema, no inheritance or union type
                 return CreateModelClassAndType(rootNode, currentNode, schema, operation, parentElement, codeNamespace);
             }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
 using Kiota.Builder.Extensions;
 using Microsoft.OpenApi.Any;
+using System.ComponentModel;
 
 namespace Kiota.Builder
 {
@@ -186,7 +187,7 @@ namespace Kiota.Builder
                     languageWriter = new TypeScriptWriter(this.config.OutputPath, this.config.ClientNamespaceName);
                     break;
                 default:
-                    throw new ArgumentException($"{language} language currently not supported.");
+                    throw new InvalidEnumArgumentException($"{language} language currently not supported.");
             }
 
             var stopwatch = new Stopwatch();

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -26,24 +26,42 @@ namespace Kiota.Builder
 
         public async Task GenerateSDK()
         {
+            var sw = new Stopwatch();
             // Step 1 - Read input stream
             string inputPath = config.OpenAPIFilePath;
+            sw.Start();
             using var input = await LoadStream(inputPath);
+            StopLogAndReset(sw, "step 1 - reading the stream - took");
 
             // Step 2 - Parse OpenAPI
+            sw.Start();
             var doc = CreateOpenApiDocument(input);
+            StopLogAndReset(sw, "step 2 - parsing the document - took");
 
             // Step 3 - Create Uri Space of API
+            sw.Start();
             var openApiTree = CreateUriSpace(doc);
+            StopLogAndReset(sw, "step 3 - create uri space - took");
 
             // Step 4 - Create Source Model
+            sw.Start();
             var generatedCode = CreateSourceModel(openApiTree);
+            StopLogAndReset(sw, "step 4 - create source model - took");
 
             // Step 5 - RefineByLanguage
+            sw.Start();
             ApplyLanguageRefinement(config.Language, generatedCode);
+            StopLogAndReset(sw, "step 5 - refine by language - took");
 
-            // Step 5 - Write language source 
+            // Step 6 - Write language source 
+            sw.Start();
             await CreateLanguageSourceFilesAsync(config.Language, generatedCode);
+            StopLogAndReset(sw, "step 6 - writing files - took");
+        }
+        private void StopLogAndReset(Stopwatch sw, string prefix) {
+            sw.Stop();
+            Debug.WriteLine($"{prefix} {sw.Elapsed}");
+            sw.Reset();
         }
 
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -344,8 +344,6 @@ namespace Kiota.Builder
                     return filterUnmappedTypeDefitions(new CodeTypeBase[] {property.Type}).Union(childElementsUnmappedTypes);
                 case CodeIndexer indexer:
                     return filterUnmappedTypeDefitions(new CodeTypeBase[] {indexer.ReturnType}).Union(childElementsUnmappedTypes);
-                case CodeParameter parameter:
-                    return filterUnmappedTypeDefitions(new CodeTypeBase[] {parameter.Type}).Union(childElementsUnmappedTypes);
                 default:
                     return childElementsUnmappedTypes;
             }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -355,7 +355,7 @@ namespace Kiota.Builder
             var prop = new CodeIndexer(codeClass)
             {
                 Name = childIdentifier,
-                Description = $"Gets an item from the {currentNode.GetNodeNamespaceFromPath().Substring(1)} collection",
+                Description = $"Gets an item from the {currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName)} collection",
             };
             prop.IndexType = new CodeType(prop) { Name = "string", IsExternal = true, };
             prop.ReturnType = new CodeType(prop)

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -260,7 +260,7 @@ namespace Kiota.Builder
             Parallel.ForEach(currentNode.Children.Values, childNode => 
             {
                 var targetNamespaceName = childNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName);
-                var targetNamespace = rootNamespace.FindChildByName<CodeNamespace>(targetNamespaceName) ?? rootNamespace.AddNamespace(targetNamespaceName);
+                var targetNamespace = rootNamespace.FindNamespaceByName(targetNamespaceName) ?? rootNamespace.AddNamespace(targetNamespaceName);
                 CreateRequestBuilderClass(targetNamespace, childNode, rootNode);
             });
         }
@@ -318,7 +318,7 @@ namespace Kiota.Builder
             var unmappedTypes = GetUnmappedTypeDefinitions(codeElement).Distinct();
             
             unmappedTypes.Where(x => string.IsNullOrEmpty(x.Name)).ToList().ForEach(x => {
-                Debug.WriteLine($"Type with empty name and parent {x.Parent.Name}");
+                logger.LogWarning($"Type with empty name and parent {x.Parent.Name}");
             });
 
             Parallel.ForEach(unmappedTypes.Where(x => !string.IsNullOrEmpty(x.Name)).GroupBy(x => x.Name), x => {
@@ -520,7 +520,7 @@ namespace Kiota.Builder
         }
         private CodeType CreateModelClassAndType(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeElement parentElement, CodeNamespace codeNamespace, string classNameSuffix = "") {
             var namespaceName = currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName);
-            var ns = rootNamespace.FindChildByName<CodeNamespace>(namespaceName);
+            var ns = rootNamespace.FindNamespaceByName(namespaceName);
             if(ns == null)
                 ns = rootNamespace.AddNamespace(namespaceName);
             var className = currentNode.GetClassName(operation: operation, suffix: classNameSuffix);
@@ -546,7 +546,7 @@ namespace Kiota.Builder
                 foreach(var currentSchema in allOfs) {
                     var isLastSchema = currentSchema == lastSchema;
                     var shortestNamespaceName = currentSchema.Reference == null ? currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName) : GetShortestNamespaceNameForModelByReferenceId(currentSchema.Reference.Id);
-                    var shortestNamespace = rootNamespace.FindChildByName<CodeNamespace>(shortestNamespaceName);
+                    var shortestNamespace = rootNamespace.FindNamespaceByName(shortestNamespaceName);
                     if(shortestNamespace == null)
                         shortestNamespace = rootNamespace.AddNamespace(shortestNamespaceName);
                     className = isLastSchema ? currentNode.GetClassName(operation: operation) : currentSchema.GetClassName();
@@ -564,7 +564,7 @@ namespace Kiota.Builder
                 };
                 foreach(var currentSchema in schemas) {
                     var shortestNamespaceName = currentSchema.Reference == null ? currentNode.GetNodeNamespaceFromPath(this.config.ClientNamespaceName) : GetShortestNamespaceNameForModelByReferenceId(currentSchema.Reference.Id);
-                    var shortestNamespace = rootNamespace.FindChildByName<CodeNamespace>(shortestNamespaceName);
+                    var shortestNamespace = rootNamespace.FindNamespaceByName(shortestNamespaceName);
                     if(shortestNamespace == null)
                         shortestNamespace = rootNamespace.AddNamespace(shortestNamespaceName);
                     var className = currentSchema.GetClassName();
@@ -638,7 +638,7 @@ namespace Kiota.Builder
                                         if(!string.IsNullOrEmpty(className) && !string.IsNullOrEmpty(propertyDefinitionSchema?.Reference?.Id)) {
                                             var shortestNamespaceName = GetShortestNamespaceNameForModelByReferenceId(propertyDefinitionSchema.Reference.Id);
                                             var targetNamespace = string.IsNullOrEmpty(shortestNamespaceName) ? ns : 
-                                                                    (rootNamespace.FindChildByName<CodeNamespace>(shortestNamespaceName) ?? rootNamespace.AddNamespace(shortestNamespaceName));
+                                                                    (rootNamespace.FindNamespaceByName(shortestNamespaceName) ?? rootNamespace.AddNamespace(shortestNamespaceName));
                                             definition = AddModelDeclarationIfDoesntExit(rootNode, currentNode, propertyDefinitionSchema, operation, className, targetNamespace, parent, null, true);
                                         }
                                         return CreateProperty(x.Key, className ?? x.Value.Type, model, typeSchema: x.Value, typeDefinition: definition);

--- a/src/Kiota.Builder/OpenApiUriSpaceNode.cs
+++ b/src/Kiota.Builder/OpenApiUriSpaceNode.cs
@@ -9,7 +9,7 @@ namespace Kiota.Builder
 {
     public class OpenApiUrlSpaceNode
     {
-        public IDictionary<string, OpenApiUrlSpaceNode> Children { get; set; } = new Dictionary<string, OpenApiUrlSpaceNode>();
+        public IDictionary<string, OpenApiUrlSpaceNode> Children { get; set; } = new Dictionary<string, OpenApiUrlSpaceNode>(StringComparer.OrdinalIgnoreCase);
         public string Segment {get;set;}
         public string Layer {get;set;}
 

--- a/src/Kiota.Builder/OpenApiUriSpaceNode.cs
+++ b/src/Kiota.Builder/OpenApiUriSpaceNode.cs
@@ -20,41 +20,6 @@ namespace Kiota.Builder
         {
             Segment = segment;
         }
-
-        public bool IsParameter()
-        {
-            return Segment.StartsWith("{");
-        }
-
-        public bool IsFunction()
-        {
-            return Segment.Contains("(");
-        }
-
-        public string Identifier
-        {
-            get
-            {
-                string identifier;
-                if (IsParameter())
-                {
-                    identifier = Segment.Substring(1, Segment.Length - 2).ToPascalCase();
-                }
-                else
-                {
-                    identifier = Segment.ToPascalCase().Replace("()", "");
-                    var openParen = identifier.IndexOf("(");
-                    if (openParen >= 0)
-                    {
-                        identifier = identifier.Substring(0, openParen);
-                    }
-                }
-                return identifier;
-            }
-        }
-
-        internal bool HasOperations() => PathItem?.Operations?.Any() ?? false;
-
         public static OpenApiUrlSpaceNode Create(OpenApiDocument doc, string layer = "")
         {
             OpenApiUrlSpaceNode root = null;
@@ -122,28 +87,6 @@ namespace Kiota.Builder
                 return node.Attach(segments.Skip(1), pathItem, layer, currentPath + pathNameSeparator + segment);
             }
         }
-        public bool DoesNodeBelongToItemSubnamespace() =>
-        (Segment?.StartsWith("{") ?? false) && (Segment?.EndsWith("}") ?? false);
         private readonly char pathNameSeparator = '\\';
-        public string GetNodeNamespaceFromPath(string prefix = default) =>
-            prefix + 
-                    ((Path?.Contains(pathNameSeparator) ?? false) ?
-                        "." + Path
-                                ?.Split(pathNameSeparator, StringSplitOptions.RemoveEmptyEntries)
-                                ?.Where(x => !x.StartsWith('{'))
-                                ?.Aggregate((x, y) => $"{x}.{y}") :
-                        string.Empty)
-                    .ReplaceValueIdentifier();
-        private static readonly Regex idClassNameCleanup = new Regex(@"Id\d?$");
-        ///<summary>
-        /// Returns the class name for the node with more or less precision depending on the provided arguments
-        ///</summary>
-        public string GetClassName(string suffix = default, string prefix = default, OpenApiOperation operation = default) {
-            var rawClassName = operation?.GetResponseSchema()?.Reference?.GetClassName() ?? 
-                                Identifier?.ReplaceValueIdentifier();
-            if(DoesNodeBelongToItemSubnamespace() && idClassNameCleanup.IsMatch(rawClassName))
-                rawClassName = idClassNameCleanup.Replace(rawClassName, string.Empty);
-            return prefix + rawClassName + suffix;
-        }
     }
 }

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -25,8 +25,7 @@ namespace Kiota.Builder {
         }
         private void MakeEnumPropertiesNullable(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model)
-                currentClass.InnerChildElements
-                    	    .Values
+                currentClass.GetChildElements(true)
                             .OfType<CodeProperty>()
                             .Where(x => x.Type is CodeType propType && propType.TypeDefinition is CodeEnum)
                             .ToList()

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -6,18 +6,22 @@ using Kiota.Builder.Extensions;
 namespace Kiota.Builder {
     public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
     {
-        public override void Refine(CodeNamespace generatedCode)
+        public CSharpRefiner(CodeNamespace root) : base(root)
         {
-            AddDefaultImports(generatedCode);
-            MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
-            ConvertUnionTypesToWrapper(generatedCode);
-            AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
-            AddAsyncSuffix(generatedCode);
-            AddInnerClasses(generatedCode);
-            AddParsableInheritanceForModelClasses(generatedCode);
-            CapitalizeNamespacesFirstLetters(generatedCode);
-            ReplaceBinaryByNativeType(generatedCode, "Stream", "System.IO");
-            MakeEnumPropertiesNullable(generatedCode);
+            
+        }
+        public override void Refine()
+        {
+            AddDefaultImports(rootNamespace);
+            MoveClassesWithNamespaceNamesUnderNamespace(rootNamespace);
+            ConvertUnionTypesToWrapper(rootNamespace);
+            AddPropertiesAndMethodTypesImports(rootNamespace, false, false, false);
+            AddAsyncSuffix(rootNamespace);
+            AddInnerClasses(rootNamespace);
+            AddParsableInheritanceForModelClasses(rootNamespace);
+            CapitalizeNamespacesFirstLetters(rootNamespace);
+            ReplaceBinaryByNativeType(rootNamespace, "Stream", "System.IO");
+            MakeEnumPropertiesNullable(rootNamespace);
         }
         private void MakeEnumPropertiesNullable(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model)

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -26,6 +26,7 @@ namespace Kiota.Builder {
         private void MakeEnumPropertiesNullable(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model)
                 currentClass.InnerChildElements
+                    	    .Values
                             .OfType<CodeProperty>()
                             .Where(x => x.Type is CodeType propType && propType.TypeDefinition is CodeEnum)
                             .ToList()

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -194,6 +194,7 @@ namespace Kiota.Builder {
                 parameter.Type = new CodeType(parameter) {
                     Name = "String",
                     IsNullable = false,
+                    IsExternal = true,
                 };
                 method.Parameters.Add(parameter);
                 parentClass.AddMethod(method);

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -197,7 +197,6 @@ namespace Kiota.Builder {
                 method.Parameters.Add(parameter);
                 parentClass.AddMethod(method);
             }
-            CrawlTree(currentElement, c => AddIndexerMethod(c, targetClass, indexerClass, pathSegment, methodNameSuffix, description));
         }
         internal void AddInnerClasses(CodeElement current) {
             if(current is CodeClass currentClass) {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -6,7 +6,12 @@ using static Kiota.Builder.CodeClass;
 namespace Kiota.Builder {
     public abstract class CommonLanguageRefiner : ILanguageRefiner
     {
-        public abstract void Refine(CodeNamespace generatedCode);
+        protected readonly CodeNamespace rootNamespace;
+        public CommonLanguageRefiner(CodeNamespace root)
+        {
+            rootNamespace = root ?? throw new ArgumentNullException(nameof(root));
+        }
+        public abstract void Refine();
 
         protected void AddDefaultImports(CodeElement current, Tuple<string, string>[] defaultNamespaces, Tuple<string, string>[] defaultNamespacesForModels, Tuple<string, string>[] defaultNamespacesForRequestBuilders) {
             if(current is CodeClass currentClass) {
@@ -81,8 +86,7 @@ namespace Kiota.Builder {
         // temporary patch of type to it resolves as the builder sets types we didn't generate to entity
         protected void FixReferencesToEntityType(CodeElement currentElement, CodeClass entityClass = null){
             if(entityClass == null)
-                entityClass = currentElement.GetImmediateParentOfType<CodeNamespace>()
-                            .GetRootNamespace()
+                entityClass = rootNamespace
                             .GetChildElementOfType<CodeClass>(x => x?.Name?.Equals("entity", StringComparison.InvariantCultureIgnoreCase) ?? false);
 
             if(currentElement is CodeMethod currentMethod 
@@ -155,7 +159,7 @@ namespace Kiota.Builder {
                                     ?.DefaultValue;
                 if(!string.IsNullOrEmpty(pathSegment))
                     foreach(var returnType in currentIndexer.ReturnType.AllTypes)
-                        AddIndexerMethod(currentElement.GetImmediateParentOfType<CodeNamespace>().GetRootNamespace(), 
+                        AddIndexerMethod(rootNamespace, 
                                         currentParentClass,
                                         returnType.TypeDefinition as CodeClass,
                                         pathSegment.Trim('\"').TrimStart('/'),

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -90,7 +90,7 @@ namespace Kiota.Builder {
 
             if(currentElement is CodeMethod currentMethod 
                 && currentMethod.ReturnType is CodeType currentReturnType
-                && currentReturnType.Name.Equals("entity", StringComparison.InvariantCultureIgnoreCase)
+                && currentReturnType.Name.Equals("entity", StringComparison.OrdinalIgnoreCase)
                 && currentReturnType.TypeDefinition == null)
                 currentReturnType.TypeDefinition = entityClass;
 
@@ -140,7 +140,7 @@ namespace Kiota.Builder {
                                                                 .Values
                                                                 .OfType<CodeNamespace>()
                                                                 .FirstOrDefault(x => x.Name
-                                                                                    .EndsWith(currentClass.Name, StringComparison.InvariantCultureIgnoreCase));
+                                                                                    .EndsWith(currentClass.Name, StringComparison.OrdinalIgnoreCase));
                 if(childNamespaceWithClassName != null) {
                     parentNamespace.InnerChildElements.Remove(currentClass.Name);
                     childNamespaceWithClassName.AddClass(currentClass);
@@ -155,7 +155,7 @@ namespace Kiota.Builder {
                 var pathSegment = currentParentClass
                                     .GetChildElements()
                                     .OfType<CodeProperty>()
-                                    .FirstOrDefault(x => x.Name.Equals(pathSegmentPropertyName, StringComparison.InvariantCultureIgnoreCase))
+                                    .FirstOrDefault(x => x.Name.Equals(pathSegmentPropertyName, StringComparison.OrdinalIgnoreCase))
                                     ?.DefaultValue;
                 if(!string.IsNullOrEmpty(pathSegment))
                     foreach(var returnType in currentIndexer.ReturnType.AllTypes)

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -153,9 +153,7 @@ namespace Kiota.Builder {
                 var currentParentClass = currentElement.Parent as CodeClass;
                 currentParentClass.InnerChildElements.Remove(currentElement.Name);
                 var pathSegment = currentParentClass
-                                    .GetChildElements()
-                                    .OfType<CodeProperty>()
-                                    .FirstOrDefault(x => x.Name.Equals(pathSegmentPropertyName, StringComparison.OrdinalIgnoreCase))
+                                    .FindChildByName<CodeProperty>(pathSegmentPropertyName)
                                     ?.DefaultValue;
                 if(!string.IsNullOrEmpty(pathSegment))
                     foreach(var returnType in currentIndexer.ReturnType.AllTypes)
@@ -203,7 +201,7 @@ namespace Kiota.Builder {
         }
         internal void AddInnerClasses(CodeElement current) {
             if(current is CodeClass currentClass) {
-                foreach(var parameter in current.GetChildElements().OfType<CodeMethod>().SelectMany(x =>x.Parameters).Where(x => x.Type.ActionOf && x.ParameterKind == CodeParameterKind.QueryParameter)) 
+                foreach(var parameter in currentClass.InnerChildElements.Values.OfType<CodeMethod>().SelectMany(x =>x.Parameters).Where(x => x.Type.ActionOf && x.ParameterKind == CodeParameterKind.QueryParameter)) 
                     foreach(var returnType in parameter.Type.AllTypes) {
                         var innerClass = returnType.TypeDefinition as CodeClass;
                         if(innerClass == null)

--- a/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
@@ -2,18 +2,18 @@ namespace Kiota.Builder
 {
     public interface ILanguageRefiner
     {
-        void Refine(CodeNamespace generatedCode);
+        void Refine();
         public static void Refine(GenerationLanguage language, CodeNamespace generatedCode) {
             switch (language)
             {
                 case GenerationLanguage.CSharp:
-                    new CSharpRefiner().Refine(generatedCode);
+                    new CSharpRefiner(generatedCode).Refine();
                     break;
                 case GenerationLanguage.TypeScript:
-                    new TypeScriptRefiner().Refine(generatedCode);
+                    new TypeScriptRefiner(generatedCode).Refine();
                     break;
                 case GenerationLanguage.Java:
-                    new JavaRefiner().Refine(generatedCode);
+                    new JavaRefiner(generatedCode).Refine();
                     break;
                 default:
                     break; //Do nothing

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -30,7 +30,7 @@ namespace Kiota.Builder {
         }
         private void AddEnumSetImport(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model &&
-                currentClass.InnerChildElements.OfType<CodeProperty>().Any(x => x.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags)) {
+                currentClass.InnerChildElements.Values.OfType<CodeProperty>().Any(x => x.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags)) {
                     var nUsing = new CodeUsing(currentClass) {
                         Name = "EnumSet",
                     };
@@ -52,9 +52,9 @@ namespace Kiota.Builder {
         }
         private void AddListImport(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass &&
-                (currentClass.InnerChildElements.OfType<CodeProperty>().Any(x => x.Type.CollectionKind == CodeType.CodeTypeCollectionKind.Complex) ||
-                currentClass.InnerChildElements.OfType<CodeMethod>().Any(x => x.ReturnType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex) ||
-                currentClass.InnerChildElements.OfType<CodeMethod>().Any(x => x.Parameters.Any(y => y.Type.CollectionKind == CodeType.CodeTypeCollectionKind.Complex))
+                (currentClass.InnerChildElements.Values.OfType<CodeProperty>().Any(x => x.Type.CollectionKind == CodeType.CodeTypeCollectionKind.Complex) ||
+                currentClass.InnerChildElements.Values.OfType<CodeMethod>().Any(x => x.ReturnType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex) ||
+                currentClass.InnerChildElements.Values.OfType<CodeMethod>().Any(x => x.Parameters.Any(y => y.Type.CollectionKind == CodeType.CodeTypeCollectionKind.Complex))
                 )) {
                     var nUsing = new CodeUsing(currentClass) {
                         Name = "List"

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -89,13 +89,13 @@ namespace Kiota.Builder {
         };
         private void CorrectCoreType(CodeElement currentElement) {
             if (currentElement is CodeProperty currentProperty) {
-                if("IHttpCore".Equals(currentProperty.Type.Name, StringComparison.InvariantCultureIgnoreCase))
+                if("IHttpCore".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "HttpCore";
-                else if(currentProperty.Name.Equals("serializerFactory", StringComparison.InvariantCultureIgnoreCase))
+                else if(currentProperty.Name.Equals("serializerFactory", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "SerializationWriterFactory";
-                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.InvariantCultureIgnoreCase))
+                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = $"Map<String, BiConsumer<T, ParseNode>>";
-                else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.InvariantCultureIgnoreCase)) {
+                else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase)) {
                     currentProperty.Type.Name = $"OffsetDateTime";
                     var nUsing = new CodeUsing(currentProperty.Parent) {
                         Name = "java.time",

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -144,26 +144,26 @@ namespace Kiota.Builder {
             CrawlTree(currentElement, AddRequireNonNullImports);
         }
         private void AndInsertOverrideMethodForRequestExecutorsAndBuilders(CodeElement currentElement) {
-            var codeMethods = currentElement
-                                    .GetChildElements()
-                                    .OfType<CodeMethod>();
-            if(currentElement is CodeClass currentClass && codeMethods.Any()) {
-                var originalExecutorMethods = codeMethods.Where(x => x.MethodKind == CodeMethodKind.RequestExecutor);
-                var executorMethodsToAdd = originalExecutorMethods
-                                    .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter))
-                                    .Union(originalExecutorMethods
-                                            .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers)))
-                                    .Union(originalExecutorMethods
-                                            .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.ResponseHandler)))
-                                    .Where(x => x != null);
-                var originalGeneratorMethods = codeMethods.Where(x => x.MethodKind == CodeMethodKind.RequestGenerator);
-                var generatorMethodsToAdd = originalGeneratorMethods
-                                    .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter))
-                                    .Union(originalGeneratorMethods
-                                            .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers)))
-                                    .Where(x => x != null);
-                if(executorMethodsToAdd.Any() || generatorMethodsToAdd.Any())
-                    currentClass.AddMethod(executorMethodsToAdd.Union(generatorMethodsToAdd).ToArray());
+            if(currentElement is CodeClass currentClass) {
+                var codeMethods = currentClass.InnerChildElements.Values.OfType<CodeMethod>();
+                if(codeMethods.Any()) {
+                    var originalExecutorMethods = codeMethods.Where(x => x.MethodKind == CodeMethodKind.RequestExecutor);
+                    var executorMethodsToAdd = originalExecutorMethods
+                                        .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter))
+                                        .Union(originalExecutorMethods
+                                                .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers)))
+                                        .Union(originalExecutorMethods
+                                                .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.ResponseHandler)))
+                                        .Where(x => x != null);
+                    var originalGeneratorMethods = codeMethods.Where(x => x.MethodKind == CodeMethodKind.RequestGenerator);
+                    var generatorMethodsToAdd = originalGeneratorMethods
+                                        .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter))
+                                        .Union(originalGeneratorMethods
+                                                .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers)))
+                                        .Where(x => x != null);
+                    if(executorMethodsToAdd.Any() || generatorMethodsToAdd.Any())
+                        currentClass.AddMethod(executorMethodsToAdd.Union(generatorMethodsToAdd).ToArray());
+                }
             }
             
             CrawlTree(currentElement, AndInsertOverrideMethodForRequestExecutorsAndBuilders);

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -6,23 +6,27 @@ using Kiota.Builder.Extensions;
 namespace Kiota.Builder {
     public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
     {
-        public override void Refine(CodeNamespace generatedCode)
+        public JavaRefiner(CodeNamespace root) : base(root)
         {
-            AddInnerClasses(generatedCode);
-            AndInsertOverrideMethodForRequestExecutorsAndBuilders(generatedCode);
-            ReplaceIndexersByMethodsWithParameter(generatedCode);
-            ConvertUnionTypesToWrapper(generatedCode);
-            AddRequireNonNullImports(generatedCode);
-            FixReferencesToEntityType(generatedCode);
-            AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
-            AddDefaultImports(generatedCode, defaultNamespaces, defaultNamespacesForModels, defaultNamespacesForRequestBuilders);
-            CorrectCoreType(generatedCode);
-            PatchHeaderParametersType(generatedCode);
-            AddListImport(generatedCode);
-            AddParsableInheritanceForModelClasses(generatedCode);
-            ConvertDeserializerPropsToMethods(generatedCode, "get");
-            ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
-            AddEnumSetImport(generatedCode);
+            
+        }
+        public override void Refine()
+        {
+            AddInnerClasses(rootNamespace);
+            AndInsertOverrideMethodForRequestExecutorsAndBuilders(rootNamespace);
+            ReplaceIndexersByMethodsWithParameter(rootNamespace);
+            ConvertUnionTypesToWrapper(rootNamespace);
+            AddRequireNonNullImports(rootNamespace);
+            FixReferencesToEntityType(rootNamespace);
+            AddPropertiesAndMethodTypesImports(rootNamespace, true, false, true);
+            AddDefaultImports(rootNamespace, defaultNamespaces, defaultNamespacesForModels, defaultNamespacesForRequestBuilders);
+            CorrectCoreType(rootNamespace);
+            PatchHeaderParametersType(rootNamespace);
+            AddListImport(rootNamespace);
+            AddParsableInheritanceForModelClasses(rootNamespace);
+            ConvertDeserializerPropsToMethods(rootNamespace, "get");
+            ReplaceBinaryByNativeType(rootNamespace, "InputStream", "java.io", true);
+            AddEnumSetImport(rootNamespace);
         }
         private void AddEnumSetImport(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model &&

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -101,7 +101,8 @@ namespace Kiota.Builder {
                         Name = "java.time",
                     };
                     nUsing.Declaration = new CodeType(nUsing) {
-                        Name = "OffsetDateTime"
+                        Name = "OffsetDateTime",
+                        IsExternal = true,
                     };
                     (currentProperty.Parent as CodeClass).AddUsing(nUsing);
                 } else if (currentProperty.PropertyKind == CodePropertyKind.AdditionalData) {

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -98,10 +98,10 @@ namespace Kiota.Builder {
                 else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase)) {
                     currentProperty.Type.Name = $"OffsetDateTime";
                     var nUsing = new CodeUsing(currentProperty.Parent) {
-                        Name = "java.time",
+                        Name = "OffsetDateTime",
                     };
                     nUsing.Declaration = new CodeType(nUsing) {
-                        Name = "OffsetDateTime",
+                        Name = "java.time",
                         IsExternal = true,
                     };
                     (currentProperty.Parent as CodeClass).AddUsing(nUsing);

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -48,13 +48,13 @@ namespace Kiota.Builder {
         };
         private void CorrectCoreType(CodeElement currentElement) {
             if (currentElement is CodeProperty currentProperty) {
-                if ("IHttpCore".Equals(currentProperty.Type.Name, StringComparison.InvariantCultureIgnoreCase))
+                if ("IHttpCore".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "HttpCore";
-                else if(currentProperty.Name.Equals("serializerFactory", StringComparison.InvariantCultureIgnoreCase))
+                else if(currentProperty.Name.Equals("serializerFactory", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "SerializationWriterFactory";
-                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.InvariantCultureIgnoreCase))
+                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = $"Map<string, (item: {currentProperty.Parent.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>";
-                else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.InvariantCultureIgnoreCase))
+                else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = $"Date";
                 else if(currentProperty.PropertyKind == CodePropertyKind.AdditionalData) {
                     currentProperty.Type.Name = "Map<string, unknown>";
@@ -70,7 +70,7 @@ namespace Kiota.Builder {
             CrawlTree(currentElement, CorrectCoreType);
         }
         private void PatchResponseHandlerType(CodeElement current) {
-            if(current is CodeMethod currentMethod && currentMethod.Name.Equals("defaultResponseHandler", StringComparison.InvariantCultureIgnoreCase)) 
+            if(current is CodeMethod currentMethod && currentMethod.Name.Equals("defaultResponseHandler", StringComparison.OrdinalIgnoreCase)) 
                 currentMethod.Parameters.First().Type.Name = "ReadableStream";
             CrawlTree(current, PatchResponseHandlerType);
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -6,17 +6,21 @@ using Kiota.Builder.Extensions;
 namespace Kiota.Builder {
     public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
     {
-        public override void Refine(CodeNamespace generatedCode)
+        public TypeScriptRefiner(CodeNamespace root) : base(root)
         {
-            PatchResponseHandlerType(generatedCode);
-            AddDefaultImports(generatedCode, defaultNamespaces, defaultNamespacesForModels, defaultNamespacesForRequestBuilders);
-            ReplaceIndexersByMethodsWithParameter(generatedCode, "ById");
-            CorrectCoreType(generatedCode);
-            FixReferencesToEntityType(generatedCode);
-            AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
-            AddParsableInheritanceForModelClasses(generatedCode);
-            ConvertDeserializerPropsToMethods(generatedCode);
-            ReplaceBinaryByNativeType(generatedCode, "ReadableStream", "web-streams-polyfill/es2018", true);
+            
+        }
+        public override void Refine()
+        {
+            PatchResponseHandlerType(rootNamespace);
+            AddDefaultImports(rootNamespace, defaultNamespaces, defaultNamespacesForModels, defaultNamespacesForRequestBuilders);
+            ReplaceIndexersByMethodsWithParameter(rootNamespace, "ById");
+            CorrectCoreType(rootNamespace);
+            FixReferencesToEntityType(rootNamespace);
+            AddPropertiesAndMethodTypesImports(rootNamespace, true, true, true);
+            AddParsableInheritanceForModelClasses(rootNamespace);
+            ConvertDeserializerPropsToMethods(rootNamespace);
+            ReplaceBinaryByNativeType(rootNamespace, "ReadableStream", "web-streams-polyfill/es2018", true);
         }
         private void AddParsableInheritanceForModelClasses(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.ClassKind == CodeClassKind.Model) {

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -198,8 +198,8 @@ namespace Kiota.Builder
             var returnType = GetTypeString(code.ReturnType);
             var parentClass = code.Parent as CodeClass;
             var shouldHide = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null && code.MethodKind == CodeMethodKind.Serializer;
-            var isVoid = VoidTypeName.Equals(returnType, StringComparison.InvariantCultureIgnoreCase);
-            var isStream = StreamTypeName.Equals(returnType, StringComparison.InvariantCultureIgnoreCase);
+            var isVoid = VoidTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
+            var isStream = StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
             WriteMethodDocumentation(code);
             WriteMethodPrototype(code, returnType, shouldHide, isVoid);
             IncreaseIndent();
@@ -230,7 +230,7 @@ namespace Kiota.Builder
                     DecreaseIndent();
                     WriteLine("};");
                     if(requestBodyParam != null) {
-                        if(requestBodyParam.Type.Name.Equals(StreamTypeName, StringComparison.InvariantCultureIgnoreCase))
+                        if(requestBodyParam.Type.Name.Equals(StreamTypeName, StringComparison.OrdinalIgnoreCase))
                             WriteLine($"requestInfo.SetStreamContent({requestBodyParam.Name});");
                         else
                             WriteLine($"requestInfo.SetJsonContentFromParsable({requestBodyParam.Name}, {SerializerFactoryPropertyName});"); //TODO we're making a big assumption here that everything will be json

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -83,7 +83,8 @@ namespace Kiota.Builder
                                                     .InnerChildElements
                                                     .Values
                                                     .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
                         WriteLine("{");
                         IncreaseIndent();
                         WriteLine($"\"{otherProp.Name.ToFirstCharacterLowerCase()}\", (o,n) => {{ o.{otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type)}(); }}");
@@ -178,7 +179,7 @@ namespace Kiota.Builder
                 WriteLine($"{docCommentPrefix}<summary>");
                 if(isDescriptionPresent)
                     WriteLine($"{docCommentPrefix}{code.Description}");
-                foreach(var paramWithDescription in parametersWithDescription)
+                foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
                     WriteLine($"{docCommentPrefix}<param name=\"{paramWithDescription.Name}\">{paramWithDescription.Description}</param>");
                 WriteLine($"{docCommentPrefix}</summary>");
             }
@@ -215,7 +216,8 @@ namespace Kiota.Builder
                                                     .InnerChildElements
                                                     .Values
                                                     .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
                     }
                     if(additionalDataProperty != null)

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -80,8 +80,7 @@ namespace Kiota.Builder
                     WriteLine($"{GetAccessModifier(code.Access)} {(hideParentMember ? "new " : string.Empty)}{code.Type.Name} {code.Name.ToFirstCharacterUpperCase()} => new Dictionary<string, Action<{parentClass.Name.ToFirstCharacterUpperCase()}, {parseNodeInterfaceName}>> {{");
                     IncreaseIndent();
                     foreach(var otherProp in parentClass
-                                                    .InnerChildElements
-                                                    .Values
+                                                    .GetChildElements(true)
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                                     .OrderBy(x => x.Name)) {
@@ -209,12 +208,11 @@ namespace Kiota.Builder
             var headersParam = code.Parameters.OfKind(CodeParameterKind.Headers);
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("base.Serialize(writer);");
                     foreach(var otherProp in parentClass
-                                                    .InnerChildElements
-                                                    .Values
+                                                    .GetChildElements(true)
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                                     .OrderBy(x => x.Name)) {
@@ -253,8 +251,7 @@ namespace Kiota.Builder
                     break;
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
-                                                .InnerChildElements
-                                                .Values
+                                                .GetChildElements(true)
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name;

--- a/src/Kiota.Builder/Writers/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharpWriter.cs
@@ -81,6 +81,7 @@ namespace Kiota.Builder
                     IncreaseIndent();
                     foreach(var otherProp in parentClass
                                                     .InnerChildElements
+                                                    .Values
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine("{");
@@ -207,11 +208,12 @@ namespace Kiota.Builder
             var headersParam = code.Parameters.OfKind(CodeParameterKind.Headers);
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("base.Serialize(writer);");
                     foreach(var otherProp in parentClass
                                                     .InnerChildElements
+                                                    .Values
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
@@ -250,6 +252,7 @@ namespace Kiota.Builder
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
                                                 .InnerChildElements
+                                                .Values
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name;

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -135,11 +135,12 @@ namespace Kiota.Builder
             }
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if((parentClass.StartBlock as CodeClass.Declaration).Inherits != null)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
                                                     .InnerChildElements
+                                                    .Values
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterLowerCase()});");
@@ -151,6 +152,7 @@ namespace Kiota.Builder
                     var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
                     var fieldToSerialize = parentClass
                             .InnerChildElements
+                            .Values
                             .OfType<CodeProperty>()
                             .Where(x => x.PropertyKind == CodePropertyKind.Custom);
                     WriteLine($"final Map<String, BiConsumer<T, ParseNode>> fields = new HashMap<>({(inherits ? "super." + code.Name+ "()" : fieldToSerialize.Count())});");
@@ -200,6 +202,7 @@ namespace Kiota.Builder
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
                                                 .InnerChildElements
+                                                .Values
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -119,7 +119,7 @@ namespace Kiota.Builder
             var returnType = GetTypeString(code.ReturnType);
             var parentClass = code.Parent as CodeClass;
             WriteMethodDocumentation(code);
-            if(returnType.Equals("void", StringComparison.InvariantCultureIgnoreCase))
+            if(returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
             {
                 if(code.MethodKind == CodeMethodKind.RequestExecutor)
                     returnType = "Void"; //generic type for the future
@@ -176,7 +176,7 @@ namespace Kiota.Builder
                     DecreaseIndent();
                     WriteLine("}};");
                     if(requestBodyParam != null)
-                        if(requestBodyParam.Type.Name.Equals(streamType, StringComparison.InvariantCultureIgnoreCase))
+                        if(requestBodyParam.Type.Name.Equals(streamType, StringComparison.OrdinalIgnoreCase))
                             WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                         else
                             WriteLine($"requestInfo.setJsonContentFromParsable({requestBodyParam.Name}, {serializerFactoryParamName});"); //TODO we're making a big assumption here that the request is json

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -89,7 +89,7 @@ namespace Kiota.Builder
                 WriteLine(docCommentStart);
                 if(isDescriptionPresent)
                     WriteLine($"{docCommentPrefix}{RemoveInvalidDescriptionCharacters(code.Description)}");
-                foreach(var paramWithDescription in parametersWithDescription)
+                foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
                     WriteLine($"{docCommentPrefix}@param {paramWithDescription.Name} {RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
                 
                 if(code.IsAsync)
@@ -130,7 +130,7 @@ namespace Kiota.Builder
             var requestBodyParam = code.Parameters.OfKind(CodeParameterKind.RequestBody);
             var queryStringParam = code.Parameters.OfKind(CodeParameterKind.QueryParameter);
             var headersParam = code.Parameters.OfKind(CodeParameterKind.Headers);
-            foreach(var parameter in code.Parameters.Where(x => !x.Optional)) {
+            foreach(var parameter in code.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name)) {
                 WriteLine($"Objects.requireNonNull({parameter.Name});");
             }
             switch(code.MethodKind) {
@@ -142,7 +142,8 @@ namespace Kiota.Builder
                                                     .InnerChildElements
                                                     .Values
                                                     .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterLowerCase()});");
                     }
                     if(additionalDataProperty != null)

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -135,12 +135,11 @@ namespace Kiota.Builder
             }
             switch(code.MethodKind) {
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if((parentClass.StartBlock as CodeClass.Declaration).Inherits != null)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
-                                                    .InnerChildElements
-                                                    .Values
+                                                    .GetChildElements(true)
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                                     .OrderBy(x => x.Name)) {
@@ -152,8 +151,7 @@ namespace Kiota.Builder
                 case CodeMethodKind.DeserializerBackwardCompatibility:
                     var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
                     var fieldToSerialize = parentClass
-                            .InnerChildElements
-                            .Values
+                            .GetChildElements(true)
                             .OfType<CodeProperty>()
                             .Where(x => x.PropertyKind == CodePropertyKind.Custom);
                     WriteLine($"final Map<String, BiConsumer<T, ParseNode>> fields = new HashMap<>({(inherits ? "super." + code.Name+ "()" : fieldToSerialize.Count())});");
@@ -203,8 +201,7 @@ namespace Kiota.Builder
                 break;
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
-                                                .InnerChildElements
-                                                .Values
+                                                .GetChildElements(true)
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name

--- a/src/Kiota.Builder/Writers/JavaWriter.cs
+++ b/src/Kiota.Builder/Writers/JavaWriter.cs
@@ -159,6 +159,7 @@ namespace Kiota.Builder
                     WriteLine($"final Map<String, BiConsumer<T, ParseNode>> fields = new HashMap<>({(inherits ? "super." + code.Name+ "()" : fieldToSerialize.Count())});");
                     if(fieldToSerialize.Any())
                         fieldToSerialize
+                                .OrderBy(x => x.Name)
                                 .Select(x => 
                                     $"fields.put(\"{x.Name.ToFirstCharacterLowerCase()}\", (o, n) -> {{ (({parentClass.Name.ToFirstCharacterUpperCase()})o).{x.Name.ToFirstCharacterLowerCase()} = {GetDeserializationMethodName(x.Type)}; }});")
                                 .ToList()

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -81,7 +81,7 @@ namespace Kiota.Builder
                 case CodeNamespace: break;
                 case CodeClass: break;
                 default:
-                    throw new ArgumentException($"Dispatcher missing for type {code.GetType()}");
+                    throw new InvalidOperationException($"Dispatcher missing for type {code.GetType()}");
             }
 
         }

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -104,12 +104,6 @@ namespace Kiota.Builder
             if(codeUsing.Declaration == null)
                 return string.Empty;//it's an external import, add nothing
             var typeDef = codeUsing.Declaration.TypeDefinition;
-            if(typeDef == null) {
-                // sometimes the definition is not attached to the declaration because it's generated after the fact, we need to search it
-                typeDef = currentNamespace
-                    .GetRootNamespace()
-                    .GetChildElementOfType<CodeClass>(x => x.Name.Equals(codeUsing.Declaration.Name));
-            }
 
             if(typeDef == null)
                 return "./"; // it's relative to the folder, with no declaration (default failsafe)

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -80,7 +80,7 @@ namespace Kiota.Builder
             }
             foreach (var codeUsing in code.Usings
                                         .Where(x => (!x.Declaration?.IsExternal) ?? true)
-                                        .Where(x => !x.Declaration.Name.Equals(code.Name, StringComparison.InvariantCultureIgnoreCase))
+                                        .Where(x => !x.Declaration.Name.Equals(code.Name, StringComparison.OrdinalIgnoreCase))
                                         .Select(x => {
                                             var relativeImportPath = GetRelativeImportPathForUsing(x, code.GetImmediateParentOfType<CodeNamespace>());
                                             return new {
@@ -118,7 +118,7 @@ namespace Kiota.Builder
                 throw new ArgumentNullException(nameof(currentNamespace));
             else if (importNamespace == null)
                 throw new ArgumentNullException(nameof(importNamespace));
-            else if(currentNamespace.Name.Equals(importNamespace.Name, StringComparison.InvariantCultureIgnoreCase)) // we're in the same namespace
+            else if(currentNamespace.Name.Equals(importNamespace.Name, StringComparison.OrdinalIgnoreCase)) // we're in the same namespace
                 return "./";
             else {
                 var currentNamespaceSegements = currentNamespace
@@ -131,7 +131,7 @@ namespace Kiota.Builder
                 var currentNamespaceSegementsCount = currentNamespaceSegements.Length;
                 var deeperMostSegmentIndex = 0;
                 while(deeperMostSegmentIndex < Math.Min(importNamespaceSegmentsCount, currentNamespaceSegementsCount)) {
-                    if(currentNamespaceSegements.ElementAt(deeperMostSegmentIndex).Equals(importNamespaceSegments.ElementAt(deeperMostSegmentIndex), StringComparison.InvariantCultureIgnoreCase))
+                    if(currentNamespaceSegements.ElementAt(deeperMostSegmentIndex).Equals(importNamespaceSegments.ElementAt(deeperMostSegmentIndex), StringComparison.OrdinalIgnoreCase))
                         deeperMostSegmentIndex++;
                     else
                         break;
@@ -260,7 +260,7 @@ namespace Kiota.Builder
         public override void WriteMethod(CodeMethod code)
         {
             var returnType = GetTypeString(code.ReturnType);
-            var isVoid = "void".Equals(returnType, StringComparison.InvariantCultureIgnoreCase);
+            var isVoid = "void".Equals(returnType, StringComparison.OrdinalIgnoreCase);
             WriteMethodDocumentation(code);
             WriteMethodPrototype(code, returnType, isVoid);
             IncreaseIndent();
@@ -311,7 +311,7 @@ namespace Kiota.Builder
                     if(queryStringParam != null)
                         WriteLines($"{queryStringParam.Name} && requestInfo.setQueryStringParametersFromRawObject(q);");
                     if(requestBodyParam != null) {
-                        if(requestBodyParam.Type.Name.Equals(StreamType, StringComparison.InvariantCultureIgnoreCase))
+                        if(requestBodyParam.Type.Name.Equals(StreamType, StringComparison.OrdinalIgnoreCase))
                             WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                         else
                             WriteLine($"requestInfo.setJsonContentFromParsable({requestBodyParam.Name}, this.{SerializerFactoryPropertyName});"); //TODO we're making a big assumption here that everything will be json
@@ -334,7 +334,7 @@ namespace Kiota.Builder
                         DecreaseIndent();
                     }
                     WriteLine(");");
-                    var isStream = StreamType.Equals(returnType, StringComparison.InvariantCultureIgnoreCase);
+                    var isStream = StreamType.Equals(returnType, StringComparison.OrdinalIgnoreCase);
                     var genericTypeForSendMethod = GetSendRequestMethodName(isVoid, isStream, returnType);
                     var newFactoryParameter = GetTypeFactory(isVoid, isStream, returnType);
                     WriteLine($"return this.httpCore?.{genericTypeForSendMethod}(requestInfo,{newFactoryParameter} responseHandler) ?? Promise.reject(new Error('http core is null'));");

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -232,7 +232,7 @@ namespace Kiota.Builder
                 WriteLine(docCommentStart);
                 if(isDescriptionPresent)
                     WriteLine($"{docCommentPrefix}{RemoveInvalidDescriptionCharacters(code.Description)}");
-                foreach(var paramWithDescription in parametersWithDescription)
+                foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
                     WriteLine($"{docCommentPrefix}@param {paramWithDescription.Name} {RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
                 
                 if(code.IsAsync)
@@ -282,7 +282,8 @@ namespace Kiota.Builder
                                                     .InnerChildElements
                                                     .Values
                                                     .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
                         WriteLine($"[\"{otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ o.{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
                     }
                     DecreaseIndent();
@@ -296,7 +297,8 @@ namespace Kiota.Builder
                                                     .InnerChildElements
                                                     .Values
                                                     .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", this.{otherProp.Name.ToFirstCharacterLowerCase()});");
                     }
                     if(additionalDataProperty != null)

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -30,8 +30,7 @@ namespace Kiota.Builder
                 {
                     IncreaseIndent(4);
                     var childElements = (currentType?.TypeDefinition as CodeClass)
-                                                ?.InnerChildElements
-                                                ?.Values
+                                                ?.GetChildElements(true)
                                                 ?.OfType<CodeProperty>()
                                                 ?.Select(x => $"{x.Name}?: {GetTypeString(x.Type)}");
                     var innerDeclaration = childElements?.Any() ?? false ? 
@@ -279,8 +278,7 @@ namespace Kiota.Builder
                     WriteLine($"return new Map<string, (item: {parentClass.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>([{(inherits ? $"...super.{code.Name.ToFirstCharacterLowerCase()}()," : string.Empty)}");
                     IncreaseIndent();
                     foreach(var otherProp in parentClass
-                                                    .InnerChildElements
-                                                    .Values
+                                                    .GetChildElements(true)
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                                     .OrderBy(x => x.Name)) {
@@ -290,12 +288,11 @@ namespace Kiota.Builder
                     WriteLine("]);");
                     break;
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
-                                                    .InnerChildElements
-                                                    .Values
+                                                    .GetChildElements(true)
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                                     .OrderBy(x => x.Name)) {
@@ -322,8 +319,7 @@ namespace Kiota.Builder
                 break;
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
-                                                .InnerChildElements
-                                                .Values
+                                                .GetChildElements(true)
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name

--- a/src/Kiota.Builder/Writers/TypeScriptWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScriptWriter.cs
@@ -31,6 +31,7 @@ namespace Kiota.Builder
                     IncreaseIndent(4);
                     var childElements = (currentType?.TypeDefinition as CodeClass)
                                                 ?.InnerChildElements
+                                                ?.Values
                                                 ?.OfType<CodeProperty>()
                                                 ?.Select(x => $"{x.Name}?: {GetTypeString(x.Type)}");
                     var innerDeclaration = childElements?.Any() ?? false ? 
@@ -279,6 +280,7 @@ namespace Kiota.Builder
                     IncreaseIndent();
                     foreach(var otherProp in parentClass
                                                     .InnerChildElements
+                                                    .Values
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"[\"{otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ o.{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
@@ -287,11 +289,12 @@ namespace Kiota.Builder
                     WriteLine("]);");
                     break;
                 case CodeMethodKind.Serializer:
-                    var additionalDataProperty = parentClass.InnerChildElements.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
+                    var additionalDataProperty = parentClass.InnerChildElements.Values.OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.AdditionalData);
                     if(shouldHide)
                         WriteLine("super.serialize(writer);");
                     foreach(var otherProp in parentClass
                                                     .InnerChildElements
+                                                    .Values
                                                     .OfType<CodeProperty>()
                                                     .Where(x => x.PropertyKind == CodePropertyKind.Custom)) {
                         WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.Name.ToFirstCharacterLowerCase()}\", this.{otherProp.Name.ToFirstCharacterLowerCase()});");
@@ -318,6 +321,7 @@ namespace Kiota.Builder
                 case CodeMethodKind.RequestExecutor:
                     var generatorMethodName = (code.Parent as CodeClass)
                                                 .InnerChildElements
+                                                .Values
                                                 .OfType<CodeMethod>()
                                                 .FirstOrDefault(x => x.MethodKind == CodeMethodKind.RequestGenerator && x.HttpMethod == code.HttpMethod)
                                                 ?.Name


### PR DESCRIPTION
## Summary

This pull request fixes multiple performance bottlenecks for large API description as well as multiple undeterministic behaviors.
I've reduced generation time from 1+ hour for v1 to ~= 2.5 minutes on my machine.
From 20+ minutes to ~= 1.5 minute on @zengin's machine.

## Generation diff
Roughly the same besides the fixes for undeterministic behavior and the ordering of properties/methods/indexers.

https://github.com/microsoft/kiota-samples/pull/11