### PR TITLE
adds doc comments for CSharp/TypeScript/Java abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial ruby abstractions #212
 - Backing store support #223
 - Better client configuration #268
+- Doc comments for abstractions libraries #324
 
 ## [0.0.5] - 2021-06-10
 

--- a/abstractions/dotnet/src/ApiClientBuilder.cs
+++ b/abstractions/dotnet/src/ApiClientBuilder.cs
@@ -5,19 +5,35 @@ using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    ///     Provides a builder for creating an ApiClient and register the default serializers/deserializers.
+    /// </summary>
     public static class ApiClientBuilder {
+        /// <summary>
+        /// Registers the default serializer to the registry.
+        /// </summary>
+        /// <typeparam name="T">The type of the serialization factory to register</typeparam>
         public static void RegisterDefaultSerializer<T>() where T: ISerializationWriterFactory, new() {
             var serializationWriterFactory = new T();
             SerializationWriterFactoryRegistry.DefaultInstance
                                             .ContentTypeAssociatedFactories
                                             .TryAdd(serializationWriterFactory.ValidContentType, serializationWriterFactory);
         }
+        /// <summary>
+        /// Registers the default deserializer to the registry.
+        /// </summary>
+        /// <typeparam name="T">The type of the parse node factory to register</typeparam>
         public static void RegisterDefaultDeserializer<T>() where T: IParseNodeFactory, new() {
             var deserializerFactory = new T();
             ParseNodeFactoryRegistry.DefaultInstance
                                     .ContentTypeAssociatedFactories
                                     .TryAdd(deserializerFactory.ValidContentType, deserializerFactory);
         }
+        /// <summary>
+        /// Enables the backing store on default serialization writers and the given serialization writer.
+        /// </summary>
+        /// <param name="original">The serialization writer to enable the backing store on.</param>
+        /// <returns>A new serialization writer with the backing store enabled.</returns>
         public static ISerializationWriterFactory EnableBackingStoreForSerializationWriterFactory(ISerializationWriterFactory original) {
             ISerializationWriterFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is SerializationWriterFactoryRegistry registry)
@@ -27,6 +43,11 @@ namespace Microsoft.Kiota.Abstractions {
             EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry.DefaultInstance);
             return result;
         }
+        /// <summary>
+        /// Enables the backing store on default parse nodes factories and the given parse node factory.
+        /// </summary>
+        /// <param name="original">The parse node factory to enable the backing store on.</param>
+        /// <returns>A new parse node factory with the backing store enabled.</returns>
         public static IParseNodeFactory EnableBackingStoreForParseNodeFactory(IParseNodeFactory original) {
             IParseNodeFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is ParseNodeFactoryRegistry registry)

--- a/abstractions/dotnet/src/HttpMethod.cs
+++ b/abstractions/dotnet/src/HttpMethod.cs
@@ -1,13 +1,43 @@
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    ///     Represents the HTTP method used by a request.
+    /// </summary>
     public enum HttpMethod {
+        /// <summary>
+        ///     The HTTP GET method.
+        /// </summary>
         GET,
+        /// <summary>
+        ///     The HTTP POST method.
+        /// </summary>
         POST,
+        /// <summary>
+        ///     The HTTP PATCH method.
+        /// </summary>
         PATCH,
+        /// <summary>
+        ///     The HTTP DELETE method.
+        /// </summary>
         DELETE,
+        /// <summary>
+        ///     The HTTP OPTIONS method.
+        /// </summary>
         OPTIONS,
+        /// <summary>
+        ///     The HTTP PUT method.
+        /// </summary>
         PUT,
+        /// <summary>
+        ///     The HTTP HEAD method.
+        /// </summary>
         HEAD,
+        /// <summary>
+        ///     The HTTP CONNECT method.
+        /// </summary>
         CONNECT,
+        /// <summary>
+        ///     The HTTP TRACE method.
+        /// </summary>
         TRACE
     }
 }

--- a/abstractions/dotnet/src/IAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/IAuthenticationProvider.cs
@@ -2,7 +2,15 @@ using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    /// Authenticates the application and returns a token.
+    /// </summary>
     public interface IAuthenticationProvider {
+        /// <summary>
+        /// Authenticates the application and returns a token base on the provided Uri.
+        /// </summary>
+        /// <param name="uri">The Uri to authenticate the request for.</param>
+        /// <returns>The Access Token or null if the target request Uri doesn't correspond to a valid resource.</returns>
         Task<string> GetAuthorizationToken(Uri requestUri);
     }
 }

--- a/abstractions/dotnet/src/IHttpCore.cs
+++ b/abstractions/dotnet/src/IHttpCore.cs
@@ -2,11 +2,38 @@ using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    ///   Service responsible for translating abstract Request Info into concrete native HTTP requests.
+    /// </summary>
     public interface IHttpCore {
+        /// <summary>
+        ///  Enables the backing store proxies for the SerializationWriters and ParseNodes in use.
+        /// </summary>
         void EnableBackingStore();
+        /// <summary>
+        /// Gets the serialization writer factory currently in use for the HTTP core service.
+        /// </summary>
         ISerializationWriterFactory SerializationWriterFactory { get; }
+        /// <summary>
+        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model.
+        /// </summary>
+        /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
+        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <returns>The deserialized response model.</returns>
         Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
+        /// <summary>
+        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
+        /// </summary>
+        /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
+        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <returns>The deserialized primitive response model.</returns>
         Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default);
+        /// <summary>
+        /// Excutes the HTTP request specified by the given RequestInfo with no return content.
+        /// </summary>
+        /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
+        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <returns>A Task to await completion.</returns>
         Task SendNoContentAsync(RequestInfo requestInfo, IResponseHandler responseHandler = default);
     }
 }

--- a/abstractions/dotnet/src/IResponseHandler.cs
+++ b/abstractions/dotnet/src/IResponseHandler.cs
@@ -1,7 +1,17 @@
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    ///     Defines the contract for a response handler.
+    /// </summary>
     public interface IResponseHandler {
+        /// <summary>
+        ///     Callback method that is invoked when a response is received.
+        /// </summary>
+        /// <param name="response">The native response object.</param>
+        /// <typeparam name="NativeResponseType">The type of the native response object.</typeparam>
+        /// <typeparam name="ModelType">The type of the response model object.</typeparam>
+        /// <returns>A task that represents the asynchronous operation and contains the deserialized response.</returns>
         Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response);
     }
 }

