### PR TITLE
Adds docs comments for the Abstractions project for dotnet

### DIFF
--- a/abstractions/dotnet/.editorconfig
+++ b/abstractions/dotnet/.editorconfig
@@ -1,0 +1,119 @@
+# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\anomondi\Documents\kiota\serialization\dotnet\json codebase based on best match to current usage at 17/08/2021
+# You can modify the rules from these initially generated values to suit your own policies
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - indentation options
+
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require members of object intializers to be on separate lines
+csharp_new_line_before_members_in_object_initializers = true
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require NO space between a cast and the value
+csharp_space_after_cast = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require NO space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+
+#Style - Code block preferences
+
+#prefer no curly braces if allowed
+csharp_prefer_braces = false:suggestion
+
+#Style - expression bodied member options
+
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer expression-bodied members for methods
+csharp_style_expression_bodied_methods = true:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration = true:suggestion
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer default over default(T)
+csharp_prefer_simple_default_expression = true:suggestion
+#prefer objects to be initialized using object initializers when possible
+dotnet_style_object_initializer = true:suggestion
+
+#Style - implicit and explicit types
+
+#prefer var over explicit type in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = true:suggestion
+#prefer var when the type is already mentioned on the right-hand side of a declaration expression
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - Miscellaneous preferences
+
+#prefer anonymous functions over local functions
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,private,static,readonly:suggestion
+
+#Style - qualification options
+
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.sln
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KiotaAbstractions", "src\Microsoft.Kiota.Abstractions.csproj", "{DEE3A7F9-7951-403C-A90C-C182A381D6B6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Kiota.Abstractions", "src\Microsoft.Kiota.Abstractions.csproj", "{DEE3A7F9-7951-403C-A90C-C182A381D6B6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{812D9C21-411D-4987-AB8E-C96185F01AD0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,9 +18,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DEE3A7F9-7951-403C-A90C-C182A381D6B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,5 +32,11 @@ Global
 		{DEE3A7F9-7951-403C-A90C-C182A381D6B6}.Release|x64.Build.0 = Release|Any CPU
 		{DEE3A7F9-7951-403C-A90C-C182A381D6B6}.Release|x86.ActiveCfg = Release|Any CPU
 		{DEE3A7F9-7951-403C-A90C-C182A381D6B6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B0E38E50-7BC8-4E28-BDAC-BF38F7AF2CD2}
 	EndGlobalSection
 EndGlobal

--- a/abstractions/dotnet/README.md
+++ b/abstractions/dotnet/README.md
@@ -5,7 +5,7 @@
 - [ ] coverage code
 - [ ] analyzers
 - [ ] unit test project
-- [ ] docs comments
+- [x] docs comments
 
 ## Using the abstractions
 

--- a/abstractions/dotnet/src/ApiClientBuilder.cs
+++ b/abstractions/dotnet/src/ApiClientBuilder.cs
@@ -1,19 +1,25 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 
-namespace Microsoft.Kiota.Abstractions {
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     ///     Provides a builder for creating an ApiClient and register the default serializers/deserializers.
     /// </summary>
-    public static class ApiClientBuilder {
+    public static class ApiClientBuilder
+    {
         /// <summary>
         /// Registers the default serializer to the registry.
         /// </summary>
         /// <typeparam name="T">The type of the serialization factory to register</typeparam>
-        public static void RegisterDefaultSerializer<T>() where T: ISerializationWriterFactory, new() {
+        public static void RegisterDefaultSerializer<T>() where T : ISerializationWriterFactory, new()
+        {
             var serializationWriterFactory = new T();
             SerializationWriterFactoryRegistry.DefaultInstance
                                             .ContentTypeAssociatedFactories
@@ -23,7 +29,8 @@ namespace Microsoft.Kiota.Abstractions {
         /// Registers the default deserializer to the registry.
         /// </summary>
         /// <typeparam name="T">The type of the parse node factory to register</typeparam>
-        public static void RegisterDefaultDeserializer<T>() where T: IParseNodeFactory, new() {
+        public static void RegisterDefaultDeserializer<T>() where T : IParseNodeFactory, new()
+        {
             var deserializerFactory = new T();
             ParseNodeFactoryRegistry.DefaultInstance
                                     .ContentTypeAssociatedFactories
@@ -34,7 +41,8 @@ namespace Microsoft.Kiota.Abstractions {
         /// </summary>
         /// <param name="original">The serialization writer to enable the backing store on.</param>
         /// <returns>A new serialization writer with the backing store enabled.</returns>
-        public static ISerializationWriterFactory EnableBackingStoreForSerializationWriterFactory(ISerializationWriterFactory original) {
+        public static ISerializationWriterFactory EnableBackingStoreForSerializationWriterFactory(ISerializationWriterFactory original)
+        {
             ISerializationWriterFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is SerializationWriterFactoryRegistry registry)
                 EnableBackingStoreForSerializationRegistry(registry);
@@ -48,7 +56,8 @@ namespace Microsoft.Kiota.Abstractions {
         /// </summary>
         /// <param name="original">The parse node factory to enable the backing store on.</param>
         /// <returns>A new parse node factory with the backing store enabled.</returns>
-        public static IParseNodeFactory EnableBackingStoreForParseNodeFactory(IParseNodeFactory original) {
+        public static IParseNodeFactory EnableBackingStoreForParseNodeFactory(IParseNodeFactory original)
+        {
             IParseNodeFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is ParseNodeFactoryRegistry registry)
                 EnableBackingStoreForParseNodeRegistry(registry);
@@ -57,19 +66,23 @@ namespace Microsoft.Kiota.Abstractions {
             EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry.DefaultInstance);
             return result;
         }
-        private static void EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry registry) {
+        private static void EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry registry)
+        {
             foreach(var entry in registry
                                     .ContentTypeAssociatedFactories
-                                    .Where(x => !(x.Value is BackingStoreParseNodeFactory || 
-                                                    x.Value is ParseNodeFactoryRegistry))) {
+                                    .Where(x => !(x.Value is BackingStoreParseNodeFactory ||
+                                                    x.Value is ParseNodeFactoryRegistry)))
+            {
                 registry.ContentTypeAssociatedFactories[entry.Key] = new BackingStoreParseNodeFactory(entry.Value);
             }
         }
-        private static void EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry registry) {
+        private static void EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry registry)
+        {
             foreach(var entry in registry
                                     .ContentTypeAssociatedFactories
-                                    .Where(x => !(x.Value is BackingStoreSerializationWriterProxyFactory || 
-                                                    x.Value is SerializationWriterFactoryRegistry))) {
+                                    .Where(x => !(x.Value is BackingStoreSerializationWriterProxyFactory ||
+                                                    x.Value is SerializationWriterFactoryRegistry)))
+            {
                 registry.ContentTypeAssociatedFactories[entry.Key] = new BackingStoreSerializationWriterProxyFactory(entry.Value);
             }
         }

--- a/abstractions/dotnet/src/HttpMethod.cs
+++ b/abstractions/dotnet/src/HttpMethod.cs
@@ -1,8 +1,14 @@
-namespace Microsoft.Kiota.Abstractions {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     ///     Represents the HTTP method used by a request.
     /// </summary>
-    public enum HttpMethod {
+    public enum HttpMethod
+    {
         /// <summary>
         ///     The HTTP GET method.
         /// </summary>

--- a/abstractions/dotnet/src/IHttpCore.cs
+++ b/abstractions/dotnet/src/IHttpCore.cs
@@ -1,13 +1,19 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 
-namespace Microsoft.Kiota.Abstractions {
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     ///   Service responsible for translating abstract Request Info into concrete native HTTP requests.
     /// </summary>
-    public interface IHttpCore {
+    public interface IHttpCore
+    {
         /// <summary>
         ///  Enables the backing store proxies for the SerializationWriters and ParseNodes in use.
         /// </summary>
@@ -18,28 +24,28 @@ namespace Microsoft.Kiota.Abstractions {
         /// </summary>
         ISerializationWriterFactory SerializationWriterFactory { get; }
         /// <summary>
-        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model.
+        /// Executes the HTTP request specified by the given RequestInfo and returns the deserialized response model.
         /// </summary>
         /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <returns>The deserialized response model.</returns>
         Task<ModelType> SendAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
         /// <summary>
-        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized response model collection.
+        /// Executes the HTTP request specified by the given RequestInfo and returns the deserialized response model collection.
         /// </summary>
         /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <returns>The deserialized response model collection.</returns>
         Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
         /// <summary>
-        /// Excutes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
+        /// Executes the HTTP request specified by the given RequestInfo and returns the deserialized primitive response model.
         /// </summary>
         /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <returns>The deserialized primitive response model.</returns>
         Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInfo requestInfo, IResponseHandler responseHandler = default);
         /// <summary>
-        /// Excutes the HTTP request specified by the given RequestInfo with no return content.
+        /// Executes the HTTP request specified by the given RequestInfo with no return content.
         /// </summary>
         /// <param name="requestInfo">The RequestInfo object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>

--- a/abstractions/dotnet/src/IMiddlewareOption.cs
+++ b/abstractions/dotnet/src/IMiddlewareOption.cs
@@ -1,7 +1,13 @@
-namespace Microsoft.Kiota.Abstractions {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     /// Represents a middleware option.
     /// </summary>
-    public interface IMiddlewareOption {
+    public interface IMiddlewareOption
+    {
     }
 }

--- a/abstractions/dotnet/src/IResponseHandler.cs
+++ b/abstractions/dotnet/src/IResponseHandler.cs
@@ -1,10 +1,16 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions {
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     ///     Defines the contract for a response handler.
     /// </summary>
-    public interface IResponseHandler {
+    public interface IResponseHandler
+    {
         /// <summary>
         ///     Callback method that is invoked when a response is received.
         /// </summary>

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
@@ -7,6 +7,7 @@
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
     <Version>1.0.17</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
   </PropertyGroup>

--- a/abstractions/dotnet/src/NativeResponseHandler.cs
+++ b/abstractions/dotnet/src/NativeResponseHandler.cs
@@ -1,12 +1,28 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions {
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     /// Default response handler to access the native response object.
     /// </summary>
-    public class NativeResponseHandler : IResponseHandler {
+    public class NativeResponseHandler : IResponseHandler
+    {
+        /// <summary>
+        /// The value of the response
+        /// </summary>
         public object Value;
-        public Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response) {
+
+        /// <summary>
+        /// Handles the response of type <typeparam name="NativeResponseType"/>and return an instance of <typeparam name="ModelType"/>
+        /// </summary>
+        /// <param name="response">The response to be handled</param>
+        /// <returns></returns>
+        public Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response)
+        {
             Value = response;
             return Task.FromResult(default(ModelType));
         }

--- a/abstractions/dotnet/src/NativeResponseWrapper.cs
+++ b/abstractions/dotnet/src/NativeResponseWrapper.cs
@@ -1,26 +1,50 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions {
+namespace Microsoft.Kiota.Abstractions
+{
     /// <summary>
     /// This class can be used to wrap a request using the fluent API and get the native response object in return.
     /// </summary>
-    public class NativeResponseWrapper {
+    public class NativeResponseWrapper
+    {
+        /// <summary>
+        /// Makes a request with the <typeparam name="QueryParametersType"/> instance to get a response with
+        /// a <typeparam name="NativeResponseType"/> instance and expect an instance of <typeparam name="ModelType"/>
+        /// </summary>
+        /// <param name="originalCall">The original request to make</param>
+        /// <param name="q">The query parameters of the request</param>
+        /// <param name="h">The request headers of the request</param>
+        /// <returns></returns>
         public static async Task<NativeResponseType> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType>(
                 Func<Action<QueryParametersType>, Action<IDictionary<string, string>>, IResponseHandler, Task<ModelType>> originalCall,
-                Action<QueryParametersType> q = default, 
-                Action<IDictionary<string, string>> h = default) where NativeResponseType : class {
+                Action<QueryParametersType> q = default,
+                Action<IDictionary<string, string>> h = default) where NativeResponseType : class
+        {
             var responseHandler = new NativeResponseHandler();
             await originalCall.Invoke(q, h, responseHandler);
             return responseHandler.Value as NativeResponseType;
         }
 
+        /// <summary>
+        /// Makes a request with the <typeparam name="RequestBodyType"/> and <typeparam name="QueryParametersType"/> instances to get a response with
+        /// a <typeparam name="NativeResponseType"/> instance and expect an instance of <typeparam name="ModelType"/>
+        /// </summary>
+        /// <param name="originalCall">The original request to make</param>
+        /// <param name="requestBody">The request body of the request</param>
+        /// <param name="q">The query parameters of the request</param>
+        /// <param name="h">The request headers of the request</param>
         public static async Task<NativeResponseType> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType, RequestBodyType>(
                 Func<RequestBodyType, Action<QueryParametersType>, Action<IDictionary<string, string>>, IResponseHandler, Task<ModelType>> originalCall,
                 RequestBodyType requestBody,
-                Action<QueryParametersType> q = default, 
-                Action<IDictionary<string, string>> h = default) where NativeResponseType : class {
+                Action<QueryParametersType> q = default,
+                Action<IDictionary<string, string>> h = default) where NativeResponseType : class
+        {
             var responseHandler = new NativeResponseHandler();
             await originalCall.Invoke(requestBody, q, h, responseHandler);
             return responseHandler.Value as NativeResponseType;

--- a/abstractions/dotnet/src/QueryParametersBase.cs
+++ b/abstractions/dotnet/src/QueryParametersBase.cs
@@ -1,17 +1,28 @@
-using System;
-using System.Linq;
-using System.Collections.Generic;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
 
-namespace Microsoft.Kiota.Abstractions {
-    public abstract class QueryParametersBase {
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    /// The base implementation of the Query Parameters 
+    /// </summary>
+    public abstract class QueryParametersBase
+    {
         /// <summary>
         /// Vanity method to add the query parameters to the request query parameters dictionary.
         /// </summary>
-        public void AddQueryParameters(IDictionary<string, object> target) {
-            if (target == null) throw new ArgumentNullException(nameof(target));
+        public void AddQueryParameters(IDictionary<string, object> target)
+        {
+            if(target == null) throw new ArgumentNullException(nameof(target));
             foreach(var property in this.GetType()
                                         .GetProperties()
-                                        .Where(x => !target.ContainsKey(x.Name))) {
+                                        .Where(x => !target.ContainsKey(x.Name)))
+            {
                 target.Add(property.Name, property.GetValue(this));
             }
         }

--- a/abstractions/dotnet/src/RequestInfo.cs
+++ b/abstractions/dotnet/src/RequestInfo.cs
@@ -1,7 +1,11 @@
-﻿using System;
-using System.Linq;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Abstractions
@@ -39,8 +43,9 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         /// Adds a middleware option to the request.
         /// </summary>
-        /// <param name="middlewareOption">The middleware option to add.</param>
-        public void AddMiddlewareOptions(params IMiddlewareOption[] options) {
+        /// <param name="options">The middleware option to add.</param>
+        public void AddMiddlewareOptions(params IMiddlewareOption[] options)
+        {
             if(!(options?.Any() ?? false)) return; // it's a no-op if there are no options and this avoid having to check in the code gen.
             foreach(var option in options.Where(x => x != null))
                 if(!_middlewareOptions.TryAdd(option.GetType().FullName, option))
@@ -50,20 +55,22 @@ namespace Microsoft.Kiota.Abstractions
         /// Removes given middleware options from the current request.
         /// </summary>
         /// <param name="options">Middleware options to remove.</param>
-        public void RemoveMiddlewareOptions(params IMiddlewareOption[] options) {
+        public void RemoveMiddlewareOptions(params IMiddlewareOption[] options)
+        {
             if(!options?.Any() ?? false) throw new ArgumentNullException(nameof(options));
             foreach(var optionName in options.Where(x => x != null).Select(x => x.GetType().FullName))
                 _middlewareOptions.Remove(optionName);
         }
-        private const string binaryContentType = "application/octet-stream";
-        private const string contentTypeHeader = "Content-Type";
+        private const string BinaryContentType = "application/octet-stream";
+        private const string ContentTypeHeader = "Content-Type";
         /// <summary>
         /// Sets the request body to a binary stream.
         /// </summary>
         /// <param name="content">The binary stream to set as a body.</param>
-        public void SetStreamContent(Stream content) {
+        public void SetStreamContent(Stream content)
+        {
             Content = content;
-            Headers.Add(contentTypeHeader, binaryContentType);
+            Headers.Add(ContentTypeHeader, BinaryContentType);
         }
         /// <summary>
         /// Sets the request body from a model with the specified content type.
@@ -72,17 +79,18 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="items">The models to serialize.</param>
         /// <param name="contentType">The content type to set.</param>
         /// <typeparam name="T">The model type to serialize.</typeparam>
-        public void SetContentFromParsable<T>(IHttpCore coreService, string contentType, params T[] items) where T : IParsable {
+        public void SetContentFromParsable<T>(IHttpCore coreService, string contentType, params T[] items) where T : IParsable
+        {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
             if(coreService == null) throw new ArgumentNullException(nameof(coreService));
-            if(items == null || !items.Any()) throw new InvalidOperationException($"{nameof(items)} cannot be null or empty"); 
+            if(items == null || !items.Any()) throw new InvalidOperationException($"{nameof(items)} cannot be null or empty");
 
             using var writer = coreService.SerializationWriterFactory.GetSerializationWriter(contentType);
             if(items.Count() == 1)
                 writer.WriteObjectValue(null, items[0]);
             else
                 writer.WriteCollectionOfObjectValues(null, items);
-            Headers.Add(contentTypeHeader, contentType);
+            Headers.Add(ContentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
         }
     }

--- a/abstractions/dotnet/src/authentication/AnonymousAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/AnonymousAuthenticationProvider.cs
@@ -1,12 +1,23 @@
-using System;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions.Authentication {
+namespace Microsoft.Kiota.Abstractions.Authentication
+{
     /// <summary>
     /// This authentication provider does not perform any authentication.
     /// </summary>
-    public class AnonymousAuthenticationProvider : IAuthenticationProvider {
-        public Task AuthenticateRequestAsync(RequestInfo request) {
+    public class AnonymousAuthenticationProvider : IAuthenticationProvider
+    {
+        /// <summary>
+        /// Authenticates the <see cref="RequestInfo"/> instance
+        /// </summary>
+        /// <param name="request">The request to authenticate</param>
+        /// <returns></returns>
+        public Task AuthenticateRequestAsync(RequestInfo request)
+        {
             return Task.CompletedTask;
         }
     }

--- a/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
@@ -1,19 +1,33 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions.Authentication {
+namespace Microsoft.Kiota.Abstractions.Authentication
+{
     /// <summary>
     ///     Provides a base class for implementing <see cref="IAuthenticationProvider" /> for Bearer token scheme.
     /// </summary>
-    public abstract class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider {
-        private const string authorizationHeaderKey = "Authorization";
-        public async Task AuthenticateRequestAsync(RequestInfo request) {
+    public abstract class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider
+    {
+        private const string AuthorizationHeaderKey = "Authorization";
+
+        /// <summary>
+        /// Authenticates the <see cref="RequestInfo"/> instance
+        /// </summary>
+        /// <param name="request">The request to authenticate</param>
+        /// <returns></returns>
+        public async Task AuthenticateRequestAsync(RequestInfo request)
+        {
             if(request == null) throw new ArgumentNullException(nameof(request));
-            if(!request.Headers.ContainsKey(authorizationHeaderKey)) {
+            if(!request.Headers.ContainsKey(AuthorizationHeaderKey))
+            {
                 var token = await GetAuthorizationTokenAsync(request);
                 if(string.IsNullOrEmpty(token))
                     throw new InvalidOperationException("Could not get an authorization token");
-                request.Headers.Add(authorizationHeaderKey, $"Bearer {token}");
+                request.Headers.Add(AuthorizationHeaderKey, $"Bearer {token}");
             }
         }
         /// <summary>

--- a/abstractions/dotnet/src/authentication/IAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/IAuthenticationProvider.cs
@@ -1,11 +1,16 @@
-using System;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions.Authentication {
+namespace Microsoft.Kiota.Abstractions.Authentication
+{
     /// <summary>
     /// Authenticates the application request.
     /// </summary>
-    public interface IAuthenticationProvider {
+    public interface IAuthenticationProvider
+    {
         /// <summary>
         /// Authenticates the application request.
         /// </summary>

--- a/abstractions/dotnet/src/extensions/StringExtensions.cs
+++ b/abstractions/dotnet/src/extensions/StringExtensions.cs
@@ -1,7 +1,14 @@
-using System.Linq;
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
 
-namespace Microsoft.Kiota.Abstractions.Extensions {
-    public static class StringExtensions {
+namespace Microsoft.Kiota.Abstractions.Extensions
+{
+    /// <summary>
+    /// The class for extension methods for <see cref="string"/> type
+    /// </summary>
+    public static class StringExtensions
+    {
         /// <summary>
         ///     Returns a string with the first letter lowered.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/IParsable.cs
+++ b/abstractions/dotnet/src/serialization/IParsable.cs
@@ -1,11 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     ///     Defines a serializable model object.
     /// </summary>
-    public interface IParsable {
+    public interface IParsable
+    {
         /// <summary>
         ///   Gets the deserialization information for this object.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -1,11 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     /// Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
     /// </summary>
-    public interface IParseNode {
+    public interface IParseNode
+    {
         /// <summary>
         ///  Gets the string value of the node.
         /// </summary>
@@ -56,17 +62,17 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// Gets the collection of model objects values of the node.
         /// </summary>
         /// <returns>The collection of model objects values.</returns>
-        IEnumerable<T> GetCollectionOfObjectValues<T>() where T: IParsable;
+        IEnumerable<T> GetCollectionOfObjectValues<T>() where T : IParsable;
         /// <summary>
         /// Gets the enum value of the node.
         /// </summary>
         /// <returns>The enum value of the node.</returns>
-        T? GetEnumValue<T>() where T: struct, Enum;
+        T? GetEnumValue<T>() where T : struct, Enum;
         /// <summary>
         /// Gets the model object value of the node.
         /// </summary>
         /// <returns>The model object value of the node.</returns>
-        T GetObjectValue<T>() where T: IParsable;
+        T GetObjectValue<T>() where T : IParsable;
         /// <summary>
         /// Callback called before the node is deserialized.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
+++ b/abstractions/dotnet/src/serialization/IParseNodeFactory.cs
@@ -1,10 +1,16 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System.IO;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     /// Defines the contract for a factory that creates parse nodes.
     /// </summary>
-    public interface IParseNodeFactory {
+    public interface IParseNodeFactory
+    {
         /// <summary>
         /// Returns the content type this factory's parse nodes can deserialize.
         /// </summary>
@@ -12,7 +18,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// <summary>
         /// Create a parse node from the given stream and content type.
         /// </summary>
-        /// <param name="stream">The stream to read the parse node from.</param>
+        /// <param name="content">The stream to read the parse node from.</param>
         /// <param name="contentType">The content type of the parse node.</param>
         /// <returns>A parse node.</returns>
         IParseNode GetRootParseNode(string contentType, Stream content);

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -1,12 +1,18 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     /// Defines an interface for serialization of objects to a stream.
     /// </summary>
-    public interface ISerializationWriter : IDisposable {
+    public interface ISerializationWriter : IDisposable
+    {
         /// <summary>
         /// Writes the specified string value to the stream with an optional given key.
         /// </summary>
@@ -81,7 +87,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// <summary>
         /// Writes the specified additional data to the stream.
         /// </summary>
-        /// <param name="data">The additional data to be written.</param>
+        /// <param name="value">The additional data to be written.</param>
         void WriteAdditionalData(IDictionary<string, object> value);
         /// <summary>
         /// Gets the value of the serialized content.

--- a/abstractions/dotnet/src/serialization/ISerializationWriterFactory.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriterFactory.cs
@@ -1,8 +1,14 @@
-namespace Microsoft.Kiota.Abstractions.Serialization {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     ///     Defines the contract for a factory that creates <see cref="ISerializationWriter" /> instances.
     /// </summary>
-    public interface ISerializationWriterFactory {
+    public interface ISerializationWriterFactory
+    {
         /// <summary>
         /// Gets the content type this factory creates serialization writers for.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/ParseNodeFactoryRegistry.cs
+++ b/abstractions/dotnet/src/serialization/ParseNodeFactoryRegistry.cs
@@ -1,16 +1,28 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Kiota.Abstractions;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     ///  This factory holds a list of all the registered factories for the various types of nodes.
     /// </summary>
-    public class ParseNodeFactoryRegistry : IParseNodeFactory {
-        public string ValidContentType { get {
-            throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
-        }}
+    public class ParseNodeFactoryRegistry : IParseNodeFactory
+    {
+        /// <summary>
+        /// The valid content type for the <see cref="ParseNodeFactoryRegistry"/>
+        /// </summary>
+        public string ValidContentType
+        {
+            get
+            {
+                throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
+            }
+        }
         /// <summary>
         /// Default singleton instance of the registry to be used when registring new factories that should be available by default.
         /// </summary>
@@ -18,8 +30,15 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// <summary>
         /// List of factories that are registered by content type.
         /// </summary>
-        public Dictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories {get; set;} = new Dictionary<string, IParseNodeFactory>();
-        public IParseNode GetRootParseNode(string contentType, Stream content) {
+        public Dictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories { get; set; } = new Dictionary<string, IParseNodeFactory>();
+        /// <summary>
+        /// Get the <see cref="IParseNode"/> instance that is the root of the content
+        /// </summary>
+        /// <param name="contentType">The content type of the stream</param>
+        /// <param name="content">The <see cref="Stream"/> to parse</param>
+        /// <returns></returns>
+        public IParseNode GetRootParseNode(string contentType, Stream content)
+        {
             if(string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException(nameof(contentType));
             _ = content ?? throw new ArgumentNullException(nameof(content));

--- a/abstractions/dotnet/src/serialization/ParseNodeProxyFactory.cs
+++ b/abstractions/dotnet/src/serialization/ParseNodeProxyFactory.cs
@@ -1,12 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.IO;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     /// Proxy factory that allows the composition of before and after callbacks on existing factories.
     /// </summary>
-    public abstract class ParseNodeProxyFactory : IParseNodeFactory {
-        public string ValidContentType { get { return _concrete.ValidContentType; }}
+    public abstract class ParseNodeProxyFactory : IParseNodeFactory
+    {
+        /// <summary>
+        /// The valid content type for the <see cref="ParseNodeProxyFactory"/> instance
+        /// </summary>
+        public string ValidContentType { get { return _concrete.ValidContentType; } }
         private readonly IParseNodeFactory _concrete;
         private readonly Action<IParsable> _onBefore;
         private readonly Action<IParsable> _onAfter;
@@ -16,20 +25,30 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// <param name="concrete">The concrete factory to wrap.</param>
         /// <param name="onBefore">The callback to invoke before the deserialization of any model object.</param>
         /// <param name="onAfter">The callback to invoke after the deserialization of any model object.</param>
-        public ParseNodeProxyFactory(IParseNodeFactory concrete, Action<IParsable> onBefore, Action<IParsable> onAfter) {
+        public ParseNodeProxyFactory(IParseNodeFactory concrete, Action<IParsable> onBefore, Action<IParsable> onAfter)
+        {
             _concrete = concrete ?? throw new ArgumentNullException(nameof(concrete));
             _onBefore = onBefore;
             _onAfter = onAfter;
         }
-        public IParseNode GetRootParseNode(string contentType, Stream content) {
+        /// <summary>
+        /// Create a parse node from the given stream and content type.
+        /// </summary>
+        /// <param name="content">The stream to read the parse node from.</param>
+        /// <param name="contentType">The content type of the parse node.</param>
+        /// <returns>A parse node.</returns>
+        public IParseNode GetRootParseNode(string contentType, Stream content)
+        {
             var node = _concrete.GetRootParseNode(contentType, content);
             var originalBefore = node.OnBeforeAssignFieldValues;
             var originalAfter = node.OnAfterAssignFieldValues;
-            node.OnBeforeAssignFieldValues = (x) => {
+            node.OnBeforeAssignFieldValues = (x) =>
+            {
                 _onBefore?.Invoke(x);
                 originalBefore?.Invoke(x);
             };
-            node.OnAfterAssignFieldValues = (x) => {
+            node.OnAfterAssignFieldValues = (x) =>
+            {
                 _onAfter?.Invoke(x);
                 originalAfter?.Invoke(x);
             };

--- a/abstractions/dotnet/src/serialization/SerializationWriterFactoryRegistry.cs
+++ b/abstractions/dotnet/src/serialization/SerializationWriterFactoryRegistry.cs
@@ -1,14 +1,27 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     ///  This factory holds a list of all the registered factories for the various types of nodes.
     /// </summary>
-    public class SerializationWriterFactoryRegistry : ISerializationWriterFactory {
-        public string ValidContentType { get {
-            throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
-        }}
+    public class SerializationWriterFactoryRegistry : ISerializationWriterFactory
+    {
+        /// <summary>
+        /// The valid content type for the <see cref="SerializationWriterFactoryRegistry"/>
+        /// </summary>
+        public string ValidContentType
+        {
+            get
+            {
+                throw new InvalidOperationException("The registry supports multiple content types. Get the registered factory instead.");
+            }
+        }
         /// <summary>
         /// Default singleton instance of the registry to be used when registring new factories that should be available by default.
         /// </summary>
@@ -17,10 +30,16 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         /// List of factories that are registered by content type.
         /// </summary>
         public Dictionary<string, ISerializationWriterFactory> ContentTypeAssociatedFactories { get; set; } = new Dictionary<string, ISerializationWriterFactory>();
-        public ISerializationWriter GetSerializationWriter(string contentType) {
+        /// <summary>
+        /// Get the relevant <see cref="ISerializationWriter"/> instance for the given content type
+        /// </summary>
+        /// <param name="contentType">The content type in use</param>
+        /// <returns>A <see cref="ISerializationWriter"/> instance to parse the content</returns>
+        public ISerializationWriter GetSerializationWriter(string contentType)
+        {
             if(string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException(nameof(contentType));
-            
+
             if(ContentTypeAssociatedFactories.ContainsKey(contentType))
                 return ContentTypeAssociatedFactories[contentType].GetSerializationWriter(contentType);
             else

--- a/abstractions/dotnet/src/serialization/SerializationWriterProxyFactory.cs
+++ b/abstractions/dotnet/src/serialization/SerializationWriterProxyFactory.cs
@@ -1,11 +1,20 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 
-namespace Microsoft.Kiota.Abstractions.Serialization {
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
     /// <summary>
     /// Proxy factory that allows the composition of before and after callbacks on existing factories.
     /// </summary>
-    public class SerializationWriterProxyFactory : ISerializationWriterFactory {
-        public string ValidContentType { get { return _concrete.ValidContentType; }}
+    public class SerializationWriterProxyFactory : ISerializationWriterFactory
+    {
+        /// <summary>
+        /// The valid content type for the <see cref="SerializationWriterProxyFactory"/>
+        /// </summary>
+        public string ValidContentType { get { return _concrete.ValidContentType; } }
         private readonly ISerializationWriterFactory _concrete;
         private readonly Action<IParsable> _onBefore;
         private readonly Action<IParsable> _onAfter;
@@ -20,26 +29,36 @@ namespace Microsoft.Kiota.Abstractions.Serialization {
         public SerializationWriterProxyFactory(ISerializationWriterFactory concrete,
             Action<IParsable> onBeforeSerialization,
             Action<IParsable> onAfterSerialization,
-            Action<IParsable, ISerializationWriter> onStartSerialization) {
+            Action<IParsable, ISerializationWriter> onStartSerialization)
+        {
             _concrete = concrete ?? throw new ArgumentNullException(nameof(concrete));
             _onBefore = onBeforeSerialization;
             _onAfter = onAfterSerialization;
             _onStartSerialization = onStartSerialization;
         }
-        public ISerializationWriter GetSerializationWriter(string contentType) {
+        /// <summary>
+        /// Creates a new <see cref="ISerializationWriter" /> instance for the given content type.
+        /// </summary>
+        /// <param name="contentType">The content type for which a serialization writer should be created.</param>
+        /// <returns>A new <see cref="ISerializationWriter" /> instance for the given content type.</returns>
+        public ISerializationWriter GetSerializationWriter(string contentType)
+        {
             var writer = _concrete.GetSerializationWriter(contentType);
             var originalBefore = writer.OnBeforeObjectSerialization;
             var originalAfter = writer.OnAfterObjectSerialization;
             var originalStart = writer.OnStartObjectSerialization;
-            writer.OnBeforeObjectSerialization = (x) => {
+            writer.OnBeforeObjectSerialization = (x) =>
+            {
                 _onBefore?.Invoke(x); // the callback set by the implementation (e.g. backing store)
                 originalBefore?.Invoke(x); // some callback that might already be set on the target
             };
-            writer.OnAfterObjectSerialization = (x) => {
+            writer.OnAfterObjectSerialization = (x) =>
+            {
                 _onAfter?.Invoke(x);
                 originalAfter?.Invoke(x);
             };
-            writer.OnStartObjectSerialization = (x, y) => {
+            writer.OnStartObjectSerialization = (x, y) =>
+            {
                 _onStartSerialization?.Invoke(x, y);
                 originalStart?.Invoke(x, y);
             };

--- a/abstractions/dotnet/src/store/BackingStoreFactorySingleton.cs
+++ b/abstractions/dotnet/src/store/BackingStoreFactorySingleton.cs
@@ -1,8 +1,14 @@
-namespace Microsoft.Kiota.Abstractions.Store {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     ///     This class is used to register the backing store factory.
     /// </summary>
-    public class BackingStoreFactorySingleton {
+    public class BackingStoreFactorySingleton
+    {
         /// <summary>
         ///     The backing store factory singleton instance.
         /// </summary>

--- a/abstractions/dotnet/src/store/BackingStoreParseNodeFactory.cs
+++ b/abstractions/dotnet/src/store/BackingStoreParseNodeFactory.cs
@@ -1,22 +1,32 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using Microsoft.Kiota.Abstractions.Serialization;
-namespace Microsoft.Kiota.Abstractions.Store {
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     /// Proxy implementation of <see cref="IParseNodeFactory"/> for the <see cref="IBackingStore">backing store</see> that automatically sets the state of the backing store when deserializing.
     /// </summary>
-    public class BackingStoreParseNodeFactory : ParseNodeProxyFactory {
+    public class BackingStoreParseNodeFactory : ParseNodeProxyFactory
+    {
         /// <summary>
         /// Initializes a new instance of the <see cref="BackingStoreParseNodeFactory"/> class given a concrete implementation of <see cref="IParseNodeFactory"/>.
         /// </summary>
-        public BackingStoreParseNodeFactory(IParseNodeFactory concrete):base(
+        public BackingStoreParseNodeFactory(IParseNodeFactory concrete) : base(
             concrete,
-            (x) => {
+            (x) =>
+            {
                 if(x is IBackedModel backedModel && backedModel.BackingStore != null)
                     backedModel.BackingStore.InitializationCompleted = false;
             },
-            (x) => {
+            (x) =>
+            {
                 if(x is IBackedModel backedModel && backedModel.BackingStore != null)
                     backedModel.BackingStore.InitializationCompleted = true;
             }
-        ) { }
+        )
+        { }
     }
 }

--- a/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxyFactory.cs
+++ b/abstractions/dotnet/src/store/BackingStoreSerializationWriterProxyFactory.cs
@@ -1,32 +1,41 @@
-using Microsoft.Kiota.Abstractions.Serialization;
-using System;
-using System.Collections.Generic;
-using System.IO;
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
 
-namespace Microsoft.Kiota.Abstractions.Store {
+using Microsoft.Kiota.Abstractions.Serialization;
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     /// Proxy implementation of <see cref="ISerializationWriterFactory"/> for the <see cref="IBackingStore">backing store</see> that automatically sets the state of the backing store when serializing.
     /// </summary>
-    public class BackingStoreSerializationWriterProxyFactory : SerializationWriterProxyFactory {
+    public class BackingStoreSerializationWriterProxyFactory : SerializationWriterProxyFactory
+    {
         /// <summary>
         /// Initializes a new instance of the <see cref="BackingStoreSerializationWriterProxyFactory"/> class given a concrete implementation of <see cref="ISerializationWriterFactory"/>.
         /// </summary>
         public BackingStoreSerializationWriterProxyFactory(ISerializationWriterFactory concrete) : base(
             concrete,
-            (x) => {
+            (x) =>
+            {
                 if(x is IBackedModel backedModel && backedModel.BackingStore != null)
                     backedModel.BackingStore.ReturnOnlyChangedValues = true;
-            },(x) => {
-                if(x is IBackedModel backedModel && backedModel.BackingStore != null) {
+            }, (x) =>
+            {
+                if(x is IBackedModel backedModel && backedModel.BackingStore != null)
+                {
                     backedModel.BackingStore.ReturnOnlyChangedValues = false;
                     backedModel.BackingStore.InitializationCompleted = true;
                 }
-            },(x, y) => {
-                if(x is IBackedModel backedModel && backedModel.BackingStore != null) {
+            }, (x, y) =>
+            {
+                if(x is IBackedModel backedModel && backedModel.BackingStore != null)
+                {
                     var nullValues = backedModel.BackingStore.EnumerateKeysForValuesChangedToNull();
                     foreach(var key in nullValues)
                         y.WriteNullValue(key);
                 }
-            }) {}
+            })
+        { }
     }
 }

--- a/abstractions/dotnet/src/store/IBackedModel.cs
+++ b/abstractions/dotnet/src/store/IBackedModel.cs
@@ -1,8 +1,14 @@
-namespace Microsoft.Kiota.Abstractions.Store {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     ///     Defines the contracts for a model that is backed by a store.
     /// </summary>
-    public interface IBackedModel {
+    public interface IBackedModel
+    {
         /// <summary>
         ///     Gets the store that is backing the model.
         /// </summary>

--- a/abstractions/dotnet/src/store/IBackingStore.cs
+++ b/abstractions/dotnet/src/store/IBackingStore.cs
@@ -1,11 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Kiota.Abstractions.Store {
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     /// Stores model information in a different location than the object properties. Implementations can provide dirty tracking capabilities, caching capabilities or integration with 3rd party stores.
     /// </summary>
-    public interface IBackingStore {
+    public interface IBackingStore
+    {
         /// <summary>Gets a value from the backing store based on its key. Returns null if the value hasn't changed and "ReturnOnlyChangedValues" is true.</summary>
         /// <returns>The value from the backing store.</returns>
         /// <param name="key">The key to lookup the backing store with.</param>

--- a/abstractions/dotnet/src/store/IBackingStoreFactory.cs
+++ b/abstractions/dotnet/src/store/IBackingStoreFactory.cs
@@ -1,8 +1,14 @@
-namespace Microsoft.Kiota.Abstractions.Store {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     ///     Defines the contract for a factory that creates backing stores.
     /// </summary>
-    public interface IBackingStoreFactory {
+    public interface IBackingStoreFactory
+    {
         /// <summary>
         ///     Creates a new instance of the backing store.
         /// </summary>

--- a/abstractions/dotnet/src/store/InMemoryBackingStore.cs
+++ b/abstractions/dotnet/src/store/InMemoryBackingStore.cs
@@ -1,17 +1,33 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Kiota.Abstractions.Store {
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     ///     In-memory implementation of the backing store. Allows for dirty tracking of changes.
     /// </summary>
-    public class InMemoryBackingStore : IBackingStore {
+    public class InMemoryBackingStore : IBackingStore
+    {
         private bool isInitializationComplete = true;
-        public bool ReturnOnlyChangedValues {get; set;}
+        /// <summary>
+        /// Determines whether the backing store should only return changed values when queried.
+        /// </summary>
+        public bool ReturnOnlyChangedValues { get; set; }
         private readonly Dictionary<string, Tuple<bool, object>> store = new();
         private Dictionary<string, Action<string, object, object>> subscriptions = new();
-        public T Get<T>(string key) {
+
+        /// <summary>
+        /// Gets the specified object with the given key from the store.
+        /// </summary>
+        /// <param name="key">The key to search with</param>
+        /// <returns>An instance of <typeparam name="T"/></returns>
+        public T Get<T>(string key)
+        {
             if(string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
@@ -20,50 +36,99 @@ namespace Microsoft.Kiota.Abstractions.Store {
             else
                 return default;
         }
-        public void Set<T>(string key, T value) {
+
+        /// <summary>
+        /// Sets the specified object with the given key in the store.
+        /// </summary>
+        /// <param name="key">The key to use</param>
+        /// <param name="value">The object value to store</param>
+        public void Set<T>(string key, T value)
+        {
             if(string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
             var valueToAdd = new Tuple<bool, object>(InitializationCompleted, value);
             Tuple<bool, object> oldValue = null;
-            if(!store.TryAdd(key, valueToAdd)) {
+            if(!store.TryAdd(key, valueToAdd))
+            {
                 oldValue = store[key];
                 store[key] = valueToAdd;
             }
             foreach(var sub in subscriptions.Values)
                 sub.Invoke(key, oldValue?.Item2, value);
         }
-        public IEnumerable<KeyValuePair<string, object>> Enumerate() {
+
+        /// <summary>
+        /// Enumerate the values in the store based on the <see cref="ReturnOnlyChangedValues"/> configuration value.
+        /// </summary>
+        /// <returns>A collection of changed values or the whole store based on the <see cref="ReturnOnlyChangedValues"/> configuration value.</returns>
+        public IEnumerable<KeyValuePair<string, object>> Enumerate()
+        {
             return (ReturnOnlyChangedValues ? store.Where(x => !x.Value.Item1) : store)
                 .Select(x => new KeyValuePair<string, object>(x.Key, x.Value.Item2));
         }
-        public IEnumerable<string> EnumerateKeysForValuesChangedToNull() {
+
+        /// <summary>
+        /// Enumerate the values in the store that have changed to null
+        /// </summary>
+        /// <returns>A collection of strings containing keys changed to null </returns>
+        public IEnumerable<string> EnumerateKeysForValuesChangedToNull()
+        {
             return store.Where(x => x.Value.Item1 && x.Value.Item2 == null).Select(x => x.Key);
         }
-        public string Subscribe(Action<string, object, object> callback) {
+
+        /// <summary>
+        /// Adds a callback to subscribe to events in the store
+        /// </summary>
+        /// <param name="callback">The callback to add</param>
+        /// <returns>The id of the subscription</returns>
+        public string Subscribe(Action<string, object, object> callback)
+        {
             var id = Guid.NewGuid().ToString();
             Subscribe(callback, id);
             return id;
         }
-        public void Subscribe(Action<string, object, object> callback, string subscriptionId) {
+
+        /// <summary>
+        /// Adds a callback to subscribe to events in the store with the given subscription id
+        /// </summary>
+        /// <param name="callback">The callback to add</param>
+        /// <param name="subscriptionId">The subscription id to use for subscription</param>
+        public void Subscribe(Action<string, object, object> callback, string subscriptionId)
+        {
             if(string.IsNullOrEmpty(subscriptionId))
                 throw new ArgumentNullException(nameof(subscriptionId));
             if(callback == null)
                 throw new ArgumentNullException(nameof(callback));
             subscriptions.Add(subscriptionId, callback);
         }
-        public void Unsubscribe(string subscriptionId) {
+
+        /// <summary>
+        /// De-register the callback with the given subscriptionId
+        /// </summary>
+        /// <param name="subscriptionId">The id of the subscription to de-register </param>
+        public void Unsubscribe(string subscriptionId)
+        {
             store.Remove(subscriptionId);
         }
-        public void Clear() {
+        /// <summary>
+        /// Clears the store
+        /// </summary>
+        public void Clear()
+        {
             store.Clear();
         }
-        public bool InitializationCompleted { 
-            get { return isInitializationComplete; } 
-            set {
+        /// <summary>
+        /// Flag to show the initialization status of the store.
+        /// </summary>
+        public bool InitializationCompleted
+        {
+            get { return isInitializationComplete; }
+            set
+            {
                 isInitializationComplete = value;
                 foreach(var entry in store)
-                    store[entry.Key] = new (!value, entry.Value.Item2);
+                    store[entry.Key] = new(!value, entry.Value.Item2);
             }
         }
     }

--- a/abstractions/dotnet/src/store/InMemoryBackingStoreFactory.cs
+++ b/abstractions/dotnet/src/store/InMemoryBackingStoreFactory.cs
@@ -1,9 +1,20 @@
-namespace Microsoft.Kiota.Abstractions.Store {
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions.Store
+{
     /// <summary>
     ///     This class is used to create instances of <see cref="InMemoryBackingStore" />.
     /// </summary>
-    public class InMemoryBackingStoreFactory : IBackingStoreFactory {
-        public IBackingStore CreateBackingStore() {
+    public class InMemoryBackingStoreFactory : IBackingStoreFactory
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="IBackingStore"/>
+        /// </summary>
+        /// <returns></returns>
+        public IBackingStore CreateBackingStore()
+        {
             return new InMemoryBackingStore();
         }
     }


### PR DESCRIPTION
This PR is purely cosmetic and does not alter any functionality in the code. It involves the following changes :-

- Adds any missing XML documentation for public methods/properties
- Adds the `<GenerateDocumentationFile>true</GenerateDocumentationFile>` attribute to the csproj file so that compiler warnings may be generated in the event the first condition above is not met.
- Adds a `.editorconfig` to the solution to help with consistent code styling
- Whitespace changes to move opening curly braces to new lines.

Related to https://github.com/microsoft/kiota/issues/358