### PR TITLE
Add Chaos and Telemetry Handlers

### DIFF
--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/ChaosHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/ChaosHandlerTests.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
                     ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0,0,5)),
                     ChaosHandler.Create500InternalServerErrorResponse(),
                     ChaosHandler.Create503Response(new TimeSpan(0,0,5)),
-                    ChaosHandler.Create502BadGatewayResponse()
+                    ChaosHandler.Create502BadGatewayResponse(),
+                    ChaosHandler.Create504GatewayTimeoutResponse(new TimeSpan(0,0,5))
                 }
             })
             {
@@ -69,7 +70,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
             Dictionary<HttpStatusCode, object> responses = new Dictionary<HttpStatusCode, object>();
 
             // Make calls until all known failures have been triggered
-            while(responses.Count < 4)
+            while(responses.Count < 5)
             {
                 var response = await invoker.SendAsync(request, new CancellationToken());
                 if(response.StatusCode != HttpStatusCode.OK)
@@ -83,6 +84,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
             Assert.True(responses.ContainsKey(HttpStatusCode.InternalServerError));
             Assert.True(responses.ContainsKey(HttpStatusCode.BadGateway));
             Assert.True(responses.ContainsKey(HttpStatusCode.ServiceUnavailable));
+            Assert.True(responses.ContainsKey(HttpStatusCode.GatewayTimeout));
         }
 
         [Fact]

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/ChaosHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/ChaosHandlerTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
+{
+    public class ChaosHandlerTests
+    {
+        [Fact]
+        public async Task RandomChaosShouldReturnRandomFailures()
+        {
+            // Arrange
+            var handler = new ChaosHandler
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            var request = new HttpRequestMessage();
+
+            // Act
+            Dictionary<HttpStatusCode, object> responses = new Dictionary<HttpStatusCode, object>();
+
+            // Make calls until all known failures have been triggered
+            while(responses.Count < 3)
+            {
+                var response = await invoker.SendAsync(request, new CancellationToken());
+                if(response.StatusCode != HttpStatusCode.OK)
+                {
+                    responses[response.StatusCode] = null;
+                }
+            }
+
+            // Assert
+            Assert.True(responses.ContainsKey(HttpStatusCode.TooManyRequests));
+            Assert.True(responses.ContainsKey(HttpStatusCode.ServiceUnavailable));
+            Assert.True(responses.ContainsKey(HttpStatusCode.GatewayTimeout));
+        }
+
+        [Fact]
+        public async Task RandomChaosWithCustomKnownFailuresShouldReturnAllFailuresRandomly()
+        {
+
+            // Arrange
+            var handler = new ChaosHandler(new ChaosHandlerOption
+            {
+                KnownChaos = new List<HttpResponseMessage>
+                {
+                    ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0,0,5)),
+                    ChaosHandler.Create500InternalServerErrorResponse(),
+                    ChaosHandler.Create503Response(new TimeSpan(0,0,5)),
+                    ChaosHandler.Create502BadGatewayResponse()
+                }
+            })
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            var request = new HttpRequestMessage();
+
+            // Act
+            Dictionary<HttpStatusCode, object> responses = new Dictionary<HttpStatusCode, object>();
+
+            // Make calls until all known failures have been triggered
+            while(responses.Count < 4)
+            {
+                var response = await invoker.SendAsync(request, new CancellationToken());
+                if(response.StatusCode != HttpStatusCode.OK)
+                {
+                    responses[response.StatusCode] = null;
+                }
+            }
+
+            // Assert
+            Assert.True(responses.ContainsKey(HttpStatusCode.TooManyRequests));
+            Assert.True(responses.ContainsKey(HttpStatusCode.InternalServerError));
+            Assert.True(responses.ContainsKey(HttpStatusCode.BadGateway));
+            Assert.True(responses.ContainsKey(HttpStatusCode.ServiceUnavailable));
+        }
+
+        [Fact]
+        public async Task PlannedChaosShouldReturnChaosWhenPlanned()
+        {
+            // Arrange
+
+            Func<HttpRequestMessage, HttpResponseMessage> plannedChaos = (req) =>
+            {
+                if(req.RequestUri?.OriginalString.Contains("/fail") ?? false)
+                {
+                    return ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0, 0, 5));
+                }
+                return null;
+            };
+
+            var handler = new ChaosHandler(new ChaosHandlerOption
+            {
+                PlannedChaosFactory = plannedChaos
+            })
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+
+
+            // Act
+            var request1 = new HttpRequestMessage
+            {
+                RequestUri = new Uri("http://example.org/success")
+            };
+            var response1 = await invoker.SendAsync(request1, new CancellationToken());
+
+            var request2 = new HttpRequestMessage
+            {
+                RequestUri = new Uri("http://example.org/fail")
+            };
+            var response2 = await invoker.SendAsync(request2, new CancellationToken());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+            Assert.Equal(HttpStatusCode.TooManyRequests, response2.StatusCode);
+        }
+
+    }
+
+    internal class FakeSuccessHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                RequestMessage = request
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/TelemetryHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Middleware/TelemetryHandlerTests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Http.HttpClient.Middleware;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+using Xunit;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Middleware
+{
+    public class TelemetryHandlerTests
+    {
+        private readonly HttpMessageInvoker _invoker;
+
+        public TelemetryHandlerTests()
+        {
+            var telemetryHandler = new TelemetryHandler
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+            this._invoker = new HttpMessageInvoker(telemetryHandler);
+        }
+
+        [Fact]
+        public async Task DefaultTelemetryHandlerDoesNotChangeRequest()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Abstractions.HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            // Act and get a request message
+            var requestMessage = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            Assert.Empty(requestMessage.Headers);
+
+            // Act
+            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+
+            // Assert the request stays the same
+            Assert.Empty(response.RequestMessage?.Headers!);
+            Assert.Equal(requestMessage,response.RequestMessage);
+        }
+
+        [Fact]
+        public async Task TelemetryHandlerSelectivelyEnrichesRequestsBasedOnRequestMiddleWare()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Abstractions.HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+            var telemetryHandlerOption = new TelemetryHandlerOption
+            {
+                TelemetryConfigurator = (httpRequestMessage) =>
+                {
+                    httpRequestMessage.Headers.Add("SdkVersion","x.x.x");
+                    return httpRequestMessage;
+                }
+            };
+            // Configures the telemetry at the request level
+            requestInfo.AddMiddlewareOptions(telemetryHandlerOption);
+            // Act and get a request message
+            var requestMessage = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+            Assert.Empty(requestMessage.Headers);
+
+            // Act
+            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+
+            // Assert the request was enriched as expected
+            Assert.NotEmpty(response.RequestMessage?.Headers!);
+            Assert.Single(response.RequestMessage?.Headers!);
+            Assert.Equal("SdkVersion", response.RequestMessage?.Headers.First().Key);
+            Assert.Equal(requestMessage, response.RequestMessage);
+        }
+
+        [Fact]
+        public async Task TelemetryHandlerGloballyEnrichesRequests()
+        {
+            // Arrange
+            // Configures the telemetry at the handler level
+            var telemetryHandlerOption = new TelemetryHandlerOption
+            {
+                TelemetryConfigurator = (httpRequestMessage) =>
+                {
+                    httpRequestMessage.Headers.Add("SdkVersion", "x.x.x");
+                    return httpRequestMessage;
+                }
+            };
+            var handler = new TelemetryHandler(telemetryHandlerOption)
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Abstractions.HttpMethod.GET,
+                URI = new Uri("http://localhost")
+            };
+
+            var requestMessage = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);// get a request message
+            Assert.Empty(requestMessage.Headers);
+
+            // Act
+            var response = await invoker.SendAsync(requestMessage, new CancellationToken());
+
+            // Assert the request was enriched as expected
+            Assert.NotEmpty(response.RequestMessage?.Headers!);
+            Assert.Single(response.RequestMessage?.Headers!);
+            Assert.Equal("SdkVersion", response.RequestMessage?.Headers.First().Key);
+            Assert.Equal(requestMessage, response.RequestMessage);
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation that is used for simulating server failures.
     /// </summary>
