### PR TITLE
Adding FetchOptions interface and static factory methods for HTTP Core

### DIFF
--- a/abstractions/typescript/tsconfig.json
+++ b/abstractions/typescript/tsconfig.json
@@ -6,7 +6,7 @@
     "incremental": true,                   /* Enable incremental compilation */
     "target": "es2020",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "es2020",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": [ "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ES2020"],                             /* Specify library files to be included in the compilation. */
+    "lib": [ "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ES2020", "dom"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/http/typescript/fetch/src/fetchOptions.ts
+++ b/http/typescript/fetch/src/fetchOptions.ts
@@ -1,0 +1,26 @@
+/**
+ * @interface {@link https://github.com/bitinn/node-fetch/#options}
+ * Signature to define the fetch request options for node environment
+ * @property {number} [follow] - node-fetch option: maximum redirect count. 0 to not follow redirect
+ * @property {number} [compress] - node-fetch option: support gzip/deflate content encoding. false to disable
+ * @property {number} [size] - node-fetch option: maximum response body size in bytes. 0 to disable
+ * @property {any} [agent] - node-fetch option: HTTP(S).Agent instance, allows custom proxy, certificate, lookup, family etc.
+ * @property {number} [highWaterMark] - node-fetch option: maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource.
+ * @property {boolean} [insecureHTTPParser] - node-fetch option: use an insecure HTTP parser that accepts invalid HTTP headers when `true`.
+ */
+ export interface NodeFetchInit {
+	follow?: number;
+	compress?: boolean;
+	size?: number;
+	agent?: any;
+	highWaterMark?: number;
+	insecureHTTPParser?: boolean;
+}
+
+/**
+ * @interface
+ * Signature to define the fetch api options which includes both fetch standard options and also the extended node fetch options
+ * @extends RequestInit @see {@link https://fetch.spec.whatwg.org/#requestinit}
+ * @extends NodeFetchInit
+ */
+export interface FetchOptions extends RequestInit, NodeFetchInit {}

--- a/http/typescript/fetch/src/httpCore.ts
+++ b/http/typescript/fetch/src/httpCore.ts
@@ -3,98 +3,118 @@ import { Headers as FetchHeadersCtor } from 'cross-fetch';
 import { ReadableStream } from 'web-streams-polyfill';
 import { URLSearchParams } from 'url';
 import { HttpClient } from './httpClient';
+import { Middleware } from "./middleware";
+import { FetchOptions } from './fetchOptions';
+
+export interface RequestBuilderConfig {
+    parseNodeFactory: ParseNodeFactory,
+    serializationWriterFactory: SerializationWriterFactory
+}
+
+export interface CoreConfig {
+    authenticationProvider: AuthenticationProvider,
+    httpClient?: HttpClient,
+    middleware?: Middleware | Middleware[],
+    fetchOptions?: FetchOptions
+}
+
+interface CoreOptions {
+    authenticationProvider: AuthenticationProvider,
+    httpClient: HttpClient,
+    fetchOptions?: FetchOptions
+}
+
 export class HttpCore implements IHttpCore {
     public getSerializationWriterFactory(): SerializationWriterFactory {
-        return this.serializationWriterFactory;
+        return this.requestBuilderConfig.serializationWriterFactory;
     }
     /**
+     * @private
+     * @constructor
      * Instantiates a new http core service
-     * @param authenticationProvider the authentication provider to use.
-     * @param parseNodeFactory the parse node factory to deserialize responses.
-     * @param serializationWriterFactory the serialization writer factory to use to serialize request bodies.
-     * @param httpClient the http client to use to execute requests.
      */
-    public constructor(public readonly authenticationProvider: AuthenticationProvider, private parseNodeFactory: ParseNodeFactory = ParseNodeFactoryRegistry.defaultInstance, private serializationWriterFactory: SerializationWriterFactory = SerializationWriterFactoryRegistry.defaultInstance, private readonly httpClient: HttpClient = new HttpClient()) {
-        if(!authenticationProvider) {
+    private constructor(private requestBuilderConfig: RequestBuilderConfig = { parseNodeFactory: ParseNodeFactoryRegistry.defaultInstance, serializationWriterFactory: SerializationWriterFactoryRegistry.defaultInstance }, private coreOptions: CoreOptions) {
+        if (!coreOptions.authenticationProvider) {
             throw new Error('authentication provider cannot be null');
         }
-        if(!parseNodeFactory) {
+        if (!requestBuilderConfig.parseNodeFactory) {
             throw new Error('parse node factory cannot be null');
         }
-        if(!serializationWriterFactory) {
+        if (!requestBuilderConfig.serializationWriterFactory) {
             throw new Error('serialization writer factory cannot be null');
         }
-        if(!httpClient) {
+        if (!coreOptions.httpClient) {
             throw new Error('http client cannot be null');
         }
+
     }
     private getResponseContentType = (response: Response): string | undefined => {
         const header = response.headers.get("content-type")?.toLowerCase();
-        if(!header) return undefined;
+        if (!header) return undefined;
         const segments = header.split(';');
-        if(segments.length === 0) return undefined;
+        if (segments.length === 0) return undefined;
         else return segments[0];
     }
-    public sendCollectionAsync = async <ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType[]> => {
-        if(!requestInfo) {
+    public sendCollectionAsync = async <ModelType extends Parsable>(requestInfo: RequestInfo, type: new () => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType[]> => {
+        if (!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }
-        await this.authenticationProvider.authenticateRequest(requestInfo);
-        
+        await this.coreOptions.authenticationProvider.authenticateRequest(requestInfo);
+
         const request = this.getRequestFromRequestInfo(requestInfo);
-        const response = await this.httpClient.fetch(this.getRequestUrl(requestInfo), request);
-        if(responseHandler) {
+        const response = await this.coreOptions.httpClient.fetch(this.getRequestUrl(requestInfo), request);
+        if (responseHandler) {
             return await responseHandler.handleResponseAsync(response);
         } else {
             const payload = await response.arrayBuffer();
             const responseContentType = this.getResponseContentType(response);
-            if(!responseContentType)
+            if (!responseContentType)
                 throw new Error("no response content type found for deserialization");
-            
-            const rootNode = this.parseNodeFactory.getRootParseNode(responseContentType, payload);
+
+            const rootNode = this.requestBuilderConfig.parseNodeFactory.getRootParseNode(responseContentType, payload);
             const result = rootNode.getCollectionOfObjectValues(type);
             return result as unknown as ModelType[];
         }
     }
-    public sendAsync = async <ModelType extends Parsable>(requestInfo: RequestInfo, type: new() => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType> => {
-        if(!requestInfo) {
+    public sendAsync = async <ModelType extends Parsable>(requestInfo: RequestInfo, type: new () => ModelType, responseHandler: ResponseHandler | undefined): Promise<ModelType> => {
+        if (!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }
-        await this.authenticationProvider.authenticateRequest(requestInfo);
-        
+        await this.coreOptions.authenticationProvider.authenticateRequest(requestInfo);
+
         const request = this.getRequestFromRequestInfo(requestInfo);
-        const response = await this.httpClient.fetch(this.getRequestUrl(requestInfo), request);
-        if(responseHandler) {
+        const response = await this.coreOptions.httpClient.fetch(this.getRequestUrl(requestInfo), request);
+        if (responseHandler) {
             return await responseHandler.handleResponseAsync(response);
         } else {
             const payload = await response.arrayBuffer();
             const responseContentType = this.getResponseContentType(response);
-            if(!responseContentType)
+            if (!responseContentType)
                 throw new Error("no response content type found for deserialization");
-            
-            const rootNode = this.parseNodeFactory.getRootParseNode(responseContentType, payload);
+
+            const rootNode = this.requestBuilderConfig.parseNodeFactory.getRootParseNode(responseContentType, payload);
             const result = rootNode.getObjectValue(type);
             return result as unknown as ModelType;
         }
     }
     public sendPrimitiveAsync = async <ResponseType>(requestInfo: RequestInfo, responseType: "string" | "number" | "boolean" | "Date" | "ReadableStream", responseHandler: ResponseHandler | undefined): Promise<ResponseType> => {
-        if(!requestInfo) {
+        if (!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }
-        await this.authenticationProvider.authenticateRequest(requestInfo);
-        
+        await this.coreOptions.authenticationProvider.authenticateRequest(requestInfo);
+
         const request = this.getRequestFromRequestInfo(requestInfo);
-        const response = await this.httpClient.fetch(this.getRequestUrl(requestInfo), request);
-        if(responseHandler) {
+        const response = await this.coreOptions.httpClient.fetch(this.getRequestUrl(requestInfo), request);
+        if (responseHandler) {
             return await responseHandler.handleResponseAsync(response);
         } else {
-            switch(responseType) {
+            switch (responseType) {
                 case "ReadableStream":
-                    const buffer =  await response.arrayBuffer();
+                    const buffer = await response.arrayBuffer();
                     let bufferPulled = false;
                     const stream = new ReadableStream({
                         pull: (controller) => {
-                            if(!bufferPulled) {
+                            if (!bufferPulled) {
                                 controller.enqueue(buffer.slice(0))
                                 bufferPulled = true;
                             }
@@ -107,15 +127,15 @@ export class HttpCore implements IHttpCore {
                 case 'Date':
                     const payload = await response.arrayBuffer();
                     const responseContentType = this.getResponseContentType(response);
-                    if(!responseContentType)
+                    if (!responseContentType)
                         throw new Error("no response content type found for deserialization");
-                    
-                    const rootNode = this.parseNodeFactory.getRootParseNode(responseContentType, payload);
-                    if(responseType === 'string') {
+
+                    const rootNode = this.requestBuilderConfig.parseNodeFactory.getRootParseNode(responseContentType, payload);
+                    if (responseType === 'string') {
                         return rootNode.getStringValue() as unknown as ResponseType;
                     } else if (responseType === 'number') {
                         return rootNode.getNumberValue() as unknown as ResponseType;
-                    } else if(responseType === 'boolean') {
+                    } else if (responseType === 'boolean') {
                         return rootNode.getBooleanValue() as unknown as ResponseType;
                     } else if (responseType === 'Date') {
                         return rootNode.getDateValue() as unknown as ResponseType;
@@ -126,23 +146,23 @@ export class HttpCore implements IHttpCore {
         }
     }
     public sendNoResponseContentAsync = async (requestInfo: RequestInfo, responseHandler: ResponseHandler | undefined): Promise<void> => {
-        if(!requestInfo) {
+        if (!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }
-        await this.authenticationProvider.authenticateRequest(requestInfo);
-        
+        await this.coreOptions.authenticationProvider.authenticateRequest(requestInfo);
+
         const request = this.getRequestFromRequestInfo(requestInfo);
-        const response = await this.httpClient.fetch(this.getRequestUrl(requestInfo), request);
-        if(responseHandler) {
+        const response = await this.coreOptions.httpClient.fetch(this.getRequestUrl(requestInfo), request);
+        if (responseHandler) {
             return await responseHandler.handleResponseAsync(response);
         }
     }
     public enableBackingStore = (backingStoreFactory?: BackingStoreFactory | undefined): void => {
-        this.parseNodeFactory = enableBackingStoreForParseNodeFactory(this.parseNodeFactory);
-        this.serializationWriterFactory = enableBackingStoreForSerializationWriterFactory(this.serializationWriterFactory);
-        if(!this.serializationWriterFactory || !this.parseNodeFactory)
+        this.requestBuilderConfig.parseNodeFactory = enableBackingStoreForParseNodeFactory(this.requestBuilderConfig.parseNodeFactory);
+        this.requestBuilderConfig.serializationWriterFactory = enableBackingStoreForSerializationWriterFactory(this.requestBuilderConfig.serializationWriterFactory);
+        if (!this.requestBuilderConfig.serializationWriterFactory || !this.requestBuilderConfig.parseNodeFactory)
             throw new Error("unable to enable backing store");
-        if(backingStoreFactory) {
+        if (backingStoreFactory) {
             BackingStoreFactorySingleton.instance = backingStoreFactory;
         }
     }
@@ -155,9 +175,9 @@ export class HttpCore implements IHttpCore {
         requestInfo.headers?.forEach((v, k) => (request.headers as Headers).set(k, v));
         return request;
     }
-    private getRequestUrl = (requestInfo: RequestInfo) : string => {
+    private getRequestUrl = (requestInfo: RequestInfo): string => {
         let url = requestInfo.URI ?? '';
-        if(requestInfo.queryParameters?.size ?? -1 > 0) {
+        if (requestInfo.queryParameters?.size ?? -1 > 0) {
             const queryParametersBuilder = new URLSearchParams();
             requestInfo.queryParameters?.forEach((v, k) => {
                 queryParametersBuilder.append(k, `${v}`);
@@ -167,4 +187,53 @@ export class HttpCore implements IHttpCore {
         return url;
     }
 
+    /**
+     * Factory method to create HttpCore instance for url requests not using RequestBuilders
+     * @param coreConfig the configuration used to set authprovider, httpClient or middleware, fetchOptions and more.
+     */
+    public static createCoreForPrimitiveRequests(coreConfig: CoreConfig): HttpCore {
+        const coreOptions: CoreOptions = {
+            httpClient: HttpCore.getHttpClient(coreConfig.httpClient, coreConfig.middleware),
+            authenticationProvider: coreConfig.authenticationProvider,
+            fetchOptions: coreConfig.fetchOptions
+        }
+        return new HttpCore({ parseNodeFactory: ParseNodeFactoryRegistry.defaultInstance, serializationWriterFactory: SerializationWriterFactoryRegistry.defaultInstance }, coreOptions);
+    }
+
+    /**
+     * Factory method to create HttpCore instance to support Kiota Request Builders
+     * @param requestBuilderConfig the configuration used to set ParseNodeFactory and serializationWriterFactory
+     * @param coreConfig the configuration used to set authprovider, httpClient or middleware, fetchOptions and more.
+     */
+    public static createCoreForRequestBuilders(requestBuilderConfig: RequestBuilderConfig, coreConfig: CoreConfig): HttpCore {
+        const coreOptions: CoreOptions = {
+            httpClient: HttpCore.getHttpClient(coreConfig.httpClient, coreConfig.middleware),
+            authenticationProvider: coreConfig.authenticationProvider,
+            fetchOptions: coreConfig.fetchOptions
+        }
+        return new HttpCore(requestBuilderConfig, coreOptions);
+    }
+
+    // TODO : add factory method  return instance with default values.
+
+
+    /**
+     * @private
+     * Static method returning an HttpClient instance which will be used by the HttpCore while making request.
+     * @param httpClient the an HttpClient instance passed as a configuration of the HttpCore
+     * @param middleware a single middleware or an array of middleware used to create an HttpClient
+     */
+    private static getHttpClient(httpClient?: HttpClient, middleware?: Middleware | Middleware[]): HttpClient {
+        if (httpClient && middleware) {
+            throw Error("Please provide either the HttpClient instance or the middleware configurations.");
+        }
+        if (httpClient) {
+            return httpClient;
+        }
+        if (middleware) {
+            // TODO: return with new middleware.
+            return new HttpClient();
+        }
+        return new HttpClient();
+    }
 }


### PR DESCRIPTION
This is the first PR. There will be more changes to the methods introduced in this PR.

1. Added  the `FetchOptions` interface.

2. Added factory methods to create `HttpCore` along with the `config object pattern`.  Reasons:

- Using a `config` object as the 4 and more number of parameters are required to initialize over populating the constructor parameter list. 
- Abstracting the creation of `HttpCore` and the `HttpClient` and using factory methods with names suggesting the usage scenario of the HTTP core.

