### PR TITLE
fixes an issue where a property with the class name would prevent compilation in CSharp

### DIFF
--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -28,7 +28,7 @@ namespace Kiota.Builder.Refiners {
                 var sameNameProperty = currentClass
                                                 .GetChildElements(true)
                                                 .OfType<CodeProperty>()
-                                                .FirstOrDefault(x => x.Name.Equals(currentClass.Name));
+                                                .FirstOrDefault(x => x.Name.Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase));
                 if(sameNameProperty != null) {
                     currentClass.RemoveChildElement(sameNameProperty);
                     sameNameProperty.SerializationName = sameNameProperty.SerializationName ?? sameNameProperty.Name;

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -73,7 +73,7 @@ namespace Kiota.Builder.Refiners.Tests {
         [Fact]
         public void DisambiguatePropertiesWithClassNames() {
             var model = root.AddClass(new CodeClass (root) {
-                Name = "model",
+                Name = "Model",
                 ClassKind = CodeClassKind.Model
             }).First();
             var propToAdd = model.AddProperty(new CodeProperty(model){
@@ -90,7 +90,7 @@ namespace Kiota.Builder.Refiners.Tests {
         public void DisambiguatePropertiesWithClassNames_DoesntReplaceSerializationName() {
             var serializationName = "serializationName";
             var model = root.AddClass(new CodeClass (root) {
-                Name = "model",
+                Name = "Model",
                 ClassKind = CodeClassKind.Model
             }).First();
             var propToAdd = model.AddProperty(new CodeProperty(model){


### PR DESCRIPTION
fixes #218 for a second time because of a casing issue. No changes to our generation results in our samples