### PR TITLE
Add doc comments for HttpClient project for dotnet

### DIFF
--- a/http/dotnet/httpclient/.editorconfig
+++ b/http/dotnet/httpclient/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements =false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators =before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = false
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.sln
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.sln
@@ -3,7 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Kiota.Http.HttpClient", "src\Microsoft.Kiota.Http.HttpClient.csproj", "{769E84B2-FD14-4173-B83B-6792DFB0BA14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Kiota.Http.HttpClient", "src\Microsoft.Kiota.Http.HttpClient.csproj", "{769E84B2-FD14-4173-B83B-6792DFB0BA14}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{178B3904-FBB4-4E5A-A569-B5082BABC124}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,9 +18,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,5 +32,11 @@ Global
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x64.Build.0 = Release|Any CPU
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x86.ActiveCfg = Release|Any CPU
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7FA22941-248E-4584-A52F-E14C68AF3876}
 	EndGlobalSection
 EndGlobal

--- a/http/dotnet/httpclient/README.md
+++ b/http/dotnet/httpclient/README.md
@@ -5,7 +5,7 @@
 - [ ] coverage code
 - [ ] analyzers
 - [ ] unit test project
-- [ ] docs comments
+- [x] docs comments
 
 ## Using the Http HttpClient implementations
 

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -1,19 +1,26 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.Kiota.Abstractions;
 