-    public class ChaosHandler : DelegatingHandler
+    public class ChaosHandler : DelegatingHandler, IDisposable
     {
         private readonly DiagnosticSource _logger = new DiagnosticListener(typeof(ChaosHandler).FullName!);
         private readonly Random _random;
@@ -220,6 +220,21 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
             };
             gatewayTimeoutResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
             return gatewayTimeoutResponse;
+        }
+
+        /// <summary>
+        /// Clean up any thing we created
+        /// </summary>
+        public new void Dispose()
+        {
+            // clean up the response messages
+            foreach(var response in _knownFailures)
+            {
+                response.Dispose();
+            }
+            // Cleanup any base resources
+            base.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
         /// <returns></returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if(request == null)
+                throw new ArgumentNullException(nameof(request));
+
             // Select global or per request options
             var chaosHandlerOptions = request.GetMiddlewareOption<ChaosHandlerOption>() ?? _chaosHandlerOptions;
 
@@ -222,7 +225,7 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
         /// <summary>
         /// Private class to model sample responses
         /// </summary>
-        internal class Error
+        private class Error
         {
             /// <summary>
             /// The error code

--- a/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/ChaosHandler.cs
@@ -1,0 +1,361 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation that is used for simulating server failures.
+    /// </summary>
+    public class ChaosHandler : DelegatingHandler
+    {
+        private readonly DiagnosticSource _logger = new DiagnosticListener(typeof(ChaosHandler).FullName!);
+        private readonly Random _random;
+        private readonly ChaosHandlerOption _globalChaosHandlerOptions;
+        private List<HttpResponseMessage> _knownGraphFailures;
+        private const string Json = "application/json";
+
+        /// <summary>
+        /// Create a ChaosHandler.  
+        /// </summary>
+        /// <param name="chaosHandlerOptions">Optional parameter to change default behavior of handler.</param>
+        public ChaosHandler(ChaosHandlerOption chaosHandlerOptions = null)
+        {
+            _globalChaosHandlerOptions = chaosHandlerOptions ?? new ChaosHandlerOption();
+            _random = new Random(DateTime.Now.Millisecond);
+            LoadKnownGraphFailures(_globalChaosHandlerOptions.KnownChaos);
+        }
+
+        /// <summary>
+        /// Sends the request
+        /// </summary>
+        /// <param name="request">The request to send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Select global or per request options
+            var chaosHandlerOptions = request.GetMiddlewareOption<ChaosHandlerOption>() ?? _globalChaosHandlerOptions;
+
+            HttpResponseMessage response = null;
+            // Planned Chaos or Random?
+            if(chaosHandlerOptions.PlannedChaosFactory != null)
+            {
+                response = chaosHandlerOptions.PlannedChaosFactory(request);
+                if(response != null)
+                {
+                    response.RequestMessage = request;
+                    if(_logger.IsEnabled("PlannedChaosResponse"))
+                        _logger.Write("PlannedChaosResponse", response);
+                }
+            }
+            else
+            {
+                if(_random.Next(100) < chaosHandlerOptions.ChaosPercentLevel)
+                {
+                    response = CreateChaosResponse(chaosHandlerOptions.KnownChaos ?? _knownGraphFailures);
+                    response.RequestMessage = request;
+                    if(_logger.IsEnabled("ChaosResponse"))
+                        _logger.Write("ChaosResponse", response);
+                }
+            }
+
+            if(response == null)
+            {
+                response = await base.SendAsync(request, cancellationToken);
+            }
+            return response;
+        }
+
+        private HttpResponseMessage CreateChaosResponse(List<HttpResponseMessage> knownFailures)
+        {
+            var responseIndex = _random.Next(knownFailures.Count);
+            return knownFailures[responseIndex];
+        }
+
+        private void LoadKnownGraphFailures(List<HttpResponseMessage> knownFailures)
+        {
+            if(knownFailures != null && knownFailures.Count > 0)
+            {
+                _knownGraphFailures = knownFailures;
+            }
+            else
+            {
+                _knownGraphFailures = new List<HttpResponseMessage>
+                {
+                    Create429TooManyRequestsResponse(new TimeSpan(0, 0, 3)),
+                    Create503Response(new TimeSpan(0, 0, 3)),
+                    Create504GatewayTimeoutResponse(new TimeSpan(0, 0, 3))
+                };
+            }
+        }
+
+        /// <summary>
+        /// Create a HTTP status 429 response message
+        /// </summary>
+        /// <param name="retry"><see cref="TimeSpan"/> for retry condition header value</param>
+        /// <returns>A <see cref="HttpResponseMessage"/> object simulating a 429 response</returns>
+        public static HttpResponseMessage Create429TooManyRequestsResponse(TimeSpan retry)
+        {
+            var contentString = JsonSerializer.Serialize(new
+            {
+                error = new Error
+                {
+                    Code = "activityLimitReached",
+                    Message ="Client application has been throttled and should not attempt to repeat the request until an amount of time has elapsed."
+                }
+            });
+            var throttleResponse = new HttpResponseMessage()
+            {
+                StatusCode = (HttpStatusCode)429,
+                Content = new StringContent(contentString, Encoding.UTF8, Json)
+            };
+            throttleResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return throttleResponse;
+        }
+
+        /// <summary>
+        /// Create a HTTP status 503 response message
+        /// </summary>
+        /// <param name="retry"><see cref="TimeSpan"/> for retry condition header value</param>
+        /// <returns>A <see cref="HttpResponseMessage"/> object simulating a 503 response</returns>
+        public static HttpResponseMessage Create503Response(TimeSpan retry)
+        {
+            var contentString = JsonSerializer.Serialize(new
+            {
+                error = new Error()
+                {
+                    Code = "serviceNotAvailable",
+                    Message = "The service is temporarily unavailable for maintenance or is overloaded. You may repeat the request after a delay, the length of which may be specified in a Retry-After header."
+                }
+            });
+            var serverUnavailableResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable,
+                Content = new StringContent(contentString, Encoding.UTF8, Json)
+            };
+            serverUnavailableResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return serverUnavailableResponse;
+        }
+
+        /// <summary>
+        /// Create a HTTP status 502 response message
+        /// </summary>
+        /// <returns>A <see cref="HttpResponseMessage"/> object simulating a 502 Response</returns>
+        public static HttpResponseMessage Create502BadGatewayResponse()
+        {
+            var contentString = JsonSerializer.Serialize(new
+            {
+                error = new Error()
+                {
+                    Code = "502"
+                }
+            });
+            var badGatewayResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadGateway,
+                Content = new StringContent(contentString, Encoding.UTF8, Json)
+            };
+            return badGatewayResponse;
+        }
+
+        /// <summary>
+        /// Create a HTTP status 500 response message
+        /// </summary>
+        /// <returns>A <see cref="HttpResponseMessage"/> object simulating a 500 Response</returns>
+        public static HttpResponseMessage Create500InternalServerErrorResponse()
+        {
+            var contentString = JsonSerializer.Serialize(new
+            {
+                error = new Error()
+                {
+                    Code = "generalException",
+                    Message = "There was an internal server error while processing the request."
+                }
+            });
+            var internalServerError = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent(contentString, Encoding.UTF8, Json)
+            };
+            return internalServerError;
+        }
+
+        /// <summary>
+        /// Create a HTTP status 504 response message
+        /// </summary>
+        /// <param name="retry"><see cref="TimeSpan"/> for retry condition header value</param>
+        /// <returns>A <see cref="HttpResponseMessage"/> object simulating a 504 response</returns>
+        public static HttpResponseMessage Create504GatewayTimeoutResponse(TimeSpan retry)
+        {
+            var contentString = JsonSerializer.Serialize(new
+            {
+                error = new Error()
+                {
+                    Code = "504",
+                    Message = "The server, while acting as a proxy, did not receive a timely response from the upstream server it needed to access in attempting to complete the request. May occur together with 503."
+                }
+            });
+            var gatewayTimeoutResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.GatewayTimeout,
+                Content = new StringContent(contentString, Encoding.UTF8, Json)
+            };
+            gatewayTimeoutResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return gatewayTimeoutResponse;
+        }
+
+        // TODO this is not your home!
+        private class Error
+        {
+            /// <summary>
+            /// This code represents the HTTP status code when this Error object accessed from the ServiceException.Error object.
+            /// This code represent a sub-code when the Error object is in the InnerError or ErrorDetails object.
+            /// </summary>
+            [JsonPropertyName("code")]
+            public string Code
+            {
+                get; set;
+            }
+
+            /// <summary>
+            /// The error message.
+            /// </summary>
+            [JsonPropertyName("message")]
+            public string Message
+            {
+                get; set;
+            }
+
+            /// <summary>
+            /// Indicates the target of the error, for example, the name of the property in error.
+            /// </summary>
+            [JsonPropertyName("target")]
+            public string Target
+            {
+                get; set;
+            }
+
+            /// <summary>
+            /// The inner error of the response. These are additional error objects that may be more specific than the top level error.
+            /// </summary>
+            [JsonPropertyName("innererror")]
+            public Error InnerError
+            {
+                get; set;
+            }
+
+            /// <summary>
+            /// The Throw site of the error.
+            /// </summary>
+            public string ThrowSite
+            {
+                get; internal set;
+            }
+
+            /// <summary>
+            /// Gets or set the client-request-id header returned in the response headers collection. 
+            /// </summary>
+            public string ClientRequestId
+            {
+                get; internal set;
+            }
+
+            /// <summary>
+            /// The AdditionalData property bag.
+            /// </summary>
+            [JsonExtensionData]
+            public IDictionary<string, object> AdditionalData
+            {
+                get; set;
+            }
+
+            /// <summary>
+            /// Concatenates the error into a string.
+            /// </summary>
+            /// <returns>A human-readable string error response.</returns>
+            public override string ToString()
+            {
+                var errorStringBuilder = new StringBuilder();
+
+                if(!string.IsNullOrEmpty(this.Code))
+                {
+                    errorStringBuilder.AppendFormat("Code: {0}", this.Code);
+                    errorStringBuilder.Append(Environment.NewLine);
+                }
+
+                if(!string.IsNullOrEmpty(this.Message))
+                {
+                    errorStringBuilder.AppendFormat("Message: {0}", this.Message);
+                    errorStringBuilder.Append(Environment.NewLine);
+                }
+
+                if(!string.IsNullOrEmpty(this.Target))
+                {
+                    errorStringBuilder.AppendFormat("Target: {0}", this.Target);
+                    errorStringBuilder.Append(Environment.NewLine);
+                }
+
+                // if(this.Details != null && this.Details.GetEnumerator().MoveNext())
+                // {
+                //     errorStringBuilder.Append("Details:");
+                //     errorStringBuilder.Append(Environment.NewLine);
+                //
+                //     int i = 0;
+                //     foreach(var detail in this.Details)
+                //     {
+                //         errorStringBuilder.AppendFormat("\tDetail{0}:{1}", i, detail.ToString());
+                //         errorStringBuilder.Append(Environment.NewLine);
+                //         i++;
+                //     }
+                // }
+
+                if(this.InnerError != null)
+                {
+                    errorStringBuilder.Append("Inner error:");
+                    errorStringBuilder.Append(Environment.NewLine);
+                    errorStringBuilder.Append("\t" + this.InnerError.ToString());
+                }
+
+                if(!string.IsNullOrEmpty(this.ThrowSite))
+                {
+                    errorStringBuilder.AppendFormat("Throw site: {0}", this.ThrowSite);
+                    errorStringBuilder.Append(Environment.NewLine);
+                }
+
+                if(!string.IsNullOrEmpty(this.ClientRequestId))
+                {
+                    errorStringBuilder.AppendFormat("ClientRequestId: {0}", this.ClientRequestId);
+                    errorStringBuilder.Append(Environment.NewLine);
+                }
+
+                if(this.AdditionalData != null && this.AdditionalData.GetEnumerator().MoveNext())
+                {
+                    errorStringBuilder.Append("AdditionalData:");
+                    errorStringBuilder.Append(Environment.NewLine);
+                    foreach(var prop in this.AdditionalData)
+                    {
+                        errorStringBuilder.AppendFormat("\t{0}: {1}", prop.Key, prop.Value?.ToString() ?? "null");
+                        errorStringBuilder.Append(Environment.NewLine);
+                    }
+                }
+
+                return errorStringBuilder.ToString();
+            }
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/Options/ChaosHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/ChaosHandlerOption.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
         /// <summary>
         /// List of failure responses that potentially could be returned when 
         /// </summary>
-        public List<HttpResponseMessage> KnownChaos { get; set; } = null;
+        public List<HttpResponseMessage> KnownChaos { get; set; }
         /// <summary>
         /// Function to return chaos response based on current request.  This is used to reproduce detected failure modes.
         /// </summary>
-        public Func<HttpRequestMessage, HttpResponseMessage> PlannedChaosFactory { get; set; } = null;
+        public Func<HttpRequestMessage, HttpResponseMessage> PlannedChaosFactory { get; set; }
     }
 }

