### PR TITLE
Adds test project for Authentication project for dotnet

### DIFF
--- a/.github/workflows/authentication-dotnet-azure.yml
+++ b/.github/workflows/authentication-dotnet-azure.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build ${{ env.solutionName }} --no-restore -c Release
         working-directory: ${{ env.relativePath }}
       - name: Test
-        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release
+        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
         working-directory: ${{ env.relativePath }}
       - name: Publish
         run: dotnet publish ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release
@@ -37,7 +37,14 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release
         working-directory: ${{ env.relativePath }}
-      - uses: actions/upload-artifact@v2
+      - name: Upload Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeCoverage
+          path: |
+            ${{ env.relativePath }}/Microsoft.Kiota.Authentication.Azure.Tests/TestResults  
+      - name: Upload Nuget package
+        uses: actions/upload-artifact@v2
         with:
           name: drop
           path: |

--- a/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
+++ b/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Azure.Core;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Authentication.Azure.Tests
+{
+    public class AzureIdentityAuthenticationProviderTests
+    {
+        [Fact]
+        public void ConstructorThrowsArgumentNullExceptionOnNullTokenCredential()
+        {
+            // Arrange
+            var exception = Assert.Throws<ArgumentNullException>(() => new AzureIdentityAuthenticationProvider(null, null));
+
+            // Assert
+            Assert.Equal("credentials", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task GetAuthorizationTokenAsyncGetsToken()
+        {
+            // Arrange
+            var expectedToken = "token";
+            var mockTokenCredential = new Mock<TokenCredential>();
+            mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
+            var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object, null);
+            var testRequest = new RequestInfo()
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+
+            // Act
+            var token = await azureIdentityAuthenticationProvider.GetAuthorizationTokenAsync(testRequest);
+
+            // Assert
+            Assert.Equal(expectedToken, token);
+        }
+
+        [Fact]
+        public async Task AuthenticateRequestAsyncSetsBearerHeader()
+        {
+            // Arrange
+            var expectedToken = "token";
+            var mockTokenCredential = new Mock<TokenCredential>();
+            mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
+            var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object,"User.Read");
+            var testRequest = new RequestInfo()
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            Assert.Empty(testRequest.Headers); // header collection is empty
+
+            // Act
+            await azureIdentityAuthenticationProvider.AuthenticateRequestAsync(testRequest);
+
+            // Assert
+            Assert.NotEmpty(testRequest.Headers); // header collection is longer empty
+            Assert.Equal("Authorization", testRequest.Headers.First().Key); // First element is Auth header
+            Assert.Equal($"Bearer {expectedToken}", testRequest.Headers.First().Value); // First element is Auth header
+        }
+    }
+}

--- a/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
+++ b/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Kiota.Authentication.Azure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.sln
+++ b/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Kiota.Authentication.Azure.Tests", "Microsoft.Kiota.Authentication.Azure.Tests\Microsoft.Kiota.Authentication.Azure.Tests.csproj", "{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,18 @@ Global
 		{3C958F05-ECD7-4017-AD8D-7B69F377695E}.Release|x64.Build.0 = Release|Any CPU
 		{3C958F05-ECD7-4017-AD8D-7B69F377695E}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C958F05-ECD7-4017-AD8D-7B69F377695E}.Release|x86.Build.0 = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|x64.Build.0 = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D45962C-0C64-4ADC-A96E-57B5B3F5D0DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/authentication/dotnet/azure/README.md
+++ b/authentication/dotnet/azure/README.md
@@ -2,9 +2,9 @@
 
 ![Dotnet](https://github.com/microsoft/kiota/actions/workflows/authentication-dotnet-azure.yml/badge.svg)
 
-- [ ] coverage code
+- [x] coverage code
 - [ ] analyzers
-- [ ] unit test project
+- [x] unit test project
 - [x] docs comments
 
 ## Using the Azure Authentication implementations


### PR DESCRIPTION
This PR is part of the work covered in #358

- Adds a unit test project for the Authentication project for dotnet
- Updates the build pipeline to generate code coverage artifact