### PR TITLE
fixes a bug where reserved keyword replacement in go would miss some cases

### DIFF
--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -40,7 +40,10 @@ namespace Kiota.Builder.Refiners {
                 generatedCode,
                 new GoReservedNamesProvider(),
                 x => $"{x}_escaped",
-                shouldReplaceCallback: x => x is not CodeProperty currentProp || currentProp.Access != AccessModifier.Public); // Go reserved keywords are all lowercase and public properties are uppercased
+                shouldReplaceCallback: x => x is not CodeProperty currentProp || 
+                                            !(currentProp.Parent is CodeClass parentClass &&
+                                            parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&
+                                            currentProp.Access == AccessModifier.Public)); // Go reserved keywords are all lowercase and public properties are uppercased when we don't provide accessors (models)
             AddPropertiesAndMethodTypesImports(
                 generatedCode,
                 true,

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -39,7 +39,21 @@ namespace Kiota.Builder.Refiners.Tests {
 
         #region GoRefinerTests
         [Fact]
-        public void DoesNotEscapePublicPropertiesReservedKeywords() {
+        public void DoesNotEscapePublicPropertiesReservedKeywordsForQueryParameters() {
+            var model = root.AddClass(new CodeClass {
+                Name = "SomeClass",
+                ClassKind = CodeClassKind.QueryParameters
+            }).First();
+            var property = model.AddProperty(new CodeProperty {
+                Name = "select",
+                Type = new CodeType { Name = "string" },
+                Access = AccessModifier.Public,
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+            Assert.Equal("select", property.Name);
+        }
+        [Fact]
+        public void EscapesPublicPropertiesReservedKeywordsForModels() {
             var model = root.AddClass(new CodeClass {
                 Name = "SomeClass",
                 ClassKind = CodeClassKind.Model
@@ -50,8 +64,7 @@ namespace Kiota.Builder.Refiners.Tests {
                 Access = AccessModifier.Public,
             }).First();
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Equal("select", property.Name);
-            Assert.DoesNotContain("escaped", property.Name);
+            Assert.Equal("select_escaped", property.Name);
         }
         [Fact]
         public void ReplacesRequestBuilderPropertiesByMethods() {


### PR DESCRIPTION
related to #910

no diff for the samples but that's because of the source description

related to https://github.com/microsoftgraph/msgraph-beta-sdk-go/pull/25
realted to https://github.com/microsoftgraph/msgraph-sdk-go/pull/39