### PR TITLE
removes json assumption for request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds kiota packaging as a dotnet tool #169
 - Adds input parameters validation #168
 - Expands code coverage to 88% #147
+- Removes json assumption for request body to support multiple formats #170
 
 ## [0.0.4] - 2021-04-28
 

--- a/abstractions/dotnet/src/KiotaAbstractions.csproj
+++ b/abstractions/dotnet/src/KiotaAbstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
   </PropertyGroup>
 
 </Project>

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -12,20 +12,20 @@ namespace Kiota.Abstractions
         public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public Stream Content { get; set; }
-        private const string jsonContentType = "application/json";
         private const string binaryContentType = "application/octet-stream";
         private const string contentTypeHeader = "Content-Type";
         public void SetStreamContent(Stream content) {
             Content = content;
             Headers.Add(contentTypeHeader, binaryContentType);
         }
-        public void SetJsonContentFromParsable<T>(T item, ISerializationWriterFactory writerFactory) where T : class, IParsable<T>, new() {
-            if(writerFactory != null) {
-                using var writer = writerFactory.GetSerializationWriter(jsonContentType);
-                writer.WriteObjectValue(null, item);
-                Headers.Add(contentTypeHeader, jsonContentType);
-                Content = writer.GetSerializedContent();
-            }
+        public void SetContentFromParsable<T>(T item, ISerializationWriterFactory writerFactory, string contentType) where T : class, IParsable<T>, new() {
+            if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
+            if(writerFactory == null) throw new ArgumentNullException(writerFactory);
+
+            using var writer = writerFactory.GetSerializationWriter(contentType);
+            writer.WriteObjectValue(null, item);
+            Headers.Add(contentTypeHeader, contentType);
+            Content = writer.GetSerializedContent();
         }
     }
 }

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -20,7 +20,7 @@ namespace Kiota.Abstractions
         }
         public void SetContentFromParsable<T>(T item, ISerializationWriterFactory writerFactory, string contentType) where T : class, IParsable<T>, new() {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
-            if(writerFactory == null) throw new ArgumentNullException(writerFactory);
+            if(writerFactory == null) throw new ArgumentNullException(nameof(writerFactory));
 
             using var writer = writerFactory.GetSerializationWriter(contentType);
             writer.WriteObjectValue(null, item);

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -44,7 +44,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.8'
+            version '1.0.9'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
@@ -25,7 +25,6 @@ public class RequestInfo {
     public HashMap<String, String> headers = new HashMap<>(); // TODO case insensitive
     @Nullable
     public InputStream content;
-    private static String jsonContentType = "application/json";
     private static String binaryContentType = "application/octet-stream";
     private static String contentTypeHeader = "Content-Type";
     public void setStreamContent(@Nonnull final InputStream value) {
@@ -33,11 +32,12 @@ public class RequestInfo {
         this.content = value;
         headers.put(contentTypeHeader, binaryContentType);
     }
-    public <T extends Parsable> void setJsonContentFromParsable(@Nonnull final T value, @Nonnull final SerializationWriterFactory serializerFactory) {
+    public <T extends Parsable> void setContentFromParsable(@Nonnull final T value, @Nonnull final SerializationWriterFactory serializerFactory, @Nonnull final String contentType) {
         Objects.requireNonNull(serializerFactory);
         Objects.requireNonNull(value);
-        try(final SerializationWriter writer = serializerFactory.getSerializationWriter(jsonContentType)) {
-            headers.put(contentTypeHeader, jsonContentType);
+        Objects.requireNonNull(contentType);
+        try(final SerializationWriter writer = serializerFactory.getSerializationWriter(contentType)) {
+            headers.put(contentTypeHeader, contentType);
             writer.writeObjectValue(null, value);
             this.content = writer.getSerializedContent();
         } catch (IOException ex) {

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/src/requestInfo.ts
+++ b/abstractions/typescript/src/requestInfo.ts
@@ -8,16 +8,16 @@ export class RequestInfo {
     public content?: ReadableStream;
     public queryParameters: Map<string, object> = new Map<string, object>();
     public headers: Map<string, string> = new Map<string, string>();
-    private static jsonContentType = "application/json";
     private static binaryContentType = "application/octet-stream";
     private static contentTypeHeader = "Content-Type";
-    public setJsonContentFromParsable = <T extends Parsable<T>>(value?: T | undefined, serializerFactory?: SerializationWriterFactory | undefined): void => {
-        if(serializerFactory) {
-            const writer = serializerFactory.getSerializationWriter(RequestInfo.jsonContentType);
-            this.headers.set(RequestInfo.contentTypeHeader, RequestInfo.jsonContentType);
-            writer.writeObjectValue(undefined, value);
-            this.content = writer.getSerializedContent();
-        }
+    public setContentFromParsable = <T extends Parsable<T>>(value?: T | undefined, serializerFactory?: SerializationWriterFactory | undefined, contentType?: string | undefined): void => {
+        if(!serializerFactory) throw new Error("serializerFactory cannot be undefined");
+        if(!contentType) throw new Error("contentType cannot be undefined");
+
+        const writer = serializerFactory.getSerializationWriter(contentType);
+        this.headers.set(RequestInfo.contentTypeHeader, contentType);
+        writer.writeObjectValue(undefined, value);
+        this.content = writer.getSerializedContent();
     }
     public setStreamContent = (value: ReadableStream): void => {
         this.headers.set(RequestInfo.contentTypeHeader, RequestInfo.binaryContentType);

--- a/core/dotnet/nuget.config
+++ b/core/dotnet/nuget.config
@@ -5,9 +5,9 @@
     </packageSources>
     <packageSourceCredentials>
         <GitHub>
-            <add key="Username" value="" /><!-- your github username -->
+            <add key="Username" value="baywet" /><!-- your github username -->
             <!-- your github PAT: read:pacakges with SSO enabled for the Microsoft org (for microsoft employees only) -->
-            <add key="ClearTextPassword" value="" />
+            <add key="ClearTextPassword" value="f020890da98247331b0bbbfb29ed2fc299e0ba28" />
         </GitHub>
     </packageSourceCredentials>
 </configuration>

--- a/core/dotnet/nuget.config
+++ b/core/dotnet/nuget.config
@@ -5,9 +5,9 @@
     </packageSources>
     <packageSourceCredentials>
         <GitHub>
-            <add key="Username" value="baywet" /><!-- your github username -->
+            <add key="Username" value="" /><!-- your github username -->
             <!-- your github PAT: read:pacakges with SSO enabled for the Microsoft org (for microsoft employees only) -->
-            <add key="ClearTextPassword" value="f020890da98247331b0bbbfb29ed2fc299e0ba28" />
+            <add key="ClearTextPassword" value="" />
         </GitHub>
     </packageSourceCredentials>
 </configuration>

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -28,12 +28,10 @@ namespace Kiota.Builder
 
     public class CodeMethod : CodeTerminal, ICloneable, IDocumentedElement
     {
-        public CodeMethod(CodeElement parent): base(parent)
-        {
-            
-        }
+        public CodeMethod(CodeElement parent): base(parent) {}
         public HttpMethod? HttpMethod {get;set;}
         public CodeMethodKind MethodKind {get;set;} = CodeMethodKind.Custom;
+        public string ContentType { get; set; }
         public AccessModifier Access {get;set;} = AccessModifier.Public;
         public CodeTypeBase ReturnType {get;set;}
         public List<CodeParameter> Parameters {get;set;} = new List<CodeParameter>();
@@ -55,6 +53,7 @@ namespace Kiota.Builder
                 IsStatic = IsStatic,
                 Description = Description?.Clone() as string,
                 GenerationProperties = new (GenerationProperties),
+                ContentType = ContentType?.Clone() as string,
             };
         }
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -379,7 +379,7 @@ namespace Kiota.Builder
 
         private CodeProperty CreateProperty(string childIdentifier, string childType, CodeClass codeClass, string defaultValue = null, OpenApiSchema typeSchema = null, CodeElement typeDefinition = null, CodePropertyKind kind = CodePropertyKind.Custom)
         {
-            var isCollection = typeSchema?.Type?.Equals("array", StringComparison.CurrentCultureIgnoreCase) ?? false;
+            var isCollection = typeSchema?.Type?.Equals("array", StringComparison.OrdinalIgnoreCase) ?? false;
             var propertyName = childIdentifier;
             this.config.PropertiesPrefixToStrip.ForEach(x => propertyName = propertyName.Replace(x, string.Empty));
             var prop = new CodeProperty(codeClass)
@@ -391,12 +391,14 @@ namespace Kiota.Builder
             };
             if(propertyName != childIdentifier)
                 prop.SerializationName = childIdentifier;
-            var typeName = childType;
+            var typeName = typeSchema?.Items?.Type ?? childType; // first value that's not null, and not "object" for primitive collections, the items type matters
+            if(typeName == "object") typeName = childType;
+            var format = typeSchema?.Items?.Format ?? typeSchema?.Format;
             var isExternal = false;
-            if("string".Equals(typeName, StringComparison.OrdinalIgnoreCase) && "date-time".Equals(typeSchema?.Format, StringComparison.OrdinalIgnoreCase)) {
+            if("string".Equals(typeName, StringComparison.OrdinalIgnoreCase) && "date-time".Equals(format, StringComparison.OrdinalIgnoreCase)) {
                 isExternal = true;
                 typeName = "DateTimeOffset";
-            } else if ("double".Equals(typeSchema?.Format, StringComparison.OrdinalIgnoreCase)) {
+            } else if ("double".Equals(format, StringComparison.OrdinalIgnoreCase)) {
                 isExternal = true;
                 typeName = "double";
             }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -409,8 +409,6 @@ namespace Kiota.Builder
             logger.LogTrace("Creating property {name} of {type}", prop.Name, prop.Type.Name);
             return prop;
         }
-
-        private const string requestBodyJsonContentType = "application/json"; //TODO: this is temporary, we should handle other content types like yaml, grpc, xml...
         private const string requestBodyBinaryContentType = "application/octet-stream";
         private void CreateOperationMethods(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OperationType operationType, OpenApiOperation operation, CodeClass parentClass)
         {
@@ -464,9 +462,10 @@ namespace Kiota.Builder
             logger.LogTrace("Creating method {name} of {type}", generatorMethod.Name, generatorMethod.ReturnType);
         }
         private void AddRequestBuilderMethodParameters(OpenApiUrlSpaceNode rootNode, OpenApiUrlSpaceNode currentNode, OpenApiOperation operation, CodeClass parameterClass, CodeMethod method) {
-            if (operation.RequestBody?.Content?.ContainsKey(requestBodyJsonContentType) ?? false)
+            var nonBinaryRequestBody = operation.RequestBody?.Content?.FirstOrDefault(x => !requestBodyBinaryContentType.Equals(x.Key, StringComparison.OrdinalIgnoreCase));
+            if (nonBinaryRequestBody.HasValue && nonBinaryRequestBody.Value.Value != null)
             {
-                var requestBodySchema = operation.RequestBody.Content[requestBodyJsonContentType].Schema;
+                var requestBodySchema = nonBinaryRequestBody.Value.Value.Schema;
                 var requestBodyType = CreateModelClasses(rootNode, currentNode, requestBodySchema, operation, method);
                 method.AddParameter(new CodeParameter(method) {
                     Name = "body",
@@ -475,6 +474,7 @@ namespace Kiota.Builder
                     ParameterKind = CodeParameterKind.RequestBody,
                     Description = requestBodySchema.Description
                 });
+                method.ContentType = nonBinaryRequestBody.Value.Key;
             } else if (operation.RequestBody?.Content?.ContainsKey(requestBodyBinaryContentType) ?? false) {
                 var nParam = new CodeParameter(method) {
                     Name = "body",

--- a/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
@@ -8,6 +8,9 @@ namespace Kiota.Builder.Writers.CSharp {
         public CodeEnumWriter(CSharpConventionService conventionService):base(conventionService) {}
         public override void WriteCodeElement(CodeEnum codeElement, LanguageWriter writer)
         {
+            if(!codeElement.Options.Any())
+                return;
+
             var codeNamespace = codeElement?.Parent as CodeNamespace;
             if(codeNamespace != null) {
                 writer.WriteLine($"namespace {codeNamespace.Name} {{");

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -74,7 +74,7 @@ namespace Kiota.Builder.Writers.CSharp {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.SetStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.SetJsonContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName});"); //TODO we're making a big assumption here that everything will be json
+                    writer.WriteLine($"requestInfo.SetContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that everything will be json
             }
             if(queryStringParam != null) {
                 writer.WriteLine($"if ({queryStringParam.Name} != null) {{");

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -74,7 +74,7 @@ namespace Kiota.Builder.Writers.CSharp {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.SetStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.SetContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that everything will be json
+                    writer.WriteLine($"requestInfo.SetContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");");
             }
             if(queryStringParam != null) {
                 writer.WriteLine($"if ({queryStringParam.Name} != null) {{");

--- a/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Kiota.Builder.Extensions;
 
@@ -11,6 +12,7 @@ namespace Kiota.Builder.Writers.Java {
                 writer.WriteLine($"package {ns.Name};");
                 writer.WriteLine();
                 codeElement.Usings
+                    .Where(x => x.Declaration.IsExternal || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
                     .Select(x => x.Declaration.IsExternal ?
                                      $"import {x.Declaration.Name}.{x.Name.ToFirstCharacterUpperCase()};" :
                                      $"import {x.Name}.{x.Declaration.Name.ToFirstCharacterUpperCase()};")

--- a/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
@@ -32,7 +32,7 @@ namespace Kiota.Builder.Writers.Java {
                         "@javax.annotation.Nullable",
                         $"public static {enumName} forValue(@javax.annotation.Nonnull final String searchValue) {{");
             writer.IncreaseIndent();
-            writer.WriteLines("Objects.requireNonNull(searchValue)",
+            writer.WriteLines("Objects.requireNonNull(searchValue);",
                             "switch(searchValue) {");
             writer.IncreaseIndent();
             writer.Write(codeElement.Options

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -121,7 +121,7 @@ namespace Kiota.Builder.Writers.Java {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that the request is json
+                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");");
             if(queryStringParam != null) {
                 var httpMethodPrefix = codeElement.HttpMethod.ToString().ToFirstCharacterUpperCase();
                 writer.WriteLine($"if ({queryStringParam.Name} != null) {{");

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -121,7 +121,7 @@ namespace Kiota.Builder.Writers.Java {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.setJsonContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName});"); //TODO we're making a big assumption here that the request is json
+                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, {conventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that the request is json
             if(queryStringParam != null) {
                 var httpMethodPrefix = codeElement.HttpMethod.ToString().ToFirstCharacterUpperCase();
                 writer.WriteLine($"if ({queryStringParam.Name} != null) {{");

--- a/src/Kiota.Builder/Writers/TypeScript/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeEnumWriter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Kiota.Builder.Extensions;
 
 namespace  Kiota.Builder.Writers.TypeScript {
@@ -6,6 +7,9 @@ namespace  Kiota.Builder.Writers.TypeScript {
         public CodeEnumWriter(TypeScriptConventionService conventionService) : base(conventionService){}
         public override void WriteCodeElement(CodeEnum codeElement, LanguageWriter writer)
         {
+            if(!codeElement.Options.Any())
+                return;
+
             conventions.WriteShortDescription(codeElement.Description, writer);
             writer.WriteLine($"export enum {codeElement.Name.ToFirstCharacterUpperCase()} {{");
             writer.IncreaseIndent();

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -105,7 +105,7 @@ namespace  Kiota.Builder.Writers.TypeScript {
                 if(requestBodyParam.Type.Name.Equals(localConventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.setJsonContentFromParsable({requestBodyParam.Name}, this.{localConventions.SerializerFactoryPropertyName});"); //TODO we're making a big assumption here that everything will be json
+                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, this.{localConventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that everything will be json
             }
             writer.WriteLine("return requestInfo;");
         }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -105,7 +105,7 @@ namespace  Kiota.Builder.Writers.TypeScript {
                 if(requestBodyParam.Type.Name.Equals(localConventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"requestInfo.setStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, this.{localConventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");"); //TODO we're making a big assumption here that everything will be json
+                    writer.WriteLine($"requestInfo.setContentFromParsable({requestBodyParam.Name}, this.{localConventions.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\");");
             }
             writer.WriteLine("return requestInfo;");
         }

--- a/tests/Kiota.Builder.IntegrationTests/ToDoApi.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/ToDoApi.yaml
@@ -29,6 +29,13 @@ paths:
                       $ref: "#/components/schemas/todo"
 
     post:
+      requestBody:
+        description: New Todo
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/todo'
+        required: true
       responses:
         '201':
           description: OK

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -45,5 +45,11 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             Assert.Contains("= 1", result);
             Assert.Contains("= 2", result);
         }
+        [Fact]
+        public void DoesntWriteAnythingOnNoOption() {
+            writer.Write(currentEnum);
+            var result = tw.ToString();
+            Assert.Empty(result);
+        }
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -141,7 +141,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             Assert.Contains("HttpMethod = HttpMethod.GET", result);
             Assert.Contains("h?.Invoke", result);
             Assert.Contains("AddQueryParameters", result);
-            Assert.Contains("SetJsonContentFromParsable", result);
+            Assert.Contains("SetContentFromParsable", result);
             Assert.Contains("return requestInfo;", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeClassDeclarationWriterTests.cs
@@ -73,5 +73,18 @@ namespace Kiota.Builder.Writers.Java.Tests {
             Assert.Contains("import project.graph.Message", result);
             Assert.Contains("import java.util.Objects", result);
         }
+        [Fact]
+        public void RemovesImportWithClassName() {
+            var declaration = parentClass.StartBlock as CodeClass.Declaration;
+            declaration.Usings.Add(new (parentClass) {
+                Name = "project.graph",
+                Declaration = new(parentClass) {
+                    Name = "parentClass",
+                }
+            });
+            codeElementWriter.WriteCodeElement(declaration, writer);
+            var result = tw.ToString();
+            Assert.DoesNotContain("project.graph.parentClass", result);
+        }
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
@@ -43,5 +43,11 @@ namespace Kiota.Builder.Writers.Java.Tests {
             AssertExtensions.CurlyBracesAreClosed(result);
             Assert.Contains(optionName, result);
         }
+        [Fact]
+        public void DoesntWriteAnythingOnNoOption() {
+            writer.Write(currentEnum);
+            var result = tw.ToString();
+            Assert.Empty(result);
+        }
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -152,7 +152,7 @@ namespace Kiota.Builder.Writers.Java.Tests {
             Assert.Contains("httpMethod = HttpMethod.GET", result);
             Assert.Contains("h.accept(requestInfo.headers)", result);
             Assert.Contains("AddQueryParameters", result);
-            Assert.Contains("setJsonContentFromParsable", result);
+            Assert.Contains("setContentFromParsable", result);
             Assert.Contains("return requestInfo;", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeEnumWriterTests.cs
@@ -34,5 +34,11 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             Assert.Contains(optionName, result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }
+        [Fact]
+        public void DoesntWriteAnythingOnNoOption() {
+            writer.Write(currentEnum);
+            var result = tw.ToString();
+            Assert.Empty(result);
+        }
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
@@ -140,7 +140,7 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             Assert.Contains("requestInfo.httpMethod = HttpMethod", result);
             Assert.Contains("setHeadersFromRawObject", result);
             Assert.Contains("setQueryStringParametersFromRawObject", result);
-            Assert.Contains("setJsonContentFromParsable", result);
+            Assert.Contains("setContentFromParsable", result);
             Assert.Contains("return requestInfo;", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }


### PR DESCRIPTION
- updates generation to remove the json assumption from request body
- updates abstration library to remove the json assumption
- updates changelog
- updates samples reference
- fixes a bu g where dotnet abstractions would not build because of missing keyword
- fixes a bug where collections of primitive values would not have the proper type
- updates samples reference
- fixes a bug where a comma would be missing in java gen
- fixes a bug in java gen where importing the same symbol as the current class would make result fail
- updates sample reference

fixes #136

## Generation diff
https://github.com/microsoft/kiota-samples/pull/19
