### PR TITLE
Fixes a bug where HttpContent headers failed to be added to the request in dotnet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where query parameters would not be added to the request in go
 - Fixes a bug where at signs in path would derail generation
 - Fixes Go doc comments in packages and generation
+- Fixes a bug where RequestInformation did not accept some content headers in dotnet 
 
 ## [0.0.14] - 2021-11-08
 

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Text;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Abstractions.Store;
@@ -65,5 +67,36 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             Assert.Contains(expectedString, requestMessage.RequestUri.Query);
         }
 
+        [Fact]
+        public void GetRequestMessageFromRequestInformationSetsContentHeaders()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = HttpMethod.PUT,
+                UrlTemplate = "https://sn3302.up.1drv.com/up/fe6987415ace7X4e1eF866337"
+            };
+            requestInfo.Headers.Add("Content-Length", "26");
+            requestInfo.Headers.Add("Content-Range", "bytes 0-25/128");
+            requestInfo.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes("contents")));
+
+            // Act
+            var requestMessage = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
+
+            // Assert
+            Assert.NotNull(requestMessage.Content);
+            // Content length set correctly
+            Assert.Equal(26,requestMessage.Content.Headers.ContentLength);
+            // Content range set correctly
+            Assert.Equal("bytes", requestMessage.Content.Headers.ContentRange.Unit);
+            Assert.Equal(0, requestMessage.Content.Headers.ContentRange.From);
+            Assert.Equal(25, requestMessage.Content.Headers.ContentRange.To);
+            Assert.Equal(128,requestMessage.Content.Headers.ContentRange.Length);
+            Assert.True(requestMessage.Content.Headers.ContentRange.HasRange);
+            Assert.True(requestMessage.Content.Headers.ContentRange.HasLength);
+            // Content type set correctly
+            Assert.Equal("application/octet-stream", requestMessage.Content.Headers.ContentType.MediaType);
+
+        }
     }
 }

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -217,11 +217,12 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(requestInfo.RequestOptions.Any())
                 requestInfo.RequestOptions.ToList().ForEach(x => message.Properties.Add(x.GetType().FullName, x));
 
-            var contentHeaders = new Dictionary<string, string>();
+if(requestInfo.Content != null)
+                message.Content = new StreamContent(requestInfo.Content);
             if(requestInfo.Headers?.Any() ?? false)
                 foreach(var (key,value) in requestInfo.Headers)
-                    if(!message.Headers.TryAddWithoutValidation(key, value))
-                        contentHeaders.Add(key, value);// if we can't add it to the HttpRequestMessage, its  most likely a HttpContent header. So pass it keep it to be added to the content headers later on.
+                    if(!message.Headers.TryAddWithoutValidation(key, value) && message.Content != null)
+                        message.Content.Headers.TryAddWithoutValidation(key, value);// Try to add the headers we couldn't add to the HttpRequestMessage before to the HttpContent
 
             if(requestInfo.Content != null)
             {

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -217,19 +217,13 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(requestInfo.RequestOptions.Any())
                 requestInfo.RequestOptions.ToList().ForEach(x => message.Properties.Add(x.GetType().FullName, x));
 
-if(requestInfo.Content != null)
+            if(requestInfo.Content != null)
                 message.Content = new StreamContent(requestInfo.Content);
             if(requestInfo.Headers?.Any() ?? false)
                 foreach(var (key,value) in requestInfo.Headers)
                     if(!message.Headers.TryAddWithoutValidation(key, value) && message.Content != null)
                         message.Content.Headers.TryAddWithoutValidation(key, value);// Try to add the headers we couldn't add to the HttpRequestMessage before to the HttpContent
 
-            if(requestInfo.Content != null)
-            {
-                message.Content = new StreamContent(requestInfo.Content);
-                foreach(var (key, value) in contentHeaders)
-                    message.Content.Headers.TryAddWithoutValidation(key, value);// Try to add the headers we couldn't add to the HttpRequestMessage before to the HttpContent
-            }
             return message;
         }
 

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->


### PR DESCRIPTION
This PR closes #849 

It ensures headers are all passed to the final `HttpRequestMessage` by first trying to set them to the `HttpRequestMessage` and setting them to the content header if this first operation is not allowed. 

Tests have been added to reflect/validate this change. 