### PR TITLE
reset middleware pipeline counter on exit

### DIFF
--- a/http/go/nethttp/middleware.go
+++ b/http/go/nethttp/middleware.go
@@ -5,5 +5,5 @@ import nethttp "net/http"
 // Middleware interface for cross cutting concerns with HTTP requests and responses.
 type Middleware interface {
 	// Intercept intercepts the request and returns the response. The implementer MUST call pipeline.Next()
-	Intercept(Pipeline, *nethttp.Request) (*nethttp.Response, error)
+	Intercept(Pipeline, int, *nethttp.Request) (*nethttp.Response, error)
 }

--- a/http/go/nethttp/pipeline.go
+++ b/http/go/nethttp/pipeline.go
@@ -5,7 +5,7 @@ import nethttp "net/http"
 // Pipeline contract for middleware infrastructure
 type Pipeline interface {
 	// Next moves the request object through middlewares in the pipeline
-	Next(req *nethttp.Request) (*nethttp.Response, error)
+	Next(req *nethttp.Request, middlewareIndex int) (*nethttp.Response, error)
 }
 
 // custom transport for net/http with a middleware pipeline
@@ -17,8 +17,6 @@ type customTransport struct {
 
 // middleware pipeline implementation using a roundtripper from net/http
 type middlewarePipeline struct {
-	// index of the middleware beeing executed
-	middlewareIndex int
 	// the round tripper to use to execute the request
 	transport nethttp.RoundTripper
 	// the middlewares to execute
@@ -27,28 +25,16 @@ type middlewarePipeline struct {
 
 func newMiddlewarePipeline(middlewares []Middleware) *middlewarePipeline {
 	return &middlewarePipeline{
-		middlewareIndex: 0,
-		transport:       nethttp.DefaultTransport,
-		middlewares:     middlewares,
+		transport:   nethttp.DefaultTransport,
+		middlewares: middlewares,
 	}
 }
 
-func (pipeline *middlewarePipeline) incrementMiddlewareIndex() {
-	pipeline.middlewareIndex++
-}
-
-func (pipeline *middlewarePipeline) resetMiddlewareIndex() {
-	pipeline.middlewareIndex = 0
-}
-
 // Next moves the request object through middlewares in the pipeline
-func (pipeline *middlewarePipeline) Next(req *nethttp.Request) (*nethttp.Response, error) {
-	defer pipeline.resetMiddlewareIndex()
-	if pipeline.middlewareIndex < len(pipeline.middlewares) {
-		middleware := pipeline.middlewares[pipeline.middlewareIndex]
-
-		pipeline.incrementMiddlewareIndex()
-		return middleware.Intercept(pipeline, req)
+func (pipeline *middlewarePipeline) Next(req *nethttp.Request, middlewareIndex int) (*nethttp.Response, error) {
+	if middlewareIndex < len(pipeline.middlewares) {
+		middleware := pipeline.middlewares[middlewareIndex]
+		return middleware.Intercept(pipeline, middlewareIndex+1, req)
 	}
 
 	return pipeline.transport.RoundTrip(req)
@@ -56,7 +42,7 @@ func (pipeline *middlewarePipeline) Next(req *nethttp.Request) (*nethttp.Respons
 
 // RoundTrip executes the the next middleware and returns a response
 func (transport *customTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
-	return transport.middlewarePipeline.Next(req)
+	return transport.middlewarePipeline.Next(req, 0)
 }
 
 // NewCustomTransport creates a new custom transport for http client with the provided set of middleware

--- a/http/go/nethttp/pipeline.go
+++ b/http/go/nethttp/pipeline.go
@@ -37,8 +37,13 @@ func (pipeline *middlewarePipeline) incrementMiddlewareIndex() {
 	pipeline.middlewareIndex++
 }
 
+func (pipeline *middlewarePipeline) resetMiddlewareIndex() {
+	pipeline.middlewareIndex = 0
+}
+
 // Next moves the request object through middlewares in the pipeline
 func (pipeline *middlewarePipeline) Next(req *nethttp.Request) (*nethttp.Response, error) {
+	defer pipeline.resetMiddlewareIndex()
 	if pipeline.middlewareIndex < len(pipeline.middlewares) {
 		middleware := pipeline.middlewares[pipeline.middlewareIndex]
 

--- a/http/go/nethttp/pipeline_test.go
+++ b/http/go/nethttp/pipeline_test.go
@@ -7,10 +7,10 @@ import (
 
 type TestMiddleware struct{}
 
-func (middleware TestMiddleware) Intercept(pipeline Pipeline, req *http.Request) (*http.Response, error) {
+func (middleware TestMiddleware) Intercept(pipeline Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
 	req.Header.Add("test", "test-header")
 
-	return pipeline.Next(req)
+	return pipeline.Next(req, middlewareIndex)
 }
 
 func TestCanInterceptRequests(t *testing.T) {
@@ -23,5 +23,26 @@ func TestCanInterceptRequests(t *testing.T) {
 
 	if expect != got {
 		t.Errorf("Expected: %v, but received: %v", expect, got)
+	}
+}
+
+func TestCanInterceptMultipleRequests(t *testing.T) {
+	transport := NewCustomTransport(&TestMiddleware{})
+	client := &http.Client{Transport: transport}
+	resp, _ := client.Get("https://example.com")
+
+	expect := "test-header"
+	got := resp.Request.Header.Get("test")
+
+	if expect != got {
+		t.Errorf("Expected: %v, but received: %v", expect, got)
+	}
+
+	resp2, _ := client.Get("https://example.com")
+
+	got2 := resp2.Request.Header.Get("test")
+
+	if expect != got2 {
+		t.Errorf("Expected: %v, but received: %v", expect, got2)
 	}
 }

--- a/http/go/nethttp/redirect_handler_test.go
+++ b/http/go/nethttp/redirect_handler_test.go
@@ -57,7 +57,7 @@ func TestItHonoursShouldRedirect(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}
@@ -79,7 +79,7 @@ func TestItHonoursMaxRedirect(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}

--- a/http/go/nethttp/retry_handler_test.go
+++ b/http/go/nethttp/retry_handler_test.go
@@ -15,7 +15,7 @@ type NoopPipeline struct {
 	client *nethttp.Client
 }
 
-func (pipeline *NoopPipeline) Next(req *nethttp.Request) (*nethttp.Response, error) {
+func (pipeline *NoopPipeline) Next(req *nethttp.Request, middlewareIndex int) (*nethttp.Response, error) {
 	return pipeline.client.Do(req)
 }
 func newNoopPipeline() *NoopPipeline {
@@ -47,7 +47,7 @@ func TestItAddsRetryAttemptHeaders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}
@@ -75,7 +75,7 @@ func TestItHonoursShouldRetry(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +96,7 @@ func TestItHonoursMaxRetries(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}
@@ -118,7 +118,7 @@ func TestItDoesntRetryOnSuccess(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resp, err := handler.Intercept(newNoopPipeline(), req)
+	resp, err := handler.Intercept(newNoopPipeline(), 0, req)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
When making an API call that goes down the
http/go/nethttp/pipeline.go Next()->middleware.Intercept()->Next() loop,
the pipeline.middlewareIndex variable keeps track to make sure the next
Intercept() call is made in the chain.

After all of them have done their work and the results are being
returned to the original API caller, the middlewareIndex is left at
non-zero, so subsequent calls down the pipeline.go path will fail to
make all the middleware.Intercept() calls as middlewareIndex is not less
than len(middlewares).

Add a defer so that the index gets reset to zero when exiting the
function call chain so that sequential passes down the pipeline chain
can behave like the very first call.