### PR TITLE
Fix for query parameter building in dotnet

### DIFF
--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/QueryParametersBaseTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/QueryParametersBaseTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Kiota.Abstractions.Tests
+{
+    public class QueryParametersBaseTests
+    {
+        [Fact]
+        public void SetsSelectQueryParameters()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+            };
+            requestInfo.SetURI("http://localhost/me", "", true);
+            Action<GetQueryParameters> q = x => x.Select = new[] { "id", "displayName" };
+            var qParams = new GetQueryParameters();
+            q.Invoke(qParams);
+
+            // Act 
+            qParams.AddQueryParameters(requestInfo.QueryParameters);
+
+            // Assert
+            Assert.True(requestInfo.QueryParameters.ContainsKey("select"));
+            Assert.Equal("select",requestInfo.QueryParameters.First().Key);
+        }
+    }
+
+    /// <summary>The messages in a mailbox or folder. Read-only. Nullable.</summary>
+    internal class GetQueryParameters : QueryParametersBase
+    {
+        /// <summary>Select properties to be returned</summary>
+        public string[] Select { get; set; }
+        /// <summary>Include count of items</summary>
+        public bool? Count { get; set; }
+        /// <summary>Expand related entities</summary>
+        public string Filter { get; set; }
+        /// <summary>Order items by property values</summary>
+        public string[] Orderby { get; set; }
+        /// <summary>Search items by search phrases</summary>
+        public string Search { get; set; }
+    }
+}

--- a/abstractions/dotnet/src/QueryParametersBase.cs
+++ b/abstractions/dotnet/src/QueryParametersBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Abstractions
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Kiota.Abstractions
                                         .GetProperties()
                                         .Where(x => !target.ContainsKey(x.Name)))
             {
-                target.Add(property.Name, property.GetValue(this));
+                target.Add(property.Name.ToFirstCharacterLowerCase(), property.GetValue(this));
             }
         }
     }

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpCoreTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClient.Tests/HttpCoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Abstractions.Store;
 using Moq;
@@ -38,5 +39,29 @@ namespace Microsoft.Kiota.Http.HttpClient.Tests
             //Assert the backing store has been updated
             Assert.IsAssignableFrom(backingStore.GetType(), BackingStoreFactorySingleton.Instance);
         }
+
+        [Theory]
+        [InlineData("select", new[] { "id", "displayName" }, "select=id,displayName")]
+        [InlineData("count", true, "count=true")]
+        [InlineData("skip", 10, "skip=10")]
+        [InlineData("skip", null, "skip")]
+        public void GetRequestMessageFromRequestInformationSetsQueryParametersCorrectlyWithSelect(string queryParam, object queryParamObject, string expectedString)
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.GET,
+            };
+            requestInfo.SetURI("http://localhost/me", "", true);
+            requestInfo.QueryParameters.Add(queryParam, queryParamObject);
+
+            // Act
+            var requestMessage = HttpCore.GetRequestMessageFromRequestInformation(requestInfo);
+
+            // Assert
+            Assert.NotNull(requestMessage.RequestUri);
+            Assert.Contains(expectedString, requestMessage.RequestUri.Query);
+        }
+
     }
 }

--- a/http/dotnet/httpclient/src/HttpCore.cs
+++ b/http/dotnet/httpclient/src/HttpCore.cs
@@ -13,6 +13,7 @@ using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Http.HttpClient
 {
@@ -188,7 +189,7 @@ namespace Microsoft.Kiota.Http.HttpClient
                 RequestUri = new Uri(requestInfo.URI +
                                         ((requestInfo.QueryParameters?.Any() ?? false) ?
                                             "?" + requestInfo.QueryParameters
-                                                        .Select(x => $"{x.Key}{(x.Value == null ? string.Empty : "=")}{x.Value?.ToString() ?? string.Empty}")
+                                                        .Select(x => $"{x.Key}{(x.Value == null ? string.Empty : "=")}{GetStringForQueryParameter(x.Value)}")
                                                         .Aggregate((x, y) => $"{x}&{y}") :
                                             string.Empty)),
             };
@@ -205,6 +206,22 @@ namespace Microsoft.Kiota.Http.HttpClient
             }
             return message;
         }
+
+        private static string GetStringForQueryParameter(object value)
+        {
+            return value switch
+            {
+                null => string.Empty,
+                bool booleanValue =>
+                    // ToString returns True/False with the first character in uppercase
+                    booleanValue.ToString().ToFirstCharacterLowerCase(),
+                IEnumerable<object> collection =>
+                    // the collection could be of booleans for all we know, make sure its cleaned up as well by this same function
+                    string.Join(',', collection.Select(GetStringForQueryParameter)),
+                _ => value.ToString()
+            };
+        }
+
         /// <summary>
         /// Enable the backing store with the provided <see cref="IBackingStoreFactory"/>
         /// </summary>


### PR DESCRIPTION
This PR closes #625.

It essentially fixes the reading of the QueryParameters Dictionary in the `RequestInformation` instance to cater for the various object types that could exist rather that simply calling `object.ToString()` method.

Tests have also been added to validate this. 