### PR TITLE
Add test project for HttpClient project for dotnet

### DIFF
--- a/.github/workflows/http-dotnet-httpclient.yml
+++ b/.github/workflows/http-dotnet-httpclient.yml
@@ -37,12 +37,18 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release
         working-directory: ${{ env.relativePath }}
-      - uses: actions/upload-artifact@v2
+      - name: Upload Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeCoverage
+          path: |
+            ${{ env.relativePath }}/Microsoft.Kiota.Http.HttpClient.Tests/TestResults  
+      - name: Upload Nuget package
+        uses: actions/upload-artifact@v2
         with:
           name: drop
           path: |
             ${{ env.relativePath }}/src/bin/Release/*.nupkg
-            ${{ env.relativePath }}/Microsoft.Kiota.Http.HttpClient.Tests/TestResults
       - run: git checkout ${{ env.relativePath }}/nuget.config
         if: always()
   deploy:

--- a/.github/workflows/http-dotnet-httpclient.yml
+++ b/.github/workflows/http-dotnet-httpclient.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build ${{ env.solutionName }} --no-restore -c Release
         working-directory: ${{ env.relativePath }}
       - name: Test
-        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release
+        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
         working-directory: ${{ env.relativePath }}
       - name: Publish
         run: dotnet publish ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release

--- a/.github/workflows/http-dotnet-httpclient.yml
+++ b/.github/workflows/http-dotnet-httpclient.yml
@@ -42,6 +42,7 @@ jobs:
           name: drop
           path: |
             ${{ env.relativePath }}/src/bin/Release/*.nupkg
+            ${{ env.relativePath }}/Microsoft.Kiota.Http.HttpClient.Tests/TestResults
       - run: git checkout ${{ env.relativePath }}/nuget.config
         if: always()
   deploy:

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpClientBuilderTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpClientBuilderTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Net.Http;
+using Microsoft.Kiota.Http.HttpClient.Tests.Mocks;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests
+{
+    public class HttpClientBuilderTests
+    {
+        [Fact]
+        public void ChainHandlersCollectionAndGetFirstLinkReturnsNullOnDefaultParams()
+        {
+            // Act
+            var delegatingHandler = HttpClientBuilder.ChainHandlersCollectionAndGetFirstLink();
+            // Assert
+            Assert.Null(delegatingHandler);
+        }
+
+        [Fact]
+        public void ChainHandlersCollectionAndGetFirstLinkWithSingleHandler()
+        {
+            // Arrange
+            var handler = new TestHttpMessageHandler();
+            // Act
+            var delegatingHandler = HttpClientBuilder.ChainHandlersCollectionAndGetFirstLink(handler);
+            // Assert
+            Assert.NotNull(delegatingHandler);
+            Assert.Null(delegatingHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void ChainHandlersCollectionAndGetFirstLinkWithMultipleHandlers()
+        {
+            // Arrange
+            var handler1 = new TestHttpMessageHandler();
+            var handler2 = new TestHttpMessageHandler();
+            // Act
+            var delegatingHandler = HttpClientBuilder.ChainHandlersCollectionAndGetFirstLink(handler1, handler2);
+            // Assert
+            Assert.NotNull(delegatingHandler);
+            Assert.NotNull(delegatingHandler.InnerHandler); // first handler has an inner handler
+
+            var innerHandler = delegatingHandler.InnerHandler as DelegatingHandler;
+            Assert.NotNull(innerHandler);
+            Assert.Null(innerHandler.InnerHandler);// end of the chain
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpCoreTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpCoreTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Abstractions.Store;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests
+{
+    public class HttpCoreTests
+    {
+        private readonly IAuthenticationProvider _authenticationProvider;
+
+        public HttpCoreTests()
+        {
+            _authenticationProvider = new Mock<IAuthenticationProvider>().Object;
+        }
+
+        [Fact]
+        public void ThrowsArgumentNullExceptionOnNullAuthenticationProvider()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new HttpCore(null));
+            Assert.Equal("authenticationProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void EnablesBackingStore()
+        {
+            // Arrange
+            var httpCore = new HttpCore(_authenticationProvider);
+            var backingStore = new Mock<IBackingStoreFactory>().Object;
+
+            //Assert the that we originally have an in memory backing store
+            Assert.IsAssignableFrom<InMemoryBackingStoreFactory>(BackingStoreFactorySingleton.Instance);
+
+            // Act
+            httpCore.EnableBackingStore(backingStore);
+
+            //Assert the backing store has been updated
+            Assert.IsAssignableFrom(backingStore.GetType(), BackingStoreFactorySingleton.Instance);
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Microsoft.Kiota.Http.HttpClient.Tests.csproj
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Microsoft.Kiota.Http.HttpClient.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Kiota.Http.HttpClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/TestHttpMessageHandler.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/TestHttpMessageHandler.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Mocks
+{
+    public class TestHttpMessageHandler : DelegatingHandler
+    {
+        private readonly Action<HttpRequestMessage> requestMessageDelegate;
+        private readonly Dictionary<string, HttpResponseMessage> responseMessages;
+
+        public TestHttpMessageHandler(Action<HttpRequestMessage> requestMessage = null)
+        {
+            this.requestMessageDelegate = requestMessage ?? DefaultRequestHandler;
+            this.responseMessages = new Dictionary<string, HttpResponseMessage>();
+        }
+
+        public void AddResponseMapping(string requestUrl, HttpResponseMessage responseMessage)
+        {
+            this.responseMessages.Add(requestUrl, responseMessage);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage responseMessage;
+
+            requestMessageDelegate(request);
+
+            if(this.responseMessages.TryGetValue(request.RequestUri.ToString(), out responseMessage))
+            {
+                responseMessage.RequestMessage = request;
+                return Task.FromResult(responseMessage);
+            }
+
+            return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+        }
+
+        private void DefaultRequestHandler(HttpRequestMessage httpRequest)
+        {
+
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.sln
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Kiota.Http.HttpClient.Tests", "Microsoft.Kiota.Http.HttpClient.Tests\Microsoft.Kiota.Http.HttpClient.Tests.csproj", "{CCD20728-D593-48F8-8627-6E7A57B31A43}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,18 @@ Global
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x64.Build.0 = Release|Any CPU
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x86.ActiveCfg = Release|Any CPU
 		{769E84B2-FD14-4173-B83B-6792DFB0BA14}.Release|x86.Build.0 = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|x64.Build.0 = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Debug|x86.Build.0 = Debug|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|x64.ActiveCfg = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|x64.Build.0 = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|x86.ActiveCfg = Release|Any CPU
+		{CCD20728-D593-48F8-8627-6E7A57B31A43}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/http/dotnet/httpclient/README.md
+++ b/http/dotnet/httpclient/README.md
@@ -2,9 +2,9 @@
 
 ![Dotnet](https://github.com/microsoft/kiota/actions/workflows/http-dotnet-httpclient.yml/badge.svg)
 
-- [ ] coverage code
+- [x] coverage code
 - [ ] analyzers
-- [ ] unit test project
+- [x] unit test project
 - [x] docs comments
 
 ## Using the Http HttpClient implementations

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -5,7 +5,6 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
-using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 
 namespace Microsoft.Kiota.Http.HttpClient

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -141,6 +141,12 @@ namespace Microsoft.Kiota.Http.HttpClient
             else
                 return await responseHandler.HandleResponseAsync<HttpResponseMessage, ModelType>(response);
         }
+        /// <summary>
+        /// Send a <see cref="RequestInfo"/> instance with an empty request body
+        /// </summary>
+        /// <param name="requestInfo">The <see cref="RequestInfo"/> instance to send</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
+        /// <returns></returns>
         public async Task SendNoContentAsync(RequestInfo requestInfo, IResponseHandler responseHandler = null)
         {
             var response = await GetHttpResponseMessage(requestInfo);


### PR DESCRIPTION
This PR is part of the work covered in #358

- Adds a unit test project for the HttpClient project for dotnet
- Updates the build pipeline to generate code coverage artifact
- Cleans up a missing XML comment in the HttpCore class