### PR TITLE
Model with dictionary property

### DIFF
--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -23,12 +23,41 @@ namespace Kiota.Builder.integrationtests
             var backingStoreSuffix = backingStore ? string.Empty : "BackingStore";
             var configuration = new GenerationConfiguration
             {
-                Language = GenerationLanguage.CSharp,
+                Language = language,
                 OpenAPIFilePath = "ToDoApi.yaml",
-                OutputPath = $".\\Generated\\{language}{backingStoreSuffix}",
+                OutputPath = $".\\Generated\\Todo\\{language}{backingStoreSuffix}",
                 UsesBackingStore = backingStore,
             };
             await new KiotaBuilder(logger, configuration).GenerateSDK();
         }
+
+
+        [InlineData(GenerationLanguage.CSharp, false)]
+        [InlineData(GenerationLanguage.Java, false)]
+        [InlineData(GenerationLanguage.TypeScript, false)]
+        [InlineData(GenerationLanguage.Go, false)]
+        [InlineData(GenerationLanguage.Ruby, false)]
+        [InlineData(GenerationLanguage.CSharp, true)]
+        [InlineData(GenerationLanguage.Java, true)]
+        [InlineData(GenerationLanguage.TypeScript, true)]
+        [Theory]
+        public async Task GeneratesModelWithDictionary(GenerationLanguage language, bool backingStore)
+        {
+            var logger = LoggerFactory.Create((builder) => {
+            }).CreateLogger<KiotaBuilder>();
+
+            var backingStoreSuffix = backingStore ? "BackingStore" : string.Empty;
+            var configuration = new GenerationConfiguration
+            {
+                Language = language,
+                OpenAPIFilePath = "ModelWithDictionary.yaml",
+                OutputPath = $".\\Generated\\ModelWithDictionary\\{language}{backingStoreSuffix}",
+                UsesBackingStore = backingStore,
+            };
+            await new KiotaBuilder(logger, configuration).GenerateSDK();
+        }
+
+
+
     }
 }

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -28,6 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="ModelWithDictionary.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ToDoApi.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Kiota.Builder.IntegrationTests/ModelWithDictionary.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/ModelWithDictionary.yaml
@@ -1,0 +1,32 @@
+﻿openapi: 3.0.0
+info:
+  title: "Dictionary API"
+  version: "1.0.0"
+servers:
+  - url: https://example.org/
+paths:
+  /resource: 
+    get:
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/resource"
+components:
+  schemas:
+    resource:
+      type: object
+      properties:
+        info:
+          type: string
+        # customSettings: Dictionary<string,string>
+        customSettings:
+          type: object
+          patternProperties:
+            ".*":
+              type: string
+            
+      
+           


### PR DESCRIPTION
Added sample for scenario #62 All languages fail to render a model for the following  OpenAPI

```yaml
openapi: 3.0.0
info:
  title: "Dictionary API"
  version: "1.0.0"
servers:
  - url: https://example.org/
paths:
  /resource: 
    get:
      responses:
        200:
          description: ok
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/resource"
components:
  schemas:
    resource:
      type: object
      properties:
        info:
          type: string
        # customSettings: Dictionary<string,string>
        customSettings:
          type: object
          patternProperties:
            ".*":
              type: string
```