### PR TITLE
Add redirect,retry and compression handlers to HttpClient library for dotnet

### DIFF
--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+using Xunit;
+using HttpMethod = Microsoft.Kiota.Abstractions.HttpMethod;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Extensions
+{
+    public class HttpRequestMessageExtensionsTests
+    {
+        [Fact]
+        public void GetMiddlewareOptionCanExtractMiddleWareOptionFromHttpRequestMessage()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation()
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            var redirectHandlerOption = new RedirectHandlerOption()
+            {
+                MaxRedirect = 7
+            };
+            requestInfo.AddMiddlewareOptions(redirectHandlerOption);
+            // Act and get a request message
+            var requestMessage = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            var extractedOption = requestMessage.GetMiddlewareOption<RedirectHandlerOption>();
+            // Assert
+            Assert.NotNull(extractedOption);
+            Assert.Equal(redirectHandlerOption, extractedOption);
+            Assert.Equal(7, redirectHandlerOption.MaxRedirect);
+        }
+
+        [Fact]
+        public async Task CloneAsyncWithEmptyHttpContent()
+        {
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            HttpRequestMessage clonedRequest = await originalRequest.CloneAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.Null(clonedRequest.Content);
+        }
+
+        [Fact]
+        public async Task CloneAsyncWithHttpContent()
+        {
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            requestInfo.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes("contents")));
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            originalRequest.Content = new StringContent("contents");
+
+            var clonedRequest = await originalRequest.CloneAsync();
+            var clonedRequestContents = await clonedRequest.Content?.ReadAsStringAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.Equal("contents", clonedRequestContents);
+            Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
+        }
+
+        [Fact]
+        public async Task CloneAsyncWithMiddlewareOption()
+        {
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            var redirectHandlerOption = new RedirectHandlerOption()
+            {
+                MaxRedirect = 7
+            };
+            requestInfo.AddMiddlewareOptions(redirectHandlerOption);
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            originalRequest.Content = new StringContent("contents");
+
+            var clonedRequest = await originalRequest.CloneAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.NotEmpty(clonedRequest.Options);
+            Assert.Equal(redirectHandlerOption, clonedRequest.Options.First().Value);
+            Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -101,5 +101,53 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Extensions
             Assert.Equal(redirectHandlerOption, clonedRequest.Options.First().Value);
             Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
         }
