### PR TITLE
- fixes a bug where at signs in path would derail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated generator to dotnet 6 #815
 - Fixes a bug where json deserialization would fail in go
 - Fixes a bug where query parameters would not be added to the request in go
+- Fixes a bug where at signs in path would derail generation
 
 ## [0.0.14] - 2021-11-08
 

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -28,6 +28,8 @@ namespace Kiota.Builder.Extensions {
             currentNode?.Path?.GetNamespaceFromPath(prefix);
         //{id}, name(idParam={id}), name(idParam='{id}'), name(idParam='{id}',idParam2='{id2}')
         private static readonly Regex PathParametersRegex = new(@"(?:\w+)?=?'?\{(?<paramName>\w+)\}'?,?", RegexOptions.Compiled);
+        // microsoft.graph.getRoleScopeTagsByIds(ids=@ids)
+        private static readonly Regex AtSignPathParameterRegex = new(@"=@(\w+)", RegexOptions.Compiled);
         private static readonly char requestParametersChar = '{';
         private static readonly char requestParametersEndChar = '}';
         private static readonly char requestParametersSectionChar = '(';
@@ -38,7 +40,9 @@ namespace Kiota.Builder.Extensions {
         private static string CleanupParametersFromPath(string pathSegment) {
             if((pathSegment?.Contains(requestParametersChar) ?? false) ||
                 (pathSegment?.Contains(requestParametersSectionChar) ?? false))
-                return PathParametersRegex.Replace(pathSegment, requestParametersMatchEvaluator)
+                return PathParametersRegex.Replace(
+                                            AtSignPathParameterRegex.Replace(pathSegment, "={$1}"),
+                                        requestParametersMatchEvaluator)
                                         .TrimEnd(requestParametersSectionEndChar)
                                         .Replace(requestParametersSectionChar.ToString(), string.Empty);
             return pathSegment;

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -82,5 +82,14 @@ namespace Kiota.Builder.Extensions.Tests {
             Assert.Equal("graph.users.messages", node.Children.First().Value.GetNodeNamespaceFromPath("graph"));
             Assert.Equal("users.messages", node.Children.First().Value.GetNodeNamespaceFromPath(null));
         }
+        [Fact]
+        public void SanitizesAtSign() {
+            var doc = new OpenApiDocument {
+                Paths = new(),
+            };
+            doc.Paths.Add("\\deviceManagement\\microsoft.graph.getRoleScopeTagsByIds(ids=@ids)", new() {});
+            var node = OpenApiUrlTreeNode.Create(doc, Label);
+            Assert.Equal("graph.deviceManagement.getRoleScopeTagsByIdsWithIds", node.Children.First().Value.GetNodeNamespaceFromPath("graph"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/3
Related https://github.com/microsoft/OpenAPI.NET.OData/issues/122

## Generation diff

No diff for the sample