### PR TITLE
Update serialization, authentication and http libs to netstandard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where arrays of enums could be wrongly mapped.
 - Fixes a bug where go deserialization would fail on collections of scalars.
 - Fixes a bug where TypeScript query parameters would be added to headers instead #812
+- Update dotnet abstractions and core libraries to target netstandard2.1 from net5.0
 
 ## [0.0.13] - 2021-10-27
 

--- a/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -2,10 +2,11 @@
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -14,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.19" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
   </ItemGroup>
 
 </Project>

--- a/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
         /// <returns>A request option</returns>
         public static T GetRequestOption<T>(this HttpRequestMessage httpRequestMessage) where T : IRequestOption
         {
-            if(httpRequestMessage.Options.TryGetValue(
-                new HttpRequestOptionsKey<IRequestOption>(typeof(T).FullName),
-                out IRequestOption requestOption))
+            if(httpRequestMessage.Properties.TryGetValue(
+                typeof(T).FullName,
+                out var requestOption))
             {
                 return (T)requestOption;
             }
@@ -50,8 +50,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
                 newRequest.Headers.TryAddWithoutValidation(key, value);
 
             // Copy request properties.
-            foreach(var (key, value) in originalRequest.Options)
-                newRequest.Options.TryAdd(key, value);
+            foreach(var (key, value) in originalRequest.Properties)
+                newRequest.Properties.TryAdd(key, value);
 
             // Set Content if previous request had one.
             if(originalRequest.Content != null)

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -213,7 +213,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             };
 
             if(requestInfo.RequestOptions.Any())
-                requestInfo.RequestOptions.ToList().ForEach(x => message.Options.Set(new HttpRequestOptionsKey<IRequestOption>(x.GetType().FullName), x));
+                requestInfo.RequestOptions.ToList().ForEach(x => message.Properties.Add(x.GetType().FullName, x));
             if(requestInfo.Headers?.Any() ?? false)
                 requestInfo.Headers.Where(x => !ContentTypeHeaderName.Equals(x.Key, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => message.Headers.Add(x.Key, x.Value));
             if(requestInfo.Content != null)

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -2,10 +2,11 @@
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -13,7 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.23" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             // Decompress response content when Content-Encoding: gzip header is present.
             if(ShouldDecompressContent(response))
             {
-                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(cancellationToken), CompressionMode.Decompress));
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
                 // Copy Content Headers to the destination stream content
                 foreach(var httpContentHeader in response.Content.Headers)
                 {

--- a/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -64,7 +64,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
                 while(redirectCount < RedirectOption.MaxRedirect)
                 {
                     // Drain response content to free responses.
-                    await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                    await response.Content.ReadAsByteArrayAsync();
 
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method
                     var newRequest = await response.RequestMessage.CloneAsync();

--- a/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             {
                 // Drain response content to free connections. Need to perform this
                 // before retry attempt and before the TooManyRetries ServiceException.
-                await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                await response.Content.ReadAsByteArrayAsync();
 
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff
                 Task delay = Delay(response, retryCount, RetryOption.Delay, out double delayInSeconds, cancellationToken);
@@ -118,7 +118,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
 
             // Drain response content to free connections. Need to perform this
             // before retry attempt and before the TooManyRetries ServiceException.
-            await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            await response.Content.ReadAsByteArrayAsync();
 
             throw new InvalidOperationException(
                 "Too many retries performed",

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var testEntity = new TestEntity()
             {
                 Id = "48d31887-5fad-4d73-a9f5-3c356e68a038",
+                Numbers = TestEnum.One | TestEnum.Two,
                 AdditionalData = new Dictionary<string, object>
                 {
                     {"mobilePhone",null}, // write null value
@@ -76,6 +77,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             // Assert
             var expectedString = "[{" +
                                  "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
+                                 "\"numbers\":\"one,two\"," +
                                  "\"mobilePhone\":null," +
                                  "\"accountEnabled\":false," +
                                  "\"jobTitle\":\"Author\"," +

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         public IDictionary<string, object> AdditionalData { get; set; }
         /// <summary>Read-only.</summary>
         public string Id { get; set; }
+        /// <summary>Read-only.</summary>
+        public TestEnum? Numbers { get; set; }
         /// <summary>
         /// Instantiates a new entity and sets the default values.
         /// </summary>
@@ -24,6 +26,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         {
             return new Dictionary<string, Action<T, IParseNode>> {
                 {"id", (o,n) => { (o as TestEntity).Id = n.GetStringValue(); } },
+                {"numbers", (o,n) => { (o as TestEntity).Numbers = n.GetEnumValue<TestEnum>(); } },
             };
         }
         /// <summary>
@@ -34,6 +37,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteStringValue("id", Id);
+            writer.WriteEnumValue<TestEnum>("numbers",Numbers);
             writer.WriteAdditionalData(AdditionalData);
         }
     }

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEnum.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEnum.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
+{
+    [Flags]
+    public enum TestEnum
+    {
+        One = 0x00000001,
+        Two = 0x00000002,
+        Four = 0x00000004,
+        Eight = 0x00000008,
+        Sixteen = 0x00000010
+    }
+}

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -170,9 +170,10 @@ namespace Microsoft.Kiota.Serialization.Json
             if(value.HasValue)
             {
                 if(typeof(T).GetCustomAttributes<FlagsAttribute>().Any())
-                    writer.WriteStringValue(Enum.GetValues<T>()
+                    writer.WriteStringValue(Enum.GetValues(typeof(T))
+                                            .Cast<T>()
                                             .Where(x => value.Value.HasFlag(x))
-                                            .Select(x => Enum.GetName<T>(x))
+                                            .Select(x => Enum.GetName(typeof(T),x))
                                             .Select(x => x.ToFirstCharacterLowerCase())
                                             .Aggregate((x, y) => $"{x},{y}"));
                 else writer.WriteStringValue(value.Value.ToString().ToFirstCharacterLowerCase());

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -2,10 +2,11 @@
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -13,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.20" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the serialization, authentication and http client libraries to support netstandard

The PR involves relevant refactoring and adding tests to cover the changes and should be merged in after #825 