### PR TITLE
Setup final handler for default httpClient

### DIFF
--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpClientBuilderTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpClientBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using Microsoft.Kiota.Http.HttpClient.Tests.Mocks;
 using Xunit;
 
@@ -42,6 +43,39 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests
             var innerHandler = delegatingHandler.InnerHandler as DelegatingHandler;
             Assert.NotNull(innerHandler);
             Assert.Null(innerHandler.InnerHandler);// end of the chain
+        }
+
+        [Fact]
+        public void ChainHandlersCollectionAndGetFirstLinkWithMultipleHandlersSetsFinalHandler()
+        {
+            // Arrange
+            var handler1 = new TestHttpMessageHandler();
+            var handler2 = new TestHttpMessageHandler();
+            var finalHandler = new HttpClientHandler();
+            // Act
+            var delegatingHandler = HttpClientBuilder.ChainHandlersCollectionAndGetFirstLink(finalHandler, handler1, handler2);
+            // Assert
+            Assert.NotNull(delegatingHandler);
+            Assert.NotNull(delegatingHandler.InnerHandler); // first handler has an inner handler
+            
+            var innerHandler = delegatingHandler.InnerHandler as DelegatingHandler;
+            Assert.NotNull(innerHandler);
+            Assert.NotNull(innerHandler.InnerHandler);
+            Assert.IsType<HttpClientHandler>(innerHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void GetDefaultHttpMessageHandlerSetsUpProxy()
+        {
+            // Arrange
+            var proxy = new WebProxy("http://localhost:8888", false);
+            // Act
+            var defaultHandler = HttpClientBuilder.GetDefaultHttpMessageHandler(proxy);
+            // Assert
+            Assert.NotNull(defaultHandler);
+            Assert.IsType<HttpClientHandler>(defaultHandler);
+            Assert.Equal(proxy, ((HttpClientHandler)defaultHandler).Proxy);
+
         }
     }
 }

--- a/http/dotnet/httpclient/src/HttpClientBuilder.cs
+++ b/http/dotnet/httpclient/src/HttpClientBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClient.Middleware;
@@ -18,20 +19,19 @@ namespace Microsoft.Kiota.Http.HttpClient
         /// <summary>
         /// Initializes the <see cref="HttpClient"/> with the default configuration and middlewares including a authentication middleware using the <see cref="IAuthenticationProvider"/> if provided.
         /// </summary>
-        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> to use for authentication.</param>
+        /// <param name="finalHandler">The final <see cref="HttpMessageHandler"/> in the http pipeline. Can be configured for proxies, auto-decompression and auto-redirects </param>
         /// <returns>The <see cref="HttpClient"/> with the default middlewares.</returns>
-        public static System.Net.Http.HttpClient Create(IAuthenticationProvider authenticationProvider = default)
+        public static System.Net.Http.HttpClient Create(HttpMessageHandler finalHandler = null)
         {
-            var defaultHandlers = CreateDefaultHandlers(authenticationProvider);
-            var handler = ChainHandlersCollectionAndGetFirstLink(defaultHandlers.ToArray());
-            return handler != null ? new System.Net.Http.HttpClient(handler) : new System.Net.Http.HttpClient(); //TODO configure the default client options
+            var defaultHandlers = CreateDefaultHandlers();
+            var handler = ChainHandlersCollectionAndGetFirstLink(finalHandler ?? GetDefaultHttpMessageHandler(), defaultHandlers.ToArray());
+            return handler != null ? new System.Net.Http.HttpClient(handler) : new System.Net.Http.HttpClient();
         }
         /// <summary>
         /// Creates a default set of middleware to be used by the <see cref="HttpClient"/>.
         /// </summary>
-        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> to authenticate requests.</param>
         /// <returns>A list of the default handlers used by the client.</returns>
