### PR TITLE
Adds support for setting multipart content in RequestInformation

### DIFF
--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/RequestInformationExtensionsTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/Extensions/RequestInformationExtensionsTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Http.HttpClient.Extensions;
+using Xunit;
+using HttpMethod = Microsoft.Kiota.Abstractions.HttpMethod;
+
+namespace Microsoft.Kiota.Http.HttpClient.Tests.Extensions
+{
+    public class RequestInformationExtensionsTests
+    {
+        [Fact]
+        public async Task SetsContentFromStringHttpContent()
+        {
+            // Arrange
+            var testRequest = new RequestInformation
+            {
+                HttpMethod = HttpMethod.POST,
+                URI = new Uri("http://localhost")
+            };
+            // Create an instance of MultipartContent
+            var content = new StringContent("test input");
+
+            // Act
+            await testRequest.SetContentFromHttpContentAsync(content);
+
+            // Assert
+            Assert.NotNull(testRequest.Content); // ensure the stream is set
+            Assert.NotEmpty(testRequest.Headers); // ensure a header is set
+            Assert.Equal("Content-Type", testRequest.Headers.First().Key); // ensure that the content type header is copied across
+            Assert.Equal("text/plain; charset=utf-8", testRequest.Headers.First().Value); // ensure that the content type header is copied across
+
+            // Act again to ensure the stream is as expected
+            using var streamReader = new StreamReader(testRequest.Content);
+            var stringContent = await streamReader.ReadToEndAsync();
+
+            // Assert again
+            Assert.Equal("test input", stringContent); // Boundary exists
+        }
+        [Fact]
+        public async Task SetsMultipartContentFromMultipartHttpContent()
+        {
+            // Arrange
+            var testRequest = new RequestInformation
+            {
+                HttpMethod = HttpMethod.POST,
+                URI = new Uri("http://localhost")
+            };
+            // Create an instance of MultipartContent
+            var content = new MultipartContent("mixed", "customBoundary")
+            {
+                new StringContent("value1"), // string content
+                JsonContent.Create(new { name = "Peter Pan"} ) // instance of JsonContent
+            };
+
+            // Act
+            await testRequest.SetContentFromHttpContentAsync(content);
+
+            // Assert
+            Assert.NotNull(testRequest.Content); // ensure the stream is set
+            Assert.NotEmpty(testRequest.Headers); // ensure a header is set
+            Assert.Equal("Content-Type", testRequest.Headers.First().Key); // ensure that the content type header is copied across
+
+            // Act again to ensure the stream is as expected
+            using var streamReader = new StreamReader(testRequest.Content);
+            var stringContent = await streamReader.ReadToEndAsync();
+
+            // Assert again
+            Assert.Contains("--customBoundary", stringContent); // Boundary exists
+            Assert.Contains("text/plain;", stringContent); // Value1 content type exists
+            Assert.Contains("value1", stringContent); // Value1 exists
+            Assert.Contains("application/json;", stringContent); // JsonContent content type exists
+            Assert.Contains("{\"name\":\"Peter Pan\"}", stringContent); // Value1 exists
+        }
+    }
+}

--- a/http/dotnet/httpclient/src/Extensions/RequestInformationExtensions.cs
+++ b/http/dotnet/httpclient/src/Extensions/RequestInformationExtensions.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+
+namespace Microsoft.Kiota.Http.HttpClient.Extensions
+{
+    /// <summary>
+    /// Extenstion methods for the <see cref="RequestInformation"/> class
+    /// </summary>
+    public static class RequestInformationExtensions
+    {
+        /// <summary>
+        /// Sets the request content from an instance of <see cref="HttpContent"/>
+        /// </summary>
+        /// <param name="requestInformation">The <see cref="RequestInformation"/> instance to set its content</param>
+        /// <param name="httpContent">The <see cref="HttpContent"/> instance to set as a content of the request.</param>
+        /// <param name="cancellationToken">The (optional) <see cref="CancellationToken"/> to use.</param>
+        public static async Task SetContentFromHttpContentAsync(this RequestInformation requestInformation, HttpContent httpContent, CancellationToken cancellationToken = default)
+        {
+            if(requestInformation == null)
+                throw new ArgumentNullException(nameof(requestInformation));
+            if(httpContent == null)
+                throw new ArgumentNullException(nameof(httpContent));
+
+            var httpContentStream = await httpContent.ReadAsStreamAsync(cancellationToken);
+            requestInformation.Content = httpContentStream;
+            foreach(var (key, value) in httpContent.Headers)
+                requestInformation.Headers.Add(key, value.First());
+        }
+    }
+}


### PR DESCRIPTION
This PR closes https://github.com/microsoft/kiota/issues/360

It adds the support of setting [`MultipartContent`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.multipartcontent?view=net-5.0) in the `RequestInformation` class through the newly added `SetContentFromHttpContentAsync` method.

This will also therefore enable a user to set the content of a `RequestInformation` instance from any derived instance of `HttpContent`.

**Example usage**

```cs
// create requestInfo
var testRequest = new RequestInformation
{
    HttpMethod = HttpMethod.POST,
    URI = new Uri("http://localhost")
};
// Create an instance of MultipartContent
var content = new MultipartContent("mixed", "customBoundary")
{
    new StringContent("value1"), // string content
    JsonContent.Create(new { name = "Peter Pan"} ) // instance of JsonContent
};

// set the content (headers will also be copied across)
await testRequest.SetContentFromHttpContentAsync(content);
```

Tests have been added to validate this as well.