+
+        [Fact]
+        public void IsBufferedReturnsTrueForGetRequest()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            // Act
+            var response = originalRequest.IsBuffered();
+            // Assert
+            Assert.True(response, "Unexpected content type");
+        }
+        [Fact]
+        public void IsBufferedReturnsTrueForPostWithNoContent()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.POST,
+                URI = new Uri("http://localhost")
+            };
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            // Act
+            var response = originalRequest.IsBuffered();
+            // Assert
+            Assert.True(response, "Unexpected content type");
+        }
+        [Fact]
+        public void IsBufferedReturnsTrueForPostWithBufferStringContent()
+        {
+            // Arrange
+            byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.POST,
+                URI = new Uri("http://localhost"),
+                Content = new MemoryStream(data)
+            };
+            var originalRequest = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            // Act
+            var response = originalRequest.IsBuffered();
+            // Assert
+            Assert.True(response, "Unexpected content type");
+        }
     }
 }

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/CompressionHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/CompressionHandlerTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
+using Microsoft.Kiota.Http.HttpClient.Tests.Mocks;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
+{
+    public class CompressionHandlerTests: IDisposable
+    {
+        private readonly MockRedirectHandler _testHttpMessageHandler;
+        private readonly CompressionHandler _compressionHandler;
+        private readonly HttpMessageInvoker _invoker;
+
+        public CompressionHandlerTests()
+        {
+            this._testHttpMessageHandler = new MockRedirectHandler();
+            this._compressionHandler = new CompressionHandler
+            {
+                InnerHandler = this._testHttpMessageHandler
+            };
+            this._invoker = new HttpMessageInvoker(this._compressionHandler);
+        }
+
+        public void Dispose()
+        {
+            this._invoker.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void CompressionHandlerShouldConstructHandler()
+        {
+            Assert.NotNull(this._compressionHandler.InnerHandler);
+        }
+
+        [Fact]
+        public async Task CompressionHandlerShouldAddAcceptEncodingGzipHeaderWhenNonIsPresent()
+        {
+            // Arrange
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
+            // Act
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(httpRequestMessage, response.RequestMessage);
+            Assert.NotNull(response.RequestMessage);
+            Assert.Contains(new StringWithQualityHeaderValue(CompressionHandler.GZip), response.RequestMessage.Headers.AcceptEncoding);
+        }
+
+        [Fact]
+        public async Task CompressionHandlerShouldDecompressResponseWithContentEncodingGzipHeader()
+        {
+            // Arrange
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            httpRequestMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue(CompressionHandler.GZip));
+            string stringToCompress = "sample string content";
+            // Compress response
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MockCompressedContent(new StringContent(stringToCompress))
+            };
+            httpResponse.Content.Headers.ContentEncoding.Add(CompressionHandler.GZip);
+            this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
+            // Act
+            HttpResponseMessage decompressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            string responseContentString = await decompressedResponse.Content.ReadAsStringAsync();
+            // Assert
+            Assert.Same(httpResponse, decompressedResponse);
+            Assert.Same(httpRequestMessage, decompressedResponse.RequestMessage);
+            Assert.Equal(stringToCompress, responseContentString);
+        }
+
+        [Fact]
+        public async Task CompressionHandlerShouldNotDecompressResponseWithoutContentEncodingGzipHeader()
+        {
+            // Arrange
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            string stringToCompress = "Microsoft Graph";
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MockCompressedContent(new StringContent(stringToCompress))
+            };
+            this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
+            // Act
+            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            string responseContentString = await compressedResponse.Content.ReadAsStringAsync();
+            // Assert
+            Assert.Same(httpResponse, compressedResponse);
+            Assert.Same(httpRequestMessage, compressedResponse.RequestMessage);
+            Assert.NotEqual(stringToCompress, responseContentString);
+        }
+
+        [Fact]
+        public async Task CompressionHandlerShouldKeepContentHeadersAfterDecompression()
+        {
+            // Arrange
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            string stringToCompress = "Microsoft Graph";
+            StringContent stringContent = new StringContent(stringToCompress);
+            stringContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MockCompressedContent(stringContent)
+            };
+            httpResponse.Content.Headers.ContentEncoding.Add(CompressionHandler.GZip);
+            httpResponse.Headers.CacheControl = new CacheControlHeaderValue { Private = true };
+            // Examples of Custom Headers returned by Microsoft Graph
+            httpResponse.Headers.Add("request-id", Guid.NewGuid().ToString());
+            httpResponse.Headers.Add("OData-Version", "4.0");
+
+            this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
+            // Arrange
+            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            string decompressedResponseString = await compressedResponse.Content.ReadAsStringAsync();
+            // Assert
+            Assert.Equal(decompressedResponseString, stringToCompress);
+            // Ensure that headers in the compressedResponse are the same as in the original, expected response.
+            Assert.NotEmpty(compressedResponse.Headers);
+            Assert.NotEmpty(compressedResponse.Content.Headers);
+            Assert.Equal(httpResponse.Headers, compressedResponse.Headers, new HttpHeaderComparer());
+            Assert.Equal(httpResponse.Content.Headers, compressedResponse.Content.Headers, new HttpHeaderComparer());
+        }
+
+        private class HttpHeaderComparer : IEqualityComparer<KeyValuePair<string, IEnumerable<string>>>
+        {
+            public bool Equals(KeyValuePair<string, IEnumerable<string>> x, KeyValuePair<string, IEnumerable<string>> y)
+            {
+                // For each key, the collection of header values should be equal.
+                return x.Key == y.Key && x.Value.SequenceEqual(y.Value);
+            }
+
+            public int GetHashCode(KeyValuePair<string, IEnumerable<string>> obj)
+            {
+                return obj.Key.GetHashCode();
+            }
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/CompressionHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/CompressionHandlerTests.cs
@@ -103,14 +103,15 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         {
             // Arrange
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            // setup the http response
             string stringToCompress = "Microsoft Graph";
-            StringContent stringContent = new StringContent(stringToCompress);
+            StringContent stringContent = new StringContent(stringToCompress); // setup the content object
             stringContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            stringContent.Headers.ContentEncoding.Add(CompressionHandler.GZip);
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)// setup the HttpResponseMessage object
             {
                 Content = new MockCompressedContent(stringContent)
             };
-            httpResponse.Content.Headers.ContentEncoding.Add(CompressionHandler.GZip);
             httpResponse.Headers.CacheControl = new CacheControlHeaderValue { Private = true };
             // Examples of Custom Headers returned by Microsoft Graph
             httpResponse.Headers.Add("request-id", Guid.NewGuid().ToString());

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RedirectHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RedirectHandlerTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+using Microsoft.Kiota.Http.HttpClient.Tests.Mocks;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
+{
+    public class RedirectHandlerTests: IDisposable
+    {
+        private readonly MockRedirectHandler _testHttpMessageHandler;
+        private readonly RedirectHandler _redirectHandler;
+        private readonly HttpMessageInvoker _invoker;
+
+        public RedirectHandlerTests()
+        {
+            this._testHttpMessageHandler = new MockRedirectHandler();
+            this._redirectHandler = new RedirectHandler
+            {
+                InnerHandler = _testHttpMessageHandler
+            };
+            this._invoker = new HttpMessageInvoker(this._redirectHandler);
+        }
+
+        public void Dispose()
+        {
+            this._invoker.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void RedirectHandler_Constructor()
+        {
+            // Assert
+            using RedirectHandler redirect = new RedirectHandler();
+            Assert.Null(redirect.InnerHandler);
+            Assert.NotNull(redirect.RedirectOption);
+            Assert.Equal(5, redirect.RedirectOption.MaxRedirect); // default MaxRedirects is 5
+            Assert.IsType<RedirectHandler>(redirect);
+        }
+
+        [Fact]
+        public void RedirectHandler_HttpMessageHandlerConstructor()
+        {
+            // Assert
+            Assert.NotNull(this._redirectHandler.InnerHandler);
+            Assert.NotNull(_redirectHandler.RedirectOption);
+            Assert.Equal(5, _redirectHandler.RedirectOption.MaxRedirect); // default MaxRedirects is 5
+            Assert.Equal(this._redirectHandler.InnerHandler, this._testHttpMessageHandler);
+            Assert.IsType<RedirectHandler>(this._redirectHandler);
+        }
+
+        [Fact]
+        public void RedirectHandler_RedirectOptionConstructor()
+        {
+            // Assert
+            using RedirectHandler redirect = new RedirectHandler(new RedirectHandlerOption { MaxRedirect = 2 });
+            Assert.Null(redirect.InnerHandler);
+            Assert.NotNull(redirect.RedirectOption);
+            Assert.Equal(2, redirect.RedirectOption.MaxRedirect);
+            Assert.IsType<RedirectHandler>(redirect);
+        }
+
+        [Fact]
+        public async Task OkStatusShouldPassThrough()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse); // sets the mock response
+            // Act
+            var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.MovedPermanently)]  // 301
+        [InlineData(HttpStatusCode.Found)]  // 302
+        [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
+        [InlineData((HttpStatusCode)308)] // 308
+        public async Task ShouldRedirectSameMethodAndContent(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Hello World")
+            };
+            var redirectResponse = new HttpResponseMessage(statusCode);
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Equal(response.RequestMessage?.Method, httpRequestMessage.Method);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.NotNull(response.RequestMessage?.Content);
+            Assert.Equal("Hello World", await response.RequestMessage.Content.ReadAsStringAsync());
+
+        }
+
+        [Fact]
+        public async Task ShouldRedirectChangeMethodAndContent()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Hello World")
+            };
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.SeeOther);
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotEqual(response.RequestMessage?.Method, httpRequestMessage.Method);
+            Assert.Equal(response.RequestMessage?.Method, HttpMethod.Get);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.Null(response.RequestMessage?.Content);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.MovedPermanently)]  // 301
+        [InlineData(HttpStatusCode.Found)]  // 302
+        [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
+        [InlineData((HttpStatusCode)308)] // 308
+        public async Task RedirectWithDifferentHostShouldRemoveAuthHeader(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("fooAuth", "aparam");
+            var redirectResponse = new HttpResponseMessage(statusCode);
+            redirectResponse.Headers.Location = new Uri("http://example.net/bar");
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.NotSame(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
+            Assert.Null(response.RequestMessage?.Headers.Authorization);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.MovedPermanently)]  // 301
+        [InlineData(HttpStatusCode.Found)]  // 302
+        [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
+        [InlineData((HttpStatusCode)308)] // 308
+        public async Task RedirectWithDifferentSchemeShouldRemoveAuthHeader(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://example.org/foo");
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("fooAuth", "aparam");
+            var redirectResponse = new HttpResponseMessage(statusCode);
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.NotSame(response.RequestMessage?.RequestUri?.Scheme, httpRequestMessage.RequestUri?.Scheme);
+            Assert.Null(response.RequestMessage?.Headers.Authorization);
+        }
+
+        [Fact]
+        public async Task RedirectWithSameHostShouldKeepAuthHeader()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("fooAuth", "aparam");
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.Redirect);
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
+            Assert.NotNull(response.RequestMessage?.Headers.Authorization);
+        }
+
+        [Fact]
+        public async Task RedirectWithRelativeUrlShouldKeepRequestHost()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.Redirect);
+            redirectResponse.Headers.Location = new Uri("/bar", UriKind.Relative);
+            this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.Equal("http://example.org/bar", response.RequestMessage?.RequestUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task ExceedMaxRedirectsShouldThrowsException()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            var response1 = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response1.Headers.Location = new Uri("http://example.org/bar");
+            var response2 = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response2.Headers.Location = new Uri("http://example.org/foo");
+            this._testHttpMessageHandler.SetHttpResponse(response1, response2);// sets the mock response
+            // Act
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await this._invoker.SendAsync(
+                   httpRequestMessage, CancellationToken.None));
+            // Assert
+            Assert.Equal("Too many redirects performed", exception.Message);
+            Assert.Equal("Max redirects exceeded. Redirect count : 3", exception.InnerException?.Message);
+            Assert.IsType<InvalidOperationException>(exception);
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RedirectHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RedirectHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -84,7 +84,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData((HttpStatusCode)308)] // 308
+        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
         public async Task ShouldRedirectSameMethodAndContent(HttpStatusCode statusCode)
         {
             // Arrange
@@ -129,7 +129,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData((HttpStatusCode)308)] // 308
+        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
         public async Task RedirectWithDifferentHostShouldRemoveAuthHeader(HttpStatusCode statusCode)
         {
             // Arrange
@@ -150,7 +150,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData((HttpStatusCode)308)] // 308
+        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
         public async Task RedirectWithDifferentSchemeShouldRemoveAuthHeader(HttpStatusCode statusCode)
         {
             // Arrange
@@ -214,7 +214,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
                    httpRequestMessage, CancellationToken.None));
             // Assert
             Assert.Equal("Too many redirects performed", exception.Message);
