### PR TITLE
Go reserved keywords fix and nil check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where RequestInformation did not accept some content headers in dotnet
 - Added support for providing cancellation token in dotnet #874, #875, #876
 - Upgrades go libraries to go17.
+- Fixes a bug in Go where reserved keywords for properties would be wrongly replaced.
 
 ## [0.0.14] - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for providing cancellation token in dotnet #874, #875, #876
 - Upgrades go libraries to go17.
 - Fixes a bug in Go where reserved keywords for properties would be wrongly replaced.
+- Fixes a bug in Go where setters would be missing nil checks.
 
 ## [0.0.14] - 2021-11-08
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -39,7 +39,8 @@ namespace Kiota.Builder.Refiners {
             ReplaceReservedNames(
                 generatedCode,
                 new GoReservedNamesProvider(),
-                x => $"{x}_escaped");
+                x => $"{x}_escaped",
+                shouldReplaceCallback: x => x is not CodeProperty currentProp || currentProp.Access != AccessModifier.Public); // Go reserved keywords are all lowercase and public properties are uppercased
             AddPropertiesAndMethodTypesImports(
                 generatedCode,
                 true,

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -255,10 +255,13 @@ namespace Kiota.Builder.Writers.Go {
         }
         private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
             var backingStore = parentClass.GetBackingStoreProperty();
+            writer.WriteLine("if m != nil {");
+            writer.IncreaseIndent();
             if(backingStore == null)
                 writer.WriteLine($"m.{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value");
             else
                 writer.WriteLine($"m.Get{backingStore.Name.ToFirstCharacterUpperCase()}().Set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value)");
+            writer.CloseBlock();
         }
         private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType) {
             var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -39,6 +39,21 @@ namespace Kiota.Builder.Refiners.Tests {
 
         #region GoRefinerTests
         [Fact]
+        public void DoesNotEscapePublicPropertiesReservedKeywords() {
+            var model = root.AddClass(new CodeClass {
+                Name = "SomeClass",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            var property = model.AddProperty(new CodeProperty {
+                Name = "select",
+                Type = new CodeType { Name = "string" },
+                Access = AccessModifier.Public,
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+            Assert.Equal("select", property.Name);
+            Assert.DoesNotContain("escaped", property.Name);
+        }
+        [Fact]
         public void ReplacesRequestBuilderPropertiesByMethods() {
             var model = root.AddClass(new CodeClass {
                 Name = "someModel",


### PR DESCRIPTION
## Summary

- Fixes #909 a bug in Go where reserved keywords for properties would be wrongly replaced
- fixes #900 a bug in Go where setters would be missing nil checks

## Generation diff

https://github.com/microsoft/kiota-samples/pull/426