### PR TITLE
Filter CodeElement type during replacement of reserved names

### DIFF
--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
 
@@ -18,7 +19,8 @@ namespace Kiota.Builder.Refiners {
             CapitalizeNamespacesFirstLetters(generatedCode);
             ReplaceBinaryByNativeType(generatedCode, "Stream", "System.IO");
             MakeEnumPropertiesNullable(generatedCode);
-            ReplaceReservedNames(generatedCode, new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}");
+            // Exclude code classes, declarations and properties as they will be capitalized making the change unnecessary in this case sensitive language
+            ReplaceReservedNames(generatedCode, new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}", new HashSet<Type>{ typeof(CodeClass), typeof(CodeClass.Declaration), typeof(CodeProperty) }); 
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
@@ -6,14 +6,27 @@ namespace Kiota.Builder.Refiners.Tests {
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
         #region CommonLanguageRefinerTests
         [Fact]
-        public void EscapesReservedKeywords() {
+        public void DoesNotEscapesReservedKeywordsForClassOrPropertyKind() {
+            // Arrange
             var model = root.AddClass(new CodeClass (root) {
-                Name = "break",
-                ClassKind = CodeClassKind.Model
+                Name = "break", // this a keyword
+                ClassKind = CodeClassKind.Model,
             }).First();
+            var property = model.AddProperty(new CodeProperty(model)
+            {
+                Name = "alias",// this a keyword
+                Type = new CodeType(model)
+                {
+                    Name = "string"
+                }
+            }).First();
+            // Act
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-            Assert.NotEqual("break", model.Name);
-            Assert.Contains("@", model.Name);
+            // Assert
+            Assert.Equal("break", model.Name);
+            Assert.DoesNotContain("@", model.Name); // classname will be capitalized
+            Assert.Equal("alias", property.Name);
+            Assert.DoesNotContain("@", property.Name); // classname will be capitalized
         }
         [Fact]
         public void ConvertsUnionTypesToWrapper() {


### PR DESCRIPTION
This PR closes #646

It adds an extra parameter to enable the addition of an exclusion list to disable the replacement of reserved names in certain codeElements.

This may come in handy if we know for example that a CodeElement will be capitalized in a case sensitive language and can be taken advantage of in other languages in the refiner stages as well