-            Assert.Equal("Max redirects exceeded. Redirect count : 3", exception.InnerException?.Message);
+            Assert.Equal("Max redirects exceeded. Redirect count : 5", exception.InnerException?.Message);
             Assert.IsType<InvalidOperationException>(exception);
         }
     }

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RetryHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RetryHandlerTests.cs
@@ -1,0 +1,380 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+using Microsoft.Kiota.Http.HttpClient.Tests.Mocks;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
+{
+    public class RetryHandlerTests : IDisposable
+    {
+        private readonly MockRedirectHandler _testHttpMessageHandler;
+        private readonly RetryHandler _retryHandler;
+        private readonly HttpMessageInvoker _invoker;
+        private const string RetryAfter = "Retry-After";
+        private const string RetryAttempt = "Retry-Attempt";
+
+        public RetryHandlerTests()
+        {
+            this._testHttpMessageHandler = new MockRedirectHandler();
+            this._retryHandler = new RetryHandler
+            {
+                InnerHandler = this._testHttpMessageHandler
+            };
+            this._invoker = new HttpMessageInvoker(this._retryHandler);
+        }
+
+        public void Dispose()
+        {
+            this._invoker.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void RetryHandlerConstructor()
+        {
+            // Act
+            using RetryHandler retry = new RetryHandler();
+            // Assert
+            Assert.Null(retry.InnerHandler);
+            Assert.NotNull(retry.RetryOption);
+            Assert.Equal(RetryHandlerOption.DefaultMaxRetry, retry.RetryOption.MaxRetry);
+            Assert.IsType<RetryHandler>(retry);
+        }
+
+
+        [Fact]
+        public void RetryHandlerHttpMessageHandlerConstructor()
+        {
+            // Assert
+            Assert.NotNull(_retryHandler.InnerHandler);
+            Assert.NotNull(_retryHandler.RetryOption);
+            Assert.Equal(RetryHandlerOption.DefaultMaxRetry, _retryHandler.RetryOption.MaxRetry);
+            Assert.Equal(_retryHandler.InnerHandler, _testHttpMessageHandler);
+            Assert.IsType<RetryHandler>(_retryHandler);
+        }
+
+        [Fact]
+        public void RetryHandlerRetryOptionConstructor()
+        {
+            // Act
+            using RetryHandler retry = new RetryHandler(new RetryHandlerOption { MaxRetry = 5, ShouldRetry = (_, _, _) => true });
+            // Assert
+            Assert.Null(retry.InnerHandler);
+            Assert.NotNull(retry.RetryOption);
+            Assert.Equal(5, retry.RetryOption.MaxRetry);
+            Assert.IsType<RetryHandler>(retry);
+        }
+
+        [Fact]
+        public async Task OkStatusShouldPassThrough()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            var retryResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse);
+            // Act
+            var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(response, retryResponse);
+            Assert.NotNull(response.RequestMessage);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
+            Assert.False(response.RequestMessage.Headers.Contains(RetryAttempt), "The request add header wrong.");
+
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData((HttpStatusCode)429)] // 429
+        public async Task ShouldRetryWithAddRetryAttemptHeader(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(response, response2);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.NotNull(response.RequestMessage);
+            Assert.NotNull(response.RequestMessage.Headers);
+            Assert.True(response.RequestMessage.Headers.Contains(RetryAttempt));
+            Assert.True(response.RequestMessage.Headers.TryGetValues(RetryAttempt, out var values));
+            Assert.Single(values);
+            Assert.Equal(values.First(), 1.ToString());
+        }
+
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData((HttpStatusCode)429)] // 429
+        public async Task ShouldRetryWithBuffedContent(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Hello World")
+            };
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(response, response2);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            Assert.NotNull(response.RequestMessage);
+            Assert.NotNull(response.RequestMessage.Content);
+            Assert.NotNull(response.RequestMessage.Content.Headers.ContentLength);
+            Assert.Equal("Hello World", response.RequestMessage.Content.ReadAsStringAsync().Result);
+
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData((HttpStatusCode)429)] // 429
+        public async Task ShouldNotRetryWithPostStreaming(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Test Content")
+            };
+            httpRequestMessage.Content.Headers.ContentLength = -1;
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotEqual(response, response2);
+            Assert.Same(response, retryResponse);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
+            Assert.NotNull(response.RequestMessage);
+            Assert.NotNull(response.RequestMessage.Content);
+            Assert.NotNull(response.RequestMessage.Content.Headers.ContentLength);
+            Assert.Equal(response.RequestMessage.Content.Headers.ContentLength, -1);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData((HttpStatusCode)429)] // 429
+        public async Task ShouldNotRetryWithPutStreaming(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "http://example.org/foo")
+            {
+                Content = new StringContent("Test Content")
+            };
+            httpRequestMessage.Content.Headers.ContentLength = -1;
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.NotEqual(response, response2);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
+            Assert.Same(response, retryResponse);
+            Assert.NotNull(response.RequestMessage);
+            Assert.NotNull(response.RequestMessage.Content);
+            Assert.Equal(response.RequestMessage.Content.Headers.ContentLength, -1);
+        }
+
+
+        [Theory(Skip = "Test takes a while to run")]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
+        public async Task ExceedMaxRetryShouldReturn(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var response2 = new HttpResponseMessage(statusCode);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            try
+            {
+                await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            }
+            catch(Exception exception)
+            {
+                // Assert
+                Assert.IsType<InvalidOperationException>(exception);
+                Assert.Equal("Too many retries performed", exception.Message);
+                Assert.False(httpRequestMessage.Headers.TryGetValues(RetryAttempt, out _), "Don't set Retry-Attempt Header");
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
+        public async Task ShouldDelayBasedOnRetryAfterHeader(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var retryResponse = new HttpResponseMessage(statusCode);
+            retryResponse.Headers.TryAddWithoutValidation(RetryAfter, 1.ToString());
+            // Act
+            await DelayTestWithMessage(retryResponse, 1, "Init");
+            // Assert
+            Assert.Equal("Init Work 1", Message);
+        }
+
+
+        [Theory(Skip = "Skipped as this takes 9 minutes to run for each scenario")] // Takes 9 minutes to run for each scenario
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData((HttpStatusCode)429)] // 429
+        public async Task ShouldDelayBasedOnExponentialBackOff(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var retryResponse = new HttpResponseMessage(statusCode);
+            var compareMessage = "Init Work ";
+
+            for(int count = 0; count < 3; count++)
+            {
+                // Act
+                await DelayTestWithMessage(retryResponse, count, "Init");
+                // Assert
+                Assert.Equal(Message, compareMessage + count);
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
+        public async Task ShouldReturnSameStatusCodeWhenDelayIsGreaterThanRetryTimeLimit(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Hello World")
+            };
+            var retryResponse = new HttpResponseMessage(statusCode);
+            retryResponse.Headers.TryAddWithoutValidation(RetryAfter, 20.ToString());
+            _retryHandler.RetryOption.RetriesTimeLimit = TimeSpan.FromSeconds(10);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(response, retryResponse);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
+        public async Task ShouldRetryBasedOnRetryAfter(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo")
+            {
+                Content = new StringContent("Hello World")
+            };
+            var retryResponse = new HttpResponseMessage(statusCode);
+            retryResponse.Headers.TryAddWithoutValidation(RetryAfter, 5.ToString());
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
+            // Act
+            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            // Assert
+            Assert.Same(response, response2);
+            Assert.NotNull(response.RequestMessage);
+            Assert.True(response.RequestMessage.Headers.TryGetValues(RetryAttempt, out var values), "Don't set Retry-Attempt Header");
+            Assert.Single(values);
+            Assert.Equal(values.First(), 1.ToString());
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+        }
+
+
+        [Theory]
+        [InlineData(1, HttpStatusCode.BadGateway, true)]
+        [InlineData(2, HttpStatusCode.BadGateway, true)]
+        [InlineData(3, HttpStatusCode.BadGateway, true)]
+        [InlineData(4, HttpStatusCode.OK, false)]
+        public async Task ShouldRetryBasedOnCustomShouldRetryDelegate(int expectedMaxRetry, HttpStatusCode expectedStatusCode, bool isExceptionExpected)
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            Queue<HttpResponseMessage> httpResponseQueue = new(new HttpResponseMessage[]
+            {
+                new(HttpStatusCode.BadGateway) { RequestMessage = request },
+                new(HttpStatusCode.BadGateway) { RequestMessage = request },
+                new(HttpStatusCode.BadGateway) { RequestMessage = request },
+                new(HttpStatusCode.BadGateway) { RequestMessage = request },
+                new(HttpStatusCode.OK) { RequestMessage = request },
+            });
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Loose);
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())
+                .Returns(() => Task.FromResult(httpResponseQueue.TryDequeue(out HttpResponseMessage r) ? r : new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request }))
+                .Verifiable();
+
+            RetryHandler retryHandler = new(new RetryHandlerOption()
+            {
+                ShouldRetry = (_, _, httpResponseMessage) => httpResponseMessage.StatusCode == HttpStatusCode.BadGateway,
+                MaxRetry = expectedMaxRetry,
+                Delay = 0
+            })
+            {
+                InnerHandler = mockHttpMessageHandler.Object
+            };
+
+            HttpMessageInvoker httpMessageInvoker = new(retryHandler);
+
+            // Act
+            try
+            {
+                var response = await httpMessageInvoker.SendAsync(request, new CancellationToken());
+
+                Assert.False(isExceptionExpected);
+                Assert.Equal(expectedStatusCode, response.StatusCode);
+            }
+            catch(Exception exception)
+            {
+                // Assert
+                Assert.IsType<InvalidOperationException>(exception);
+                Assert.True(isExceptionExpected);
+                Assert.Equal("Too many retries performed", exception.Message);
+            }
+
+            // Assert
+            mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1 + expectedMaxRetry), ItExpr.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>());
+
+        }
+
+        private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message, int delay = RetryHandlerOption.MaxDelay)
+        {
+            Message = message;
+            await Task.Run(async () =>
+            {
+                await this._retryHandler.Delay(response, count, delay, out _, new CancellationToken());
+                Message += " Work " + count;
+            });
+        }
+
+        private string Message
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RetryHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/RetryHandlerTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [Theory]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
-        [InlineData((HttpStatusCode)429)] // 429
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
         public async Task ShouldRetryWithAddRetryAttemptHeader(HttpStatusCode statusCode)
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [Theory]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
-        [InlineData((HttpStatusCode)429)] // 429
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
         public async Task ShouldRetryWithBuffedContent(HttpStatusCode statusCode)
         {
             // Arrange
@@ -145,7 +145,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [Theory]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
-        [InlineData((HttpStatusCode)429)] // 429
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
         public async Task ShouldNotRetryWithPostStreaming(HttpStatusCode statusCode)
         {
             // Arrange
@@ -172,7 +172,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
         [Theory]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
-        [InlineData((HttpStatusCode)429)] // 429
+        [InlineData(HttpStatusCode.TooManyRequests)] // 429
         public async Task ShouldNotRetryWithPutStreaming(HttpStatusCode statusCode)
         {
             // Arrange

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/MockCompressedContent.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/MockCompressedContent.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Mocks
+{
+    public class MockCompressedContent : HttpContent
+    {
+        private readonly HttpContent _originalContent;
+
+        public MockCompressedContent(HttpContent httpContent)
+        {
+            _originalContent = httpContent;
+            foreach(var (key, value) in _originalContent.Headers)
+                Headers.TryAddWithoutValidation(key, value);
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            Stream compressedStream = new GZipStream(stream, CompressionMode.Compress, true);
+            await _originalContent.CopyToAsync(compressedStream);
+            await compressedStream.DisposeAsync();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+            return false;
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/MockRedirectHandler.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/MockRedirectHandler.cs
@@ -1,0 +1,44 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Mocks
+{
+    public class MockRedirectHandler : HttpMessageHandler
+    {
+        private HttpResponseMessage Response1
+        {
+            get; set;
+        }
+        private HttpResponseMessage Response2
+        {
+            get; set;
+        }
+
+        private bool _response1Sent = false;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if(!_response1Sent)
+            {
+                _response1Sent = true;
+                Response1.RequestMessage = request;
+                return await Task.FromResult(Response1);
+            }
+            else
+            {
+                _response1Sent = false;
+                Response2.RequestMessage = request;
+                return await Task.FromResult(Response2);
+            }
+        }
+
+        public void SetHttpResponse(HttpResponseMessage response1, HttpResponseMessage response2 = null)
+        {
+            this._response1Sent = false;
+            this.Response1 = response1;
+            this.Response2 = response2;
+        }
+
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/TestHttpMessageHandler.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Mocks/TestHttpMessageHandler.cs
@@ -24,11 +24,9 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Mocks
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            HttpResponseMessage responseMessage;
-
             requestMessageDelegate(request);
 
-            if(this.responseMessages.TryGetValue(request.RequestUri.ToString(), out responseMessage))
+            if(this.responseMessages.TryGetValue(request.RequestUri.ToString(), out HttpResponseMessage responseMessage))
             {
                 responseMessage.RequestMessage = request;
                 return Task.FromResult(responseMessage);

--- a/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,76 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Extensions
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="HttpRequestMessage"/>
+    /// </summary>
+    public static class HttpRequestMessageExtensions
+    {
+        /// <summary>
+        /// Gets a <see cref="IMiddlewareOption"/> from <see cref="HttpRequestMessage"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="httpRequestMessage">The <see cref="HttpRequestMessage"/> representation of the request.</param>
+        /// <returns>A middleware option</returns>
+        public static T GetMiddlewareOption<T>(this HttpRequestMessage httpRequestMessage) where T : IMiddlewareOption
+        {
+            if(httpRequestMessage.Options.TryGetValue(
+                new HttpRequestOptionsKey<IMiddlewareOption>(typeof(T).FullName),
+                out IMiddlewareOption middlewareOption))
+            {
+                return (T)middlewareOption;
+            }
+            return default;
+        }
+
+        /// <summary>
+        /// Create a new HTTP request by copying previous HTTP request's headers and properties from response's request message.
+        /// </summary>
+        /// <param name="originalRequest">The previous <see cref="HttpRequestMessage"/> needs to be copy.</param>
+        /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
+        /// <remarks>
+        /// Re-issue a new HTTP request with the previous request's headers and properties
+        /// </remarks>
+        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage originalRequest)
+        {
+            var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
+
+            // Copy request headers.
+            foreach(var (key, value) in originalRequest.Headers)
+                newRequest.Headers.TryAddWithoutValidation(key, value);
+
+            // Copy request properties.
+            foreach(var (key, value) in originalRequest.Options)
+                newRequest.Options.TryAdd(key, value);
+
+            // Set Content if previous request had one.
+            if(originalRequest.Content != null)
+            {
+                // HttpClient doesn't rewind streams and we have to explicitly do so.
+                var contentStream = await originalRequest.Content.ReadAsStreamAsync();
+                
+                if(contentStream.CanSeek)
+                    contentStream.Seek(0, SeekOrigin.Begin);
+
+                newRequest.Content = new StreamContent(contentStream);
+
+                // Copy content headers.
+                foreach(var (key, value) in originalRequest.Content.Headers)
+                {
+                    newRequest.Content?.Headers.TryAddWithoutValidation(key, value);
+                }
+            }
+
+            return newRequest;
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions;
+using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Microsoft.Kiota.Http.HttpClient.Extensions
 {
@@ -71,6 +72,23 @@ namespace Microsoft.Kiota.Http.HttpClient.Extensions
             }
 
             return newRequest;
+        }
+
+        /// <summary>
+        /// Checks the HTTP request's content to determine if it's buffered or streamed content.
+        /// </summary>
+        /// <param name="httpRequestMessage">The <see cref="HttpRequestMessage"/>needs to be sent.</param>
+        /// <returns></returns>
+        internal static bool IsBuffered(this HttpRequestMessage httpRequestMessage)
+        {
+            HttpContent requestContent = httpRequestMessage.Content;
+
+            if((httpRequestMessage.Method == HttpMethod.Put || httpRequestMessage.Method == HttpMethod.Post || httpRequestMessage.Method == HttpMethod.Patch)
+               && requestContent != null && (requestContent.Headers.ContentLength == null || (int)requestContent.Headers.ContentLength == -1))
+            {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Kiota.Http.HttpClient
             return new List<DelegatingHandler>
             {
                 //add the default middlewares as they are ready
+                new CompressionHandler(),
                 new RedirectHandler()
             };
         }

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Kiota.Http.HttpClient
             return new List<DelegatingHandler>
             {
                 //add the default middlewares as they are ready
-                new CompressionHandler(),
                 new RetryHandler(),
                 new RedirectHandler()
             };

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
 
 namespace Microsoft.Kiota.Http.HttpClient
 {
@@ -32,7 +33,11 @@ namespace Microsoft.Kiota.Http.HttpClient
         /// <returns>A list of the default handlers used by the client.</returns>
         public static IList<DelegatingHandler> CreateDefaultHandlers(IAuthenticationProvider authenticationProvider = default)
         {
-            return new List<DelegatingHandler>(); //TODO add the default middlewares when they are ready
+            return new List<DelegatingHandler>
+            {
+                //add the default middlewares as they are ready
+                new RedirectHandler()
+            };
         }
         /// <summary>
         /// Creates a <see cref="DelegatingHandler"/> to use for the <see cref="HttpClient" /> from the provided <see cref="DelegatingHandler"/> instances. Order matters.
@@ -42,7 +47,7 @@ namespace Microsoft.Kiota.Http.HttpClient
         public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
         {
             if(handlers == null || !handlers.Any()) return default;
-            var handlersCount = handlers.Count();
+            var handlersCount = handlers.Length;
             for(var i = 0; i < handlersCount; i++)
             {
                 var handler = handlers[i];

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Kiota.Http.HttpClient
             {
                 //add the default middlewares as they are ready
                 new CompressionHandler(),
+                new RetryHandler(),
                 new RedirectHandler()
             };
         }

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Kiota.Http.HttpClient
         {
             if(createdClient)
                 client?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Kiota.Http.HttpClient
             return response;
         }
         private const string ContentTypeHeaderName = "content-type";
-        private HttpRequestMessage GetRequestMessageFromRequestInformation(RequestInformation requestInfo)
+        internal static HttpRequestMessage GetRequestMessageFromRequestInformation(RequestInformation requestInfo)
         {
             var message = new HttpRequestMessage
             {

--- a/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using System;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -25,6 +26,9 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
         /// <returns></returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
         {
+            if(httpRequest == null)
+                throw new ArgumentNullException(nameof(httpRequest));
+
             StringWithQualityHeaderValue gzipQHeaderValue = new StringWithQualityHeaderValue(GZip);
 
             // Add Accept-encoding: gzip header to incoming request if it doesn't have one.

--- a/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
@@ -1,0 +1,63 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.IO.Compression;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation that handles compression.
+    /// </summary>
+    public class CompressionHandler : DelegatingHandler
+    {
+        internal const string GZip = "gzip";
+
+        /// <summary>
+        /// Sends a HTTP request.
+        /// </summary>
+        /// <param name="httpRequest">The <see cref="HttpRequestMessage"/> to be sent.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        {
+            StringWithQualityHeaderValue gzipQHeaderValue = new StringWithQualityHeaderValue(GZip);
+
+            // Add Accept-encoding: gzip header to incoming request if it doesn't have one.
+            if(!httpRequest.Headers.AcceptEncoding.Contains(gzipQHeaderValue))
+            {
+                httpRequest.Headers.AcceptEncoding.Add(gzipQHeaderValue);
+            }
+
+            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken);
+
+            // Decompress response content when Content-Encoding: gzip header is present.
+            if(ShouldDecompressContent(response))
+            {
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(cancellationToken), CompressionMode.Decompress));
+                // Copy Content Headers to the destination stream content
+                foreach(var httpContentHeader in response.Content.Headers)
+                {
+                    streamContent.Headers.TryAddWithoutValidation(httpContentHeader.Key, httpContentHeader.Value);
+                }
+                response.Content = streamContent;
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Checks if a <see cref="HttpResponseMessage"/> contains a Content-Encoding: gzip header.
+        /// </summary>
+        /// <param name="httpResponse">The <see cref="HttpResponseMessage"/> to check for header.</param>
+        /// <returns></returns>
+        private static bool ShouldDecompressContent(HttpResponseMessage httpResponse)
+        {
+            return httpResponse.Content.Headers.ContentEncoding.Contains(GZip);
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
     /// </summary>
     public class RedirectHandlerOption: IMiddlewareOption
     {
-        internal const int DEFAULT_MAX_REDIRECT = 5;
-        internal const int MAX_MAX_REDIRECT = 20;
-        private int _maxRedirect = DEFAULT_MAX_REDIRECT;
+        private const int DefaultMaxRedirect = 5;
+        private const int MaxMaxRedirect = 20;
+        private int _maxRedirect = DefaultMaxRedirect;
 
         /// <summary>
         /// The maximum number of redirects with a maximum value of 20. This defaults to 5 redirects.
@@ -28,7 +28,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
             }
             set
             {
-                if(value > MAX_MAX_REDIRECT)
+                if(value > MaxMaxRedirect)
                     throw new InvalidOperationException($"Maximum value for {nameof(MaxRedirect)} property exceeded ");
 
                 _maxRedirect = value;

--- a/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
@@ -1,0 +1,43 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
+{
+    /// <summary>
+    /// The redirect middleware option class
+    /// </summary>
+    public class RedirectHandlerOption: IMiddlewareOption
+    {
+        internal const int DEFAULT_MAX_REDIRECT = 5;
+        internal const int MAX_MAX_REDIRECT = 20;
+        private int _maxRedirect = DEFAULT_MAX_REDIRECT;
+
+        /// <summary>
+        /// The maximum number of redirects with a maximum value of 20. This defaults to 5 redirects.
+        /// </summary>
+        public int MaxRedirect
+        {
+            get
+            {
+                return _maxRedirect;
+            }
+            set
+            {
+                if(value > MAX_MAX_REDIRECT)
+                    throw new InvalidOperationException($"Maximum value for {nameof(MaxRedirect)} property exceeded ");
+
+                _maxRedirect = value;
+            }
+        }
+
+        /// <summary>
+        /// A delegate that's called to determine whether a response should be redirected or not. The delegate method should accept <see cref="HttpResponseMessage"/> as it's parameter and return a <see cref="bool"/>. This defaults to true.
+        /// </summary>
+        public Func<HttpResponseMessage, bool> ShouldRedirect { get; set; } = (response) => true;
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/RedirectHandlerOption.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
         /// A delegate that's called to determine whether a response should be redirected or not. The delegate method should accept <see cref="HttpResponseMessage"/> as it's parameter and return a <see cref="bool"/>. This defaults to true.
         /// </summary>
         public Func<HttpResponseMessage, bool> ShouldRedirect { get; set; } = (response) => true;
+
+        /// <summary>
+        /// A boolean value to determine if we redirects are allowed if the scheme changes(e.g. https to http). Defaults to false. 
+        /// </summary>
+        public bool AllowRedirectOnSchemeChange { get; set; } = false;
     }
 }

--- a/http/dotnet/httpclient/src/Middleware/Options/RetryHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/RetryHandlerOption.cs
@@ -1,0 +1,73 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
+{
+    /// <summary>
+    /// The retry middleware option class
+    /// </summary>
+    public class RetryHandlerOption : IMiddlewareOption
+    {
+        internal const int DefaultDelay = 3;
+        internal const int DefaultMaxRetry = 3;
+        internal const int MaxMaxRetry = 10;
+        internal const int MaxDelay = 180;
+        private int _maxRetry = DefaultMaxRetry;
+        private int _delay = DefaultDelay;
+
+        /// <summary>
+        /// The waiting time in seconds before retrying a request with a maximum value of 180 seconds. This defaults to 3 seconds.
+        /// </summary>
+        public int Delay
+        {
+            get
+            {
+                return _delay;
+            }
+            set
+            {
+                if(value > MaxDelay)
+                {
+                    throw new InvalidOperationException($"Maximum value for {nameof(MaxDelay)} property exceeded ");
+                }
+
+                _delay = value;
+            }
+        }
+
+        /// <summary>
+        /// The maximum number of retries for a request with a maximum value of 10. This defaults to 3.
+        /// </summary>
+        public int MaxRetry
+        {
+            get
+            {
+                return _maxRetry;
+            }
+            set
+            {
+                if(value > MaxMaxRetry)
+                {
+                    throw new InvalidOperationException($"Maximum value for {nameof(MaxMaxRetry)} property exceeded ");
+                }
+                _maxRetry = value;
+            }
+        }
+
+        /// <summary>
+        /// The maximum time allowed for request retries.
+        /// </summary>
+        public TimeSpan RetriesTimeLimit { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// A delegate that's called to determine whether a request should be retried or not.
+        /// The delegate method should accept a delay time in seconds of, number of retry attempts and <see cref="HttpResponseMessage"/> as it's parameters and return a <see cref="bool"/>. This defaults to false
+        /// </summary>
+        public Func<int, int, HttpResponseMessage, bool> ShouldRetry { get; set; } = (_, _, _) => false;
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
@@ -94,6 +94,14 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
                         newRequest.Headers.Authorization = null;
                     }
 
+                    // If scheme has changed. Ensure that this has been opted in for security reasons
+                    if(!newRequest.RequestUri.Scheme.Equals(httpRequestMessage.RequestUri?.Scheme) && !RedirectOption.AllowRedirectOnSchemeChange)
+                    {
+                        throw new InvalidOperationException(
+                            $"Redirects with changing schemes not allowed by default. You can change this by modifying the {nameof(RedirectOption.AllowRedirectOnSchemeChange)} option",
+                            new Exception($"Scheme changed from {httpRequestMessage.RequestUri?.Scheme} to {newRequest.RequestUri.Scheme}."));
+                    }
+
                     // Send redirect request to get response
                     response = await base.SendAsync(newRequest, cancellationToken);
 

--- a/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -61,13 +61,12 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
 
                 var redirectCount = 0;
 
-                while(redirectCount < 3)//RedirectOption.MaxRedirect)
+                while(redirectCount < RedirectOption.MaxRedirect)
                 {
                     // Drain response content to free responses.
                     await response.Content.ReadAsByteArrayAsync(cancellationToken);
 
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                    // var newRequest = await response.RequestMessage.CloneAsync();
                     var newRequest = await response.RequestMessage.CloneAsync();
 
                     // status code == 303: change request method from post to get and content to be null

--- a/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
@@ -1,0 +1,143 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation for handling redirection of requests.
+    /// </summary>
+    public class RedirectHandler: DelegatingHandler
+    {
+        /// <summary>
+        /// Constructs a new <see cref="RedirectHandler"/> 
+        /// </summary>
+        /// <param name="redirectOption">An OPTIONAL <see cref="RedirectHandlerOption"/> to configure <see cref="RedirectHandler"/></param>
+        public RedirectHandler(RedirectHandlerOption redirectOption = null)
+        {
+            RedirectOption = redirectOption ?? new RedirectHandlerOption();
+        }
+
+        /// <summary>
+        /// RedirectOption property
+        /// </summary>
+        internal RedirectHandlerOption RedirectOption
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Sends the Request and handles redirect responses if needed
+        /// </summary>
+        /// <param name="httpRequestMessage">The <see cref="HttpRequestMessage"/> to send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>for the request.</param>
+        /// <returns>The <see cref="HttpResponseMessage"/>.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken)
+        {
+            if(httpRequestMessage == null) throw new ArgumentNullException(nameof(httpRequestMessage));
+
+            RedirectOption = httpRequestMessage.GetMiddlewareOption<RedirectHandlerOption>() ?? RedirectOption;
+
+            // send request first time to get response
+            var response = await base.SendAsync(httpRequestMessage, cancellationToken);
+
+            // check response status code and redirect handler option
+            if(ShouldRedirect(response))
+            {
+                if(response.Headers.Location == null)
+                {
+                    throw new InvalidOperationException(
+                        "Unable to perform redirect as Location Header is not set in response",
+                                new Exception($"No header present in response with status code {response.StatusCode}"));
+                }
+
+                var redirectCount = 0;
+
+                while(redirectCount < 3)//RedirectOption.MaxRedirect)
+                {
+                    // Drain response content to free responses.
+                    await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+                    // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                    // var newRequest = await response.RequestMessage.CloneAsync();
+                    var newRequest = await response.RequestMessage.CloneAsync();
+
+                    // status code == 303: change request method from post to get and content to be null
+                    if(response.StatusCode == HttpStatusCode.SeeOther)
+                    {
+                        newRequest.Content = null;
+                        newRequest.Method = HttpMethod.Get;
+                    }
+
+                    // Set newRequestUri from response
+                    if(response.Headers.Location?.IsAbsoluteUri ?? false)
+                    {
+                        newRequest.RequestUri = response.Headers.Location;
+                    }
+                    else
+                    {
+                        var baseAddress = newRequest.RequestUri?.GetComponents(UriComponents.SchemeAndServer | UriComponents.KeepDelimiter, UriFormat.Unescaped);
+                        newRequest.RequestUri = new Uri(baseAddress + response.Headers.Location);
+                    }
+
+                    // Remove Auth if http request's scheme or host changes
+                    if(!newRequest.RequestUri.Host.Equals(httpRequestMessage.RequestUri?.Host) ||
+                       !newRequest.RequestUri.Scheme.Equals(httpRequestMessage.RequestUri?.Scheme))
+                    {
+                        newRequest.Headers.Authorization = null;
+                    }
+
+                    // Send redirect request to get response
+                    response = await base.SendAsync(newRequest, cancellationToken);
+
+                    // Check response status code
+                    if(ShouldRedirect(response))
+                    {
+                        redirectCount++;
+                    }
+                    else
+                    {
+                        return response;
+                    }
+                }
+
+                throw new InvalidOperationException(
+                    "Too many redirects performed",
+                    new Exception($"Max redirects exceeded. Redirect count : {redirectCount}"));
+            }
+            return response;
+        }
+
+        private bool ShouldRedirect(HttpResponseMessage responseMessage)
+        {
+            return IsRedirect(responseMessage.StatusCode) && RedirectOption.ShouldRedirect(responseMessage) && RedirectOption.MaxRedirect > 0;
+        }
+
+        /// <summary>
+        /// Checks whether <see cref="HttpStatusCode"/> is redirected
+        /// </summary>
+        /// <param name="statusCode">The <see cref="HttpStatusCode"/>.</param>
+        /// <returns>Bool value for redirection or not</returns>
+        private static bool IsRedirect(HttpStatusCode statusCode)
+        {
+            return statusCode switch
+            {
+                HttpStatusCode.MovedPermanently => true,
+                HttpStatusCode.Found => true,
+                HttpStatusCode.SeeOther => true,
+                HttpStatusCode.TemporaryRedirect => true,
+                (HttpStatusCode)308 => true,
+                _ => false
+            };
+        }
+
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
         /// <returns></returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
         {
+            if(httpRequest == null)
+                throw new ArgumentNullException(nameof(httpRequest));
+
             RetryOption = httpRequest.GetMiddlewareOption<RetryHandlerOption>() ?? RetryOption;
 
             var response = await base.SendAsync(httpRequest, cancellationToken);

--- a/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
@@ -1,0 +1,185 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
+    /// </summary>
+    public class RetryHandler : DelegatingHandler
+    {
+        private const string RetryAfter = "Retry-After";
+        private const string RetryAttempt = "Retry-Attempt";
+        private double _mPow = 1;
+
+        /// <summary>
+        /// RetryOption property
+        /// </summary>
+        internal RetryHandlerOption RetryOption
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Construct a new <see cref="RetryHandler"/>
+        /// </summary>
+        /// <param name="retryOption">An OPTIONAL <see cref="RetryHandlerOption"/> to configure <see cref="RetryHandler"/></param>
+        public RetryHandler(RetryHandlerOption retryOption = null)
+        {
+            RetryOption = retryOption ?? new RetryHandlerOption();
+        }
+
+        /// <summary>
+        /// Send a HTTP request 
+        /// </summary>
+        /// <param name="httpRequest">The HTTP request<see cref="HttpRequestMessage"/>needs to be sent.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        {
+            RetryOption = httpRequest.GetMiddlewareOption<RetryHandlerOption>() ?? RetryOption;
+
+            var response = await base.SendAsync(httpRequest, cancellationToken);
+
+            // Check whether retries are permitted and that the MaxRetry value is a non - negative, non - zero value
+            if(httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && (ShouldRetry(response.StatusCode) || RetryOption.ShouldRetry(RetryOption.Delay, 0, response)))
+            {
+                response = await SendRetryAsync(response, cancellationToken);
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Retry sending the HTTP request 
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/> which is returned and includes the HTTP request needs to be retried.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the retry.</param>
+        /// <returns></returns>
+        private async Task<HttpResponseMessage> SendRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            int retryCount = 0;
+            TimeSpan cumulativeDelay = TimeSpan.Zero;
+
+            while(retryCount < RetryOption.MaxRetry)
+            {
+                // Drain response content to free connections. Need to perform this
+                // before retry attempt and before the TooManyRetries ServiceException.
+                await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+                // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
+                Task delay = Delay(response, retryCount, RetryOption.Delay, out double delayInSeconds, cancellationToken);
+
+                // If client specified a retries time limit, let's honor it
+                if(RetryOption.RetriesTimeLimit > TimeSpan.Zero)
+                {
+                    // Get the cumulative delay time
+                    cumulativeDelay += TimeSpan.FromSeconds(delayInSeconds);
+
+                    // Check whether delay will exceed the client-specified retries time limit value 
+                    if(cumulativeDelay > RetryOption.RetriesTimeLimit)
+                    {
+                        return response;
+                    }
+                }
+
+                // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                var request = await response.RequestMessage.CloneAsync();
+
+                // Increase retryCount and then update Retry-Attempt in request header
+                retryCount++;
+                AddOrUpdateRetryAttempt(request, retryCount);
+
+                // Delay time
+                await delay;
+
+                // Call base.SendAsync to send the request
+                response = await base.SendAsync(request, cancellationToken);
+
+                if(!(request.IsBuffered() && (ShouldRetry(response.StatusCode) || RetryOption.ShouldRetry(RetryOption.Delay, retryCount, response))))
+                {
+                    return response;
+                }
+            }
+
+            // Drain response content to free connections. Need to perform this
+            // before retry attempt and before the TooManyRetries ServiceException.
+            await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+            throw new InvalidOperationException(
+                "Too many retries performed",
+                new Exception($"More than {retryCount} retries encountered while sending the request."));
+        }
+
+        /// <summary>
+        /// Update Retry-Attempt header in the HTTP request
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/>needs to be sent.</param>
+        /// <param name="retryCount">Retry times</param>
+        private static void AddOrUpdateRetryAttempt(HttpRequestMessage request, int retryCount)
+        {
+            if(request.Headers.Contains(RetryAttempt))
+            {
+                request.Headers.Remove(RetryAttempt);
+            }
+            request.Headers.Add(RetryAttempt, retryCount.ToString());
+        }
+
+        /// <summary>
+        /// Delay task operation for timed-retries based on Retry-After header in the response or exponential back-off
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/>returned.</param>
+        /// <param name="retryCount">The retry counts</param>
+        /// <param name="delay">Delay value in seconds.</param>
+        /// <param name="delayInSeconds"></param>
+        /// <param name="cancellationToken">The cancellationToken for the Http request</param>
+        /// <returns>The <see cref="Task"/> for delay operation.</returns>
+        internal Task Delay(HttpResponseMessage response, int retryCount, int delay, out double delayInSeconds, CancellationToken cancellationToken)
+        {
+            delayInSeconds = delay;
+            if(response.Headers.TryGetValues(RetryAfter, out IEnumerable<string> values))
+            {
+                string retryAfter = values.First();
+                if(Int32.TryParse(retryAfter, out int delaySeconds))
+                {
+                    delayInSeconds = delaySeconds;
+                }
+            }
+            else
+            {
+                _mPow = Math.Pow(2, retryCount);
+                delayInSeconds = _mPow * delay;
+            }
+
+            TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MaxDelay));
+            return Task.Delay(delayTimeSpan, cancellationToken);
+        }
+
+        /// <summary>
+        /// Check the HTTP status to determine whether it should be retried or not.
+        /// </summary>
+        /// <param name="statusCode">The <see cref="HttpStatusCode"/>returned.</param>
+        /// <returns></returns>
+        private static bool ShouldRetry(HttpStatusCode statusCode)
+        {
+            return statusCode switch
+            {
+                HttpStatusCode.ServiceUnavailable => true,
+                HttpStatusCode.GatewayTimeout => true,
+                HttpStatusCode.TooManyRequests => true,
+                _ => false
+            };
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Properties/AssemblyInfo.cs
+++ b/http/dotnet/httpclient/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+
+[assembly: Guid("b0c91cbc-af85-4c64-b989-d320e6989b2a")]
+[assembly: InternalsVisibleTo("Microsoft.Kiota.Http.HttpClient.Tests")]


### PR DESCRIPTION
This PR covers part of the work outlined in https://github.com/microsoft/kiota/issues/360

It involves the addition of the following middlewares to the httpClient library.
-  redirect handler
-  compression handler
-  retry handler