### PR TITLE
- updates vs tasks to bring macos compatibility

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,18 +31,20 @@
         {
             "label": "coverage:clean",
             "type": "shell",
-            "command": "powershell",
             "group": "test",
-            "args": [
-                "-command",
-                "Remove-Item -Recurse -Include TestResults -Path tests"
-            ],
             "linux": {
                 "command": "rm",
                 "args": [
                     "-r",
                     "${workspaceFolder}/tests/Kiota.Builder.Tests/TestResults",
                     "${workspaceFolder}/tests/Kiota.Builder.IntegrationTests/TestResults"
+                ]
+            },
+            "windows": {
+                "command": "powershell",
+                "args": [
+                    "-command",
+                    "Remove-Item -Recurse -Include TestResults -Path tests"
                 ]
             }
         },
@@ -71,18 +73,21 @@
         {
             "label": "coverage:unit",
             "type": "process",
-            "command": "reportgenerator",
+            
             "group": "test",
-            "args": [
-                "-reports:${workspaceFolder}\\tests\\Kiota.Builder.Tests\\**\\coverage.cobertura.xml",
-                "-targetdir:${workspaceFolder}\\reports\\coverage"
-            ],
             "linux":{
                 "command": "reportgenerator",
                 "args": [
                     "-reports:${workspaceFolder}/tests/Kiota.Builder.Tests/**/coverage.cobertura.xml",
                     "-targetdir:${workspaceFolder}/reports/coverage"
                 ],
+            },
+            "windows": {
+                "command": "reportgenerator",
+                "args": [
+                    "-reports:${workspaceFolder}\\tests\\Kiota.Builder.Tests\\**\\coverage.cobertura.xml",
+                    "-targetdir:${workspaceFolder}\\reports\\coverage"
+                ]
             },
             "dependsOn": [
                 "coverage:clean",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,18 +51,20 @@
         {
             "label": "coverage:global",
             "type": "process",
-            "command": "reportgenerator",
             "group": "test",
-            "args": [
-                "-reports:${workspaceFolder}\\tests\\**\\coverage.cobertura.xml",
-                "-targetdir:${workspaceFolder}\\reports\\coverage"
-            ],
             "linux":{
                 "command": "reportgenerator",
                 "args": [
                     "-reports:${workspaceFolder}/tests/**/coverage.cobertura.xml",
                     "-targetdir:${workspaceFolder}/reports/coverage"
                 ],
+            },
+            "windows": {
+                "command": "reportgenerator",
+                "args": [
+                    "-reports:${workspaceFolder}\\tests\\**\\coverage.cobertura.xml",
+                    "-targetdir:${workspaceFolder}\\reports\\coverage"
+                ]
             },
             "dependsOn": [
                 "coverage:clean",
@@ -73,7 +75,6 @@
         {
             "label": "coverage:unit",
             "type": "process",
-            
             "group": "test",
             "linux":{
                 "command": "reportgenerator",
@@ -98,7 +99,6 @@
         {
             "label": "coverage:launch",
             "type": "shell",
-            "command": "start",
             "linux": {
                 "command": "xdg-open",
                 "args": [
@@ -111,10 +111,13 @@
                     "${workspaceFolder}/reports/coverage/index.html"
                 ]
             },
+            "windows": {
+                "command": "start",
+                "args": [
+                    "${workspaceFolder}/reports/coverage/index.html"
+                ]
+            },
             "group": "test",
-            "args": [
-                "${workspaceFolder}/reports/coverage/index.html"
-            ],
         },
         {
             "label": "coverage:launch:global",


### PR DESCRIPTION
for some reason vs code on macos looks at the main task definition instead of going straight to the linux one. Moving the main task definition under windows fixes that issue