--- a/http/dotnet/httpclient/src/Middleware/Options/ChaosHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/ChaosHandlerOption.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
+{
+    /// <summary>
+    /// The Chaos Handler Option middleware class
+    /// </summary>
+    public class ChaosHandlerOption : IMiddlewareOption
+    {
+        /// <summary>
+        /// Percentage of responses that will have KnownChaos responses injected, assuming no PlannedChaosFactory is provided
+        /// </summary>
+        public int ChaosPercentLevel { get; set; } = 10;
+        /// <summary>
+        /// List of failure responses that potentially could be returned when 
+        /// </summary>
+        public List<HttpResponseMessage> KnownChaos { get; set; } = null;
+        /// <summary>
+        /// Function to return chaos response based on current request.  This is used to reproduce detected failure modes.
+        /// </summary>
+        public Func<HttpRequestMessage, HttpResponseMessage> PlannedChaosFactory { get; set; } = null;
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/Options/TelemetryHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/TelemetryHandlerOption.cs
@@ -5,7 +5,7 @@ using Microsoft.Kiota.Abstractions;
 namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
 {
     /// <summary>
-    /// The retry middleware option class
+    /// The Telemetry middleware option class
     /// </summary>
     public class TelemetryHandlerOption : IMiddlewareOption
     {

--- a/http/dotnet/httpclient/src/Middleware/Options/TelemetryHandlerOption.cs
+++ b/http/dotnet/httpclient/src/Middleware/Options/TelemetryHandlerOption.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware.Options
+{
+    /// <summary>
+    /// The retry middleware option class
+    /// </summary>
+    public class TelemetryHandlerOption : IMiddlewareOption
+    {
+        /// <summary>
+        /// A delegate that's called to configure the <see cref="HttpRequestMessage"/> with the appropriate telemetry values.
+        /// </summary>
+        public Func<HttpRequestMessage, HttpRequestMessage> TelemetryConfigurator { get; set; } = (request) => request;
+    }
+}

--- a/http/dotnet/httpclient/src/Middleware/TelemetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/TelemetryHandler.cs
@@ -41,9 +41,14 @@ namespace Microsoft.Kiota.Http.HttpClient.Middleware
             var telemetryHandlerOption = httpRequest.GetMiddlewareOption<TelemetryHandlerOption>() ?? _telemetryHandlerOption;
 
             // use the enriched request from the handler
-            var enrichedRequest = telemetryHandlerOption.TelemetryConfigurator(httpRequest);
+            if(telemetryHandlerOption.TelemetryConfigurator != null)
+            {
+                var enrichedRequest = telemetryHandlerOption.TelemetryConfigurator(httpRequest);
+                return await base.SendAsync(enrichedRequest, cancellationToken);
+            }
 
-            return await base.SendAsync(enrichedRequest, cancellationToken);
+            // Just forward the request if TelemetryConfigurator was intentionally set to null
+            return await base.SendAsync(httpRequest, cancellationToken);
         }
     }
 }

--- a/http/dotnet/httpclient/src/Middleware/TelemetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/TelemetryHandler.cs
@@ -1,0 +1,49 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Microsoft.Kiota.Http.HttpClient.Middleware.Options;
+
+namespace Microsoft.Kiota.Http.HttpClient.Middleware
+{
+    /// <summary>
+    /// A <see cref="TelemetryHandler"/> implementation using standard .NET libraries.
+    /// </summary>
+    public class TelemetryHandler : DelegatingHandler
+    {
+        private readonly TelemetryHandlerOption _telemetryHandlerOption;
+
+        /// <summary>
+        /// The <see cref="TelemetryHandlerOption"/> constructor
+        /// </summary>
+        /// <param name="telemetryHandlerOption">The <see cref="TelemetryHandlerOption"/> instance to configure the telemetry</param>
+        public TelemetryHandler(TelemetryHandlerOption telemetryHandlerOption = null)
+        {
+            this._telemetryHandlerOption = telemetryHandlerOption ?? new TelemetryHandlerOption();
+        }
+
+        /// <summary>
+        /// Send a HTTP request 
+        /// </summary>
+        /// <param name="httpRequest">The HTTP request<see cref="HttpRequestMessage"/>needs to be sent.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        {
+            if(httpRequest == null)
+                throw new ArgumentNullException(nameof(httpRequest));
+
+            var telemetryHandlerOption = httpRequest.GetMiddlewareOption<TelemetryHandlerOption>() ?? _telemetryHandlerOption;
+
+            // use the enriched request from the handler
+            var enrichedRequest = telemetryHandlerOption.TelemetryConfigurator(httpRequest);
+
+            return await base.SendAsync(enrichedRequest, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This PR covers part of the work outlined in https://github.com/microsoft/kiota/issues/360

- Adds a Telemetry Handler that takes in as an option a function to configure requests to enrich it with telemetry information.
This will ideally be used by the core library by passing in the relevant configurator to sent telemetry information
- Adds a Chaos Handler to enable users to simulate error responses from API backends
- Adds tests to validate the items above.