### PR TITLE
Adds test project for Serialization project

### DIFF
--- a/.github/workflows/serialization-dotnet-json.yml
+++ b/.github/workflows/serialization-dotnet-json.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build ${{ env.solutionName }} --no-restore -c Release
         working-directory: ${{ env.relativePath }}
       - name: Test
-        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release
+        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
         working-directory: ${{ env.relativePath }}
       - name: Publish
         run: dotnet publish ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release
@@ -37,7 +37,14 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ env.solutionName }} --no-restore --no-build --verbosity normal -c Release
         working-directory: ${{ env.relativePath }}
-      - uses: actions/upload-artifact@v2
+      - name: Upload Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeCoverage
+          path: |
+            ${{ env.relativePath }}/Microsoft.Kiota.Serialization.Json.Tests/TestResults  
+      - name: Upload Nuget Package
+        uses: actions/upload-artifact@v2
         with:
           name: drop
           path: |

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeFactoryTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeFactoryTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests
+{
+    public class JsonParseNodeFactoryTests
+    {
+        private readonly JsonParseNodeFactory _jsonParseNodeFactory;
+        private const string TestJsonString = "{\"key\":\"value\"}";
+
+        public JsonParseNodeFactoryTests()
+        {
+            _jsonParseNodeFactory = new JsonParseNodeFactory();
+        }
+
+        [Fact]
+        public void GetsWriterForJsonContentType()
+        {
+            using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
+            var jsonWriter = _jsonParseNodeFactory.GetRootParseNode(_jsonParseNodeFactory.ValidContentType,jsonStream);
+
+            // Assert
+            Assert.NotNull(jsonWriter);
+            Assert.IsAssignableFrom<JsonParseNode>(jsonWriter);
+        }
+
+        [Fact]
+        public void ThrowsArgumentOutOfRangeExceptionForInvalidContentType()
+        {
+            var streamContentType = "application/octet-stream";
+            using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _jsonParseNodeFactory.GetRootParseNode(streamContentType,jsonStream));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal($"expected a {_jsonParseNodeFactory.ValidContentType} content type", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ThrowsArgumentNullExceptionForNoContentType(string contentType)
+        {
+            using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
+            var exception = Assert.Throws<ArgumentNullException>(() => _jsonParseNodeFactory.GetRootParseNode(contentType,jsonStream));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal("contentType", exception.ParamName);
+        }
+    }
+}

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Text.Json;
+using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
+using Xunit;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests
+{
+    public class JsonParseNodeTests
+    {
+        private const string TestUserJson = "{\r\n" +
+                                            "    \"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#users/$entity\",\r\n" +
+                                            "    \"@odata.id\": \"https://graph.microsoft.com/v2/dcd219dd-bc68-4b9b-bf0b-4a33a796be35/directoryObjects/48d31887-5fad-4d73-a9f5-3c356e68a038/Microsoft.DirectoryServices.User\",\r\n" +
+                                            "    \"businessPhones\": [\r\n" +
+                                            "        \"+1 412 555 0109\"\r\n" +
+                                            "    ],\r\n" +
+                                            "    \"displayName\": \"Megan Bowen\",\r\n" +
+                                            "    \"givenName\": \"Megan\",\r\n" +
+                                            "    \"accountEnabled\": true,\r\n" +
+                                            "    \"createdDateTime\": \"2017-07-29T03:07:25Z\",\r\n" +
+                                            "    \"jobTitle\": \"Auditor\",\r\n" +
+                                            "    \"mail\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
+                                            "    \"mobilePhone\": null,\r\n" +
+                                            "    \"officeLocation\": \"12/1110\",\r\n" +
+                                            "    \"preferredLanguage\": \"en-US\",\r\n" +
+                                            "    \"surname\": \"Bowen\",\r\n" +
+                                            "    \"userPrincipalName\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
+                                            "    \"id\": \"48d31887-5fad-4d73-a9f5-3c356e68a038\"\r\n" +
+                                            "}";
+
+        private static readonly string TestUserCollectionString = $"[{TestUserJson}]";
+
+        [Fact]
+        public void GetsEntityValueFromJson()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestUserJson);
+            var jsonParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act
+            var testEntity = jsonParseNode.GetObjectValue<TestEntity>();
+            // Assert
+            Assert.NotNull(testEntity);
+            Assert.NotEmpty(testEntity.AdditionalData);
+            Assert.True(testEntity.AdditionalData.ContainsKey("jobTitle"));
+            Assert.Equal("Auditor", testEntity.AdditionalData["jobTitle"]);
+            Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntity.Id);
+        }
+
+        [Fact]
+        public void GetCollectionOfObjectValuesFromJson()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestUserCollectionString);
+            var jsonParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act
+            var testEntityCollection = jsonParseNode.GetCollectionOfObjectValues<TestEntity>().ToArray();
+            // Assert
+            Assert.NotEmpty(testEntityCollection);
+            Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntityCollection[0].Id);
+        }
+
+        [Fact]
+        public void GetsChildNodeAndGetCollectionOfPrimitiveValuesFromJsonParseNode()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestUserJson);
+            var rootParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act to get business phones list
+            var phonesListChildNode = rootParseNode.GetChildNode("businessPhones");
+            var phonesList = phonesListChildNode.GetCollectionOfPrimitiveValues<string>().ToArray();
+            // Assert
+            Assert.NotEmpty(phonesList);
+            Assert.Equal("+1 412 555 0109", phonesList[0]);
+        }
+    }
+}

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterFactoryTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterFactoryTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Xunit;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests
+{
+    public class JsonSerializationWriterFactoryTests
+    {
+        private readonly JsonSerializationWriterFactory _jsonSerializationFactory;
+
+        public JsonSerializationWriterFactoryTests()
+        {
+            _jsonSerializationFactory = new JsonSerializationWriterFactory();
+        }
+
+        [Fact]
+        public void GetsWriterForJsonContentType()
+        {
+            var jsonWriter = _jsonSerializationFactory.GetSerializationWriter(_jsonSerializationFactory.ValidContentType);
+            
+            // Assert
+            Assert.NotNull(jsonWriter);
+            Assert.IsAssignableFrom<JsonSerializationWriter>(jsonWriter);
+        }
+
+        [Fact]
+        public void ThrowsArgumentOutOfRangeExceptionForInvalidContentType()
+        {
+            var streamContentType = "application/octet-stream";
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _jsonSerializationFactory.GetSerializationWriter(streamContentType));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal($"expected a {_jsonSerializationFactory.ValidContentType} content type", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ThrowsArgumentNullExceptionForNoContentType(string contentType)
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => _jsonSerializationFactory.GetSerializationWriter(contentType));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal("contentType", exception.ParamName);
+        }
+    }
+}

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
+using Xunit;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests
+{
+    public class JsonSerializationWriterTests
+    {
+        [Fact]
+        public void WritesSampleObjectValue()
+        {
+            // Arrange
+            var testEntity = new TestEntity()
+            {
+                Id = "48d31887-5fad-4d73-a9f5-3c356e68a038",
+                AdditionalData = new Dictionary<string, object>
+                {
+                    {"mobilePhone",null}, // write null value
+                    {"accountEnabled",false}, // write bool value
+                    {"jobTitle","Author"}, // write string value
+                    {"createdDateTime", DateTimeOffset.MinValue}, // write date value
+                    {"businessPhones", new List<string>() {"+1 412 555 0109"}}, // write collection of primitives value
+                    {"manager", new TestEntity{Id = "48d31887-5fad-4d73-a9f5-3c356e68a038"}}, // write nested object value
+                }
+            };
+            using var jsonSerializerWriter = new JsonSerializationWriter();
+            // Act
+            jsonSerializerWriter.WriteObjectValue(string.Empty,testEntity);
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
+            
+            // Assert
+            var expectedString = "{" +
+                                 "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
+                                 "\"mobilePhone\":null," +
+                                 "\"accountEnabled\":false," +
+                                 "\"jobTitle\":\"Author\"," +
+                                 "\"createdDateTime\":\"0001-01-01T00:00:00+00:00\"," +
+                                 "\"businessPhones\":[\"\\u002B1 412 555 0109\"]," +
+                                 "\"manager\":{\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"}"+
+                                 "}";
+            Assert.Equal(expectedString, serializedJsonString);
+        }
+
+        [Fact]
+        public void WritesSampleCollectionOfObjectValues()
+        {
+            // Arrange
+            var testEntity = new TestEntity()
+            {
+                Id = "48d31887-5fad-4d73-a9f5-3c356e68a038",
+                AdditionalData = new Dictionary<string, object>
+                {
+                    {"mobilePhone",null}, // write null value
+                    {"accountEnabled",false}, // write bool value
+                    {"jobTitle","Author"}, // write string value
+                    {"createdDateTime", DateTimeOffset.MinValue}, // write date value
+                    {"businessPhones", new List<string>() {"+1 412 555 0109"}}, // write collection of primitives value
+                    {"manager", new TestEntity{Id = "48d31887-5fad-4d73-a9f5-3c356e68a038"}}, // write nested object value
+                }
+            };
+            var entityList = new List<TestEntity>() { testEntity};
+            using var jsonSerializerWriter = new JsonSerializationWriter();
+            // Act
+            jsonSerializerWriter.WriteCollectionOfObjectValues(string.Empty, entityList);
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
+
+            // Assert
+            var expectedString = "[{" +
+                                 "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
+                                 "\"mobilePhone\":null," +
+                                 "\"accountEnabled\":false," +
+                                 "\"jobTitle\":\"Author\"," +
+                                 "\"createdDateTime\":\"0001-01-01T00:00:00+00:00\"," +
+                                 "\"businessPhones\":[\"\\u002B1 412 555 0109\"]," +
+                                 "\"manager\":{\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"}" +
+                                 "}]";
+            Assert.Equal(expectedString, serializedJsonString);
+        }
+
+    }
+}

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Microsoft.Kiota.Serialization.Json.Tests.csproj
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Microsoft.Kiota.Serialization.Json.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Kiota.Serialization.Json.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Kiota.Abstractions.Serialization;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
+{
+    public class TestEntity : IParsable
+    {
+        /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
+        public IDictionary<string, object> AdditionalData { get; set; }
+        /// <summary>Read-only.</summary>
+        public string Id { get; set; }
+        /// <summary>
+        /// Instantiates a new entity and sets the default values.
+        /// </summary>
+        public TestEntity()
+        {
+            AdditionalData = new Dictionary<string, object>();
+        }
+        /// <summary>
+        /// The deserialization information for the current model
+        /// </summary>
+        public IDictionary<string, Action<T, IParseNode>> GetFieldDeserializers<T>()
+        {
+            return new Dictionary<string, Action<T, IParseNode>> {
+                {"id", (o,n) => { (o as TestEntity).Id = n.GetStringValue(); } },
+            };
+        }
+        /// <summary>
+        /// Serializes information the current object
+        /// <param name="writer">Serialization writer to use to serialize this model</param>
+        /// </summary>
+        public void Serialize(ISerializationWriter writer)
+        {
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteStringValue("id", Id);
+            writer.WriteAdditionalData(AdditionalData);
+        }
+    }
+}

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.sln
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Kiota.Serialization.Json.Tests", "Microsoft.Kiota.Serialization.Json.Tests\Microsoft.Kiota.Serialization.Json.Tests.csproj", "{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,18 @@ Global
 		{8CC6634E-A611-4FB9-9C31-1BE038D75E1E}.Release|x64.Build.0 = Release|Any CPU
 		{8CC6634E-A611-4FB9-9C31-1BE038D75E1E}.Release|x86.ActiveCfg = Release|Any CPU
 		{8CC6634E-A611-4FB9-9C31-1BE038D75E1E}.Release|x86.Build.0 = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Debug|x86.Build.0 = Debug|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|x64.Build.0 = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{AC81733F-EC61-4241-ADCF-E16BA1EDD7AF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/serialization/dotnet/json/README.md
+++ b/serialization/dotnet/json/README.md
@@ -2,9 +2,9 @@
 
 ![Dotnet Serialization Json](https://github.com/microsoft/kiota/actions/workflows/serialization-dotnet-json.yml/badge.svg)
 
-- [ ] coverage code
+- [x] coverage code
 - [ ] analyzers
-- [ ] unit test project
+- [x] unit test project
 - [x] docs comments
 
 ## Using the JSON Serialization implementations

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// <summary>
         /// The <see cref="JsonParseNode"/> constructor.
         /// </summary>
-        /// <param name="node">The JsonElement to intialize the node with</param>
+        /// <param name="node">The JsonElement to initialize the node with</param>
         public JsonParseNode(JsonElement node)
         {
             _jsonNode = node;
@@ -156,7 +156,6 @@ namespace Microsoft.Kiota.Serialization.Json
         /// The action to perform after assigning field values.
         /// </summary>
         public Action<IParsable> OnAfterAssignFieldValues { get; set; }
-        private static Type objectType = typeof(object);
 
         /// <summary>
         /// Get the object of type <typeparam name="T"/>from the json node

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Kiota.Serialization.Json
     /// <summary>
     /// The <see cref="ISerializationWriter"/> implementation for json content types.
     /// </summary>
-    public class JsonSerializationWriter : ISerializationWriter
+    public class JsonSerializationWriter : ISerializationWriter, IDisposable
     {
         private readonly MemoryStream _stream = new MemoryStream();
 
@@ -272,11 +272,11 @@ namespace Microsoft.Kiota.Serialization.Json
                 case IEnumerable<object> coll:
                     WriteCollectionOfPrimitiveValues(key, coll);
                     break;
+                case IParsable parseable:
+                    WriteObjectValue(key, parseable);
+                    break;
                 case object o:
-                    if(o is IParsable parseable)
-                        WriteObjectValue(key, parseable);
-                    else
-                        WriteNonParsableObjectValue(key, o);
+                    WriteNonParsableObjectValue(key, o);
                     break;
                 case null:
                     WriteNullValue(key);

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -16,7 +16,7 @@ namespace Microsoft.Kiota.Serialization.Json
     /// <summary>
     /// The <see cref="ISerializationWriter"/> implementation for json content types.
     /// </summary>
-    public class JsonSerializationWriter : ISerializationWriter, IDisposable
+    public class JsonSerializationWriter : ISerializationWriter
     {
         private readonly MemoryStream _stream = new MemoryStream();
 
@@ -66,7 +66,7 @@ namespace Microsoft.Kiota.Serialization.Json
         public void WriteStringValue(string key, string value)
         {
             if(value != null)
-            { // we want to keep empty string because they are meaningfull
+            { // we want to keep empty string because they are meaningful
                 if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
                 writer.WriteStringValue(value);
             }
@@ -246,12 +246,6 @@ namespace Microsoft.Kiota.Serialization.Json
         }
         private void WriteAnyValue<T>(string key, T value)
         {
-            if(value == null)
-            {
-                if(!string.IsNullOrEmpty(key))
-                    this.writer.WritePropertyName(key);
-                this.writer.WriteNullValue();
-            }
             switch(value)
             {
                 case string s:
@@ -276,10 +270,13 @@ namespace Microsoft.Kiota.Serialization.Json
                     WriteDateTimeOffsetValue(key, dto);
                     break;
                 case IEnumerable<object> coll:
-                    WriteCollectionOfPrimitiveValues(key, coll); // should we support collections of parsables here too?
+                    WriteCollectionOfPrimitiveValues(key, coll);
                     break;
                 case object o:
-                    WriteNonParsableObjectValue(key, o); // should we support parsables here too?
+                    if(o is IParsable parseable)
+                        WriteObjectValue(key, parseable);
+                    else
+                        WriteNonParsableObjectValue(key, o);
                     break;
                 case null:
                     WriteNullValue(key);

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
@@ -233,9 +233,7 @@ public class JsonSerializationWriter implements SerializationWriter {
     private void writeAnyValue(final String key, final Object value) {
         try {
             if(value == null) {
-                if(key != null && !key.isEmpty())
-                    this.writer.name(key);
-                this.writer.nullValue();
+                this.writeNullValue(key);
             } else {
                 final Class<?> valueClass = value.getClass();
                 if(valueClass.equals(String.class))
@@ -256,8 +254,6 @@ public class JsonSerializationWriter implements SerializationWriter {
                     this.writeCollectionOfPrimitiveValues(key, (Iterable<?>)value);
                 else if(!valueClass.isPrimitive())
                     this.writeNonParsableObject(key, value);
-                else if(value == null)
-                    this.writeNullValue(key);
                 else
                     throw new RuntimeException("unknown type to serialize " + valueClass.getName());
             }

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
@@ -231,34 +231,30 @@ public class JsonSerializationWriter implements SerializationWriter {
         }
     }
     private void writeAnyValue(final String key, final Object value) {
-        try {
-            if(value == null) {
-                this.writeNullValue(key);
-            } else {
-                final Class<?> valueClass = value.getClass();
-                if(valueClass.equals(String.class))
-                    this.writeStringValue(key, (String)value);
-                else if(valueClass.equals(Boolean.class))
-                    this.writeBooleanValue(key, (Boolean)value);
-                else if(valueClass.equals(Float.class))
-                    this.writeFloatValue(key, (Float)value);
-                else if(valueClass.equals(Long.class))
-                    this.writeLongValue(key, (Long)value);
-                else if(valueClass.equals(Integer.class))
-                    this.writeIntegerValue(key, (Integer)value);
-                else if(valueClass.equals(UUID.class))
-                    this.writeUUIDValue(key, (UUID)value);
-                else if(valueClass.equals(OffsetDateTime.class))
-                    this.writeOffsetDateTimeValue(key, (OffsetDateTime)value);
-                else if(value instanceof Iterable<?>)
-                    this.writeCollectionOfPrimitiveValues(key, (Iterable<?>)value);
-                else if(!valueClass.isPrimitive())
-                    this.writeNonParsableObject(key, value);
-                else
-                    throw new RuntimeException("unknown type to serialize " + valueClass.getName());
-            }
-        } catch (IOException ex) {
-            throw new RuntimeException("could not serialize value", ex);
+        if(value == null) {
+            this.writeNullValue(key);
+        } else {
+            final Class<?> valueClass = value.getClass();
+            if(valueClass.equals(String.class))
+                this.writeStringValue(key, (String)value);
+            else if(valueClass.equals(Boolean.class))
+                this.writeBooleanValue(key, (Boolean)value);
+            else if(valueClass.equals(Float.class))
+                this.writeFloatValue(key, (Float)value);
+            else if(valueClass.equals(Long.class))
+                this.writeLongValue(key, (Long)value);
+            else if(valueClass.equals(Integer.class))
+                this.writeIntegerValue(key, (Integer)value);
+            else if(valueClass.equals(UUID.class))
+                this.writeUUIDValue(key, (UUID)value);
+            else if(valueClass.equals(OffsetDateTime.class))
+                this.writeOffsetDateTimeValue(key, (OffsetDateTime)value);
+            else if(value instanceof Iterable<?>)
+                this.writeCollectionOfPrimitiveValues(key, (Iterable<?>)value);
+            else if(!valueClass.isPrimitive())
+                this.writeNonParsableObject(key, value);
+            else
+                throw new RuntimeException("unknown type to serialize " + valueClass.getName());
         }
     }
     public Consumer<Parsable> getOnBeforeObjectSerialization() {


### PR DESCRIPTION
This PR is part of the work covered in #358. 

- Adds a unit test project for the Serialization project for dotnet
- Updates the build pipeline to generate code coverage artifact

It also fixes the following bugs with the `JsonSerializationWriter` where
- `null` properties in an object would be repeated in final serialized payload
- `IParsable` objects would fail in serialization due to the code trying to reflect properties of `AdditionalData` rather than using the object's serialization methods