### PR TITLE
Exclude namespace and type declarations in reserved words replacement for dotnet

### DIFF
--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -19,11 +19,14 @@ namespace Kiota.Builder.Refiners {
             CapitalizeNamespacesFirstLetters(generatedCode);
             ReplaceBinaryByNativeType(generatedCode, "Stream", "System.IO");
             MakeEnumPropertiesNullable(generatedCode);
-            // Exclude code classes, declarations and properties as they will be capitalized making the change unnecessary in this case sensitive language
+            /* Exclude the following as their names will be capitalized making the change unnecessary in this case sensitive language
+             * code classes, class declarations, property names, using declarations, namespace names
+             * Exclude CodeMethod as the return type will also be capitalized (excluding the CodeType is not enough since this is evaluated at the code method level)
+            */
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type>{ typeof(CodeClass), typeof(CodeClass.Declaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace) }
+                new HashSet<Type>{ typeof(CodeClass), typeof(CodeClass.Declaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod) }
             ); 
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -23,8 +23,8 @@ namespace Kiota.Builder.Refiners {
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type>{ typeof(CodeClass), typeof(CodeClass.Declaration), typeof(CodeProperty), typeof(CodeUsing)
-            }); 
+                new HashSet<Type>{ typeof(CodeClass), typeof(CodeClass.Declaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace) }
+            ); 
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -168,7 +168,7 @@ namespace Kiota.Builder.Refiners {
                 (!codeElementExceptions?.Contains(typeof(CodeMethod)) ?? true)) {
                 if(currentMethod.ReturnType is CodeType returnType &&
                     !returnType.IsExternal &&
-                    provider.ReservedNames.Contains(currentMethod.ReturnType.Name))
+                    provider.ReservedNames.Contains(returnType.Name))
                     returnType.Name = replacement.Invoke(returnType.Name);
                 ReplaceReservedParameterNamesTypes(currentMethod, provider, replacement);
             } else if (current is CodeProperty currentProperty &&


### PR DESCRIPTION
This PR updates the CSharpRefiner to exclude the `CodeNamespace` and `CodeMethod` types when replacing names for reseved words to clean up the unneccessary `@` character appended to namespace names and type names appearing in source as they are already capitalized in the case sensitive language

Therefore, a namespace like 
`namespace ApiSdk.Applications.Item.CreatedOnBehalfOf.@Ref`
changes to 
`namespace ApiSdk.Applications.Item.CreatedOnBehalfOf.Ref`

Note: this change does not affect the compilation of the current code when using the full v1.0 description.

Related to https://github.com/microsoft/kiota/pull/657