-namespace Microsoft.Kiota.Http.HttpClient {
+namespace Microsoft.Kiota.Http.HttpClient
+{
     /// <summary>
     /// This class is used to build the HttpClient instance used by the core service.
     /// </summary>
-    public static class HttpClientBuilder {
+    public static class HttpClientBuilder
+    {
         /// <summary>
-        /// Initializes the <see cref="HttpClient"/> with the default configuration and middlewares including a authentention middleware using the <see cref="IAuthenticationProvider"/> if provided.
+        /// Initializes the <see cref="HttpClient"/> with the default configuration and middlewares including a authentication middleware using the <see cref="IAuthenticationProvider"/> if provided.
         /// </summary>
-        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> to use for authentention.</param>
+        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> to use for authentication.</param>
         /// <returns>The <see cref="HttpClient"/> with the default middlewares.</returns>
-        public static System.Net.Http.HttpClient Create(IAuthenticationProvider authenticationProvider = default) {
+        public static System.Net.Http.HttpClient Create(IAuthenticationProvider authenticationProvider = default)
+        {
             var defaultHandlers = CreateDefaultHandlers(authenticationProvider);
             var handler = ChainHandlersCollectionAndGetFirstLink(defaultHandlers.ToArray());
             return handler != null ? new System.Net.Http.HttpClient(handler) : new System.Net.Http.HttpClient(); //TODO configure the default client options
@@ -32,13 +39,16 @@ namespace Microsoft.Kiota.Http.HttpClient {
         /// </summary>
         /// <param name="handlers">The <see cref="DelegatingHandler"/> instances to create the <see cref="DelegatingHandler"/> from.</param>
         /// <returns>The created <see cref="DelegatingHandler"/>.</returns>
-        public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers) {
+        public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
+        {
             if(handlers == null || !handlers.Any()) return default;
             var handlersCount = handlers.Count();
-            for(var i = 0; i < handlersCount; i++) {
+            for(var i = 0; i < handlersCount; i++)
+            {
                 var handler = handlers[i];
                 var previousItemIndex = i - 1;
-                if(previousItemIndex >= 0) {
+                if(previousItemIndex >= 0)
+                {
                     var previousHandler = handlers[previousItemIndex];
                     previousHandler.InnerHandler = handler;
                 }

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,9 +15,12 @@ using Microsoft.Kiota.Abstractions.Store;
 
 namespace Microsoft.Kiota.Http.HttpClient
 {
+    /// <summary>
+    /// The <see cref="IHttpCore"/> implementation for sending requests.
+    /// </summary>
     public class HttpCore : IHttpCore, IDisposable
     {
-        private const string authorizationHeaderKey = "Authorization";
+        private const string AuthorizationHeaderKey = "Authorization";
         private readonly System.Net.Http.HttpClient client;
         private readonly IAuthenticationProvider authProvider;
         private IParseNodeFactory pNodeFactory;
@@ -21,10 +28,10 @@ namespace Microsoft.Kiota.Http.HttpClient
         private readonly bool createdClient;
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpCore"/> class.
-        /// <param name="authProvider">The authentication provider.</param>
-        /// <param name="pNodeFactory">The parse node factory.</param>
-        /// <param name="sWriterFactory">The serialization writer factory.</param>
-        /// <param name="client">The native HTTP client.</param>
+        /// <param name="authenticationProvider">The authentication provider.</param>
+        /// <param name="parseNodeFactory">The parse node factory.</param>
+        /// <param name="serializationWriterFactory">The serialization writer factory.</param>
+        /// <param name="httpClient">The native HTTP client.</param>
         /// </summary>
         public HttpCore(IAuthenticationProvider authenticationProvider, IParseNodeFactory parseNodeFactory = null, ISerializationWriterFactory serializationWriterFactory = null, System.Net.Http.HttpClient httpClient = null)
         {
@@ -35,11 +42,24 @@ namespace Microsoft.Kiota.Http.HttpClient
             sWriterFactory = serializationWriterFactory ?? SerializationWriterFactoryRegistry.DefaultInstance;
         }
         /// <summary>Factory to use to get a serializer for payload serialization</summary>
-        public ISerializationWriterFactory SerializationWriterFactory { get { return sWriterFactory; } }
-        public async Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable {
+        public ISerializationWriterFactory SerializationWriterFactory
+        {
+            get
+            {
+                return sWriterFactory;
+            }
+        }
+        /// <summary>
+        /// Send a <see cref="RequestInfo"/> instance with a collection instance of <typeparam name="ModelType"></typeparam>
+        /// </summary>
+        /// <param name="requestInfo">The <see cref="RequestInfo"/> instance to send</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
+        public async Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable
+        {
             var response = await GetHttpResponseMessage(requestInfo);
             requestInfo.Content?.Dispose();
-            if(responseHandler == null) {
+            if(responseHandler == null)
+            {
                 var rootNode = await GetRootParseNode(response);
                 var result = rootNode.GetCollectionOfObjectValues<ModelType>();
                 return result;
@@ -47,11 +67,17 @@ namespace Microsoft.Kiota.Http.HttpClient
             else
                 return await responseHandler.HandleResponseAsync<HttpResponseMessage, IEnumerable<ModelType>>(response);
         }
+        /// <summary>
+        /// Send a <see cref="RequestInfo"/> instance with an instance of <typeparam name="ModelType"></typeparam>
+        /// </summary>
+        /// <param name="requestInfo">The <see cref="RequestInfo"/> instance to send</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
         public async Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = null) where ModelType : IParsable
         {
             var response = await GetHttpResponseMessage(requestInfo);
             requestInfo.Content?.Dispose();
-            if(responseHandler == null) {
+            if(responseHandler == null)
+            {
                 var rootNode = await GetRootParseNode(response);
                 var result = rootNode.GetObjectValue<ModelType>();
                 return result;
@@ -59,31 +85,56 @@ namespace Microsoft.Kiota.Http.HttpClient
             else
                 return await responseHandler.HandleResponseAsync<HttpResponseMessage, ModelType>(response);
         }
-        public async Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) {
+        /// <summary>
+        /// Send a <see cref="RequestInfo"/> instance with a primitive instance of <typeparam name="ModelType"></typeparam>
+        /// </summary>
+        /// <param name="requestInfo">The <see cref="RequestInfo"/> instance to send</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
+        /// <returns></returns>
+        public async Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default)
+        {
             var response = await GetHttpResponseMessage(requestInfo);
             requestInfo.Content?.Dispose();
-            if(responseHandler == null) {
+            if(responseHandler == null)
+            {
                 var modelType = typeof(ModelType);
-                if(modelType == typeof(Stream)) {
+                if(modelType == typeof(Stream))
+                {
                     return (ModelType)(await response.Content.ReadAsStreamAsync() as object);
-                } else {
+                }
+                else
+                {
                     var rootNode = await GetRootParseNode(response);
                     object result;
-                    if(modelType == typeof(bool)) {
+                    if(modelType == typeof(bool))
+                    {
                         result = rootNode.GetBoolValue();
-                    } else if(modelType == typeof(string)) {
+                    }
+                    else if(modelType == typeof(string))
+                    {
                         result = rootNode.GetStringValue();
-                    } else if(modelType == typeof(int)) {
+                    }
+                    else if(modelType == typeof(int))
+                    {
                         result = rootNode.GetIntValue();
-                    } else if(modelType == typeof(float)) {
+                    }
+                    else if(modelType == typeof(float))
+                    {
                         result = rootNode.GetFloatValue();
-                    } else if(modelType == typeof(double)) {
+                    }
+                    else if(modelType == typeof(double))
+                    {
                         result = rootNode.GetDoubleValue();
-                    } else if(modelType == typeof(Guid)) {
+                    }
+                    else if(modelType == typeof(Guid))
+                    {
                         result = rootNode.GetGuidValue();
-                    } else if(modelType == typeof(DateTimeOffset)) {
+                    }
+                    else if(modelType == typeof(DateTimeOffset))
+                    {
                         result = rootNode.GetDateTimeOffsetValue();
-                    } else throw new InvalidOperationException("error handling the response, unexpected type");
+                    }
+                    else throw new InvalidOperationException("error handling the response, unexpected type");
                     return (ModelType)result;
                 }
             }
@@ -91,24 +142,33 @@ namespace Microsoft.Kiota.Http.HttpClient
                 return await responseHandler.HandleResponseAsync<HttpResponseMessage, ModelType>(response);
         }
 
-        private async Task AddBearerIfNotPresent(RequestInfo requestInfo) {
-            if(!requestInfo.Headers.ContainsKey(authorizationHeaderKey)) {
+        private async Task AddBearerIfNotPresent(RequestInfo requestInfo)
+        {
+            if(!requestInfo.Headers.ContainsKey(AuthorizationHeaderKey))
+            {
                 var token = await authProvider.GetAuthorizationToken(requestInfo.URI);
                 if(string.IsNullOrEmpty(token))
                     throw new InvalidOperationException("Could not get an authorization token");
-                requestInfo.Headers.Add(authorizationHeaderKey, $"Bearer {token}");
+                requestInfo.Headers.Add(AuthorizationHeaderKey, $"Bearer {token}");
             }
         }
+        /// <summary>
+        /// Send a <see cref="RequestInfo"/> instance with no content.
+        /// </summary>
+        /// <param name="requestInfo">The <see cref="RequestInfo"/> instance to send</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
+        /// <returns></returns>
         public async Task SendNoContentAsync(RequestInfo requestInfo, IResponseHandler responseHandler = null)
         {
             var response = await GetHttpResponseMessage(requestInfo);
             requestInfo.Content?.Dispose();
-            if(responseHandler == null) 
+            if(responseHandler == null)
                 response.Dispose();
             else
                 await responseHandler.HandleResponseAsync<HttpResponseMessage, object>(response);
         }
-        private async Task<IParseNode> GetRootParseNode(HttpResponseMessage response) {
+        private async Task<IParseNode> GetRootParseNode(HttpResponseMessage response)
+        {
             var responseContentType = response.Content.Headers?.ContentType?.MediaType?.ToLowerInvariant();
             if(string.IsNullOrEmpty(responseContentType))
                 throw new InvalidOperationException("no response content type header for deserialization");
@@ -117,48 +177,61 @@ namespace Microsoft.Kiota.Http.HttpClient
             response.Dispose();
             return rootNode;
         }
-        private async Task<HttpResponseMessage> GetHttpResponseMessage(RequestInfo requestInfo) {
+        private async Task<HttpResponseMessage> GetHttpResponseMessage(RequestInfo requestInfo)
+        {
             if(requestInfo == null)
                 throw new ArgumentNullException(nameof(requestInfo));
-            
+
             await AddBearerIfNotPresent(requestInfo);
-            
+
             using var message = GetRequestMessageFromRequestInfo(requestInfo);
             var response = await this.client.SendAsync(message);
             if(response == null)
                 throw new InvalidOperationException("Could not get a response after calling the service");
             return response;
         }
-        private const string contentTypeHeaderName = "content-type";
-        private HttpRequestMessage GetRequestMessageFromRequestInfo(RequestInfo requestInfo) {
-            var message = new HttpRequestMessage {
+        private const string ContentTypeHeaderName = "content-type";
+        private HttpRequestMessage GetRequestMessageFromRequestInfo(RequestInfo requestInfo)
+        {
+            var message = new HttpRequestMessage
+            {
                 Method = new System.Net.Http.HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),
-                RequestUri = new Uri(requestInfo.URI + 
-                                        ((requestInfo.QueryParameters?.Any() ?? false) ? 
+                RequestUri = new Uri(requestInfo.URI +
+                                        ((requestInfo.QueryParameters?.Any() ?? false) ?
                                             "?" + requestInfo.QueryParameters
                                                         .Select(x => $"{x.Key}{(x.Value == null ? string.Empty : "=")}{x.Value?.ToString() ?? string.Empty}")
                                                         .Aggregate((x, y) => $"{x}&{y}") :
                                             string.Empty)),
-                
             };
+
             if(requestInfo.MiddlewareOptions.Any())
                 requestInfo.MiddlewareOptions.ToList().ForEach(x => message.Options.Set(new HttpRequestOptionsKey<IMiddlewareOption>(x.GetType().FullName), x));
             if(requestInfo.Headers?.Any() ?? false)
-                requestInfo.Headers.Where(x => !contentTypeHeaderName.Equals(x.Key, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => message.Headers.Add(x.Key, x.Value));
-            if(requestInfo.Content != null) {
+                requestInfo.Headers.Where(x => !ContentTypeHeaderName.Equals(x.Key, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => message.Headers.Add(x.Key, x.Value));
+            if(requestInfo.Content != null)
+            {
                 message.Content = new StreamContent(requestInfo.Content);
-                if(requestInfo?.Headers?.ContainsKey(contentTypeHeaderName) ?? false)
-                    message.Content.Headers.ContentType = new MediaTypeHeaderValue(requestInfo.Headers[contentTypeHeaderName]);
+                if(requestInfo?.Headers?.ContainsKey(ContentTypeHeaderName) ?? false)
+                    message.Content.Headers.ContentType = new MediaTypeHeaderValue(requestInfo.Headers[ContentTypeHeaderName]);
             }
             return message;
         }
-        public void EnableBackingStore(IBackingStoreFactory backingStoreFactory) {
+        /// <summary>
+        /// Enable the backing store with the provided <see cref="IBackingStoreFactory"/>
+        /// </summary>
+        /// <param name="backingStoreFactory">The <see cref="IBackingStoreFactory"/> to use</param>
+        public void EnableBackingStore(IBackingStoreFactory backingStoreFactory)
+        {
             pNodeFactory = ApiClientBuilder.EnableBackingStoreForParseNodeFactory(pNodeFactory) ?? throw new InvalidOperationException("Could not enable backing store for the parse node factory");
             sWriterFactory = ApiClientBuilder.EnableBackingStoreForSerializationWriterFactory(sWriterFactory) ?? throw new InvalidOperationException("Could not enable backing store for the serializer writer factory");
             if(backingStoreFactory != null)
                 BackingStoreFactorySingleton.Instance = backingStoreFactory;
         }
-        public void Dispose() {
+        /// <summary>
+        /// Dispose/cleanup the client
+        /// </summary>
+        public void Dispose()
+        {
             if(createdClient)
                 client?.Dispose();
         }

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClient.csproj
@@ -9,6 +9,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is purely cosmetic and does not alter any functionality in the code. It involves the following changes :-

- Adds any missing XML documentation for public methods/properties
- Adds the `<GenerateDocumentationFile>true</GenerateDocumentationFile>` attribute to the csproj file so that compiler warnings may be generated in the event the first condition above is not met.
- Adds a `.editorconfig` to the solution to help with consistent code styling
- Whitespace changes to move opening curly braces to new lines.

Related to https://github.com/microsoft/kiota/issues/358