### PR TITLE
[Abstractions] Add CancellationToken parameter in send methods in dotnet

### DIFF
--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Serialization/ParseNodeFactoryRegistryTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Serialization/ParseNodeFactoryRegistryTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Kiota.Abstractions.Serialization;
 using Moq;
 using Xunit;
 
-namespace Microsoft.Kiota.Abstractions.Tests.serialization
+namespace Microsoft.Kiota.Abstractions.Tests.Serialization
 {
     public class ParseNodeFactoryRegistryTests
     {

--- a/abstractions/dotnet/src/IRequestAdapter.cs
+++ b/abstractions/dotnet/src/IRequestAdapter.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
@@ -28,36 +29,41 @@ namespace Microsoft.Kiota.Abstractions
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model.</returns>
-        Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
+        Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable;
+        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model.</returns>
-        Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default);
+        Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default);
+        Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation with no return content.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>A Task to await completion.</returns>
-        Task SendNoContentAsync(RequestInformation requestInfo, IResponseHandler responseHandler = default);
+        Task SendNoContentAsync(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// The base url for every request.
         /// </summary>

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.24</Version>
+    <Version>1.0.25</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -12,6 +12,7 @@ using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 using Microsoft.Kiota.Abstractions.Authentication;
+using System.Threading;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary
 {
@@ -57,9 +58,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// </summary>
         /// <param name="requestInfo">The <see cref="RequestInformation"/> instance to send</param>
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
-        public async Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default) where ModelType : IParsable
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the request.</param>
+        public async Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default) where ModelType : IParsable
         {
-            var response = await GetHttpResponseMessage(requestInfo);
+            var response = await GetHttpResponseMessage(requestInfo, cancellationToken);
             requestInfo.Content?.Dispose();
             if(responseHandler == null)
             {
@@ -75,9 +77,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the request.</param>
         /// <returns>The deserialized primitive response model collection.</returns>
-        public async Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default) {
-            var response = await GetHttpResponseMessage(requestInfo);
+        public async Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default) {
+            var response = await GetHttpResponseMessage(requestInfo, cancellationToken);
             requestInfo.Content?.Dispose();
             if(responseHandler == null)
             {
@@ -93,9 +96,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// </summary>
         /// <param name="requestInfo">The <see cref="RequestInformation"/> instance to send</param>
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
-        public async Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = null) where ModelType : IParsable
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the request.</param>
+        /// <returns>The deserialized response model.</returns>
+        public async Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = null, CancellationToken cancellationToken = default) where ModelType : IParsable
         {
-            var response = await GetHttpResponseMessage(requestInfo);
+            var response = await GetHttpResponseMessage(requestInfo, cancellationToken);
             requestInfo.Content?.Dispose();
             if(responseHandler == null)
             {
@@ -111,10 +116,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// </summary>
         /// <param name="requestInfo">The <see cref="RequestInformation"/> instance to send</param>
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
-        /// <returns></returns>
-        public async Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default)
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the request.</param>
+        /// <returns>The deserialized primitive response model.</returns>
+        public async Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, CancellationToken cancellationToken = default)
         {
-            var response = await GetHttpResponseMessage(requestInfo);
+            var response = await GetHttpResponseMessage(requestInfo, cancellationToken);
             requestInfo.Content?.Dispose();
             if(responseHandler == null)
             {
@@ -167,10 +173,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// </summary>
         /// <param name="requestInfo">The <see cref="RequestInformation"/> instance to send</param>
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> to use with the response</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the request.</param>
         /// <returns></returns>
-        public async Task SendNoContentAsync(RequestInformation requestInfo, IResponseHandler responseHandler = null)
+        public async Task SendNoContentAsync(RequestInformation requestInfo, IResponseHandler responseHandler = null, CancellationToken cancellationToken = default)
         {
-            var response = await GetHttpResponseMessage(requestInfo);
+            var response = await GetHttpResponseMessage(requestInfo, cancellationToken);
             requestInfo.Content?.Dispose();
             if(responseHandler == null)
                 response.Dispose();
@@ -187,7 +194,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             response.Dispose();
             return rootNode;
         }
-        private async Task<HttpResponseMessage> GetHttpResponseMessage(RequestInformation requestInfo)
+        private async Task<HttpResponseMessage> GetHttpResponseMessage(RequestInformation requestInfo, CancellationToken cancellationToken)
         {
             if(requestInfo == null)
                 throw new ArgumentNullException(nameof(requestInfo));
@@ -195,7 +202,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             await authProvider.AuthenticateRequestAsync(requestInfo);
 
             using var message = GetRequestMessageFromRequestInformation(requestInfo);
-            var response = await this.client.SendAsync(message);
+            var response = await this.client.SendAsync(message,cancellationToken);
             if(response == null)
                 throw new InvalidOperationException("Could not get a response after calling the service");
             return response;

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.15</Version>
+    <Version>1.0.16</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.25" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>

--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -29,6 +29,10 @@ namespace Kiota.Builder
         /// Only used for languages that do not support overloads or optional parameters like go.
         /// </summary>
         ParameterSet,
+        /// <summary>
+        /// A single parameter to be provided by the SDK user which can be used to cancel requests.
+        /// </summary>
+        Cancellation
     }
 
     public class CodeParameter : CodeTerminal, ICloneable, IDocumentedElement

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -579,7 +579,16 @@ namespace Kiota.Builder
                 Description = "Response handler to use in place of the default response handling provided by the core service",
                 Type = new CodeType { Name = "IResponseHandler", IsExternal = true },
             };
-            executorMethod.AddParameter(handlerParam);
+            executorMethod.AddParameter(handlerParam);// Add response handler parameter
+
+            var cancellationParam = new CodeParameter{
+                Name = "cancellationToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancellationToken", IsExternal = true },
+            };
+            executorMethod.AddParameter(cancellationParam);// Add cancellation token parameter
             logger.LogTrace("Creating method {name} of {type}", executorMethod.Name, executorMethod.ReturnType);
 
             var generatorMethod = new CodeMethod {

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -93,6 +93,8 @@ namespace Kiota.Builder.Refiners {
                 "System.Collections.Generic", "List", "Dictionary"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
                 "System.IO", "Stream"),
+            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+                "System.Threading", "CancellationToken"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
                 "System.Threading.Tasks", "Task"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -488,6 +488,13 @@ namespace Kiota.Builder.Refiners {
                     parentClass.AddMethod(overloadCtor);
                 }
             CrawlTree(currentElement, AddRawUrlConstructorOverload);
+        }
+        protected static void RemoveCancellationParameter(CodeElement currentElement){
+            if (currentElement is CodeMethod currentMethod &&
+                currentMethod.IsOfKind(CodeMethodKind.RequestExecutor)){
+                    currentMethod.RemoveParametersByKind(CodeParameterKind.Cancellation);
+            }
+            CrawlTree(currentElement, RemoveCancellationParameter);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Extensions;
@@ -19,6 +19,7 @@ namespace Kiota.Builder.Refiners {
                 generatedCode,
                 false,
                 "ById");
+            RemoveCancellationParameter(generatedCode);
             ReplaceRequestBuilderPropertiesByMethods(
                 generatedCode
             );

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -11,6 +11,7 @@ namespace Kiota.Builder.Refiners {
             AddInnerClasses(generatedCode, false);
             InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
+            RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
             AddRawUrlConstructorOverload(generatedCode);
             ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -11,6 +11,7 @@ namespace Kiota.Builder.Refiners {
         {
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "_by_id");
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
+            RemoveCancellationParameter(generatedCode);
             AddParsableInheritanceForModelClasses(generatedCode);
             AddInheritedAndMethodTypesImports(generatedCode);
             AddDefaultImports(generatedCode, defaultUsingEvaluators);

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System;
 using Kiota.Builder.Extensions;
 
@@ -10,6 +10,7 @@ namespace Kiota.Builder.Refiners {
         {
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
+            RemoveCancellationParameter(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
             AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -178,7 +178,7 @@ namespace Kiota.Builder.Writers.CSharp {
             var parametersList = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options }
                                 .Select(x => x?.Name).Where(x => x != null).Aggregate((x,y) => $"{x}, {y}");
             writer.WriteLine($"var requestInfo = {generatorMethodName}({parametersList});");
-            writer.WriteLine($"{(isVoid ? string.Empty : "return ")}await RequestAdapter.{GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnType)}(requestInfo, responseHandler);");
+            writer.WriteLine($"{(isVoid ? string.Empty : "return ")}await RequestAdapter.{GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnType)}(requestInfo, responseHandler, cancellationToken);");
         }
         private const string RequestInfoVarName = "requestInfo";
         private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -81,6 +81,35 @@ namespace Kiota.Builder.Refiners.Tests {
             Assert.Single(modelNS.GetChildElements(true));
             Assert.Equal(modelNS, model.Parent);
         }
+        [Fact]
+        public void KeepsCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType { 
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.True(method.Parameters.Any());
+            Assert.Contains(cancellationParam, method.Parameters);
+        }
         #endregion
         #region CSharp
         [Fact]

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -1,11 +1,40 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
     public class GoLanguageRefinerTests {
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
         #region CommonLangRefinerTests
-
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
         #endregion
 
         #region GoRefinerTests

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
@@ -135,6 +135,36 @@ namespace Kiota.Builder.Refiners.Tests {
             method.AddParameter(parameter);
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
             Assert.Equal(2, model.GetChildElements(true).Count());
+        }
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
         }
         #endregion
         #region JavaLanguageRefinerTests

--- a/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
@@ -16,6 +16,36 @@ namespace Kiota.Builder.Refiners.Tests {
             graphNS.AddClass(parentClass);
         }
         #region CommonLanguageRefinerTests
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
         [Fact]
         public void AddsDefaultImports() {
             var model = root.AddClass(new CodeClass {

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -161,6 +161,36 @@ namespace Kiota.Builder.Refiners.Tests {
             Assert.NotEmpty(using2.Alias);
             Assert.NotEqual(using1.Alias, using2.Alias);
         }
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
 #endregion
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -130,6 +130,12 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
                 ParameterKind = CodeParameterKind.Options,
                 Type = stringType,
             });
+            method.AddParameter(new CodeParameter
+            {
+                Name = "c",
+                ParameterKind = CodeParameterKind.Cancellation,
+                Type = stringType,
+            });
         }
         [Fact]
         public void WritesRequestBuilder() {
@@ -154,6 +160,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             Assert.Contains("SendAsync", result);
             Assert.Contains(AsyncKeyword, result);
             Assert.Contains("await", result);
+            Assert.Contains("cancellationToken", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
@@ -165,6 +172,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             writer.Write(method);
             var result = tw.ToString();
             Assert.Contains("SendCollectionAsync", result);
+            Assert.Contains("cancellationToken", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]


### PR DESCRIPTION
This PR updates the `IRequestAdapter` interface in the dotnet abstractions library to consume a `CancellationToken` parameter to be forwarded to the client to allow the cancelling of requests

Part of #868 