### PR TITLE
alings parsable interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for collections as root responses #191
 - Splits the core libraries in 3 separate libraries #197
 - Changes default namespace and class name to api client #199
+- Aligns Parsable interfaces across languages #204
 
 ## [0.0.4] - 2021-04-28
 

--- a/abstractions/dotnet/src/IHttpCore.cs
+++ b/abstractions/dotnet/src/IHttpCore.cs
@@ -3,7 +3,7 @@ using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Abstractions {
     public interface IHttpCore {
-        Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : class, IParsable<ModelType>, new();
+        Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
         Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default);
         Task SendNoContentAsync(RequestInfo requestInfo, IResponseHandler responseHandler = default);
     }

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
   </PropertyGroup>
 
 </Project>

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Kiota.Abstractions
             Content = content;
             Headers.Add(contentTypeHeader, binaryContentType);
         }
-        public void SetContentFromParsable<T>(T item, ISerializationWriterFactory writerFactory, string contentType) where T : class, IParsable<T>, new() {
+        public void SetContentFromParsable<T>(T item, ISerializationWriterFactory writerFactory, string contentType) where T : IParsable {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
             if(writerFactory == null) throw new ArgumentNullException(nameof(writerFactory));
 

--- a/abstractions/dotnet/src/serialization/IParsable.cs
+++ b/abstractions/dotnet/src/serialization/IParsable.cs
@@ -2,12 +2,8 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
-    public interface IParsable<T> where T : class {
-        IDictionary<string, Action<T, IParseNode>> DeserializeFields
-        {
-            get;
-        }
-
+    public interface IParsable {
+        IDictionary<string, Action<T, IParseNode>> GetFieldDeserializers<T>();
         void Serialize(ISerializationWriter writer);
 
         IDictionary<string, object> AdditionalData { get; }

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         Guid? GetGuidValue();
         DateTimeOffset? GetDateTimeOffsetValue();
         IEnumerable<T> GetCollectionOfPrimitiveValues<T>();
-        IEnumerable<T> GetCollectionOfObjectValues<T>() where T: class, IParsable<T>, new();
+        IEnumerable<T> GetCollectionOfObjectValues<T>() where T: IParsable;
         T? GetEnumValue<T>() where T: struct, Enum;
-        T GetObjectValue<T>() where T: class, IParsable<T>, new();
+        T GetObjectValue<T>() where T: IParsable;
     }
 }

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         void WriteGuidValue(string key, Guid? value);
         void WriteDateTimeOffsetValue(string key, DateTimeOffset? value);
         void WriteCollectionOfPrimitiveValues<T>(string key, IEnumerable<T> values);
-        void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : class, IParsable<T>, new();
-        void WriteObjectValue<T>(string key, T value) where T : class, IParsable<T>, new();
+        void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable;
+        void WriteObjectValue<T>(string key, T value) where T : IParsable;
         void WriteEnumValue<T>(string key, T? value) where T : struct, Enum;
         void WriteAdditionalData(IDictionary<string, object> value);
         Stream GetSerializedContent();

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -44,7 +44,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.10'
+            version '1.0.11'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
@@ -6,9 +6,8 @@ import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 
 public interface Parsable {
-    // the generic type is on the method to avoid multiple generic interface implementation which is impossible in Java
     @Nonnull
-    <T> Map<String, BiConsumer<T, ParseNode>> getDeserializeFields();
+    <T> Map<String, BiConsumer<T, ParseNode>> getFieldDeserializers();
     void serialize(@Nonnull final SerializationWriter writer);
     @Nonnull
     Map<String, Object> getAdditionalData();

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/src/httpCore.ts
+++ b/abstractions/typescript/src/httpCore.ts
@@ -2,7 +2,7 @@ import { RequestInfo } from "./requestInfo";
 import { ResponseHandler } from "./responseHandler";
 import { Parsable } from "./serialization";
 export interface HttpCore {
-    sendAsync<ModelType extends Parsable<ModelType>>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType>;
+    sendAsync<ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType>;
     sendPrimitiveAsync<ResponseType>(requestInfo: RequestInfo, responseType: "string" | "number" | "boolean" | "Date" | "ReadableStream", responseHandler: ResponseHandler | undefined): Promise<ResponseType>;
     sendNoResponseContentAsync(requestInfo: RequestInfo, responseHandler: ResponseHandler | undefined): Promise<void>;
 }

--- a/abstractions/typescript/src/requestInfo.ts
+++ b/abstractions/typescript/src/requestInfo.ts
@@ -10,7 +10,7 @@ export class RequestInfo {
     public headers: Map<string, string> = new Map<string, string>();
     private static binaryContentType = "application/octet-stream";
     private static contentTypeHeader = "Content-Type";
-    public setContentFromParsable = <T extends Parsable<T>>(value?: T | undefined, serializerFactory?: SerializationWriterFactory | undefined, contentType?: string | undefined): void => {
+    public setContentFromParsable = <T extends Parsable>(value?: T | undefined, serializerFactory?: SerializationWriterFactory | undefined, contentType?: string | undefined): void => {
         if(!serializerFactory) throw new Error("serializerFactory cannot be undefined");
         if(!contentType) throw new Error("contentType cannot be undefined");
 

--- a/abstractions/typescript/src/serialization/parsable.ts
+++ b/abstractions/typescript/src/serialization/parsable.ts
@@ -1,8 +1,8 @@
 import { ParseNode } from './parseNode';
 import { SerializationWriter } from './serializationWriter';
 
-export interface Parsable<T> {
-    deserializeFields(): Map<string, (item: T, node: ParseNode) => void>;
+export interface Parsable {
+    getFieldDeserializers<T>(): Map<string, (item: T, node: ParseNode) => void>;
     serialize(writer: SerializationWriter): void;
     additionalData: Map<string, unknown>;
 }

--- a/abstractions/typescript/src/serialization/parseNode.ts
+++ b/abstractions/typescript/src/serialization/parseNode.ts
@@ -8,8 +8,8 @@ export interface ParseNode {
     getGuidValue(): string; //TODO https://www.npmjs.com/package/guid-typescript
     getDateValue(): Date;
     getCollectionOfPrimitiveValues<T>(): T[] | undefined;
-    getCollectionOfObjectValues<T extends Parsable<T>>(type: new() => T): T[] | undefined;
-    getObjectValue<T extends Parsable<T>>(type: new() => T): T;
+    getCollectionOfObjectValues<T extends Parsable>(type: new() => T): T[] | undefined;
+    getObjectValue<T extends Parsable>(type: new() => T): T;
     getEnumValues<T>(type: any): T[];
     getEnumValue<T>(type: any): T | undefined;
 }

--- a/abstractions/typescript/src/serialization/serializationWriter.ts
+++ b/abstractions/typescript/src/serialization/serializationWriter.ts
@@ -8,8 +8,8 @@ export interface SerializationWriter {
     writeGuidValue(key?: string | undefined, value?: string | undefined): void;
     writeDateValue(key?: string | undefined, value?: Date | undefined): void;
     writeCollectionOfPrimitiveValues<T>(key?: string | undefined, values?: T[] | undefined): void;
-    writeCollectionOfObjectValues<T extends Parsable<T>>(key?: string | undefined, values?: T[]): void;
-    writeObjectValue<T extends Parsable<T>>(key?: string | undefined, value?: T | undefined): void;
+    writeCollectionOfObjectValues<T extends Parsable>(key?: string | undefined, values?: T[]): void;
+    writeObjectValue<T extends Parsable>(key?: string | undefined, value?: T | undefined): void;
     writeEnumValue<T>(key?: string | undefined, ...values: (T | undefined)[]): void;
     getSerializedContent(): ReadableStream;
     writeAdditionalData(value: Map<string, unknown>): void;

--- a/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -4,12 +4,12 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.11" />
   </ItemGroup>
 
 </Project>

--- a/authentication/java/azure/lib/build.gradle
+++ b/authentication/java/azure/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     api 'com.azure:azure-core:1.16.0'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.10'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.11'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-authentication-azure'
-            version '1.0.0'
+            version '1.0.1'
             from(components.java)
         }
     }

--- a/authentication/typescript/azure/package-lock.json
+++ b/authentication/typescript/azure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-authentication-azure",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/authentication/typescript/azure/package.json
+++ b/authentication/typescript/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-authentication-azure",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Authentication provider for Kiota using Azure Identity",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@microsoft/kiota-abstractions": "^1.0.10"
+    "@microsoft/kiota-abstractions": "^1.0.11"
   },
   "devDependencies": {
     "@types/node": "^15.12.0",

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Kiota.Http.HttpClient
             client = httpClient ?? new System.Net.Http.HttpClient();
             pNodeFactory = parseNodeFactory ?? new ParseNodeFactoryRegistry() {};
         }
-        public async Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = null) where ModelType : class, IParsable<ModelType>, new()
+        public async Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = null) where ModelType : IParsable
         {
             if(requestInfo == null)
                 throw new ArgumentNullException(nameof(requestInfo));

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
@@ -4,11 +4,11 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.11" />
   </ItemGroup>
 
 </Project>

--- a/http/java/okhttp/lib/build.gradle
+++ b/http/java/okhttp/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     api 'com.squareup.okhttp3:okhttp:4.9.1'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.10'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.11'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-http-okhttp'
-            version '1.0.0'
+            version '1.0.1'
             from(components.java)
         }
     }

--- a/http/typescript/fetch/package-lock.json
+++ b/http/typescript/fetch/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-http-fetch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/http/typescript/fetch/package.json
+++ b/http/typescript/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-http-fetch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Kiota HttpCore implementation with fetch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@microsoft/kiota-abstractions": "^1.0.10",
+    "@microsoft/kiota-abstractions": "^1.0.11",
     "cross-fetch": "^3.1.4",
     "web-streams-polyfill": "^3.0.3"
   },

--- a/http/typescript/fetch/src/httpCore.ts
+++ b/http/typescript/fetch/src/httpCore.ts
@@ -19,7 +19,7 @@ export class HttpCore implements IHttpCore {
         if(segments.length === 0) return undefined;
         else return segments[0];
     }
-    public sendAsync = async <ModelType extends Parsable<ModelType>>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType> => {
+    public sendAsync = async <ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType> => {
         if(!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Kiota.Serialization.Json {
                 writer.WriteEndArray();
             }
         }
-        public void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : class, IParsable<T>, new() {
+        public void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable {
             if(values != null) { //empty array is meaningful
                 if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
                 writer.WriteStartArray();
@@ -83,7 +83,7 @@ namespace Microsoft.Kiota.Serialization.Json {
                 writer.WriteEndArray();
             }
         }
-        public void WriteObjectValue<T>(string key, T value) where T : class, IParsable<T>, new() {
+        public void WriteObjectValue<T>(string key, T value) where T : IParsable {
             if(value != null) {
                 if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
                 writer.WriteStartObject();

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -4,11 +4,11 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.11" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 </Project>

--- a/serialization/java/json/lib/build.gradle
+++ b/serialization/java/json/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     api 'com.google.code.gson:gson:2.8.6'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.10'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.11'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-serialization-json'
-            version '1.0.0'
+            version '1.0.1'
             from(components.java)
         }
     }

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -132,8 +132,7 @@ public class JsonParseNode implements ParseNode {
         try {
             final Constructor<T> constructor = targetClass.getConstructor();
             final T item = constructor.newInstance();
-            assignFieldValues(item, item.getDeserializeFields());
-            //TODO additional properties when the strucutre is available
+            assignFieldValues(item, item.getFieldDeserializers());
             return item;
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
             throw new RuntimeException("Error during deserialization", ex);

--- a/serialization/typescript/json/package-lock.json
+++ b/serialization/typescript/json/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-serialization-json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/serialization/typescript/json/package.json
+++ b/serialization/typescript/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-serialization-json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Implementation of Kiota Serialization interfaces for JSON",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,7 +34,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@microsoft/kiota-abstractions": "^1.0.10",
+    "@microsoft/kiota-abstractions": "^1.0.11",
     "web-streams-polyfill": "^3.0.3"
   }
 }

--- a/serialization/typescript/json/src/jsonParseNode.ts
+++ b/serialization/typescript/json/src/jsonParseNode.ts
@@ -29,12 +29,12 @@ export class JsonParseNode implements ParseNode {
                 } else throw new Error(`encountered an unknown type during deserialization ${typeof x}`);
             });
     }
-    public getCollectionOfObjectValues = <T extends Parsable<T>>(type: new() => T): T[] | undefined => {
+    public getCollectionOfObjectValues = <T extends Parsable>(type: new() => T): T[] | undefined => {
         return (this._jsonNode as unknown[])
             .map(x => new JsonParseNode(x))
             .map(x => x.getObjectValue<T>(type));
     }
-    public getObjectValue = <T extends Parsable<T>>(type: new() => T): T => {
+    public getObjectValue = <T extends Parsable>(type: new() => T): T => {
         const result = new type();
         this.assignFieldValues(result);
         return result;
@@ -54,8 +54,8 @@ export class JsonParseNode implements ParseNode {
             return undefined;
         }
     }
-    private assignFieldValues = <T extends Parsable<T>>(item: T) : void => {
-        const fields = item.deserializeFields();
+    private assignFieldValues = <T extends Parsable>(item: T) : void => {
+        const fields = item.getFieldDeserializers();
         Object.entries(this._jsonNode as any).forEach(([k, v]) => {
             const deserializer = fields.get(k);
             if(deserializer)

--- a/serialization/typescript/json/src/jsonSerializationWriter.ts
+++ b/serialization/typescript/json/src/jsonSerializationWriter.ts
@@ -45,7 +45,7 @@ export class JsonSerializationWriter implements SerializationWriter {
             key && this.writer.push(JsonSerializationWriter.propertySeparator);
         }
     }
-    public writeCollectionOfObjectValues = <T extends Parsable<T>>(key?: string, values?: T[]): void => {
+    public writeCollectionOfObjectValues = <T extends Parsable>(key?: string, values?: T[]): void => {
         if(values) {
             key && this.writePropertyName(key);
             this.writer.push(`[`);
@@ -60,7 +60,7 @@ export class JsonSerializationWriter implements SerializationWriter {
             key && this.writer.push(JsonSerializationWriter.propertySeparator);
         }
     }
-    public writeObjectValue = <T extends Parsable<T>>(key?: string, value?: T): void => {
+    public writeObjectValue = <T extends Parsable>(key?: string, value?: T): void => {
         if(value) {
             if(key) {
                 this.writePropertyName(key);

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -11,7 +11,7 @@ namespace Kiota.Builder
         RequestExecutor,
         RequestGenerator,
         Serializer,
-        DeserializerBackwardCompatibility,
+        Deserializer,
         AdditionalDataAccessor
     }
     public enum HttpMethod {

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -6,7 +6,6 @@ namespace Kiota.Builder
     {
         Custom,
         RequestBuilder,
-        Deserializer,
         AdditionalData
     }
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -707,7 +707,7 @@ namespace Kiota.Builder
             else if(schema?.AllOf?.Any(x => x.IsObject()) ?? false)
                 CreatePropertiesForModelClass(currentNode, schema.AllOf.Last(x => x.IsObject()), ns, model, parent);
         }
-        private const string fieldDeserializersMethodName = "GetFieldDeserializers";
+        private const string fieldDeserializersMethodName = "GetFieldDeserializers<T>";
         private const string serializeMethodName = "Serialize";
         private const string additionalDataPropName = "AdditionalData";
         private static void AddSerializationMembers(CodeClass model, bool includeAdditionalProperties) {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -707,25 +707,25 @@ namespace Kiota.Builder
             else if(schema?.AllOf?.Any(x => x.IsObject()) ?? false)
                 CreatePropertiesForModelClass(currentNode, schema.AllOf.Last(x => x.IsObject()), ns, model, parent);
         }
-        private const string deserializeFieldsPropName = "DeserializeFields";
+        private const string fieldDeserializersMethodName = "GetFieldDeserializers";
         private const string serializeMethodName = "Serialize";
         private const string additionalDataPropName = "AdditionalData";
         private static void AddSerializationMembers(CodeClass model, bool includeAdditionalProperties) {
-            var serializationPropsType = $"IDictionary<string, Action<{model.Name.ToFirstCharacterUpperCase()}, IParseNode>>";
-            if(!model.ContainsMember(deserializeFieldsPropName)) {
-                var deserializeProp = new CodeProperty(model) {
-                    Name = deserializeFieldsPropName,
-                    PropertyKind = CodePropertyKind.Deserializer,
+            var serializationPropsType = $"IDictionary<string, Action<T, IParseNode>>";
+            if(!model.ContainsMember(fieldDeserializersMethodName)) {
+                var deserializeProp = new CodeMethod(model) {
+                    Name = fieldDeserializersMethodName,
+                    MethodKind = CodeMethodKind.Deserializer,
                     Access = AccessModifier.Public,
-                    ReadOnly = true,
-                    Description = "The serialization information for the current model"
+                    Description = "The deserialization information for the current model",
+                    IsAsync = false,
                 };
-                deserializeProp.Type = new CodeType(deserializeProp) {
+                deserializeProp.ReturnType = new CodeType(deserializeProp) {
                     Name = serializationPropsType,
                     IsNullable = false,
                     IsExternal = true,
                 };
-                model.AddProperty(deserializeProp);
+                model.AddMethod(deserializeProp);
             }
             if(!model.ContainsMember(serializeMethodName)) {
                 var serializeMethod = new CodeMethod(model) {

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -33,7 +33,7 @@ namespace Kiota.Builder.Refiners {
                 var declaration = currentClass.StartBlock as CodeClass.Declaration;
                 declaration.Implements.Add(new CodeType(currentClass) {
                     IsExternal = true,
-                    Name = $"IParsable<{currentClass.Name.ToFirstCharacterUpperCase()}>",
+                    Name = $"IParsable",
                 });
                 declaration.Usings.Add(new CodeUsing(currentClass) {
                     Name = "Microsoft.Kiota.Abstractions.Serialization"

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -76,24 +76,6 @@ namespace Kiota.Builder.Refiners {
             CrawlTree(currentElement, c => ReplaceBinaryByNativeType(c, symbol, ns, addDeclaration));
         }
         private const string pathSegmentPropertyName = "pathSegment";
-        protected static void ConvertDeserializerPropsToMethods(CodeElement currentElement, string prefix = null) {
-            if(currentElement is CodeClass currentClass) {
-                var deserializerProp = currentClass.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.PropertyKind == CodePropertyKind.Deserializer);
-                if(deserializerProp != null) {
-                    currentClass.RemoveChildElement(deserializerProp);
-                    currentClass.AddMethod(new CodeMethod(currentClass) {
-                        Name = $"{prefix}{deserializerProp.Name}",
-                        MethodKind = CodeMethodKind.DeserializerBackwardCompatibility,
-                        IsAsync = false,
-                        IsStatic = false,
-                        ReturnType = deserializerProp.Type,
-                        Access = AccessModifier.Public,
-                        Description = deserializerProp.Description
-                    });
-                }
-            }
-            CrawlTree(currentElement, c => ConvertDeserializerPropsToMethods(c, prefix));
-        }
         // temporary patch of type to it resolves as the builder sets types we didn't generate to entity
         protected static void FixReferencesToEntityType(CodeElement currentElement, CodeClass entityClass = null){
             if(entityClass == null && currentElement is CodeNamespace currentNamespace)

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -20,7 +20,6 @@ namespace Kiota.Builder.Refiners {
             PatchHeaderParametersType(generatedCode);
             AddListImport(generatedCode);
             AddParsableInheritanceForModelClasses(generatedCode);
-            ConvertDeserializerPropsToMethods(generatedCode, "get");
             ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
             AddEnumSetImport(generatedCode);
             ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -121,8 +121,10 @@ namespace Kiota.Builder.Refiners {
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("IResponseHandler")).ToList().ForEach(x => x.Type.Name = "ResponseHandler");
                 else if(currentMethod.MethodKind == CodeMethodKind.Serializer)
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
-                else if(currentMethod.MethodKind == CodeMethodKind.Deserializer)
+                else if(currentMethod.MethodKind == CodeMethodKind.Deserializer) {
                     currentMethod.ReturnType.Name = $"Map<String, BiConsumer<T, ParseNode>>";
+                    currentMethod.Name = "getFieldDeserializers";
+                }
             }
             CrawlTree(currentElement, CorrectCoreType);
         }

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -90,8 +90,6 @@ namespace Kiota.Builder.Refiners {
                     currentProperty.Type.Name = "HttpCore";
                 else if(currentProperty.Name.Equals("serializerFactory", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "SerializationWriterFactory";
-                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.OrdinalIgnoreCase))
-                    currentProperty.Type.Name = $"Map<String, BiConsumer<T, ParseNode>>";
                 else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase)) {
                     currentProperty.Type.Name = $"OffsetDateTime";
                     var nUsing = new CodeUsing(currentProperty.Parent) {
@@ -123,6 +121,8 @@ namespace Kiota.Builder.Refiners {
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("IResponseHandler")).ToList().ForEach(x => x.Type.Name = "ResponseHandler");
                 else if(currentMethod.MethodKind == CodeMethodKind.Serializer)
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
+                else if(currentMethod.MethodKind == CodeMethodKind.Deserializer)
+                    currentMethod.ReturnType.Name = $"Map<String, BiConsumer<T, ParseNode>>";
             }
             CrawlTree(currentElement, CorrectCoreType);
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -48,8 +48,6 @@ namespace Kiota.Builder.Refiners {
                     currentProperty.Type.Name = "HttpCore";
                 else if(currentProperty.Name.Equals("serializerFactory", StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = "SerializationWriterFactory";
-                else if(currentProperty.Name.Equals("deserializeFields", StringComparison.OrdinalIgnoreCase))
-                    currentProperty.Type.Name = $"Map<string, (item: {currentProperty.Parent.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>";
                 else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase))
                     currentProperty.Type.Name = $"Date";
                 else if(currentProperty.PropertyKind == CodePropertyKind.AdditionalData) {
@@ -62,6 +60,8 @@ namespace Kiota.Builder.Refiners {
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("IResponseHandler")).ToList().ForEach(x => x.Type.Name = "ResponseHandler");
                 else if(currentMethod.MethodKind == CodeMethodKind.Serializer)
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
+                else if(currentMethod.MethodKind == CodeMethodKind.Deserializer)
+                    currentMethod.ReturnType.Name = $"Map<string, (item: {currentMethod.Parent.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>";
             }
             CrawlTree(currentElement, CorrectCoreType);
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -15,7 +15,6 @@ namespace Kiota.Builder.Refiners {
             FixReferencesToEntityType(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
             AddParsableInheritanceForModelClasses(generatedCode);
-            ConvertDeserializerPropsToMethods(generatedCode);
             ReplaceBinaryByNativeType(generatedCode, "ReadableStream", "web-streams-polyfill/es2018", true);
             ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}_escaped");
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -23,7 +23,7 @@ namespace Kiota.Builder.Refiners {
                 var declaration = currentClass.StartBlock as CodeClass.Declaration;
                 declaration.Implements.Add(new CodeType(currentClass) {
                     IsExternal = true,
-                    Name = $"Parsable<{currentClass.Name.ToFirstCharacterUpperCase()}>",
+                    Name = "Parsable",
                 });
             }
             CrawlTree(currentElement, AddParsableInheritanceForModelClasses);
@@ -61,7 +61,7 @@ namespace Kiota.Builder.Refiners {
                 else if(currentMethod.MethodKind == CodeMethodKind.Serializer)
                     currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
                 else if(currentMethod.MethodKind == CodeMethodKind.Deserializer)
-                    currentMethod.ReturnType.Name = $"Map<string, (item: {currentMethod.Parent.Name.ToFirstCharacterUpperCase()}, node: ParseNode) => void>";
+                    currentMethod.ReturnType.Name = $"Map<string, (item: T, node: ParseNode) => void>";
             }
             CrawlTree(currentElement, CorrectCoreType);
         }

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -16,7 +16,9 @@ namespace Kiota.Builder.Writers.CSharp {
 
             var returnType = conventions.GetTypeString(codeElement.ReturnType);
             var parentClass = codeElement.Parent as CodeClass;
-            var shouldHide = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null && codeElement.MethodKind == CodeMethodKind.Serializer;
+            var shouldHide = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null && 
+                            (codeElement.MethodKind == CodeMethodKind.Serializer ||
+                            codeElement.MethodKind == CodeMethodKind.Deserializer);
             var isVoid = conventions.VoidTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
             WriteMethodDocumentation(codeElement, writer);
             WriteMethodPrototype(codeElement, writer, returnType, shouldHide, isVoid);
@@ -34,14 +36,52 @@ namespace Kiota.Builder.Writers.CSharp {
                 case CodeMethodKind.RequestExecutor:
                     WriteRequestExecutorBody(codeElement, requestBodyParam, queryStringParam, headersParam, isVoid, returnType, writer);
                     break;
-                case CodeMethodKind.DeserializerBackwardCompatibility:
-                    throw new InvalidOperationException("Deserialization information is held by a property in CSharp");
+                case CodeMethodKind.Deserializer:
+                    var hideParentMember = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
+                    var parentSerializationInfo = hideParentMember ? $"(base.{codeElement.Name.ToFirstCharacterUpperCase()}())" : string.Empty;
+                    writer.WriteLine($"return new Dictionary<string, Action<T, {conventions.ParseNodeInterfaceName}>>{parentSerializationInfo} {{");
+                    writer.IncreaseIndent();
+                    foreach(var otherProp in parentClass
+                                                    .GetChildElements(true)
+                                                    .OfType<CodeProperty>()
+                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
+                                                    .OrderBy(x => x.Name)) {
+                        writer.WriteLine($"{{\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o,n) => {{ (o as {parentClass.Name.ToFirstCharacterUpperCase()}).{otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type)}(); }} }},");
+                    }
+                    writer.DecreaseIndent();
+                    writer.WriteLine("};");
+                break;
                 default:
                     writer.WriteLine("return null;");
                 break;
             }
             writer.DecreaseIndent();
             writer.WriteLine("}");
+        }
+        private string GetDeserializationMethodName(CodeTypeBase propType) {
+            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
+            var propertyType = conventions.TranslateType(propType.Name);
+            if(propType is CodeType currentType) {
+                if(isCollection)
+                    if(currentType.TypeDefinition == null)
+                        return $"GetCollectionOfPrimitiveValues<{propertyType}>().ToList";
+                    else
+                        return $"GetCollectionOfObjectValues<{propertyType}>().ToList";
+                else if (currentType.TypeDefinition is CodeEnum enumType)
+                    return $"GetEnumValue<{enumType.Name.ToFirstCharacterUpperCase()}>";
+            }
+            switch(propertyType) {
+                case "string":
+                case "bool":
+                case "int":
+                case "float":
+                case "double":
+                case "Guid":
+                case "DateTimeOffset":
+                    return $"Get{propertyType.ToFirstCharacterUpperCase()}Value";
+                default:
+                    return $"GetObjectValue<{propertyType.ToFirstCharacterUpperCase()}>";
+            }
         }
         private void WriteRequestExecutorBody(CodeMethod codeElement, CodeParameter requestBodyParam, CodeParameter queryStringParam, CodeParameter headersParam, bool isVoid, string returnType, LanguageWriter writer) {
             if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -25,54 +25,11 @@ namespace Kiota.Builder.Writers.CSharp {
                     writer.DecreaseIndent();
                     writer.WriteLine("}");
                 break;
-                case CodePropertyKind.Deserializer:
-                    var parentClass = codeElement.Parent as CodeClass;
-                    var hideParentMember = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-                    writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {(hideParentMember ? "new " : string.Empty)}{codeElement.Type.Name} {codeElement.Name.ToFirstCharacterUpperCase()} => new Dictionary<string, Action<{parentClass.Name.ToFirstCharacterUpperCase()}, {conventions.ParseNodeInterfaceName}>> {{");
-                    writer.IncreaseIndent();
-                    foreach(var otherProp in parentClass
-                                                    .GetChildElements(true)
-                                                    .OfType<CodeProperty>()
-                                                    .Where(x => x.PropertyKind == CodePropertyKind.Custom)
-                                                    .OrderBy(x => x.Name)) {
-                        writer.WriteLine("{");
-                        writer.IncreaseIndent();
-                        writer.WriteLine($"\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o,n) => {{ o.{otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type)}(); }}");
-                        writer.DecreaseIndent();
-                        writer.WriteLine("},");
-                    }
-                    writer.DecreaseIndent();
-                    writer.WriteLine("};");
-                break;
                 default:
                     writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ {simpleBody} }}{defaultValue}");
                 break;
             }
         }
-        private string GetDeserializationMethodName(CodeTypeBase propType) {
-            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-            var propertyType = conventions.TranslateType(propType.Name);
-            if(propType is CodeType currentType) {
-                if(isCollection)
-                    if(currentType.TypeDefinition == null)
-                        return $"GetCollectionOfPrimitiveValues<{propertyType}>().ToList";
-                    else
-                        return $"GetCollectionOfObjectValues<{propertyType}>().ToList";
-                else if (currentType.TypeDefinition is CodeEnum enumType)
-                    return $"GetEnumValue<{enumType.Name.ToFirstCharacterUpperCase()}>";
-            }
-            switch(propertyType) {
-                case "string":
-                case "bool":
-                case "int":
-                case "float":
-                case "double":
-                case "Guid":
-                case "DateTimeOffset":
-                    return $"Get{propertyType.ToFirstCharacterUpperCase()}Value";
-                default:
-                    return $"GetObjectValue<{propertyType.ToFirstCharacterUpperCase()}>";
-            }
-        }
+        
     }
 }

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -67,7 +67,7 @@ namespace Kiota.Builder.Writers.Java {
                     .GetChildElements(true)
                     .OfType<CodeProperty>()
                     .Where(x => x.PropertyKind == CodePropertyKind.Custom);
-            writer.WriteLine($"final Map<String, BiConsumer<T, {conventions.ParseNodeInterfaceName}>> fields = new HashMap<>({(inherits ? "super." + codeElement.Name+ "()" : fieldToSerialize.Count())});");
+            writer.WriteLine($"final Map<String, BiConsumer<T, {conventions.ParseNodeInterfaceName}>> fields = new HashMap<>({(inherits ? "super." + codeElement.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())});");
             if(fieldToSerialize.Any())
                 fieldToSerialize
                         .OrderBy(x => x.Name)

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -67,15 +67,18 @@ namespace Kiota.Builder.Writers.Java {
                     .GetChildElements(true)
                     .OfType<CodeProperty>()
                     .Where(x => x.PropertyKind == CodePropertyKind.Custom);
-            writer.WriteLine($"final Map<String, BiConsumer<T, {conventions.ParseNodeInterfaceName}>> fields = new HashMap<>({(inherits ? "super." + codeElement.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())});");
-            if(fieldToSerialize.Any())
+            writer.WriteLine($"return new HashMap<>({(inherits ? "super." + codeElement.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())}) {{{{");
+            if(fieldToSerialize.Any()) {
+                writer.IncreaseIndent();
                 fieldToSerialize
                         .OrderBy(x => x.Name)
                         .Select(x => 
-                            $"fields.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (o, n) -> {{ (({parentClass.Name.ToFirstCharacterUpperCase()})o).{x.Name.ToFirstCharacterLowerCase()} = {GetDeserializationMethodName(x.Type)}; }});")
+                            $"this.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (o, n) -> {{ (({parentClass.Name.ToFirstCharacterUpperCase()})o).{x.Name.ToFirstCharacterLowerCase()} = {GetDeserializationMethodName(x.Type)}; }});")
                         .ToList()
                         .ForEach(x => writer.WriteLine(x));
-            writer.WriteLine("return fields;");
+                writer.DecreaseIndent();
+            }
+            writer.WriteLine("}};");
         }
         private void WriteRequestExecutorBody(CodeMethod codeElement, CodeParameter requestBodyParam, CodeParameter queryStringParam, CodeParameter headersParam, string returnType, LanguageWriter writer) {
             if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -35,7 +35,7 @@ namespace Kiota.Builder.Writers.Java {
                 case CodeMethodKind.Serializer:
                     WriteSerializerBody(parentClass, writer);
                 break;
-                case CodeMethodKind.DeserializerBackwardCompatibility:
+                case CodeMethodKind.Deserializer:
                     WriteDeserializerBody(codeElement, parentClass, writer);
                 break;
                 case CodeMethodKind.IndexerBackwardCompatibility:
@@ -157,7 +157,7 @@ namespace Kiota.Builder.Writers.Java {
         }
         private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType) {
             var accessModifier = conventions.GetAccessModifier(code.Access);
-            var genericTypeParameterDeclaration = code.MethodKind == CodeMethodKind.DeserializerBackwardCompatibility ? "<T> ": string.Empty;
+            var genericTypeParameterDeclaration = code.MethodKind == CodeMethodKind.Deserializer ? "<T> ": string.Empty;
             var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
             var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
             var methodName = code.Name.ToFirstCharacterLowerCase();

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -18,8 +18,6 @@ namespace Kiota.Builder.Writers.Java {
                     writer.DecreaseIndent();
                     writer.WriteLine("}");
                 break;
-                case CodePropertyKind.Deserializer:
-                    throw new InvalidOperationException("java uses methods for the deserializer and this property should have been converted by the refiner");
                 default:
                     var defaultValue = string.IsNullOrEmpty(codeElement.DefaultValue) ? string.Empty : $" = {codeElement.DefaultValue}";
                     if(codeElement.Type is CodeType currentType && currentType.TypeDefinition is CodeEnum enumType && enumType.Flags)

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -31,7 +31,7 @@ namespace  Kiota.Builder.Writers.TypeScript {
                     var pathSegment = codeElement.GenerationProperties.ContainsKey(localConventions.PathSegmentPropertyName) ? codeElement.GenerationProperties[localConventions.PathSegmentPropertyName] as string : string.Empty;
                     localConventions.AddRequestBuilderBody(returnType, writer, $" + \"/{(string.IsNullOrEmpty(pathSegment) ? string.Empty : pathSegment + "/" )}\" + id");
                     break;
-                case CodeMethodKind.DeserializerBackwardCompatibility:
+                case CodeMethodKind.Deserializer:
                     WriteDeserializerBody(codeElement, parentClass, writer);
                     break;
                 case CodeMethodKind.Serializer:

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -57,14 +57,15 @@ namespace  Kiota.Builder.Writers.TypeScript {
         }
         private void WriteDeserializerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer) {
             var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-            writer.WriteLine($"return new Map<string, (item: {parentClass.Name.ToFirstCharacterUpperCase()}, node: {localConventions.ParseNodeInterfaceName}) => void>([{(inherits ? $"...super.{codeElement.Name.ToFirstCharacterLowerCase()}()," : string.Empty)}");
+            writer.WriteLine($"return new Map<string, (item: T, node: {localConventions.ParseNodeInterfaceName}) => void>([{(inherits ? $"...super.{codeElement.Name.ToFirstCharacterLowerCase()}()," : string.Empty)}");
             writer.IncreaseIndent();
+            var parentClassName = parentClass.Name.ToFirstCharacterUpperCase();
             foreach(var otherProp in parentClass
                                             .GetChildElements(true)
                                             .OfType<CodeProperty>()
                                             .Where(x => x.PropertyKind == CodePropertyKind.Custom)
                                             .OrderBy(x => x.Name)) {
-                writer.WriteLine($"[\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ o.{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
+                writer.WriteLine($"[\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ (o as unknown as {parentClassName}).{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
             }
             writer.DecreaseIndent();
             writer.WriteLine("]);");

--- a/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
@@ -11,8 +11,6 @@ namespace  Kiota.Builder.Writers.TypeScript {
             var isFlagEnum = codeElement.Type is CodeType currentType && currentType.TypeDefinition is CodeEnum currentEnum && currentEnum.Flags;
             conventions.WriteShortDescription(codeElement.Description, writer);
             switch(codeElement.PropertyKind) {
-                case CodePropertyKind.Deserializer:
-                    throw new InvalidOperationException("typescript uses methods for the deserializers and this property should have been converted to a method");
                 case CodePropertyKind.RequestBuilder:
                     writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} get {codeElement.Name.ToFirstCharacterLowerCase()}(): {returnType} {{");
                     writer.IncreaseIndent();

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -31,7 +31,7 @@ namespace Kiota.Builder.Refiners.Tests {
             });
             var property = model.AddProperty(new CodeProperty(model) {
                 Name = "deserialize",
-                PropertyKind = CodePropertyKind.Deserializer,
+                PropertyKind = CodePropertyKind.Custom,
                 Type = union,
             }).First();
             var method = model.AddMethod(new CodeMethod(model) {

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -192,11 +192,6 @@ namespace Kiota.Builder.Refiners.Tests {
                     Name = factoryDefaultName,
                 }
             }, new (model) {
-                Name = "deserializeFields",
-                Type = new CodeType(model) {
-                    Name = deserializeDefaultName,
-                }
-            }, new (model) {
                 Name = "someDate",
                 Type = new CodeType(model) {
                     Name = dateTimeOffsetDefaultName,
@@ -216,6 +211,12 @@ namespace Kiota.Builder.Refiners.Tests {
                 ReturnType = new CodeType(model) {
                     Name = "string"
                 }
+            }, new (model) {
+                Name = "deserializeFields",
+                ReturnType = new CodeType(model) {
+                    Name = deserializeDefaultName,
+                },
+                MethodKind = CodeMethodKind.Deserializer
             }).First();
             executorMethod.AddParameter(new (executorMethod) {
                 Name = "handler",
@@ -246,9 +247,9 @@ namespace Kiota.Builder.Refiners.Tests {
             ILanguageRefiner.Refine(GenerationLanguage.Java, root);
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => httpCoreDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => factoryDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => deserializeDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
+            Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -64,20 +64,6 @@ namespace Kiota.Builder.Refiners.Tests {
             Assert.NotEqual("binary", method.ReturnType.Name);
         }
         [Fact]
-        public void ConvertsDeserializerPropsToMethods() {
-            var model = root.AddClass(new CodeClass (root) {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var property = model.AddProperty(new CodeProperty(model) {
-                Name = "deserialize",
-                PropertyKind = CodePropertyKind.Deserializer,
-            }).First();
-            ILanguageRefiner.Refine(GenerationLanguage.Java, root);
-            Assert.Empty(model.GetChildElements().OfType<CodeProperty>());
-            Assert.NotEmpty(model.GetChildElements().OfType<CodeMethod>());
-        }
-        [Fact]
         public void ReplacesIndexersByMethodsWithParameter() {
             var model = root.AddClass(new CodeClass (root) {
                 Name = "model",

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -38,11 +38,6 @@ namespace Kiota.Builder.Refiners.Tests {
                     Name = factoryDefaultName,
                 }
             }, new (model) {
-                Name = "deserializeFields",
-                Type = new CodeType(model) {
-                    Name = deserializeDefaultName,
-                }
-            }, new (model) {
                 Name = "someDate",
                 Type = new CodeType(model) {
                     Name = dateTimeOffsetDefaultName,
@@ -86,6 +81,12 @@ namespace Kiota.Builder.Refiners.Tests {
                 ReturnType = new CodeType(model) {
                     Name = "string"
                 }
+            }, new (model) {
+                Name = "deserializeFields",
+                ReturnType = new CodeType(model) {
+                    Name = deserializeDefaultName,
+                },
+                MethodKind = CodeMethodKind.Deserializer
             }).First();
             const string streamDefaultName = "Stream";
             responseHandlerMethod.AddParameter(new CodeParameter(responseHandlerMethod) {
@@ -97,9 +98,9 @@ namespace Kiota.Builder.Refiners.Tests {
             ILanguageRefiner.Refine(GenerationLanguage.TypeScript, root);
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => httpCoreDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => factoryDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => deserializeDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeProperty>().Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
+            Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
             Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().SelectMany(x => x.Parameters).Where(x => streamDefaultName.Equals(x.Type.Name)));

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -146,18 +146,25 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
-        public void ThrowsOnDeserializerMethods() {
-            var parameter = new CodeParameter(method){
-                Description = paramDescription,
-                Name = paramName
-            };
-            parameter.Type = new CodeType(parameter) {
-                Name = "string"
-            };
-            method.MethodKind = CodeMethodKind.DeserializerBackwardCompatibility;
-            method.IsAsync = false;
+        public void WritesInheritedDeSerializerBody() {
+            method.MethodKind = CodeMethodKind.Deserializer;
             AddSerializationProperties();
-            Assert.Throws<InvalidOperationException>(() => writer.Write(method));
+            AddInheritanceClass();
+            writer.Write(method);
+            var result = tw.ToString();
+            Assert.Contains("base.", result);
+            Assert.Contains("new", result);
+        }
+        [Fact]
+        public void WritesDeSerializerBody() {
+            method.MethodKind = CodeMethodKind.Deserializer;
+            AddSerializationProperties();
+            writer.Write(method);
+            var result = tw.ToString();
+            Assert.Contains("GetStringValue", result);
+            Assert.Contains("GetCollectionOfPrimitiveValues", result);
+            Assert.Contains("GetCollectionOfObjectValues", result);
+            Assert.Contains("GetEnumValue", result);
         }
         [Fact]
         public void WritesInheritedSerializerBody() {

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -81,26 +81,6 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             };
         }
         [Fact]
-        public void WritesInheritedDeSerializerBody() {
-            property.PropertyKind = CodePropertyKind.Deserializer;
-            AddSerializationProperties();
-            AddInheritanceClass();
-            writer.Write(property);
-            var result = tw.ToString();
-            Assert.Contains("new", result);
-        }
-        [Fact]
-        public void WritesDeSerializerBody() {
-            property.PropertyKind = CodePropertyKind.Deserializer;
-            AddSerializationProperties();
-            writer.Write(property);
-            var result = tw.ToString();
-            Assert.Contains("GetStringValue", result);
-            Assert.Contains("GetCollectionOfPrimitiveValues", result);
-            Assert.Contains("GetCollectionOfObjectValues", result);
-            Assert.Contains("GetEnumValue", result);
-        }
-        [Fact]
         public void WritesDefaultValue() {
             var defaultValue = "someDefaultValue";
             property.DefaultValue = defaultValue;

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -158,7 +158,7 @@ namespace Kiota.Builder.Writers.Java.Tests {
         }
         [Fact]
         public void WritesInheritedDeSerializerBody() {
-            method.MethodKind = CodeMethodKind.DeserializerBackwardCompatibility;
+            method.MethodKind = CodeMethodKind.Deserializer;
             method.IsAsync = false;
             AddSerializationProperties();
             AddInheritanceClass();
@@ -176,7 +176,7 @@ namespace Kiota.Builder.Writers.Java.Tests {
             parameter.Type = new CodeType(parameter) {
                 Name = "string"
             };
-            method.MethodKind = CodeMethodKind.DeserializerBackwardCompatibility;
+            method.MethodKind = CodeMethodKind.Deserializer;
             method.IsAsync = false;
             AddSerializationProperties();
             writer.Write(method);

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
@@ -35,11 +35,6 @@ namespace Kiota.Builder.Writers.Java.Tests {
             tw?.Dispose();
         }
         [Fact]
-        public void WritesDeserializerThrows() {
-            property.PropertyKind = CodePropertyKind.Deserializer;
-            Assert.Throws<InvalidOperationException>(() => writer.Write(property));
-        }
-        [Fact]
         public void WritesDefaultValue() {
             var defaultValue = "someDefaultValue";
             property.DefaultValue = defaultValue;

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
@@ -146,7 +146,7 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
         }
         [Fact]
         public void WritesInheritedDeSerializerBody() {
-            method.MethodKind = CodeMethodKind.DeserializerBackwardCompatibility;
+            method.MethodKind = CodeMethodKind.Deserializer;
             method.IsAsync = false;
             AddSerializationProperties();
             AddInheritanceClass();
@@ -164,7 +164,7 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             parameter.Type = new CodeType(parameter) {
                 Name = "string"
             };
-            method.MethodKind = CodeMethodKind.DeserializerBackwardCompatibility;
+            method.MethodKind = CodeMethodKind.Deserializer;
             method.IsAsync = false;
             AddSerializationProperties();
             writer.Write(method);

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
@@ -35,11 +35,6 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             tw?.Dispose();
         }
         [Fact]
-        public void WritesDeserializerThrows() {
-            property.PropertyKind = CodePropertyKind.Deserializer;
-            Assert.Throws<InvalidOperationException>(() => writer.Write(property));
-        }
-        [Fact]
         public void WritesDefaultValue() {
             var defaultValue = "someDefaultValue";
             property.DefaultValue = defaultValue;


### PR DESCRIPTION
- aligns parsable interfaces across languages
- makes deserialize fields a method instead of a property
- updates java deserilizer method name
- renames deserializer for typescript
- updates refiner tests after typescript and java deserializer method rename
- relaxes generic type constraint on dotnet abstractions and implementations
- csharp missing generic type for deserializer

fixes #193

# Generation diff
https://github.com/microsoft/kiota-samples/pull/60
