### PR TITLE
adds dotnet tool packaging for kiota

### DIFF
--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish Dotnet tool
 on:
   push
     # branches: [main]

--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -1,9 +1,9 @@
 name: Publish Docker image
 on:
-  push:
-    branches: [main]
-    tags: ['v*']
-    paths: ['src/**', '.github/workflows/**']
+  push
+    # branches: [main]
+    # tags: ['v*']
+    # paths: ['src/**', '.github/workflows/**']
 jobs:
   push_to_feed:
     env:

--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -1,9 +1,9 @@
 name: Publish Dotnet tool
 on:
-  push
-    # branches: [main]
-    # tags: ['v*']
-    # paths: ['src/**', '.github/workflows/**']
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths: ['src/**', '.github/workflows/**']
 jobs:
   push_to_feed:
     env:

--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           name: drop
           path: |
-            ${{ env.relativePath }}/nuget/*.nupkg
-      - run: dotnet nuget push "${{ env.relativePath }}/nuget/*.nupkg" --skip-duplicate -s https://nuget.pkg.github.com/microsoft/index.json -k ${{ secrets.PUBLISH_GH_TOKEN }}
+            ${{ env.relativePath }}/nupkg/*.nupkg
+      - run: dotnet nuget push "${{ env.relativePath }}/nupkg/*.nupkg" --skip-duplicate -s https://nuget.pkg.github.com/microsoft/index.json -k ${{ secrets.PUBLISH_GH_TOKEN }}

--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths: ['src/**', '.github/workflows/**']
+jobs:
+  push_to_feed:
+    env:
+      relativePath: ./src/kiota
+    environment:
+      name: staging_feeds
+    name: Push tool to GitHub packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2.3.4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1.8.0
+        with:
+          dotnet-version: 5.0.x
+      - name: Restore dependencies
+        run: dotnet restore kiota.csproj
+        working-directory: ${{ env.relativePath }}
+      - name: Build
+        run: dotnet build kiota.csproj --no-restore -c Release
+        working-directory: ${{ env.relativePath }}
+      - name: Pack
+        run: dotnet pack kiota.csproj --no-restore --no-build --verbosity normal -c Release
+        working-directory: ${{ env.relativePath }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: drop
+          path: |
+            ${{ env.relativePath }}/nuget/*.nupkg
+      - run: dotnet nuget push "${{ env.relativePath }}/nuget/*.nupkg" --skip-duplicate -s https://nuget.pkg.github.com/microsoft/index.json -k ${{ secrets.PUBLISH_GH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adds kiota packaging as a dotnet tool #169
+- Adds input parameters validation #168
+- Expands code coverage to 88% #147
+
 ## [0.0.4] - 2021-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,42 @@ No additional tools are required for dotnet projects.
 
 ### Generating SDKs
 
-You can either clone the repository and build Kiota locally, download and run binaries or run the docker image.
+You can either clone the repository and [build Kiota locally](#building-kiota), [download and run binaries](#running-kiota-from-binaries), [install and run the dotnet tool](#running-kiota-from-the-dotnet-tool) or [run the docker image](#running-kiota-with-docker).
+
+#### Running Kiota from the dotnet tool
+
+1. Navigate to [New personal access token](https://github.com/settings/tokens/new) and generate a new token. (permissions: read:package).
+1. Copy the token, you will need it later.
+1. Enable the SSO on the token if you are a Microsoft employee.
+1. Create a `nuget.config` file in the current directory with the following content.
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+        <packageSources>
+            <add key="GitHub" value="https://nuget.pkg.github.com/microsoft/index.json" />
+        </packageSources>
+        <packageSourceCredentials>
+            <GitHub>
+                <add key="Username" value="" /><!-- your github username -->
+                <!-- your github PAT: read:pacakges with SSO enabled for the Microsoft org (for microsoft employees only) -->
+                <add key="ClearTextPassword" value="" />
+            </GitHub>
+        </packageSourceCredentials>
+    </configuration>
+    ```
+
+1. Execute the following command to install the tool.
+
+    ```Shell
+    dotnet tool install --global --configfile nuget.config kiota
+    ```
+
+1. Execute the following command to run kiota.
+
+    ```Shell
+    kiota -d /some/input/description.yml -o /some/output/path --language csharp -n samespaceprefix
+    ```
 
 #### Running Kiota with Docker
 
@@ -72,7 +107,7 @@ Navigate to the output directory (usually under `src/kiota/bin/Release/net5.0`) 
 If you haven't built kiota locally, select the appropriate version from the [releases page](https://github.com/microsoft/kiota/releases).
 
 ```Shell
-kiota.exe --openapi ../msgraph-sdk-powershell/openApiDocs/v1.0/mail.yml --language csharp -o ../somepath -n namespaceprefix
+kiota.exe -d ../msgraph-sdk-powershell/openApiDocs/v1.0/mail.yml --language csharp -o ../somepath -n namespaceprefix
 ```
 
 > Note: once your SDK is generated in your target project, you will need to add references to kiota abstractions and kiota core in your project. Refer to [Initializing target projects](#initializing-target-projects)

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -7,6 +7,8 @@
     <ToolCommandName>kiota</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Version>0.0.4</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>kiota</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <Version>0.0.4</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- adds packing information for dotnet tool
- adds workflow to publish the dotnet tool
- adds install instructions for the dotnet tool
- temporary disables branch filters for dotnet tool to try the workflow
- fixes workflow name
- fixes nupkg path for publishing
- adds missing package information for github packages
- Revert "- temporary disables branch filters for dotnet tool to try the workflow"

fixes #123

no generation changes
