### PR TITLE
Adds support for package validation on dotnet build

### DIFF
--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
     <Version>1.0.16</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Enable this line once we go live to prevent breaking changes -->
+    <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
   </PropertyGroup>
 
 </Project>

--- a/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
     <Version>1.0.3</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Enable this line once we go live to prevent breaking changes -->
+    <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
     <Version>1.0.6</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Enable this line once we go live to prevent breaking changes -->
+    <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
     <Version>1.0.4</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Enable this line once we go live to prevent breaking changes -->
+    <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> --> 
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #279 

This PR edits the project files of the following projects so that the `Microsoft.DotNet.PackageValidation` package may perform package validation when `dotnet build` is ran. This therefore means there is no need to edit pipelines as they already leverage the use of calling `dotnet build`.

- Microsoft.Kiota.Abstractions
- Microsoft.Kiota.Authentication.Azure
- Microsoft.Kiota.Http.HttpClient
- Microsoft.Kiota.Serialization.Json

For now, the `PackageValidationBaselineVersion` directive has been commented out(disabled) and will be enabled once we go live with a stable version of the packages to enable package validation to prevent breaking changes.

Related info
- https://devblogs.microsoft.com/dotnet/package-validation/