### PR TITLE
Fix for possible null content in a HttpResponseMessage

### DIFF
--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.13</Version>
+    <Version>1.0.14</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->

--- a/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/CompressionHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -61,7 +61,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
         /// <returns></returns>
         private static bool ShouldDecompressContent(HttpResponseMessage httpResponse)
         {
-            return httpResponse.Content.Headers.ContentEncoding.Contains(GZip);
+            return httpResponse.Content?.Headers?.ContentEncoding.Contains(GZip) ?? false;
         }
     }
 }

--- a/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RedirectHandler.cs
@@ -64,7 +64,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
                 while(redirectCount < RedirectOption.MaxRedirect)
                 {
                     // Drain response content to free responses.
-                    await response.Content.ReadAsByteArrayAsync();
+                    if(response.Content != null)
+                    {
+                        await response.Content.ReadAsByteArrayAsync();
+                    }
 
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method
                     var newRequest = await response.RequestMessage.CloneAsync();

--- a/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
+++ b/http/dotnet/httpclient/src/Middleware/RetryHandler.cs
@@ -79,7 +79,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             {
                 // Drain response content to free connections. Need to perform this
                 // before retry attempt and before the TooManyRetries ServiceException.
-                await response.Content.ReadAsByteArrayAsync();
+                if(response.Content != null)
+                {
+                    await response.Content.ReadAsByteArrayAsync();
+                }
 
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff
                 Task delay = Delay(response, retryCount, RetryOption.Delay, out double delayInSeconds, cancellationToken);
@@ -118,7 +121,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
 
             // Drain response content to free connections. Need to perform this
             // before retry attempt and before the TooManyRetries ServiceException.
-            await response.Content.ReadAsByteArrayAsync();
+            if(response.Content != null)
+            {
+                await response.Content.ReadAsByteArrayAsync();
+            }
 
             throw new InvalidOperationException(
                 "Too many retries performed",


### PR DESCRIPTION
Moving to netstandard2.1 results to the possibility that the `Content` property in a `HttpResponseMessage` can be null. 

This PR resolves this to prevent any issues brought about by using a runtime that isn't `net5.0`