-        public static IList<DelegatingHandler> CreateDefaultHandlers(IAuthenticationProvider authenticationProvider = default)
+        public static IList<DelegatingHandler> CreateDefaultHandlers()
         {
             return new List<DelegatingHandler>
             {
@@ -43,9 +43,10 @@ namespace Microsoft.Kiota.Http.HttpClient
         /// <summary>
         /// Creates a <see cref="DelegatingHandler"/> to use for the <see cref="HttpClient" /> from the provided <see cref="DelegatingHandler"/> instances. Order matters.
         /// </summary>
+        /// <param name="finalHandler">The final <see cref="HttpMessageHandler"/> in the http pipeline. Can be configured for proxies, auto-decompression and auto-redirects </param>
         /// <param name="handlers">The <see cref="DelegatingHandler"/> instances to create the <see cref="DelegatingHandler"/> from.</param>
         /// <returns>The created <see cref="DelegatingHandler"/>.</returns>
-        public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
+        public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(HttpMessageHandler finalHandler, params DelegatingHandler[] handlers)
         {
             if(handlers == null || !handlers.Any()) return default;
             var handlersCount = handlers.Length;
@@ -59,7 +60,27 @@ namespace Microsoft.Kiota.Http.HttpClient
                     previousHandler.InnerHandler = handler;
                 }
             }
+            if(finalHandler != null)
+                handlers[^1].InnerHandler = finalHandler;
             return handlers.First();
+        }
+        /// <summary>
+        /// Creates a <see cref="DelegatingHandler"/> to use for the <see cref="HttpClient" /> from the provided <see cref="DelegatingHandler"/> instances. Order matters.
+        /// </summary>
+        /// <param name="handlers">The <see cref="DelegatingHandler"/> instances to create the <see cref="DelegatingHandler"/> from.</param>
+        /// <returns>The created <see cref="DelegatingHandler"/>.</returns>
+        public static DelegatingHandler ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
+        {
+            return ChainHandlersCollectionAndGetFirstLink(null,handlers);
+        }
+        /// <summary>
+        /// Gets a default Http Client handler with the appropriate proxy configurations
+        /// </summary>
+        /// <param name="proxy">The proxy to be used with created client.</param>
+        /// <returns/>
+        public static HttpMessageHandler GetDefaultHttpMessageHandler(IWebProxy proxy = null)
+        {
+            return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
         }
     }
 }

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Kiota.Http.HttpClient
         {
             authProvider = authenticationProvider ?? throw new ArgumentNullException(nameof(authenticationProvider));
             createdClient = httpClient == null;
-            client = httpClient ?? HttpClientBuilder.Create(authProvider);
+            client = httpClient ?? HttpClientBuilder.Create();
             pNodeFactory = parseNodeFactory ?? ParseNodeFactoryRegistry.DefaultInstance;
             sWriterFactory = serializationWriterFactory ?? SerializationWriterFactoryRegistry.DefaultInstance;
         }

--- a/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/HttpCore.java
+++ b/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/HttpCore.java
@@ -2,7 +2,6 @@ package com.microsoft.kiota.http;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.UnsupportedOperationException;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Objects;
@@ -54,7 +53,7 @@ public class HttpCore implements com.microsoft.kiota.HttpCore {
     public HttpCore(@Nonnull final AuthenticationProvider authenticationProvider, @Nullable final ParseNodeFactory parseNodeFactory, @Nullable final SerializationWriterFactory serializationWriterFactory, @Nullable final OkHttpClient client) {
         this.authProvider = Objects.requireNonNull(authenticationProvider, "parameter authenticationProvider cannot be null");
         if(client == null) {
-            this.client = OkHttpClientBuilder.Create(this.authProvider).build();
+            this.client = OkHttpClientBuilder.Create().build();
         } else {
             this.client = client;
         }

--- a/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/OkHttpClientBuilder.java
+++ b/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/OkHttpClientBuilder.java
@@ -1,20 +1,15 @@
 package com.microsoft.kiota.http;
 
-import com.microsoft.kiota.authentication.AuthenticationProvider;
-
 import okhttp3.OkHttpClient;
-
-import javax.annotation.Nullable;
 
 /** This class is used to build the HttpClient instance used by the core service. */
 public class OkHttpClientBuilder {
     private OkHttpClientBuilder() { }
     /**
-     * Creates an OkHttpClient Builder with the default configuration and middlewares including a authentention middleware using the {@link AuthenticationProvider} if provided.
-     * @param authenticationProvider the authentication provider used to authenticate the requests.
+     * Creates an OkHttpClient Builder with the default configuration and middlewares.
      * @return an OkHttpClient Builder instance.
      */
-    public static OkHttpClient.Builder Create(@Nullable final AuthenticationProvider authenticationProvider) {
+    public static OkHttpClient.Builder Create() {
         return new OkHttpClient.Builder(); //TODO configure the default client options.
         //TODO add the default middlewares when they are ready
     }


### PR DESCRIPTION
This PR setups the ability to configure the default options of the default httpClient by adding the ability to pass in an instance `HttpMessageHandler` to be the final handler in the http pipeline.

This will give the users the ability to pass in a handler to configure the proxy or cookie authentication. 
Example using proxy
```cs
var proxy = new WebProxy("http://localhost:8888", false);
var finalHandler = HttpClientBuilder.GetDefaultHttpMessageHandler(proxy); // this returns a handler with the appropiate defaults 
var httpClient = HttpClientBuilder.Create(finalHandler );
```

This PR also
- removes the `authenticationProvider` parameter from the `HttpClientBuilder.Create()` and `HttpClientBuilder.CreateDefaultHandlers()`method as this is not being used in the pipeline. (Ref [here](https://github.com/microsoft/kiota/issues/360#issuecomment-914079619))

**Notes**
With this change, the `HttpClientBuilder.Create()` method will ensure that there is an instance of `HttpClientHandler` at the end of the pipeline as not passing a handler to the `HttpClient` constructor internally does this as well. 
This therefore means that there is no need to implement our own version of the `LoggingHandler` as the `HttpClientHandler` 
implicitly contains the `DiagnosticHandler` which users can take advantage of as outlined in the guidance [here](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/dev/docs/logging-requests.md#b-take-advantage-of-opentelemetrys-instrumentation-of-httpclient) (related to #360 )