--- a/abstractions/dotnet/src/NativeResponseHandler.cs
+++ b/abstractions/dotnet/src/NativeResponseHandler.cs
@@ -1,6 +1,9 @@
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    /// Default response handler to access the native response object.
+    /// </summary>
     public class NativeResponseHandler : IResponseHandler {
         public object Value;
         public Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response) {

--- a/abstractions/dotnet/src/NativeResponseWrapper.cs
+++ b/abstractions/dotnet/src/NativeResponseWrapper.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions {
+    /// <summary>
+    /// This class can be used to wrap a request using the fluent API and get the native response object in return.
+    /// </summary>
     public class NativeResponseWrapper {
         public static async Task<NativeResponseType> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType>(
                 Func<Action<QueryParametersType>, Action<IDictionary<string, string>>, IResponseHandler, Task<ModelType>> originalCall,

--- a/abstractions/dotnet/src/QueryParametersBase.cs
+++ b/abstractions/dotnet/src/QueryParametersBase.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions {
     public abstract class QueryParametersBase {
+        /// <summary>
+        /// Vanity method to add the query parameters to the request query parameters dictionary.
+        /// </summary>
         public void AddQueryParameters(IDictionary<string, object> target) {
             if (target == null) throw new ArgumentNullException(nameof(target));
             foreach(var property in this.GetType()

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -5,19 +5,48 @@ using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Abstractions
 {
+    /// <summary>
+    ///     This class represents an abstract HTTP request.
+    /// </summary>
     public class RequestInfo
     {
+        /// <summary>
+        ///  The URI of the request.
+        /// </summary>
         public Uri URI { get; set; }
+        /// <summary>
+        ///  The <see cref="HttpMethod">HTTP method</see> of the request.
+        /// </summary>
         public HttpMethod HttpMethod { get; set; }
+        /// <summary>
+        /// The Query Parameters of the request.
+        /// </summary>
         public IDictionary<string, object> QueryParameters { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// The Request Headers.
+        /// </summary>
         public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// The Request Body.
+        /// </summary>
         public Stream Content { get; set; }
         private const string binaryContentType = "application/octet-stream";
         private const string contentTypeHeader = "Content-Type";
+        /// <summary>
+        /// Sets the request body to a binary stream.
+        /// </summary>
+        /// <param name="content">The binary stream to set as a body.</param>
         public void SetStreamContent(Stream content) {
             Content = content;
             Headers.Add(contentTypeHeader, binaryContentType);
         }
+        /// <summary>
+        /// Sets the request body from a model with the specified content type.
+        /// </summary>
+        /// <param name="coreService">The core service to get the serialization writer from.</param>
+        /// <param name="item">The model to serialize.</param>
+        /// <param name="contentType">The content type to set.</param>
+        /// <typeparam name="T">The model type to serialize.</typeparam>
         public void SetContentFromParsable<T>(T item, IHttpCore coreService, string contentType) where T : IParsable {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
             if(coreService == null) throw new ArgumentNullException(nameof(coreService));

--- a/abstractions/dotnet/src/extensions/StringExtensions.cs
+++ b/abstractions/dotnet/src/extensions/StringExtensions.cs
@@ -2,6 +2,11 @@ using System.Linq;
 
 namespace Microsoft.Kiota.Abstractions.Extensions {
     public static class StringExtensions {
+        /// <summary>
+        ///     Returns a string with the first letter lowered.
+        /// </summary>
+        /// <param name="input">The string to lowercase.</param>
+        /// <returns>The input string with the first letter lowered.</returns>
         public static string ToFirstCharacterLowerCase(this string input)
             => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input[0])}{input[1..]}";
     }

--- a/abstractions/dotnet/src/serialization/IParsable.cs
+++ b/abstractions/dotnet/src/serialization/IParsable.cs
@@ -2,10 +2,23 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    ///     Defines a serializable model object.
+    /// </summary>
     public interface IParsable {
+        /// <summary>
+        ///   Gets the deserialization information for this object.
+        /// </summary>
+        /// <returns>The deserialization information for this object where each entry is a property key with its deserialization callback.</returns>
         IDictionary<string, Action<T, IParseNode>> GetFieldDeserializers<T>();
+        /// <summary>
+        ///  Writes the objects properties to the current writer.
+        /// </summary>
+        /// <param name="writer">The <see cref="ISerializationWriter">writer</see> to write to.</param>
         void Serialize(ISerializationWriter writer);
-
+        /// <summary>
+        ///  Stores the additional data for this object that did not belong to the properties.
+        /// </summary>
         IDictionary<string, object> AdditionalData { get; set; }
     }
 }

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    /// Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
+    /// </summary>
     public interface IParseNode {
         /// <summary>
         ///  Gets the string value of the node.

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -3,19 +3,74 @@ using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
     public interface IParseNode {
+        /// <summary>
+        ///  Gets the string value of the node.
+        /// </summary>
+        /// <returns>The string value of the node.</returns>
         string GetStringValue();
+        /// <summary>
+        ///  Gets a new parse node for the given identifier.
+        /// </summary>
+        /// <param name="identifier">The identifier.</param>
+        /// <returns>The new parse node.</returns>
         IParseNode GetChildNode(string identifier);
+        /// <summary>
+        ///  Gets the boolean value of the node.
+        /// </summary>
+        /// <returns>The boolean value of the node.</returns>
         bool? GetBoolValue();
+        /// <summary>
+        ///  Gets the integer value of the node.
+        /// </summary>
+        /// <returns>The integer value of the node.</returns>
         int? GetIntValue();
+        /// <summary>
+        ///  Gets the float value of the node.
+        /// </summary>
+        /// <returns>The float value of the node.</returns>
         decimal? GetFloatValue();
+        /// <summary>
+        /// Gets the double value of the node.
+        /// </summary>
+        /// <returns>The double value of the node.</returns>
         double? GetDoubleValue();
+        /// <summary>
+        /// Gets the GUID value of the node.
+        /// </summary>
+        /// <returns>The GUID value of the node.</returns>
         Guid? GetGuidValue();
+        /// <summary>
+        /// Gets the DateTimeOffset value of the node.
+        /// </summary>
+        /// <returns>The DateTimeOffset value of the node.</returns>
         DateTimeOffset? GetDateTimeOffsetValue();
+        /// <summary>
+        /// Gets the collection of primitive values of the node.
+        /// </summary>
+        /// <returns>The collection of primitive values.</returns>
         IEnumerable<T> GetCollectionOfPrimitiveValues<T>();
+        /// <summary>
+        /// Gets the collection of model objects values of the node.
+        /// </summary>
+        /// <returns>The collection of model objects values.</returns>
         IEnumerable<T> GetCollectionOfObjectValues<T>() where T: IParsable;
+        /// <summary>
+        /// Gets the enum value of the node.
+        /// </summary>
+        /// <returns>The enum value of the node.</returns>
         T? GetEnumValue<T>() where T: struct, Enum;
+        /// <summary>
+        /// Gets the model object value of the node.
+        /// </summary>
+        /// <returns>The model object value of the node.</returns>
         T GetObjectValue<T>() where T: IParsable;
+        /// <summary>
+        /// Callback called before the node is deserialized.
+        /// </summary>
         Action<IParsable> OnBeforeAssignFieldValues { get; set; }
+        /// <summary>
+        /// Callback called after the node is deserialized.
+        /// </summary>
         Action<IParsable> OnAfterAssignFieldValues { get; set; }
     }
 }

--- a/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
+++ b/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
@@ -1,8 +1,20 @@
 using System.IO;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    /// Defines the contract for a factory that creates parse nodes.
+    /// </summary>
     public interface IParseNodeFactory {
+        /// <summary>
+        /// Return the content type this factory's parse nodes can deserialize.
+        /// </summary>
         string ValidContentType { get; }
+        /// <summary>
+        /// Create a parse node from the given stream and content type.
+        /// </summary>
+        /// <param name="stream">The stream to read the parse node from.</param>
+        /// <param name="contentType">The content type of the parse node.</param>
+        /// <returns>A parse node.</returns>
         IParseNode GetRootParseNode(string contentType, Stream content);
     }
 }

--- a/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
+++ b/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
     /// </summary>
     public interface IParseNodeFactory {
         /// <summary>
-        /// Return the content type this factory's parse nodes can deserialize.
+        /// Returns the content type this factory's parse nodes can deserialize.
         /// </summary>
         string ValidContentType { get; }
         /// <summary>

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -3,21 +3,93 @@ using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    /// Defines an interface for serialization of objects to a stream.
+    /// </summary>
     public interface ISerializationWriter : IDisposable {
+        /// <summary>
+        /// Writes the specified string value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The string value to be written.</param>
         void WriteStringValue(string key, string value);
+        /// <summary>
+        /// Writes the specified byte boolean value to the stream with an optional given key. 
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The byte boolean value to be written.</param>
         void WriteBoolValue(string key, bool? value);
+        /// <summary>
+        /// Writes the specified byte integer value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The byte integer value to be written.</param>
         void WriteIntValue(string key, int? value);
+        /// <summary>
+        /// Writes the specified float value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The float value to be written.</param>
         void WriteFloatValue(string key, float? value);
+        /// <summary>
+        /// Writes the specified double value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The double value to be written.</param>
         void WriteDoubleValue(string key, double? value);
+        /// <summary>
+        /// Writes the specified Guid value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The Guid value to be written.</param>
         void WriteGuidValue(string key, Guid? value);
+        /// <summary>
+        /// Writes the specified DateTimeOffset value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The DateTimeOffset value to be written.</param>
         void WriteDateTimeOffsetValue(string key, DateTimeOffset? value);
+        /// <summary>
+        /// Writes the specified collection of primitive values to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="values">The collection of primitive values to be written.</param>
         void WriteCollectionOfPrimitiveValues<T>(string key, IEnumerable<T> values);
+        /// <summary>
+        /// Writes the specified collection of model objects to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="values">The collection of model objects to be written.</param>
         void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable;
+        /// <summary>
+        /// Writes the specified model object to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The model object to be written.</param>
         void WriteObjectValue<T>(string key, T value) where T : IParsable;
+        /// <summary>
+        /// Writes the specified enum value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The enum value to be written.</param>
         void WriteEnumValue<T>(string key, T? value) where T : struct, Enum;
+        /// <summary>
+        /// Writes the specified additional data to the stream.
+        /// </summary>
+        /// <param name="data">The additional data to be written.</param>
         void WriteAdditionalData(IDictionary<string, object> value);
+        /// <summary>
+        /// Gets the value of the serialized content.
+        /// </summary>
+        /// <returns>The value of the serialized content.</returns>
         Stream GetSerializedContent();
+        /// <summary>
+        /// Callback called before the serialization process starts.
+        /// </summary>
         Action<IParsable> OnBeforeObjectSerialization { get; set; }
+        /// <summary>
+        /// Callback called after the serialization process ends.
+        /// </summary>
         Action<IParsable> OnAfterObjectSerialization { get; set; }
     }
 }

--- a/abstractions/dotnet/src/serialization/ISerializationWriterFactory.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriterFactory.cs
@@ -1,6 +1,17 @@
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    ///     Defines the contract for a factory that creates <see cref="ISerializationWriter" /> instances.
+    /// </summary>
     public interface ISerializationWriterFactory {
+        /// <summary>
+        /// Gets the content type this factory creates serialization writers for.
+        /// </summary>
         string ValidContentType { get; }
+        /// <summary>
+        ///     Creates a new <see cref="ISerializationWriter" /> instance for the given content type.
+        /// </summary>
+        /// <param name="contentType">The content type for which a serialization writer should be created.</param>
+        /// <returns>A new <see cref="ISerializationWriter" /> instance for the given content type.</returns>
         ISerializationWriter GetSerializationWriter(string contentType);
     }
 }

--- a/abstractions/dotnet/src/serialization/ParseNodeFactoryRegistry.cs
+++ b/abstractions/dotnet/src/serialization/ParseNodeFactoryRegistry.cs
@@ -4,11 +4,20 @@ using System.IO;
 using Microsoft.Kiota.Abstractions;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    ///  This factory holds a list of all the registered factories for the various types of nodes.
+    /// </summary>
     public class ParseNodeFactoryRegistry : IParseNodeFactory {
         public string ValidContentType { get {
             throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
         }}
+        /// <summary>
+        /// Default singleton instance of the registry to be used when registring new factories that should be available by default.
+        /// </summary>
         public static readonly ParseNodeFactoryRegistry DefaultInstance = new();
+        /// <summary>
+        /// List of factories that are registered by content type.
+        /// </summary>
         public Dictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories {get; set;} = new Dictionary<string, IParseNodeFactory>();
         public IParseNode GetRootParseNode(string contentType, Stream content) {
             if(string.IsNullOrEmpty(contentType))

--- a/abstractions/dotnet/src/serialization/ParseNodeProxyFactory.cs
+++ b/abstractions/dotnet/src/serialization/ParseNodeProxyFactory.cs
@@ -2,11 +2,20 @@ using System;
 using System.IO;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    /// Proxy factory that allows the composition of before and after callbacks on existing factories.
+    /// </summary>
     public abstract class ParseNodeProxyFactory : IParseNodeFactory {
         public string ValidContentType { get { return _concrete.ValidContentType; }}
         private readonly IParseNodeFactory _concrete;
         private readonly Action<IParsable> _onBefore;
         private readonly Action<IParsable> _onAfter;
+        /// <summary>
+        /// Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+        /// </summary>
+        /// <param name="concrete">The concrete factory to wrap.</param>
+        /// <param name="onBefore">The callback to invoke before the deserialization of any model object.</param>
+        /// <param name="onAfter">The callback to invoke after the deserialization of any model object.</param>
         public ParseNodeProxyFactory(IParseNodeFactory concrete, Action<IParsable> onBefore, Action<IParsable> onAfter) {
             _concrete = concrete ?? throw new ArgumentNullException(nameof(concrete));
             _onBefore = onBefore;

--- a/abstractions/dotnet/src/serialization/SerializationWriterFactoryRegistry.cs
+++ b/abstractions/dotnet/src/serialization/SerializationWriterFactoryRegistry.cs
@@ -2,11 +2,20 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    ///  This factory holds a list of all the registered factories for the various types of nodes.
+    /// </summary>
     public class SerializationWriterFactoryRegistry : ISerializationWriterFactory {
         public string ValidContentType { get {
             throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
         }}
+        /// <summary>
+        /// Default singleton instance of the registry to be used when registring new factories that should be available by default.
+        /// </summary>
         public static readonly SerializationWriterFactoryRegistry DefaultInstance = new();
+        /// <summary>
+        /// List of factories that are registered by content type.
+        /// </summary>
         public Dictionary<string, ISerializationWriterFactory> ContentTypeAssociatedFactories { get; set; } = new Dictionary<string, ISerializationWriterFactory>();
         public ISerializationWriter GetSerializationWriter(string contentType) {
             if(string.IsNullOrEmpty(contentType))

--- a/abstractions/dotnet/src/serialization/SerializationWriterProxyFactory.cs
+++ b/abstractions/dotnet/src/serialization/SerializationWriterProxyFactory.cs
@@ -1,11 +1,20 @@
 using System;
 
 namespace Microsoft.Kiota.Abstractions.Serialization {
+    /// <summary>
+    /// Proxy factory that allows the composition of before and after callbacks on existing factories.
+    /// </summary>
     public class SerializationWriterProxyFactory : ISerializationWriterFactory {
         public string ValidContentType { get { return _concrete.ValidContentType; }}
         private readonly ISerializationWriterFactory _concrete;
         private readonly Action<IParsable> _onBefore;
         private readonly Action<IParsable> _onAfter;
+        /// <summary>
+        /// Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+        /// </summary>
+        /// <param name="concrete">The concrete factory to wrap.</param>
+        /// <param name="onBefore">The callback to invoke before the serialization of any model object.</param>
+        /// <param name="onAfter">The callback to invoke after the serialization of any model object.</param>
         public SerializationWriterProxyFactory(ISerializationWriterFactory concrete,
             Action<IParsable> onBeforeSerialization, Action<IParsable> onAfterSerialization) {
             _concrete = concrete ?? throw new ArgumentNullException(nameof(concrete));

--- a/abstractions/dotnet/src/store/BackingStoreParseNodeFactory.cs
+++ b/abstractions/dotnet/src/store/BackingStoreParseNodeFactory.cs
@@ -1,6 +1,12 @@
 using Microsoft.Kiota.Abstractions.Serialization;
 namespace Microsoft.Kiota.Abstractions.Store {
+    /// <summary>
+    /// Proxy implementation of <see cref="IParseNodeFactory"/> for the <see cref="IBackingStore">backing store</see> that automatically sets the state of the backing store when deserializing.
+    /// </summary>
     public class BackingStoreParseNodeFactory : ParseNodeProxyFactory {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BackingStoreParseNodeFactory"/> class given a concrete implementation of <see cref="IParseNodeFactory"/>.
+        /// </summary>
         public BackingStoreParseNodeFactory(IParseNodeFactory concrete):base(
             concrete,
             (x) => {

--- a/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxy.cs
+++ b/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxy.cs
@@ -4,7 +4,13 @@ using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Kiota.Abstractions.Store {
+    /// <summary>
+    /// Proxy implementation of <see cref="ISerializationWriterFactory"/> for the <see cref="IBackingStore">backing store</see> that automatically sets the state of the backing store when serializing.
+    /// </summary>
     public class BackingStoreSerializationWriterProxyFactory : SerializationWriterProxyFactory {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BackingStoreSerializationWriterFactory"/> class given a concrete implementation of <see cref="ISerializationWriterFactory"/>.
+        /// </summary>
         public BackingStoreSerializationWriterProxyFactory(ISerializationWriterFactory concrete) : base(
             concrete,
             (x) => {

--- a/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxyFactory.cs
+++ b/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxyFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Kiota.Abstractions.Store {
     /// </summary>
     public class BackingStoreSerializationWriterProxyFactory : SerializationWriterProxyFactory {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BackingStoreSerializationWriterFactory"/> class given a concrete implementation of <see cref="ISerializationWriterFactory"/>.
+        /// Initializes a new instance of the <see cref="BackingStoreSerializationWriterProxyFactory"/> class given a concrete implementation of <see cref="ISerializationWriterFactory"/>.
         /// </summary>
         public BackingStoreSerializationWriterProxyFactory(ISerializationWriterFactory concrete) : base(
             concrete,

--- a/abstractions/dotnet/src/store/IBackedModel.cs
+++ b/abstractions/dotnet/src/store/IBackedModel.cs
@@ -1,5 +1,11 @@
 namespace Microsoft.Kiota.Abstractions.Store {
+    /// <summary>
+    ///     Defines the contracts for a model that is backed by a store.
+    /// </summary>
     public interface IBackedModel {
+        /// <summary>
+        ///     Gets the store that is backing the model.
+        /// </summary>
         IBackingStore BackingStore { get; }
     }
 }

--- a/abstractions/dotnet/src/store/InMemoryBackingStore.cs
+++ b/abstractions/dotnet/src/store/InMemoryBackingStore.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Kiota.Abstractions.Store {
+    /// <summary>
+    ///     In-memory implementation of the backing store. Allows for dirty tracking of changes.
+    /// </summary>
     public class InMemoryBackingStore : IBackingStore {
         private bool isInitializationComplete = true;
         public bool ReturnOnlyChangedValues {get; set;}

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/ApiClientBuilder.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/ApiClientBuilder.java
@@ -16,10 +16,14 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-
+/** Provides a builder for creating an ApiClient and register the default serializers/deserializers. */
 public class ApiClientBuilder {
     // private constructor to prevent instantiation
     private ApiClientBuilder() { }
+    /**
+     * Registers the default serializer to the registry.
+     * @param factoryClass the class of the factory to be registered.
+     */
     public static void registerDefaultSerializer(@Nonnull final Class<? extends SerializationWriterFactory> factoryClass) {
         Objects.requireNonNull(factoryClass);
         try {
@@ -30,6 +34,10 @@ public class ApiClientBuilder {
             throw new RuntimeException(e);
         }
     }
+    /**
+     * Registers the default deserializer to the registry.
+     * @param factoryClass the class of the factory to be registered.
+     */
     public static void registerDefaultDeserializer(@Nonnull final Class<? extends ParseNodeFactory> factoryClass) {
         Objects.requireNonNull(factoryClass);
         try {
@@ -40,6 +48,11 @@ public class ApiClientBuilder {
             throw new RuntimeException(e);
         }
     }
+    /**
+     * Enables the backing store on default serialization writers and the given serialization writer.
+     * @param original The serialization writer to enable the backing store on.
+     * @return A new serialization writer with the backing store enabled.
+     */
     @Nonnull
     public static SerializationWriterFactory enableBackingStoreForSerializationWriterFactory(@Nonnull final SerializationWriterFactory original) {
         SerializationWriterFactory result = Objects.requireNonNull(original);
@@ -50,6 +63,11 @@ public class ApiClientBuilder {
         enableBackingStoreForSerializationWriterRegistry(SerializationWriterFactoryRegistry.defaultInstance);
         return result;
     }
+    /**
+     * Enables the backing store on default parse node factories and the given parse node factory.
+     * @param original The parse node factory to enable the backing store on.
+     * @return A new parse node factory with the backing store enabled.
+     */
     @Nonnull
     public static ParseNodeFactory enableBackingStoreForParseNodeFactory(@Nonnull final ParseNodeFactory original) {
         ParseNodeFactory result = Objects.requireNonNull(original);

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/AuthenticationProvider.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/AuthenticationProvider.java
@@ -5,6 +5,12 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 
+/** Authenticates the application and returns a token. */
 public interface AuthenticationProvider {
+    /**
+     * Authenticates the application and returns a token base on the provided Uri.
+     * @param uri the Uri to authenticate the request for.
+     * @return a CompletableFuture that will be completed with the token or null if the target request Uri doesn't correspond to a valid resource.
+     */
     CompletableFuture<String> getAuthorizationToken(@Nonnull final URI requestUri);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/AuthenticationProvider.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/AuthenticationProvider.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 public interface AuthenticationProvider {
     /**
      * Authenticates the application and returns a token base on the provided Uri.
-     * @param uri the Uri to authenticate the request for.
+     * @param requestUri the Uri to authenticate the request for.
      * @return a CompletableFuture that will be completed with the token or null if the target request Uri doesn't correspond to a valid resource.
      */
     CompletableFuture<String> getAuthorizationToken(@Nonnull final URI requestUri);

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
@@ -8,10 +8,30 @@ import javax.annotation.Nullable;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.SerializationWriterFactory;
 
+/** Service responsible for translating abstract Request Info into concrete native HTTP requests. */
 public interface HttpCore {
+    /** Enables the backing store proxies for the SerializationWriters and ParseNodes in use. */
     void enableBackingStore();
+    /**
+     * Gets the serialization writer factory currently in use for the HTTP core service.
+     * @return the serialization writer factory currently in use for the HTTP core service.
+     */
     @Nonnull
     SerializationWriterFactory getSerializationWriterFactory();
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param targetClass the class of the response model to deserialize the response into.
+     * @return a CompletableFuture with the deserialized response model.
+     */
     <ModelType extends Parsable> CompletableFuture<ModelType> sendAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param targetClass the class of the response model to deserialize the response into.
+     * @return a CompletableFuture with the deserialized primitive response model.
+     */
     <ModelType> CompletableFuture<ModelType> sendPrimitiveAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
@@ -23,7 +23,8 @@ public interface HttpCore {
      * @param requestInfo the request info to execute.
      * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
      * @param targetClass the class of the response model to deserialize the response into.
-     * @return a CompletableFuture with the deserialized response model.
+     * @param <ModelType> the type of the response model to deserialize the response into.
+     * @return a {@link CompletableFuture} with the deserialized response model.
      */
     <ModelType extends Parsable> CompletableFuture<ModelType> sendAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
     /**
@@ -31,7 +32,8 @@ public interface HttpCore {
      * @param requestInfo the request info to execute.
      * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
      * @param targetClass the class of the response model to deserialize the response into.
-     * @return a CompletableFuture with the deserialized primitive response model.
+     * @param <ModelType> the type of the response model to deserialize the response into.
+     * @return a {@link CompletableFuture} with the deserialized primitive response model.
      */
     <ModelType> CompletableFuture<ModelType> sendPrimitiveAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpMethod.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpMethod.java
@@ -1,13 +1,24 @@
 package com.microsoft.kiota;
-
+/** 
+ * Represents the HTTP method used by a request.
+ */
 public enum HttpMethod {
+    /** The HTTP GET method */
     GET,
+    /** The HTTP POST method */
     POST,
+    /** The HTTP PATCH method */
     PATCH,
+    /** The HTTP DELETE method */
     DELETE,
+    /** The HTTP OPTIONS method */
     OPTIONS,
+    /** The HTTP CONNECT method */
     CONNECT,
+    /** The HTTP PUT method */
     PUT,
+    /** The HTTP TRACE method */
     TRACE,
+    /** The HTTP HEAD method */
     HEAD
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseHandler.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseHandler.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 
 /** Default response handler to access the native response object. */
 public class NativeResponseHandler implements ResponseHandler {
+    /** Native response object as returned by the core service */
     @Nullable
     public Object value;
 

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseHandler.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseHandler.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** Default response handler to access the native response object. */
 public class NativeResponseHandler implements ResponseHandler {
     @Nullable
     public Object value;

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseWrapper.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/NativeResponseWrapper.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** This class can be used to wrap a request using the fluent API and get the native response object in return. */
 public class NativeResponseWrapper {
     @SuppressWarnings("unchecked")
     @Nonnull

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
@@ -35,7 +35,7 @@ public class RequestInfo {
     private static String contentTypeHeader = "Content-Type";
     /**
      * Sets the request body to be a binary stream.
-     * @param content the binary stream
+     * @param value the binary stream
      */
     public void setStreamContent(@Nonnull final InputStream value) {
         Objects.requireNonNull(value);

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
@@ -14,24 +14,41 @@ import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.SerializationWriter;
 import com.microsoft.kiota.HttpCore;
 
+/** This class represents an abstract HTTP request. */
 public class RequestInfo {
+    /** The URI of the request. */
     @Nullable
     public URI uri;
+    /** The HTTP method for the request */
     @Nullable
     public HttpMethod httpMethod;
+    /** The Query Parameters of the request. */
     @Nonnull
     public HashMap<String, Object> queryParameters = new HashMap<>(); //TODO case insensitive
+    /** The Request Headers. */
     @Nonnull
     public HashMap<String, String> headers = new HashMap<>(); // TODO case insensitive
+    /** The Request Body. */
     @Nullable
     public InputStream content;
     private static String binaryContentType = "application/octet-stream";
     private static String contentTypeHeader = "Content-Type";
+    /**
+     * Sets the request body to be a binary stream.
+     * @param content the binary stream
+     */
     public void setStreamContent(@Nonnull final InputStream value) {
         Objects.requireNonNull(value);
         this.content = value;
         headers.put(contentTypeHeader, binaryContentType);
     }
+    /**
+     * Sets the request body from a model with the specified content type.
+     * @param value the model.
+     * @param contentType the content type.
+     * @param httpCore The core service to get the serialization writer from.
+     * @param <T> the model type.
+     */
     public <T extends Parsable> void setContentFromParsable(@Nonnull final T value, @Nonnull final HttpCore httpCore, @Nonnull final String contentType) {
         Objects.requireNonNull(httpCore);
         Objects.requireNonNull(value);

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/ResponseHandler.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/ResponseHandler.java
@@ -4,7 +4,15 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 
+/** Defines the contract for a response handler. */
 public interface ResponseHandler {
+    /**
+     * Callback method that is invoked when a response is received.
+     * @param response The native response object.
+     * @param <NativeResponseType> The type of the native response object.
+     * @param <ModelType> The type of the response model object.
+     * @return A CompletableFuture that represents the asynchronous operation and contains the deserialized response.
+     */
     @Nonnull
     <NativeResponseType, ModelType> CompletableFuture<ModelType> handleResponseAsync(@Nonnull final NativeResponseType response);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
@@ -4,11 +4,25 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nonnull;
-
+/**
+ * Defines a serializable model object.
+ */
 public interface Parsable {
+    /**
+     * Gets the deserialization information for this object.
+     * @return The deserialization information for this object where each entry is a property key with its deserialization callback.
+     */
     @Nonnull
     <T> Map<String, BiConsumer<T, ParseNode>> getFieldDeserializers();
+    /**
+     * Writes the objects properties to the current writer.
+     * @param writer The writer to write to.
+     */
     void serialize(@Nonnull final SerializationWriter writer);
+    /**
+     * Gets the additional data for this object that did not belong to the properties.
+     * @return The additional data for this object.
+     */
     @Nonnull
     Map<String, Object> getAdditionalData();
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNode.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNode.java
@@ -10,37 +10,109 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
+ */
 public interface ParseNode {
+    /**
+     * Gets a new parse node for the given identifier.
+     * @param identitier the identifier of the current node property.
+     * @return a new parse node for the given identifier.
+     */
     @Nonnull
     ParseNode getChildNode(@Nonnull final String identifier);
+    /**
+     * Gets the string value of the node.
+     * @return the string value of the node.
+     */
     @Nonnull
     String getStringValue();
+    /**
+     * Gets the boolean value of the node.
+     * @return the boolean value of the node.
+     */
     @Nonnull
     Boolean getBooleanValue();
+    /**
+     * Gets the Integer value of the node.
+     * @return the Integer value of the node.
+     */
     @Nonnull
     Integer getIntegerValue();
+    /**
+     * Gets the Float value of the node.
+     * @return the Float value of the node.
+     */
     @Nonnull
     Float getFloatValue();
+    /**
+     * Gets the Long value of the node.
+     * @return the Long value of the node.
+     */
     @Nonnull
     Long getLongValue();
+    /**
+     * Gets the UUID value of the node.
+     * @return the UUID value of the node.
+     */
     @Nonnull
     UUID getUUIDValue();
+    /**
+     * Gets the OffsetDateTime value of the node.
+     * @return the OffsetDateTime value of the node.
+     */
     @Nonnull
     OffsetDateTime getOffsetDateTimeValue();
+    /**
+     * Gets the Enum value of the node.
+     * @return the Enum value of the node.
+     */
     @Nullable
     <T extends Enum<T>> T getEnumValue(@Nonnull final Class<T> targetEnum);
+    /**
+     * Gets the EnumSet value of the node.
+     * @return the EnumSet value of the node.
+     */
     @Nullable
     <T extends Enum<T>> EnumSet<T> getEnumSetValue(@Nonnull final Class<T> targetEnum);
+    /**
+     * Gets the collection of primitive values of the node.
+     * @return the collection of primitive values of the node.
+     */
     @Nonnull
     <T> List<T> getCollectionOfPrimitiveValues(@Nonnull final Class<T> targetClass);
+    /**
+     * Gets the collection of object values of the node.
+     * @return the collection of object values of the node.
+     */
     @Nonnull
     <T extends Parsable> List<T> getCollectionOfObjectValues(@Nonnull final Class<T> targetClass);
+    /**
+     * Gets the model object value of the node.
+     * @return the model object value of the node.
+     */
     @Nonnull
     <T extends Parsable> T getObjectValue(@Nonnull final Class<T> targetClass);
+    /**
+     * Gets the callback called before the node is deserialized.
+     * @return the callback called before the node is deserialized.
+     */
     @Nullable
     Consumer<Parsable> getOnBeforeAssignFieldValues();
+    /**
+     * Gets the callback called after the node is deseserialized.
+     * @return the callback called after the node is deserialized.
+     */
     @Nullable
     Consumer<Parsable> getOnAfterAssignFieldValues();
+    /**
+     * Sets the callback called before the node is deserialized.
+     * @param value the callback called before the node is deserialized.
+     */
     void setOnBeforeAssignFieldValues(@Nullable final Consumer<Parsable> value);
+    /**
+     * Sets the callback called after the node is deserialized.
+     * @param value the callback called after the node is deserialized.
+     */
     void setOnAfterAssignFieldValues(@Nullable final Consumer<Parsable> value);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeFactory.java
@@ -4,10 +4,21 @@ import java.io.InputStream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
+/**
+ * Defines the contract for a factory that is used to create {@link ParseNode}s.
+ */
 public interface ParseNodeFactory {
+    /**
+     * Returns the content type this factory's parse nodes can deserialize.
+     */
     @Nonnull
     String getValidContentType();
+    /**
+     * Creates a {@link ParseNode} from the given {@link InputStream} and content type.
+     * @param inputStream the {@link InputStream} to read from.
+     * @param contentType the content type of the {@link InputStream}.
+     * @return a {@link ParseNode} that can deserialize the given {@link InputStream}.
+     */
     @Nonnull
     ParseNode getParseNode(@Nonnull final String contentType, @Nonnull final InputStream rawResponse);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeFactoryRegistry.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeFactoryRegistry.java
@@ -6,9 +6,13 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
+/**
+ * This factory holds a list of all the registered factories for the various types of nodes.
+ */
 public class ParseNodeFactoryRegistry implements ParseNodeFactory {
-    // default instance
+    /** Default singleton instance of the registry to be used when registring new factories that should be available by default. */
     public static final ParseNodeFactoryRegistry defaultInstance = new ParseNodeFactoryRegistry();
+    /** List of factories that are registered by content type. */
     public HashMap<String, ParseNodeFactory> contentTypeAssociatedFactories = new HashMap<>();
     public String getValidContentType() {
         throw new UnsupportedOperationException("The registry supports multiple content types. Get the registered factory instead.");

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeProxyFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNodeProxyFactory.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 public abstract class ParseNodeProxyFactory implements ParseNodeFactory {
     public String getValidContentType() {
         return _concrete.getValidContentType();
@@ -15,6 +16,12 @@ public abstract class ParseNodeProxyFactory implements ParseNodeFactory {
     private final ParseNodeFactory _concrete;
     private final Consumer<Parsable> _onBefore;
     private final Consumer<Parsable> _onAfter;
+    /**
+     * Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+     * @param concreteFactory the concrete factory to wrap
+     * @param onBefore the callback to invoke before the deserialization of any model object.
+     * @param onAfter the callback to invoke after the deserialization of any model object.
+     */
     public ParseNodeProxyFactory(@Nonnull final ParseNodeFactory concrete,
         @Nullable final Consumer<Parsable> onBefore,
         @Nullable final Consumer<Parsable> onAfter) {

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
@@ -12,26 +12,111 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** Defines an interface for serialization of objects to a stream. */
 public interface SerializationWriter extends Closeable {
+    /**
+     * Writes the specified string value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeStringValue(@Nullable final String key, @Nonnull final String value);
+    /**
+     * Writes the specified Boolean value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeBooleanValue(@Nullable final String key, @Nonnull final Boolean value);
+    /**
+     * Writes the specified Integer value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeIntegerValue(@Nullable final String key, @Nonnull final Integer value);
+    /**
+     * Writes the specified Float value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeFloatValue(@Nullable final String key, @Nonnull final Float value);
+    /**
+     * Writes the specified Long value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeLongValue(@Nullable final String key, @Nonnull final Long value);
+    /**
+     * Writes the specified UUID value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeUUIDValue(@Nullable final String key, @Nonnull final UUID value);
+    /**
+     * Writes the specified OffsetDateTime value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     void writeOffsetDateTimeValue(@Nullable final String key, @Nonnull final OffsetDateTime value);
+    /**
+     * Writes the specified collection of primitive values to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     <T> void writeCollectionOfPrimitiveValues(@Nullable final String key, @Nonnull final Iterable<T> values);
+    /**
+     * Writes the specified collection of object values to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     <T extends Parsable> void writeCollectionOfObjectValues(@Nullable final String key, @Nonnull final Iterable<T> values);
+    /**
+     * Writes the specified model object value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     <T extends Parsable> void writeObjectValue(@Nullable final String key, @Nonnull final T value);
+    /**
+     * Gets the value of the serialized content.
+     * @return the value of the serialized content.
+     */
     @Nonnull
     InputStream getSerializedContent();
+    /**
+     * Writes the specified enum set value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     <T extends Enum<T>> void writeEnumSetValue(@Nullable final String key, @Nullable final EnumSet<T> values);
+    /**
+     * Writes the specified enum value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     <T extends Enum<T>> void writeEnumValue(@Nullable final String key, @Nullable final T value);
+    /**
+     * Writes the specified additional data values to the stream with an optional given key.
+     * @param value the values to write to the stream.
+     */
     void writeAdditionalData(@Nonnull final Map<String, Object> value);
+    /**
+     * Gets the callback called before the object gets serialized.
+     * @return the callback called before the object gets serialized.
+     */
     @Nullable
     Consumer<Parsable> getOnBeforeObjectSerialization();
+    /**
+     * Gets the callback called after the object gets serialized.
+     * @return the callback called after the object gets serialized.
+     */
     @Nullable
     Consumer<Parsable> getOnAfterObjectSerialization();
+    /**
+     * Sets the callback called before the objects gets serialized.
+     * @param value the callback called before the objects gets serialized.
+     */
     void setOnBeforeObjectSerialization(@Nullable final Consumer<Parsable> value);
+    /**
+     * Sets the callback called after the objects gets serialized.
+     * @param value the callback called after the objects gets serialized.
+     */
     void setOnAfterObjectSerialization(@Nullable final Consumer<Parsable> value);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactory.java
@@ -1,10 +1,19 @@
 package com.microsoft.kiota.serialization;
 
 import javax.annotation.Nonnull;
-
+/** Defines the contract for a factory that creates SerializationWriter instances. */
 public interface SerializationWriterFactory {
+    /**
+     * Gets the content type this factory creates serialization writers for.
+     * @return the content type this factory creates serialization writers for.
+     */
     @Nonnull
     String getValidContentType();
+    /**
+     * Creates a new SerializationWriter instance for the given content type.
+     * @param contentType the content type to create a serialization writer for.
+     * @return a new SerializationWriter instance for the given content type.
+     */
     @Nonnull
     SerializationWriter getSerializationWriter(@Nonnull final String contentType);
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
@@ -4,9 +4,11 @@ import java.util.HashMap;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
-
+/** This factory holds a list of all the registered factories for the various types of nodes. */
 public class SerializationWriterFactoryRegistry implements SerializationWriterFactory {
+    /** Default singleton instance of the registry to be used when registring new factories that should be available by default. */
     public final static SerializationWriterFactoryRegistry defaultInstance = new SerializationWriterFactoryRegistry();
+    /** List of factories that are registered by content type. */
     public HashMap<String, SerializationWriterFactory> contentTypeAssociatedFactories = new HashMap<>();
     public String getValidContentType() {
         throw new UnsupportedOperationException("The registry supports multiple content types. Get the registered factory instead.");

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 public abstract class SerializationWriterProxyFactory implements SerializationWriterFactory {
     public String getValidContentType() {
         return _concrete.getValidContentType();
@@ -13,6 +14,12 @@ public abstract class SerializationWriterProxyFactory implements SerializationWr
     private final SerializationWriterFactory _concrete;
     private final Consumer<Parsable> _onBefore;
     private final Consumer<Parsable> _onAfter;
+    /**
+     * Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+     * @param concreteFactory the concrete factory to wrap
+     * @param onBefore the callback to invoke before the serialization of any model object.
+     * @param onAfter the callback to invoke after the serialization of any model object.
+     */
     public SerializationWriterProxyFactory(@Nonnull final SerializationWriterFactory concrete,
         @Nullable final Consumer<Parsable> onBeforeSerialization, @Nullable final Consumer<Parsable> onAfterSerialization) {
         _concrete = Objects.requireNonNull(concrete);

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackedModel.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackedModel.java
@@ -2,7 +2,12 @@ package com.microsoft.kiota.store;
 
 import javax.annotation.Nonnull;
 
+/** Defines the contracts for a model that is backed by a store. */
 public interface BackedModel {
+    /**
+     * Gets the store that is backing the model.
+     * @return the backing store.
+     */
     @Nonnull
     BackingStore getBackingStore();
 }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreParseNodeFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreParseNodeFactory.java
@@ -4,8 +4,12 @@ import javax.annotation.Nonnull;
 
 import com.microsoft.kiota.serialization.ParseNodeProxyFactory;
 import com.microsoft.kiota.serialization.ParseNodeFactory;
-
+/** Proxy implementation of ParseNodeFactory for the backing store that automatically sets the state of the backing store when deserializing. */
 public class BackingStoreParseNodeFactory extends ParseNodeProxyFactory {
+    /**
+     * Initializes a new instance of the BackingStoreParseNodeFactory class given the concrete implementation.
+     * @param concrete the concrete implementation of the ParseNodeFactory
+     */
     public BackingStoreParseNodeFactory(@Nonnull final ParseNodeFactory concrete) {
         super(
             concrete,

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 public class BackingStoreSerializationWriterProxyFactory extends SerializationWriterProxyFactory {
     /**
      * Initializes a new instance of the BackingStoreSerializationWriterProxyFactory class given a concrete implementation of SerializationWriterFactory.
+     * @param concrete a concrete implementation of SerializationWriterFactory to wrap.
      */
     public BackingStoreSerializationWriterProxyFactory(@Nonnull final SerializationWriterFactory concrete) {
         super(concrete,

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
@@ -4,8 +4,11 @@ import com.microsoft.kiota.serialization.SerializationWriterFactory;
 import com.microsoft.kiota.serialization.SerializationWriterProxyFactory;
 
 import javax.annotation.Nonnull;
-
+/**Proxy implementation of SerializationWriterFactory for the backing store that automatically sets the state of the backing store when serializing. */
 public class BackingStoreSerializationWriterProxyFactory extends SerializationWriterProxyFactory {
+    /**
+     * Initializes a new instance of the BackingStoreSerializationWriterProxyFactory class given a concrete implementation of SerializationWriterFactory.
+     */
     public BackingStoreSerializationWriterProxyFactory(@Nonnull final SerializationWriterFactory concrete) {
         super(concrete,
         (x) -> {

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import com.microsoft.kiota.TriConsumer;
 
 import org.javatuples.Pair;
-
+/** In-memory implementation of the backing store. Allows for dirty tracking of changes. */
 public class InMemoryBackingStore implements BackingStore {
     private boolean isInitializationCompleted = true;
     private boolean returnOnlyChangedValues;

--- a/abstractions/typescript/src/apiClientBuilder.ts
+++ b/abstractions/typescript/src/apiClientBuilder.ts
@@ -1,16 +1,29 @@
 import { BackingStoreParseNodeFactory, BackingStoreSerializationWriterProxyFactory } from "./store";
 import { ParseNodeFactory, ParseNodeFactoryRegistry, SerializationWriterFactory, SerializationWriterFactoryRegistry } from "./serialization";
 
+/**
+ * Registers the default serializer to the registry.
+ * @param type the class of the factory to be registered.
+ */
 export function registerDefaultSerializer(type: new() => SerializationWriterFactory): void {
     if(!type) throw new Error("Type is required");
     const serializer = new type();
     SerializationWriterFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.set(serializer.getValidContentType(), serializer);
 }
+/**
+ * Registers the default deserializer to the registry.
+ * @param type the class of the factory to be registered.
+ */
 export function registerDefaultDeserializer(type: new() => ParseNodeFactory): void {
     if(!type) throw new Error("Type is required");
     const deserializer = new type();
     ParseNodeFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.set(deserializer.getValidContentType(), deserializer);
 }
+/**
+ * Enables the backing store on default serialization writers and the given serialization writer.
+ * @param original The serialization writer to enable the backing store on.
+ * @return A new serialization writer with the backing store enabled.
+ */
 export function enableBackingStoreForSerializationWriterFactory(original: SerializationWriterFactory): SerializationWriterFactory {
     if(!original) throw new Error("Original must be specified");
     let result = original;
@@ -22,6 +35,11 @@ export function enableBackingStoreForSerializationWriterFactory(original: Serial
     enableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry.defaultInstance);
     return result;
 }
+/**
+ * Enables the backing store on default parse node factories and the given parse node factory.
+ * @param original The parse node factory to enable the backing store on.
+ * @return A new parse node factory with the backing store enabled.
+ */
 export function enableBackingStoreForParseNodeFactory(original: ParseNodeFactory): ParseNodeFactory {
     if(!original) throw new Error("Original must be specified");
     let result = original;

--- a/abstractions/typescript/src/authenticationProvider.ts
+++ b/abstractions/typescript/src/authenticationProvider.ts
@@ -1,3 +1,9 @@
+/** Authenticates the application and returns a token. */
 export interface AuthenticationProvider {
+    /**
+     * Authenticates the application and returns a token base on the provided Uri.
+     * @param requestUrl the Uri to authenticate the request for.
+     * @return a Promise that will be completed with the token or undefined if the target request Uri doesn't correspond to a valid resource.
+     */
     getAuthorizationToken: (requestUrl: string) => Promise<string>;
 }

--- a/abstractions/typescript/src/httpCore.ts
+++ b/abstractions/typescript/src/httpCore.ts
@@ -1,10 +1,39 @@
 import { RequestInfo } from "./requestInfo";
 import { ResponseHandler } from "./responseHandler";
 import { Parsable, SerializationWriterFactory } from "./serialization";
+
+/** Service responsible for translating abstract Request Info into concrete native HTTP requests. */
 export interface HttpCore {
+    /**
+     * Gets the serialization writer factory currently in use for the HTTP core service.
+     * @return the serialization writer factory currently in use for the HTTP core service.
+     */
     getSerializationWriterFactory(): SerializationWriterFactory;
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param type the class of the response model to deserialize the response into.
+     * @typeParam ModelType the type of the response model to deserialize the response into.
+     * @return a {@link Promise} with the deserialized response model.
+     */
     sendAsync<ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType>;
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param responseType the class of the response model to deserialize the response into.
+     * @typeParam responseType the type of the response model to deserialize the response into.
+     * @return a {@link Promise} with the deserialized primitive response model.
+     */
     sendPrimitiveAsync<ResponseType>(requestInfo: RequestInfo, responseType: "string" | "number" | "boolean" | "Date" | "ReadableStream", responseHandler: ResponseHandler | undefined): Promise<ResponseType>;
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @return a {@link Promise} of void.
+     */
     sendNoResponseContentAsync(requestInfo: RequestInfo, responseHandler: ResponseHandler | undefined): Promise<void>;
+    /** Enables the backing store proxies for the SerializationWriters and ParseNodes in use. */
     enableBackingStore(): void;
 }

--- a/abstractions/typescript/src/httpMethod.ts
+++ b/abstractions/typescript/src/httpMethod.ts
@@ -1,11 +1,23 @@
+/** 
+ * Represents the HTTP method used by a request.
+ */
 export enum HttpMethod {
+    /** The HTTP GET method */
     GET = "GET",
+    /** The HTTP POST method */
     POST = "POST",
+    /** The HTTP PATCH method */
     PATCH = "PATCH",
+    /** The HTTP DELETE method */
     DELETE = "DELETE",
+    /** The HTTP OPTIONS method */
     OPTIONS = "OPTIONS",
+    /** The HTTP CONNECT method */
     CONNECT = "CONNECT",
+    /** The HTTP TRACE method */
     TRACE = "TRACE",
+    /** The HTTP HEAD method */
     HEAD = "HEAD",
+    /** The HTTP PUT method */
     PUT = "PUT"
 }

--- a/abstractions/typescript/src/nativeResponseHandler.ts
+++ b/abstractions/typescript/src/nativeResponseHandler.ts
@@ -1,6 +1,8 @@
 import { ResponseHandler } from "./responseHandler";
 
+/** Default response handler to access the native response object. */
 export class NativeResponseHandler implements ResponseHandler {
+    /** Native response object as returned by the core service */
     public value?: any;
     public handleResponseAsync<NativeResponseType, ModelType>(response: NativeResponseType): Promise<ModelType> {
         this.value = response;

--- a/abstractions/typescript/src/nativeResponseWrapper.ts
+++ b/abstractions/typescript/src/nativeResponseWrapper.ts
@@ -4,6 +4,7 @@ import { ResponseHandler } from "./responseHandler";
 type originalCallType<modelType, queryParametersType, headersType> = (q?: queryParametersType, h?: headersType, responseHandler?: ResponseHandler) => Promise<modelType>;
 type originalCallWithBodyType<modelType, queryParametersType, headersType, requestBodyType> = (requestBody: requestBodyType, q?: queryParametersType, h?: headersType, responseHandler?: ResponseHandler) => Promise<modelType>;
 
+/** This class can be used to wrap a request using the fluent API and get the native response object in return. */
 export class NativeResponseWrapper {
     public static CallAndGetNative = async <modelType, nativeResponseType, queryParametersType, headersType>(
         originalCall: originalCallType<modelType, queryParametersType, headersType>,

--- a/abstractions/typescript/src/requestInfo.ts
+++ b/abstractions/typescript/src/requestInfo.ts
@@ -3,14 +3,27 @@ import { ReadableStream } from 'web-streams-polyfill/es2018';
 import { Parsable } from "./serialization";
 import { HttpCore } from "./httpCore";
 
+/** This class represents an abstract HTTP request. */
 export class RequestInfo {
+    /** The URI of the request. */
     public URI?: string;
+    /** The HTTP method for the request */
     public httpMethod?: HttpMethod;
+    /** The Request Body. */
     public content?: ReadableStream;
-    public queryParameters: Map<string, object> = new Map<string, object>();
-    public headers: Map<string, string> = new Map<string, string>();
+    /** The Query Parameters of the request. */
+    public queryParameters: Map<string, object> = new Map<string, object>(); //TODO: case insensitive
+    /** The Request Headers. */
+    public headers: Map<string, string> = new Map<string, string>(); //TODO: case insensitive
     private static binaryContentType = "application/octet-stream";
     private static contentTypeHeader = "Content-Type";
+    /**
+     * Sets the request body from a model with the specified content type.
+     * @param value the model.
+     * @param contentType the content type.
+     * @param httpCore The core service to get the serialization writer from.
+     * @typeParam T the model type.
+     */
     public setContentFromParsable = <T extends Parsable>(value?: T | undefined, httpCore?: HttpCore | undefined, contentType?: string | undefined): void => {
         if(!httpCore) throw new Error("httpCore cannot be undefined");
         if(!contentType) throw new Error("contentType cannot be undefined");
@@ -20,15 +33,27 @@ export class RequestInfo {
         writer.writeObjectValue(undefined, value);
         this.content = writer.getSerializedContent();
     }
+    /**
+     * Sets the request body to be a binary stream.
+     * @param value the binary stream
+     */
     public setStreamContent = (value: ReadableStream): void => {
         this.headers.set(RequestInfo.contentTypeHeader, RequestInfo.binaryContentType);
         this.content = value;
     }
+    /**
+     * Sets the request headers from a raw object.
+     * @param headers the headers.
+     */
     public setHeadersFromRawObject = (h: object) : void => {
         Object.entries(h).forEach(([k, v]) => {
             this.headers.set(k, v as string);
         });
     }
+    /**
+     * Sets the query string parameters from a raw object.
+     * @param parameters the parameters.
+     */
     public setQueryStringParametersFromRawObject = (q: object): void => {
         Object.entries(q).forEach(([k, v]) => {
             this.headers.set(k, v as string);

--- a/abstractions/typescript/src/responseHandler.ts
+++ b/abstractions/typescript/src/responseHandler.ts
@@ -1,3 +1,11 @@
+/** Defines the contract for a response handler. */
 export interface ResponseHandler {
+    /**
+     * Callback method that is invoked when a response is received.
+     * @param response The native response object.
+     * @typeParam NativeResponseType The type of the native response object.
+     * @typeParam ModelType The type of the response model object.
+     * @return A {@link Promise} that represents the asynchronous operation and contains the deserialized response.
+     */
     handleResponseAsync<NativeResponseType, ModelType>(response: NativeResponseType): Promise<ModelType>;
 }

--- a/abstractions/typescript/src/serialization/parsable.ts
+++ b/abstractions/typescript/src/serialization/parsable.ts
@@ -1,8 +1,23 @@
 import { ParseNode } from './parseNode';
 import { SerializationWriter } from './serializationWriter';
 
+/**
+ * Defines a serializable model object.
+ */
 export interface Parsable {
+    /**
+     * Gets the deserialization information for this object.
+     * @return The deserialization information for this object where each entry is a property key with its deserialization callback.
+     */
     getFieldDeserializers<T>(): Map<string, (item: T, node: ParseNode) => void>;
+    /**
+     * Writes the objects properties to the current writer.
+     * @param writer The writer to write to.
+     */
     serialize(writer: SerializationWriter): void;
+    /**
+     * Gets the additional data for this object that did not belong to the properties.
+     * @return The additional data for this object.
+     */
     additionalData: Map<string, unknown>;
 }

--- a/abstractions/typescript/src/serialization/parseNode.ts
+++ b/abstractions/typescript/src/serialization/parseNode.ts
@@ -1,17 +1,73 @@
 import { Parsable } from "./parsable";
 
+/**
+ * Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
+ */
 export interface ParseNode {
+    /**
+     * Gets the string value of the node.
+     * @return the string value of the node.
+     */
     getStringValue(): string;
+    /**
+     * Gets a new parse node for the given identifier.
+     * @param identitier the identifier of the current node property.
+     * @return a new parse node for the given identifier.
+     */
     getChildNode(identifier: string): ParseNode;
+    /**
+     * Gets the boolean value of the node.
+     * @return the boolean value of the node.
+     */
     getBooleanValue(): boolean;
+    /**
+     * Gets the Number value of the node.
+     * @return the Number value of the node.
+     */
     getNumberValue(): number;
+    /**
+     * Gets the Guid value of the node.
+     * @return the Guid value of the node.
+     */
     getGuidValue(): string; //TODO https://www.npmjs.com/package/guid-typescript
+    /**
+     * Gets the Date value of the node.
+     * @return the Date value of the node.
+     */
     getDateValue(): Date;
+    /**
+     * Gets the collection of primitive values of the node.
+     * @return the collection of primitive values of the node.
+     */
     getCollectionOfPrimitiveValues<T>(): T[] | undefined;
+    /**
+     * Gets the collection of object values of the node.
+     * @return the collection of object values of the node.
+     */
     getCollectionOfObjectValues<T extends Parsable>(type: new() => T): T[] | undefined;
+    /**
+     * Gets the model object value of the node.
+     * @return the model object value of the node.
+     */
     getObjectValue<T extends Parsable>(type: new() => T): T;
+    /**
+     * Gets the Enum values of the node.
+     * @return the Enum values of the node.
+     */
     getEnumValues<T>(type: any): T[];
+    /**
+     * Gets the Enum value of the node.
+     * @return the Enum value of the node.
+     */
     getEnumValue<T>(type: any): T | undefined;
+    /**
+     * Gets the callback called before the node is deserialized.
+     * @return the callback called before the node is deserialized.
+     */
     onBeforeAssignFieldValues: ((value: Parsable) => void) | undefined;
+    /**
+     * Gets the callback called after the node is deseserialized.
+     * @return the callback called after the node is deserialized.
+     */
     onAfterAssignFieldValues: ((value: Parsable) => void) | undefined;
 }

--- a/abstractions/typescript/src/serialization/parseNodeFactory.ts
+++ b/abstractions/typescript/src/serialization/parseNodeFactory.ts
@@ -1,6 +1,18 @@
 import { ParseNode } from './parseNode';
 
+/**
+ * Defines the contract for a factory that is used to create {@link ParseNode}s.
+ */
 export interface ParseNodeFactory {
+    /**
+     * Returns the content type this factory's parse nodes can deserialize.
+     */
     getValidContentType(): string;
+    /**
+     * Creates a {@link ParseNode} from the given {@link ArrayBuffer} and content type.
+     * @param content the {@link ArrayBuffer} to read from.
+     * @param contentType the content type of the {@link ArrayBuffer}.
+     * @return a {@link ParseNode} that can deserialize the given {@link ArrayBuffer}.
+     */
     getRootParseNode(contentType: string, content: ArrayBuffer): ParseNode;
 }

--- a/abstractions/typescript/src/serialization/parseNodeFactoryRegistry.ts
+++ b/abstractions/typescript/src/serialization/parseNodeFactoryRegistry.ts
@@ -1,11 +1,16 @@
 import { ParseNode } from "./parseNode";
 import { ParseNodeFactory } from "./parseNodeFactory";
 
+/**
+ * This factory holds a list of all the registered factories for the various types of nodes.
+ */
 export class ParseNodeFactoryRegistry implements ParseNodeFactory {
+    /** Default singleton instance of the registry to be used when registring new factories that should be available by default. */
     public static readonly defaultInstance = new ParseNodeFactoryRegistry();
     public getValidContentType(): string {
         throw new Error("The registry supports multiple content types. Get the registered factory instead.");
     }
+    /** List of factories that are registered by content type. */
     public contentTypeAssociatedFactories = new Map<string, ParseNodeFactory>();
     public getRootParseNode(contentType: string, content: ArrayBuffer): ParseNode {
         if(!contentType) {

--- a/abstractions/typescript/src/serialization/parseNodeProxyFactory.ts
+++ b/abstractions/typescript/src/serialization/parseNodeProxyFactory.ts
@@ -2,10 +2,17 @@ import { Parsable } from "./parsable";
 import { ParseNode } from "./parseNode";
 import { ParseNodeFactory } from "./parseNodeFactory";
 
+/** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 export abstract class ParseNodeProxyFactory implements ParseNodeFactory {
     public getValidContentType(): string {
         return this._concrete.getValidContentType();
     }
+    /**
+     * Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+     * @param _concrete the concrete factory to wrap
+     * @param _onBefore the callback to invoke before the deserialization of any model object.
+     * @param _onAfter the callback to invoke after the deserialization of any model object.
+     */
     constructor(private readonly _concrete: ParseNodeFactory,
         private readonly _onBefore: (value: Parsable) => void,
         private readonly _onAfter: (value: Parsable) => void) {

--- a/abstractions/typescript/src/serialization/serializationWriter.ts
+++ b/abstractions/typescript/src/serialization/serializationWriter.ts
@@ -1,18 +1,80 @@
 import { Parsable } from "./parsable";
 import { ReadableStream } from 'web-streams-polyfill/es2018';
 
+/** Defines an interface for serialization of objects to a stream. */
 export interface SerializationWriter {
+    /**
+     * Writes the specified string value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeStringValue(key?: string | undefined, value?: string | undefined): void;
+    /**
+     * Writes the specified boolean value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeBooleanValue(key?: string | undefined, value?: boolean | undefined): void;
+    /**
+     * Writes the specified number value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeNumberValue(key?: string | undefined, value?: number | undefined): void;
+    /**
+     * Writes the specified Guid value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeGuidValue(key?: string | undefined, value?: string | undefined): void;
+    /**
+     * Writes the specified Date value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeDateValue(key?: string | undefined, value?: Date | undefined): void;
+    /**
+     * Writes the specified collection of primitive values to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeCollectionOfPrimitiveValues<T>(key?: string | undefined, values?: T[] | undefined): void;
+    /**
+     * Writes the specified collection of object values to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeCollectionOfObjectValues<T extends Parsable>(key?: string | undefined, values?: T[]): void;
+    /**
+     * Writes the specified model object value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
     writeObjectValue<T extends Parsable>(key?: string | undefined, value?: T | undefined): void;
+    /**
+     * Writes the specified enum value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param values the value to write to the stream.
+     */
     writeEnumValue<T>(key?: string | undefined, ...values: (T | undefined)[]): void;
+    /**
+     * Gets the value of the serialized content.
+     * @return the value of the serialized content.
+     */
     getSerializedContent(): ReadableStream;
+    /**
+     * Writes the specified additional data values to the stream with an optional given key.
+     * @param value the values to write to the stream.
+     */
     writeAdditionalData(value: Map<string, unknown>): void;
+    /**
+     * Gets the callback called before the object gets serialized.
+     * @return the callback called before the object gets serialized.
+     */
     onBeforeObjectSerialization: ((value: Parsable) => void) | undefined;
+    /**
+     * Gets the callback called after the object gets serialized.
+     * @return the callback called after the object gets serialized.
+     */
     onAfterObjectSerialization: ((value: Parsable) => void) | undefined;
 }

--- a/abstractions/typescript/src/serialization/serializationWriterFactory.ts
+++ b/abstractions/typescript/src/serialization/serializationWriterFactory.ts
@@ -1,6 +1,16 @@
 import { SerializationWriter } from './serializationWriter';
 
+/** Defines the contract for a factory that creates SerializationWriter instances. */
 export interface SerializationWriterFactory {
+    /**
+     * Gets the content type this factory creates serialization writers for.
+     * @return the content type this factory creates serialization writers for.
+     */
     getValidContentType(): string;
+    /**
+     * Creates a new SerializationWriter instance for the given content type.
+     * @param contentType the content type to create a serialization writer for.
+     * @return a new SerializationWriter instance for the given content type.
+     */
     getSerializationWriter(contentType: string): SerializationWriter;
 }

--- a/abstractions/typescript/src/serialization/serializationWriterFactoryRegistry.ts
+++ b/abstractions/typescript/src/serialization/serializationWriterFactoryRegistry.ts
@@ -1,11 +1,14 @@
 import { SerializationWriter } from "./serializationWriter";
 import { SerializationWriterFactory } from "./serializationWriterFactory";
 
+/** This factory holds a list of all the registered factories for the various types of nodes. */
 export class SerializationWriterFactoryRegistry implements SerializationWriterFactory {
+    /** Default singleton instance of the registry to be used when registring new factories that should be available by default. */
     public static readonly defaultInstance = new SerializationWriterFactoryRegistry();
     public getValidContentType(): string {
         throw new Error("The registry supports multiple content types. Get the registered factory instead.");
     }
+    /** List of factories that are registered by content type. */
     public contentTypeAssociatedFactories = new Map<string, SerializationWriterFactory>();
     public getSerializationWriter(contentType: string): SerializationWriter {
         if(!contentType) {

--- a/abstractions/typescript/src/serialization/serializationWriterProxyFactory.ts
+++ b/abstractions/typescript/src/serialization/serializationWriterProxyFactory.ts
@@ -2,10 +2,17 @@ import { Parsable } from "./parsable";
 import { SerializationWriter } from "./serializationWriter";
 import { SerializationWriterFactory } from "./serializationWriterFactory";
 
+/** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 export abstract class SerializationWriterProxyFactory implements SerializationWriterFactory {
     public getValidContentType(): string {
         return this._concrete.getValidContentType();
     }
+    /**
+     * Creates a new proxy factory that wraps the specified concrete factory while composing the before and after callbacks.
+     * @param _concrete the concrete factory to wrap
+     * @param _onBefore the callback to invoke before the serialization of any model object.
+     * @param _onAfter the callback to invoke after the serialization of any model object.
+     */
     constructor(private readonly _concrete: SerializationWriterFactory,
         private readonly _onBefore: (value: Parsable) => void,
         private readonly _onAfter: (value: Parsable) => void) {

--- a/abstractions/typescript/src/store/backedModel.ts
+++ b/abstractions/typescript/src/store/backedModel.ts
@@ -1,5 +1,9 @@
 import { BackingStore } from "./backingStore";
 
+/** Defines the contracts for a model that is backed by a store. */
 export interface BackedModel {
+    /**
+     * Gets the store that is backing the model.
+     */
     backingStore: BackingStore;
 }

--- a/abstractions/typescript/src/store/backingStoreParseNodeFactory.ts
+++ b/abstractions/typescript/src/store/backingStoreParseNodeFactory.ts
@@ -1,7 +1,12 @@
 import { ParseNodeFactory, ParseNodeProxyFactory } from "../serialization";
 import { BackedModel } from "./backedModel";
 
+/** Proxy implementation of ParseNodeFactory for the backing store that automatically sets the state of the backing store when deserializing. */
 export class BackingStoreParseNodeFactory extends ParseNodeProxyFactory {
+    /**
+     * Initializes a new instance of the BackingStoreParseNodeFactory class given the concrete implementation.
+     * @param concrete the concrete implementation of the ParseNodeFactory
+     */
     public constructor(concrete: ParseNodeFactory) {
         super(concrete, 
             value => {

--- a/abstractions/typescript/src/store/backingStoreSerializationWriterProxyFactory.ts
+++ b/abstractions/typescript/src/store/backingStoreSerializationWriterProxyFactory.ts
@@ -1,7 +1,12 @@
 import { SerializationWriterFactory, SerializationWriterProxyFactory } from "../serialization";
 import { BackedModel } from "./backedModel";
 
+/**Proxy implementation of SerializationWriterFactory for the backing store that automatically sets the state of the backing store when serializing. */
 export class BackingStoreSerializationWriterProxyFactory extends SerializationWriterProxyFactory {
+    /**
+     * Initializes a new instance of the BackingStoreSerializationWriterProxyFactory class given a concrete implementation of SerializationWriterFactory.
+     * @param concrete a concrete implementation of SerializationWriterFactory to wrap.
+     */
     public constructor(concrete: SerializationWriterFactory) {
         super(concrete,
             value => {

--- a/abstractions/typescript/src/store/inMemoryBackingStore.ts
+++ b/abstractions/typescript/src/store/inMemoryBackingStore.ts
@@ -6,6 +6,7 @@ type storeEntryWrapper = {changed: boolean, value: unknown};
 type subscriptionCallback = (key: string, previousValue: unknown, newValue: unknown) => void;
 type storeEntry = {key: string, value: unknown};
 
+/** In-memory implementation of the backing store. Allows for dirty tracking of changes. */
 export class InMemoryBackingStore implements BackingStore {
     public get<T>(key: string): T | undefined {
         const wrapper = this.store.get(key);


### PR DESCRIPTION
# Summary
- adds doc comments for all of dotnet abstractions
- documentation typos and naming conventions fixes
- adds doc comments for java abstractions

fixes #255

No generation diff for this one.