### PR TITLE
adds constructors to request builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backing store support #223
 - Better client configuration #268
 - Doc comments for abstractions libraries #324
+- Request builders constructors for data validation #322
 
 ## [0.0.5] - 2021-06-10
 

--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -11,7 +11,8 @@ namespace Kiota.Builder
         ResponseHandler,
         RequestBody,
         SetterValue,
-        HttpCore
+        HttpCore,
+        CurrentPath
     }
 
     public class CodeParameter : CodeTerminal, ICloneable, IDocumentedElement

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -304,6 +304,7 @@ namespace Kiota.Builder
             httpCoreProperty.Type = new CodeType(httpCoreProperty) {
                 Name = coreInterfaceType,
                 IsExternal = true,
+                IsNullable = false,
             };
             currentClass.AddProperty(httpCoreProperty);
             var constructor = currentClass.AddMethod(new CodeMethod(currentClass) {
@@ -329,6 +330,7 @@ namespace Kiota.Builder
                 currentPathProperty.Type = new CodeType(currentPathProperty) {
                     Name = "string",
                     IsExternal = true,
+                    IsNullable = false,
                 };
                 currentClass.AddProperty(currentPathProperty);
                 constructor.AddParameter(new CodeParameter(constructor) {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -218,8 +218,8 @@ namespace Kiota.Builder
         {
             // Determine Class Name
             CodeClass codeClass;
-            var isRootClientClass = currentNode == rootNode;
-            if (isRootClientClass)
+            var isApiClientClass = currentNode == rootNode;
+            if (isApiClientClass)
                 codeClass = currentNamespace.AddClass(new CodeClass(currentNamespace) { 
                 Name = config.ClientClassName,
                 ClassKind = CodeClassKind.RequestBuilder,
@@ -268,7 +268,7 @@ namespace Kiota.Builder
                                         .Where(x => x.Value.RequestBody?.Content?.Any(y => !this.config.IgnoredRequestContentTypes.Contains(y.Key)) ?? true))
                     CreateOperationMethods(currentNode, operation.Key, operation.Value, codeClass);
             }
-            CreatePathManagement(codeClass, currentNode, isRootClientClass);
+            CreatePathManagement(codeClass, currentNode, isApiClientClass);
            
             Parallel.ForEach(currentNode.Children.Values, childNode =>
             {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -294,19 +294,6 @@ namespace Kiota.Builder
             };
             currentClass.AddProperty(pathProperty);
 
-            var currentPathProperty = new CodeProperty(currentClass) {
-                Name = currentPathParameterName,
-                Description = "Current path for the request",
-                PropertyKind = CodePropertyKind.CurrentPath,
-                Access = AccessModifier.Private,
-                ReadOnly = true,
-            };
-            currentPathProperty.Type = new CodeType(currentPathProperty) {
-                Name = "string",
-                IsExternal = true,
-            };
-            currentClass.AddProperty(currentPathProperty);
-
             var httpCoreProperty = new CodeProperty(currentClass) {
                 Name = httpCoreParameterName,
                 Description = "The http core service to use to execute the requests.",
@@ -331,8 +318,19 @@ namespace Kiota.Builder
             if(isRootClientClass) {
                 constructor.SerializerModules = config.Serializers;
                 constructor.DeserializerModules = config.Deserializers;
-            }
-            else
+            } else {
+                var currentPathProperty = new CodeProperty(currentClass) {
+                    Name = currentPathParameterName,
+                    Description = "Current path for the request",
+                    PropertyKind = CodePropertyKind.CurrentPath,
+                    Access = AccessModifier.Private,
+                    ReadOnly = true,
+                };
+                currentPathProperty.Type = new CodeType(currentPathProperty) {
+                    Name = "string",
+                    IsExternal = true,
+                };
+                currentClass.AddProperty(currentPathProperty);
                 constructor.AddParameter(new CodeParameter(constructor) {
                     Name = currentPathParameterName,
                     Type = currentPathProperty.Type,
@@ -340,6 +338,7 @@ namespace Kiota.Builder
                     Description = currentPathProperty.Description,
                     ParameterKind = CodeParameterKind.CurrentPath,
                 });
+            }
             constructor.AddParameter(new CodeParameter(constructor) {
                 Name = httpCoreParameterName,
                 Type = httpCoreProperty.Type,

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -278,11 +278,11 @@ namespace Kiota.Builder
             });
         }
         private static readonly string currentPathParameterName = "currentPath";
-        private void CreatePathManagement(CodeClass currentClass, OpenApiUrlTreeNode currentNode, bool isRootClientClass) {
+        private void CreatePathManagement(CodeClass currentClass, OpenApiUrlTreeNode currentNode, bool isApiClientClass) {
             var pathProperty = new CodeProperty(currentClass) {
                 Access = AccessModifier.Private,
                 Name = "pathSegment",
-                DefaultValue = isRootClientClass ? $"\"{this.config.ApiRootUrl}\"" : (currentNode.IsParameter() ? "\"\"" : $"\"/{currentNode.Segment}\""),
+                DefaultValue = isApiClientClass ? $"\"{this.config.ApiRootUrl}\"" : (currentNode.IsParameter() ? "\"\"" : $"\"/{currentNode.Segment}\""),
                 ReadOnly = true,
                 Description = "Path segment to use to build the URL for the current request builder",
                 PropertyKind = CodePropertyKind.PathSegment
@@ -309,14 +309,14 @@ namespace Kiota.Builder
             currentClass.AddProperty(httpCoreProperty);
             var constructor = currentClass.AddMethod(new CodeMethod(currentClass) {
                 Name = constructorMethodName,
-                MethodKind = isRootClientClass ? CodeMethodKind.ClientConstructor : CodeMethodKind.Constructor,
+                MethodKind = isApiClientClass ? CodeMethodKind.ClientConstructor : CodeMethodKind.Constructor,
                 IsAsync = false,
                 IsStatic = false,
                 Description = $"Instantiates a new {currentClass.Name} and sets the default values.",
                 Access = AccessModifier.Public,
             }).First();
             constructor.ReturnType = new CodeType(constructor) { Name = voidType, IsExternal = true };
-            if(isRootClientClass) {
+            if(isApiClientClass) {
                 constructor.SerializerModules = config.Serializers;
                 constructor.DeserializerModules = config.Deserializers;
             } else {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -131,7 +131,8 @@ namespace Kiota.Builder.Refiners {
             CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional));
         }
         protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited) {
-            if(current is CodeClass currentClass && 
+            if(current is CodeClass currentClass &&
+                !currentClass.IsOfKind(CodeClassKind.RequestBuilder, CodeClassKind.QueryParameters) &&
                 (currentClass.GetChildElements(true).OfType<CodeProperty>().Any(x => !string.IsNullOrEmpty(x.DefaultValue)) ||
                 addIfInherited && DoesAnyParentHaveAPropertyWithDefaultValue(currentClass)) &&
                 !currentClass.GetChildElements(true).OfType<CodeMethod>().Any(x => x.IsOfKind(CodeMethodKind.ClientConstructor)))

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -130,7 +130,10 @@ namespace Kiota.Builder.Refiners {
                     currentMethod.Name = "getFieldDeserializers";
                 }
                 else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor))
-                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.HttpCore)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
+                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.HttpCore))
+                        .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
+                        .ToList()
+                        .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
             }
             CrawlTree(currentElement, CorrectCoreType);
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -76,7 +76,10 @@ namespace Kiota.Builder.Refiners {
                 else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer))
                     currentMethod.ReturnType.Name = $"Map<string, (item: T, node: ParseNode) => void>";
                 else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor))
