### PR TITLE
[Generation] Add CancellationToken parameter in send methods in dotnet

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeParameter.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeParameter.cs
@@ -29,6 +29,10 @@ namespace Kiota.Builder
         /// Only used for languages that do not support overloads or optional parameters like go.
         /// </summary>
         ParameterSet,
+        /// <summary>
+        /// A single parameter to be provided by the SDK user which can be used to cancel requests.
+        /// </summary>
+        Cancellation
     }
 
     public class CodeParameter : CodeTerminal, ICloneable, IDocumentedElement

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -579,7 +579,16 @@ namespace Kiota.Builder
                 Description = "Response handler to use in place of the default response handling provided by the core service",
                 Type = new CodeType { Name = "IResponseHandler", IsExternal = true },
             };
-            executorMethod.AddParameter(handlerParam);
+            executorMethod.AddParameter(handlerParam);// Add response handler parameter
+
+            var cancellationParam = new CodeParameter{
+                Name = "cancellationToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancellationToken", IsExternal = true },
+            };
+            executorMethod.AddParameter(cancellationParam);// Add cancellation token parameter
             logger.LogTrace("Creating method {name} of {type}", executorMethod.Name, executorMethod.ReturnType);
 
             var generatorMethod = new CodeMethod {

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -93,6 +93,8 @@ namespace Kiota.Builder.Refiners {
                 "System.Collections.Generic", "List", "Dictionary"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
                 "System.IO", "Stream"),
+            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+                "System.Threading", "CancellationToken"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
                 "System.Threading.Tasks", "Task"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -488,6 +488,13 @@ namespace Kiota.Builder.Refiners {
                     parentClass.AddMethod(overloadCtor);
                 }
             CrawlTree(currentElement, AddRawUrlConstructorOverload);
+        }
+        protected static void RemoveCancellationParameter(CodeElement currentElement){
+            if (currentElement is CodeMethod currentMethod &&
+                currentMethod.IsOfKind(CodeMethodKind.RequestExecutor)){
+                    currentMethod.RemoveParametersByKind(CodeParameterKind.Cancellation);
+            }
+            CrawlTree(currentElement, RemoveCancellationParameter);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Extensions;
@@ -19,6 +19,7 @@ namespace Kiota.Builder.Refiners {
                 generatedCode,
                 false,
                 "ById");
+            RemoveCancellationParameter(generatedCode);
             ReplaceRequestBuilderPropertiesByMethods(
                 generatedCode
             );

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -11,6 +11,7 @@ namespace Kiota.Builder.Refiners {
             AddInnerClasses(generatedCode, false);
             InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
+            RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
             AddRawUrlConstructorOverload(generatedCode);
             ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -11,6 +11,7 @@ namespace Kiota.Builder.Refiners {
         {
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "_by_id");
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
+            RemoveCancellationParameter(generatedCode);
             AddParsableInheritanceForModelClasses(generatedCode);
             AddInheritedAndMethodTypesImports(generatedCode);
             AddDefaultImports(generatedCode, defaultUsingEvaluators);

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System;
 using Kiota.Builder.Extensions;
 
@@ -10,6 +10,7 @@ namespace Kiota.Builder.Refiners {
         {
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
+            RemoveCancellationParameter(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
             AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -178,7 +178,7 @@ namespace Kiota.Builder.Writers.CSharp {
             var parametersList = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options }
                                 .Select(x => x?.Name).Where(x => x != null).Aggregate((x,y) => $"{x}, {y}");
             writer.WriteLine($"var requestInfo = {generatorMethodName}({parametersList});");
-            writer.WriteLine($"{(isVoid ? string.Empty : "return ")}await RequestAdapter.{GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnType)}(requestInfo, responseHandler);");
+            writer.WriteLine($"{(isVoid ? string.Empty : "return ")}await RequestAdapter.{GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnType)}(requestInfo, responseHandler, cancellationToken);");
         }
         private const string RequestInfoVarName = "requestInfo";
         private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -81,6 +81,35 @@ namespace Kiota.Builder.Refiners.Tests {
             Assert.Single(modelNS.GetChildElements(true));
             Assert.Equal(modelNS, model.Parent);
         }
+        [Fact]
+        public void KeepsCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType { 
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.True(method.Parameters.Any());
+            Assert.Contains(cancellationParam, method.Parameters);
+        }
         #endregion
         #region CSharp
         [Fact]

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -1,11 +1,40 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
     public class GoLanguageRefinerTests {
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
         #region CommonLangRefinerTests
-
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
         #endregion
 
         #region GoRefinerTests

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
@@ -135,6 +135,36 @@ namespace Kiota.Builder.Refiners.Tests {
             method.AddParameter(parameter);
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
             Assert.Equal(2, model.GetChildElements(true).Count());
+        }
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
         }
         #endregion
         #region JavaLanguageRefinerTests

--- a/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Xunit;
 
 namespace Kiota.Builder.Refiners.Tests {
@@ -16,6 +16,36 @@ namespace Kiota.Builder.Refiners.Tests {
             graphNS.AddClass(parentClass);
         }
         #region CommonLanguageRefinerTests
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
         [Fact]
         public void AddsDefaultImports() {
             var model = root.AddClass(new CodeClass {

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -161,6 +161,36 @@ namespace Kiota.Builder.Refiners.Tests {
             Assert.NotEmpty(using2.Alias);
             Assert.NotEqual(using1.Alias, using2.Alias);
         }
+        [Fact]
+        public void DoesNotKeepCancellationParametersInRequestExecutors()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.RequestBuilder
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "getMethod",
+                MethodKind = CodeMethodKind.RequestExecutor,
+                ReturnType = new CodeType
+                {
+                    Name = "string"
+                }
+            }).First();
+            var cancellationParam = new CodeParameter
+            {
+                Name = "cancelletionToken",
+                Optional = true,
+                ParameterKind = CodeParameterKind.Cancellation,
+                Description = "Cancellation token to use when cancelling requests",
+                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+            };
+            method.AddParameter(cancellationParam);
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
+            Assert.False(method.Parameters.Any());
+            Assert.DoesNotContain(cancellationParam, method.Parameters);
+        }
 #endregion
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -130,6 +130,12 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
                 ParameterKind = CodeParameterKind.Options,
                 Type = stringType,
             });
+            method.AddParameter(new CodeParameter
+            {
+                Name = "c",
+                ParameterKind = CodeParameterKind.Cancellation,
+                Type = stringType,
+            });
         }
         [Fact]
         public void WritesRequestBuilder() {
@@ -154,6 +160,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             Assert.Contains("SendAsync", result);
             Assert.Contains(AsyncKeyword, result);
             Assert.Contains("await", result);
+            Assert.Contains("cancellationToken", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]
@@ -165,6 +172,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             writer.Write(method);
             var result = tw.ToString();
             Assert.Contains("SendCollectionAsync", result);
+            Assert.Contains("cancellationToken", result);
             AssertExtensions.CurlyBracesAreClosed(result);
         }
         [Fact]


### PR DESCRIPTION
This PR updates the generation of the SDK to pass in a cancellation token to the newly updated send methods created via #875.

Samples generation can be seen at https://github.com/microsoft/kiota-samples/pull/416

Closes #868