### PR TITLE
bugfix/raw collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ruby JSON serialization #429
 
+### Changed
+
+- Fixed a bug where raw collections requests would not be supported #467
+
 ## [0.0.7] - 2021-08-04
 
 ### Added

--- a/abstractions/dotnet/src/IHttpCore.cs
+++ b/abstractions/dotnet/src/IHttpCore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions.Serialization;
 
@@ -21,6 +22,13 @@ namespace Microsoft.Kiota.Abstractions {
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <returns>The deserialized response model.</returns>
         Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
+        /// <summary>
+        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model collection.
+        /// </summary>
+        /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
+        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <returns>The deserialized response model collection.</returns>
+        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
         /// <summary>
         /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
         /// </summary>

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
   </PropertyGroup>
 
 </Project>

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -69,15 +69,19 @@ namespace Microsoft.Kiota.Abstractions
         /// Sets the request body from a model with the specified content type.
         /// </summary>
         /// <param name="coreService">The core service to get the serialization writer from.</param>
-        /// <param name="item">The model to serialize.</param>
+        /// <param name="items">The models to serialize.</param>
         /// <param name="contentType">The content type to set.</param>
         /// <typeparam name="T">The model type to serialize.</typeparam>
-        public void SetContentFromParsable<T>(T item, IHttpCore coreService, string contentType) where T : IParsable {
+        public void SetContentFromParsable<T>(IHttpCore coreService, string contentType, params T[] items) where T : IParsable {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
             if(coreService == null) throw new ArgumentNullException(nameof(coreService));
+            if(items == null || !items.Any()) throw new InvalidOperationException($"{nameof(items)} cannot be null or empty"); 
 
             using var writer = coreService.SerializationWriterFactory.GetSerializationWriter(contentType);
-            writer.WriteObjectValue(null, item);
+            if(items.Count() == 1)
+                writer.WriteObjectValue(null, items[0]);
+            else
+                writer.WriteCollectionOfObjectValues(null, items);
             Headers.Add(contentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
         }

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -46,7 +46,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.14'
+            version '1.0.15'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/HttpCore.java
@@ -1,6 +1,7 @@
 package com.microsoft.kiota;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,6 +28,15 @@ public interface HttpCore {
      * @return a {@link CompletableFuture} with the deserialized response model.
      */
     <ModelType extends Parsable> CompletableFuture<ModelType> sendAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
+    /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model collection.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param targetClass the class of the response model to deserialize the response into.
+     * @param <ModelType> the type of the response model to deserialize the response into.
+     * @return a {@link CompletableFuture} with the deserialized response model collection.
+     */
+    <ModelType extends Parsable> CompletableFuture<Iterable<ModelType>> sendCollectionAsync(@Nonnull final RequestInfo requestInfo, @Nonnull final Class<ModelType> targetClass, @Nullable final ResponseHandler responseHandler);
     /**
      * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
      * @param requestInfo the request info to execute.

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/RequestInfo.java
@@ -3,6 +3,7 @@ package com.microsoft.kiota;
 import java.net.URI;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Objects;
@@ -71,18 +72,23 @@ public class RequestInfo {
     }
     /**
      * Sets the request body from a model with the specified content type.
-     * @param value the model.
+     * @param values the models.
      * @param contentType the content type.
      * @param httpCore The core service to get the serialization writer from.
      * @param <T> the model type.
      */
-    public <T extends Parsable> void setContentFromParsable(@Nonnull final T value, @Nonnull final HttpCore httpCore, @Nonnull final String contentType) {
+    public <T extends Parsable> void setContentFromParsable(@Nonnull final HttpCore httpCore, @Nonnull final String contentType, @Nonnull final T... values) {
         Objects.requireNonNull(httpCore);
-        Objects.requireNonNull(value);
+        Objects.requireNonNull(values);
         Objects.requireNonNull(contentType);
+        if(values.length == 0) throw new RuntimeException("values cannot be empty");
+
         try(final SerializationWriter writer = httpCore.getSerializationWriterFactory().getSerializationWriter(contentType)) {
             headers.put(contentTypeHeader, contentType);
-            writer.writeObjectValue(null, value);
+            if(values.length == 1) 
+                writer.writeObjectValue(null, values[0]);
+            else
+                writer.writeCollectionOfObjectValues(null, Arrays.asList(values));
             this.content = writer.getSerializedContent();
         } catch (IOException ex) {
             throw new RuntimeException("could not serialize payload", ex);

--- a/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/request_info.rb
+++ b/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/request_info.rb
@@ -28,11 +28,15 @@ module MicrosoftKiotaAbstractions
       @headers[@@content_type_header] = @@binary_content_type
     end
 
-    def set_content_from_parsable(value, serializer_factory, content_type)
+    def set_content_from_parsable(serializer_factory, content_type, values)
       begin
         writer  = serializer_factory.get_serialization_writer(content_type)
         headers[@@content_type_header] = content_type
-        writer.write_object_value(nil, value);
+        if values != nil && values.kind_of?(Array)
+          writer.write_collection_of_object_values(nil, values)
+        else
+          writer.write_object_value(nil, values);
+        end
         this.content = writer.get_serialized_content();
       rescue => exception
         raise Exception.new "could not serialize payload"

--- a/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/version.rb
+++ b/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicrosoftKiotaAbstractions
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/src/httpCore.ts
+++ b/abstractions/typescript/src/httpCore.ts
@@ -19,6 +19,15 @@ export interface HttpCore {
      */
     sendAsync<ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType>;
     /**
+     * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model collection.
+     * @param requestInfo the request info to execute.
+     * @param responseHandler The response handler to use for the HTTP request instead of the default handler.
+     * @param type the class of the response model to deserialize the response into.
+     * @typeParam ModelType the type of the response model to deserialize the response into.
+     * @return a {@link Promise} with the deserialized response model collection.
+     */
+    sendCollectionAsync<ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType[]>;
+    /**
      * Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
      * @param requestInfo the request info to execute.
      * @param responseHandler The response handler to use for the HTTP request instead of the default handler.

--- a/abstractions/typescript/src/requestInfo.ts
+++ b/abstractions/typescript/src/requestInfo.ts
@@ -36,18 +36,22 @@ export class RequestInfo {
     private static contentTypeHeader = "Content-Type";
     /**
      * Sets the request body from a model with the specified content type.
-     * @param value the model.
+     * @param values the models.
      * @param contentType the content type.
      * @param httpCore The core service to get the serialization writer from.
      * @typeParam T the model type.
      */
-    public setContentFromParsable = <T extends Parsable>(value?: T | undefined, httpCore?: HttpCore | undefined, contentType?: string | undefined): void => {
+    public setContentFromParsable = <T extends Parsable>(httpCore?: HttpCore | undefined, contentType?: string | undefined, ...values: T[]): void => {
         if(!httpCore) throw new Error("httpCore cannot be undefined");
         if(!contentType) throw new Error("contentType cannot be undefined");
+        if(!values || values.length === 0) throw new Error("values cannot be undefined or empty");
 
         const writer = httpCore.getSerializationWriterFactory().getSerializationWriter(contentType);
         this.headers.set(RequestInfo.contentTypeHeader, contentType);
-        writer.writeObjectValue(undefined, value);
+        if(values.length === 1) 
+            writer.writeObjectValue(undefined, values[0]);
+        else
+            writer.writeCollectionOfObjectValues(undefined, values);
         this.content = writer.getSerializedContent();
     }
     /**

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -35,6 +35,17 @@ namespace Microsoft.Kiota.Http.HttpClient
         }
         /// <summary>Factory to use to get a serializer for payload serialization</summary>
         public ISerializationWriterFactory SerializationWriterFactory { get { return sWriterFactory; } }
+        public async Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable {
+            var response = await GetHttpResponseMessage(requestInfo);
+            requestInfo.Content?.Dispose();
+            if(responseHandler == null) {
+                var rootNode = await GetRootParseNode(response);
+                var result = rootNode.GetCollectionOfObjectValues<ModelType>();
+                return result;
+            }
+            else
+                return await responseHandler.HandleResponseAsync<HttpResponseMessage, IEnumerable<ModelType>>(response);
+        }
         public async Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = null) where ModelType : IParsable
         {
             var response = await GetHttpResponseMessage(requestInfo);

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
@@ -4,11 +4,11 @@
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.14" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.15" />
   </ItemGroup>
 
 </Project>

--- a/http/java/okhttp/lib/build.gradle
+++ b/http/java/okhttp/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     api 'com.squareup.okhttp3:okhttp:4.9.1'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.14'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.15'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-http-okhttp'
-            version '1.0.4'
+            version '1.0.5'
             from(components.java)
         }
     }

--- a/http/typescript/fetch/package-lock.json
+++ b/http/typescript/fetch/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-http-fetch",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/http/typescript/fetch/package.json
+++ b/http/typescript/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-http-fetch",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Kiota HttpCore implementation with fetch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@microsoft/kiota-abstractions": "^1.0.14",
+    "@microsoft/kiota-abstractions": "^1.0.15",
     "cross-fetch": "^3.1.4",
     "web-streams-polyfill": "^3.1.0"
   },

--- a/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeTypeBase.cs
@@ -15,7 +15,8 @@ namespace Kiota.Builder {
         public bool ActionOf {get;set;} = false;
         public bool IsNullable {get;set;} = true;
         public CodeTypeCollectionKind CollectionKind {get;set;} = CodeTypeCollectionKind.None;
-
+        public bool IsCollection { get { return CollectionKind != CodeTypeCollectionKind.None; } }
+        public bool IsArray { get { return CollectionKind == CodeTypeCollectionKind.Array; } }
         public ChildType BaseClone<ChildType>(CodeTypeBase source) where ChildType : CodeTypeBase
         {
             ActionOf = source.ActionOf;

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -366,7 +366,7 @@ namespace Kiota.Builder.Refiners {
                                     .Distinct();
                 var methodsParametersTypes = methods
                                     .SelectMany(x => x.Parameters)
-                                    .Where(x => x.IsOfKind(CodeParameterKind.Custom))
+                                    .Where(x => x.IsOfKind(CodeParameterKind.Custom, CodeParameterKind.RequestBody))
                                     .Select(x => x.Type)
                                     .Distinct();
                 var indexerTypes = currentClass

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -66,6 +66,11 @@ namespace Kiota.Builder.Writers.CSharp {
                 default: return typeName?.ToFirstCharacterUpperCase() ?? "object";
             }
         }
+        public bool IsPrimitiveType(string typeName) {
+            return !string.IsNullOrEmpty(typeName) &&
+                        (NullableTypes.Contains(typeName) ||
+                        "string".Equals(typeName, StringComparison.OrdinalIgnoreCase));
+        }
         public string GetParameterSignature(CodeParameter parameter)
         {
             var parameterType = GetTypeString(parameter.Type);

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -199,9 +199,9 @@ namespace Kiota.Builder.Writers.CSharp {
             if(additionalDataProperty != null)
                 writer.WriteLine($"writer.WriteAdditionalData({additionalDataProperty.Name});");
         }
-        private static string GetSendRequestMethodName(bool isVoid, bool isStream, string returnType) {
+        private string GetSendRequestMethodName(bool isVoid, bool isStream, string returnType) {
             if(isVoid) return "SendNoContentAsync";
-            else if(isStream) return $"SendPrimitiveAsync<{returnType}>";
+            else if(isStream || conventions.IsPrimitiveType(returnType)) return $"SendPrimitiveAsync<{returnType}>";
             else return $"SendAsync<{returnType}>";
         }
         private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer) {

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -168,7 +168,7 @@ namespace Kiota.Builder.Writers.CSharp {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"{_requestInfoVarName}.SetStreamContent({requestBodyParam.Name});");
                 else
-                    writer.WriteLine($"{_requestInfoVarName}.SetContentFromParsable({requestBodyParam.Name}, {conventions.HttpCorePropertyName}, \"{codeElement.ContentType}\");");
+                    writer.WriteLine($"{_requestInfoVarName}.SetContentFromParsable({conventions.HttpCorePropertyName}, \"{codeElement.ContentType}\", {requestBodyParam.Name});");
             }
             if(queryStringParam != null) {
                 writer.WriteLine($"if ({queryStringParam.Name} != null) {{");

--- a/src/Kiota.Builder/Writers/CSharp/StringExtensions.cs
+++ b/src/Kiota.Builder/Writers/CSharp/StringExtensions.cs
@@ -1,0 +1,5 @@
+namespace Kiota.Builder.Writers.CSharp {
+    public static class StringExtensions {
+        public static string StripArraySuffix(this string original) => string.IsNullOrEmpty(original) ? original : original.TrimEnd(']').TrimEnd('[');
+    }
+}

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -149,7 +149,7 @@ namespace Kiota.Builder.Writers.Ruby {
                 if(requestBodyParam.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"request_info.set_stream_content({requestBodyParam.Name})");
                 else
-                    writer.WriteLine($"request_info.set_content_from_parsable({requestBodyParam.Name}, self.{RubyConventionService.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\")");
+                    writer.WriteLine($"request_info.set_content_from_parsable(self.{RubyConventionService.SerializerFactoryPropertyName}, \"{codeElement.ContentType}\", {requestBodyParam.Name})");
             }
             writer.WriteLine("return request_info;");
         }

--- a/src/Kiota.Builder/Writers/StringExtensions.cs
+++ b/src/Kiota.Builder/Writers/StringExtensions.cs
@@ -1,4 +1,4 @@
-namespace Kiota.Builder.Writers.CSharp {
+namespace Kiota.Builder.Writers {
     public static class StringExtensions {
         public static string StripArraySuffix(this string original) => string.IsNullOrEmpty(original) ? original : original.TrimEnd(']').TrimEnd('[');
     }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -90,7 +90,12 @@ namespace Kiota.Builder.Writers.TypeScript {
                 _ => typeName.ToFirstCharacterUpperCase() ?? "object",
             };
         }
-
+        public bool IsPrimitiveType(string typeName) {
+            return typeName switch {
+                ("number" or "string" or "byte[]" or "boolean" or "void") => true,
+                _ => false,
+            };
+        }
         internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
         public void WriteShortDescription(string description, LanguageWriter writer)
         {

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -137,6 +137,17 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
+        public void WritesRequestExecutorBodyForCollections() {
+            method.MethodKind = CodeMethodKind.RequestExecutor;
+            method.HttpMethod = HttpMethod.Get;
+            method.ReturnType.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+            AddRequestBodyParameters();
+            writer.Write(method);
+            var result = tw.ToString();
+            Assert.Contains("SendCollectionAsync", result);
+            AssertExtensions.CurlyBracesAreClosed(result);
+        }
+        [Fact]
         public void WritesRequestGeneratorBody() {
             method.MethodKind = CodeMethodKind.RequestGenerator;
             method.HttpMethod = HttpMethod.Get;

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -148,6 +148,17 @@ namespace Kiota.Builder.Writers.Java.Tests {
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
+        public void WritesRequestExecutorBodyForCollections() {
+            method.MethodKind = CodeMethodKind.RequestExecutor;
+            method.HttpMethod = HttpMethod.Get;
+            method.ReturnType.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+            AddRequestBodyParameters();
+            writer.Write(method);
+            var result = tw.ToString();
+            Assert.Contains("sendCollectionAsync", result);
+            AssertExtensions.CurlyBracesAreClosed(result);
+        }
+        [Fact]
         public void WritesRequestGeneratorBody() {
             method.MethodKind = CodeMethodKind.RequestGenerator;
             method.HttpMethod = HttpMethod.Get;

--- a/tests/Kiota.Builder.Tests/Writers/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/StringExtensionsTests.cs
@@ -1,0 +1,17 @@
+using Kiota.Builder.Writers;
+using Xunit;
+
+namespace Kiota.Builder.Tests.Writers {
+    public class StringExtensionsTests {
+        [Fact]
+        public void Defensive() {
+            Assert.Null(StringExtensions.StripArraySuffix(null));
+            Assert.Empty(StringExtensions.StripArraySuffix(string.Empty));
+        }
+        [Fact]
+        public void StripsSuffix() {
+            Assert.Equal("foo", StringExtensions.StripArraySuffix("foo[]"));
+            Assert.Equal("[]foo", StringExtensions.StripArraySuffix("[]foo"));
+        }
+    }
+}

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
@@ -136,6 +136,17 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
+        public void WritesRequestExecutorBodyForCollections() {
+            method.MethodKind = CodeMethodKind.RequestExecutor;
+            method.HttpMethod = HttpMethod.Get;
+            method.ReturnType.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+            AddRequestBodyParameters();
+            writer.Write(method);
+            var result = tw.ToString();
+            Assert.Contains("sendCollectionAsync", result);
+            AssertExtensions.CurlyBracesAreClosed(result);
+        }
+        [Fact]
         public void WritesRequestGeneratorBody() {
             method.MethodKind = CodeMethodKind.RequestGenerator;
             method.HttpMethod = HttpMethod.Get;


### PR DESCRIPTION
- fixes a bug where sending collections of objects would not be supported in CSharp
- fixes a bug in CSharp were primitive types would map to the wrong http core method
- adds an overload for collections in dotnet httpcore
- fixes a bug in dotnet generation where raw collections would not be mapped properly
- fixes a bug in java where raw collections requests would not be supported
- fixes a bug for typescript where raw collections would not be supported
- fixes a bug where body types would not be imported
- fixes support for raw collections in ruby

fixes #467

## Generation diff

https://github.com/microsoft/kiota-samples/pull/212