-                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.HttpCore)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
+                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.HttpCore))
+                        .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
+                        .ToList()
+                        .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
             }
             
                 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -27,7 +27,7 @@ namespace Kiota.Builder.Writers.CSharp {
             };
         }
         internal void AddRequestBuilderBody(string returnType, LanguageWriter writer, string suffix = default, string prefix = default) {
-            writer.WriteLine($"{prefix}new {returnType} {{ {HttpCorePropertyName} = {HttpCorePropertyName}, {CurrentPathPropertyName} = {CurrentPathPropertyName} + {PathSegmentPropertyName} {suffix}}};");
+            writer.WriteLine($"{prefix}new {returnType}({CurrentPathPropertyName} + {PathSegmentPropertyName} {suffix}, {HttpCorePropertyName});");
         }
         internal bool ShouldTypeHaveNullableMarker(CodeTypeBase propType, string propTypeName) {
             return propType.IsNullable && (NullableTypes.Contains(propTypeName) || (propType is CodeType codeType && codeType.TypeDefinition is CodeEnum));

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -26,8 +26,9 @@ namespace Kiota.Builder.Writers.CSharp {
                 _ => "private",
             };
         }
-        internal void AddRequestBuilderBody(string returnType, LanguageWriter writer, string suffix = default, string prefix = default) {
-            writer.WriteLine($"{prefix}new {returnType}({CurrentPathPropertyName} + {PathSegmentPropertyName} {suffix}, {HttpCorePropertyName});");
+        internal void AddRequestBuilderBody(bool addCurrentPath, string returnType, LanguageWriter writer, string suffix = default, string prefix = default) {
+            var currentPath = addCurrentPath ? $"{CurrentPathPropertyName} + " : string.Empty;
+            writer.WriteLine($"{prefix}new {returnType}({currentPath}{PathSegmentPropertyName} {suffix}, {HttpCorePropertyName});");
         }
         internal bool ShouldTypeHaveNullableMarker(CodeTypeBase propType, string propTypeName) {
             return propType.IsNullable && (NullableTypes.Contains(propTypeName) || (propType is CodeType codeType && codeType.TypeDefinition is CodeEnum));

--- a/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
@@ -1,14 +1,17 @@
+using System.Linq;
+
 namespace Kiota.Builder.Writers.CSharp {
     public class CodeIndexerWriter : BaseElementWriter<CodeIndexer, CSharpConventionService>
     {
         public CodeIndexerWriter(CSharpConventionService conventionService) : base(conventionService) {}
         public override void WriteCodeElement(CodeIndexer codeElement, LanguageWriter writer)
         {
+            var currentPathProperty = codeElement.Parent.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.IsOfKind(CodePropertyKind.CurrentPath));
             var returnType = conventions.GetTypeString(codeElement.ReturnType);
             conventions.WriteShortDescription(codeElement.Description, writer);
             writer.WriteLine($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexType)} position] {{ get {{");
             writer.IncreaseIndent();
-            conventions.AddRequestBuilderBody(returnType, writer, " + \"/\" + position", "return ");
+            conventions.AddRequestBuilderBody(currentPathProperty != null, returnType, writer, " + \"/\" + position", "return ");
             writer.DecreaseIndent();
             writer.WriteLine("} }");
         }

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -17,9 +17,10 @@ namespace Kiota.Builder.Writers.CSharp {
             conventions.WriteShortDescription(codeElement.Description, writer);
             switch(codeElement.PropertyKind) {
                 case CodePropertyKind.RequestBuilder:
+                    var currentPathProperty = codeElement.Parent.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.IsOfKind(CodePropertyKind.CurrentPath));
                     writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get =>");
                     writer.IncreaseIndent();
-                    conventions.AddRequestBuilderBody(propertyType, writer);
+                    conventions.AddRequestBuilderBody(currentPathProperty != null, propertyType, writer);
                     writer.DecreaseIndent();
                     writer.WriteLine("}");
                 break;

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kiota.Builder.Extensions;
 
 namespace Kiota.Builder.Writers.Java {
@@ -9,12 +10,13 @@ namespace Kiota.Builder.Writers.Java {
         {
             conventions.WriteShortDescription(codeElement.Description, writer);
             var returnType = conventions.GetTypeString(codeElement.Type);
+            var currentPathProperty = codeElement.Parent.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.IsOfKind(CodePropertyKind.CurrentPath));
             switch(codeElement.PropertyKind) {
                 case CodePropertyKind.RequestBuilder:
                     writer.WriteLine("@javax.annotation.Nonnull");
                     writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.Name.ToFirstCharacterLowerCase()}() {{");
                     writer.IncreaseIndent();
-                    conventions.AddRequestBuilderBody(returnType, writer);
+                    conventions.AddRequestBuilderBody(currentPathProperty != null, returnType, writer);
                     writer.DecreaseIndent();
                     writer.WriteLine("}");
                 break;

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -65,12 +65,10 @@ namespace Kiota.Builder.Writers.Java {
                 writer.WriteLine($"{DocCommentStart} {RemoveInvalidDescriptionCharacters(description)} {DocCommentEnd}");
         }
         internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
-        internal void AddRequestBuilderBody(string returnType, LanguageWriter writer, string suffix = default) {
-            // we're assigning this temp variable because java doesn't have a way to differentiate references with same names in properties initializers
-            // and because if currentPath is null it'll add "null" to the string...
-            writer.WriteLines($"final String parentPath = ({CurrentPathPropertyName} == null ? \"\" : {CurrentPathPropertyName}) + {PathSegmentPropertyName}{suffix};",
-                        $"final HttpCore parentCore = {HttpCorePropertyName};", //this variable naming is because Java can't tell the difference in terms of scopes priority in property initializers
-                        $"return new {returnType}() {{{{ {CurrentPathPropertyName} = parentPath; {HttpCorePropertyName} = parentCore; }}}};");
+        internal void AddRequestBuilderBody(bool addCurrentPath, string returnType, LanguageWriter writer, string suffix = default) {
+            // because if currentPath is null it'll add "null" to the string...
+            var currentPath = addCurrentPath ? $"{CurrentPathPropertyName} + " : string.Empty;
+            writer.WriteLines($"return new {returnType}({currentPath}{PathSegmentPropertyName}{suffix}, {HttpCorePropertyName});");
         }
     }
 }

--- a/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Refiners;
 
@@ -13,9 +14,10 @@ namespace Kiota.Builder.Writers.TypeScript {
             conventions.WriteShortDescription(codeElement.Description, writer);
             switch(codeElement.PropertyKind) {
                 case CodePropertyKind.RequestBuilder:
+                    var currentPathProperty = codeElement.Parent.GetChildElements(true).OfType<CodeProperty>().FirstOrDefault(x => x.IsOfKind(CodePropertyKind.CurrentPath));
                     writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} get {codeElement.Name.ToFirstCharacterLowerCase()}(): {returnType} {{");
                     writer.IncreaseIndent();
-                    conventions.AddRequestBuilderBody(returnType, writer);
+                    conventions.AddRequestBuilderBody(currentPathProperty != null, returnType, writer);
                     writer.DecreaseIndent();
                     writer.WriteLine("}");
                 break;

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -26,11 +26,9 @@ namespace Kiota.Builder.Writers.TypeScript {
 
         internal string DocCommentStart = "/**";
         internal string DocCommentEnd = " */";
-        internal void AddRequestBuilderBody(string returnType, LanguageWriter writer, string suffix = default) {
-            writer.WriteLines($"const builder = new {returnType}();",
-                    $"builder.{CurrentPathPropertyName} = (this.{CurrentPathPropertyName} ?? '') + this.{PathSegmentPropertyName}{suffix};",
-                    $"builder.{HttpCorePropertyName} = this.{HttpCorePropertyName};",
-                    "return builder;");
+        internal void AddRequestBuilderBody(bool addCurrentPath, string returnType, LanguageWriter writer, string suffix = default) {
+            var currentPath = addCurrentPath ? $"this.{CurrentPathPropertyName} + " : string.Empty;
+            writer.WriteLines($"return new {returnType}({currentPath}this.{PathSegmentPropertyName}{suffix}, this.{HttpCorePropertyName});");
         }
 
         public string GetAccessModifier(AccessModifier access)

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeIndexerWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeIndexerWriterTests.cs
@@ -39,8 +39,8 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
         public void WritesIndexer() {
             writer.Write(indexer);
             var result = tw.ToString();
-            Assert.Contains("HttpCore = HttpCore", result);
-            Assert.Contains("CurrentPath = CurrentPath + PathSegment", result);
+            Assert.Contains("HttpCore", result);
+            Assert.Contains("PathSegment", result);
             Assert.Contains("+ position", result);
             Assert.Contains("public SomeRequestBuilder this[string position]", result);
             AssertExtensions.CurlyBracesAreClosed(result);

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -88,8 +88,8 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             var result = tw.ToString();
             Assert.Contains("get =>", result);
             Assert.Contains($"new {typeName}", result);
-            Assert.Contains("HttpCore = HttpCore", result);
-            Assert.Contains("CurrentPath = CurrentPath + PathSegment", result);
+            Assert.Contains("HttpCore", result);
+            Assert.Contains("PathSegment", result);
         }
         [Fact]
         public void WritesCustomProperty() {

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -328,8 +328,9 @@ namespace Kiota.Builder.Writers.Java.Tests {
             method.PathSegment = "somePath";
             writer.Write(method);
             var result = tw.ToString();
-            Assert.Contains("final HttpCore parentCore", result);
-            Assert.Contains("final String parentPath", result);
+            Assert.Contains("httpCore", result);
+            Assert.Contains("pathSegment", result);
+            Assert.Contains("+ id", result);
             Assert.Contains("return new", result);
             Assert.Contains(method.PathSegment, result);
         }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
@@ -39,9 +39,9 @@ namespace Kiota.Builder.Writers.Java.Tests {
             property.PropertyKind = CodePropertyKind.RequestBuilder;
             writer.Write(property);
             var result = tw.ToString();
-            Assert.Contains($"new {typeName}", result);
-            Assert.Contains("HttpCore parentCore = httpCore", result);
-            Assert.Contains("String parentPath =", result);
+            Assert.Contains($"return new {typeName}", result);
+            Assert.Contains("httpCore", result);
+            Assert.Contains("pathSegment", result);
         }
         [Fact]
         public void WritesCustomProperty() {

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
@@ -327,9 +327,10 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             method.PathSegment = "somePath";
             writer.Write(method);
             var result = tw.ToString();
-            Assert.Contains("builder.httpCore = ", result);
-            Assert.Contains("builder.currentPath", result);
-            Assert.Contains("const builder = new", result);
+            Assert.Contains("this.httpCore", result);
+            Assert.Contains("this.pathSegment", result);
+            Assert.Contains("+ id", result);
+            Assert.Contains("return new", result);
             Assert.Contains(method.PathSegment, result);
         }
         [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
@@ -39,10 +39,9 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             property.PropertyKind = CodePropertyKind.RequestBuilder;
             writer.Write(property);
             var result = tw.ToString();
-            Assert.Contains($"new {typeName}", result);
-            Assert.Contains("builder.httpCore = this.httpCore", result);
-            Assert.Contains("builder.currentPath = (this.currentPath ?? '') + this.pathSegment", result);
-            Assert.Contains("return builder", result);
+            Assert.Contains($"return new {typeName}", result);
+            Assert.Contains("this.httpCore", result);
+            Assert.Contains("this.pathSegment", result);
         }
         [Fact]
         public void WritesCustomProperty() {


### PR DESCRIPTION
# Summary
- switches to constuctors for request builders in dotnet
- request builder constructors for java
- adds support for request builders constructors for typescript
- updates unit test for request builders constructors

fixes #301

This pull request adds constructors to request builders so they:

- Encapsulate properties that don't need to be exposed to consumers
- Validate what's passed (and lead consummers to pass the required information should they choose to instantiate request builers)
- Have a simpler code-gen story when it comes to indexers and navigation properties


# Generetion changes

https://github.com/microsoft/kiota-samples/pull/135