### PR TITLE
bugfix/Typescript removed extra collection map

### DIFF
--- a/serialization/typescript/json/src/jsonParseNode.ts
+++ b/serialization/typescript/json/src/jsonParseNode.ts
@@ -17,7 +17,6 @@ export class JsonParseNode implements ParseNode {
     public getDateValue = (): Date => this._jsonNode as Date;
     public getCollectionOfPrimitiveValues = <T>(): T[] | undefined => {
         return (this._jsonNode as unknown[])
-            .map(x => new JsonParseNode(x))
             .map(x => {
                 const currentParseNode = new JsonParseNode(x);
                 if(x instanceof Boolean) {


### PR DESCRIPTION
Typescript deserializer had extra map that converted collection to a JsonParseNode before second map that returned the scalar values inside the collection instead. Removed the extra map.