### PR TITLE
Use dotnet cli to update nuget sources

### DIFF
--- a/.github/workflows/authentication-dotnet-azure.yml
+++ b/.github/workflows/authentication-dotnet-azure.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      NUGET_URL: https://nuget.pkg.github.com/microsoft/index.json
       relativePath: ./authentication/dotnet/azure
       solutionName: Microsoft.Kiota.Authentication.Azure.sln
     steps:
@@ -20,8 +21,10 @@ jobs:
         uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: 6.0.x
-      - run: ./scripts/updateNugetCredentials.ps1 -username "${{ secrets.PUBLISH_GH_USERNAME }}" -apiToken "${{ secrets.PUBLISH_GH_TOKEN }}" -nugetFileAbsolutePath "${{ env.relativePath }}/nuget.config"
-        shell: pwsh
+      - name: Add NuGet kiota source
+        # NOTE: Password encryption is not supported for the linux platform (Encryption is only supported on Windows platforms.)
+        run: |
+          dotnet nuget add source ${{env.NUGET_URL}} -n github -u ${{secrets.PUBLISH_GH_USERNAME}} -p ${{secrets.PUBLISH_GH_TOKEN}} --store-password-in-clear-text
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
         working-directory: ${{ env.relativePath }}
@@ -49,8 +52,6 @@ jobs:
           name: drop
           path: |
             ${{ env.relativePath }}/src/bin/Release/*.nupkg
-      - run: rm ${{ env.relativePath }}/nuget.config
-        if: always()
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment:

--- a/.github/workflows/http-dotnet-httpclient.yml
+++ b/.github/workflows/http-dotnet-httpclient.yml
@@ -52,8 +52,6 @@ jobs:
           name: drop
           path: |
             ${{ env.relativePath }}/src/bin/Release/*.nupkg
-      - run: rm ${{ env.relativePath }}/nuget.config
-        if: always()
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment:

--- a/.github/workflows/http-dotnet-httpclient.yml
+++ b/.github/workflows/http-dotnet-httpclient.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      NUGET_URL: https://nuget.pkg.github.com/microsoft/index.json
       relativePath: ./http/dotnet/httpclient
       solutionName: Microsoft.Kiota.Http.HttpClientLibrary.sln
     steps:
@@ -20,8 +21,10 @@ jobs:
         uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: 6.0.x
-      - run: ./scripts/updateNugetCredentials.ps1 -username "${{ secrets.PUBLISH_GH_USERNAME }}" -apiToken "${{ secrets.PUBLISH_GH_TOKEN }}" -nugetFileAbsolutePath "${{ env.relativePath }}/nuget.config"
-        shell: pwsh
+      - name: Add NuGet kiota source
+        # NOTE: Password encryption is not supported for the linux platform (Encryption is only supported on Windows platforms.)
+        run: |
+          dotnet nuget add source ${{env.NUGET_URL}} -n github -u ${{secrets.PUBLISH_GH_USERNAME}} -p ${{secrets.PUBLISH_GH_TOKEN}} --store-password-in-clear-text
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
         working-directory: ${{ env.relativePath }}

--- a/.github/workflows/serialization-dotnet-json.yml
+++ b/.github/workflows/serialization-dotnet-json.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      NUGET_URL: https://nuget.pkg.github.com/microsoft/index.json
       relativePath: ./serialization/dotnet/json
       solutionName: Microsoft.Kiota.Serialization.Json.sln
     steps:
@@ -20,8 +21,10 @@ jobs:
         uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: 6.0.x
-      - run: ./scripts/updateNugetCredentials.ps1 -username "${{ secrets.PUBLISH_GH_USERNAME }}" -apiToken "${{ secrets.PUBLISH_GH_TOKEN }}" -nugetFileAbsolutePath "${{ env.relativePath }}/nuget.config"
-        shell: pwsh
+      - name: Add NuGet kiota source
+        # NOTE: Password encryption is not supported for the linux platform (Encryption is only supported on Windows platforms.)
+        run: |
+          dotnet nuget add source ${{env.NUGET_URL}} -n github -u ${{secrets.PUBLISH_GH_USERNAME}} -p ${{secrets.PUBLISH_GH_TOKEN}} --store-password-in-clear-text
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
         working-directory: ${{ env.relativePath }}
@@ -49,8 +52,6 @@ jobs:
           name: drop
           path: |
             ${{ env.relativePath }}/src/bin/Release/*.nupkg
-      - run: rm ${{ env.relativePath }}/nuget.config
-        if: always()
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment:

--- a/scripts/updateNugetCredentials.ps1
+++ b/scripts/updateNugetCredentials.ps1
@@ -1,8 +1,0 @@
-param([Parameter(Mandatory=$true)][string]$username, [Parameter(Mandatory=$true)][string]$apiToken, [Parameter(Mandatory=$true)][string]$nugetFileAbsolutePath)
-$template = "<?xml version=`"1.0`" encoding=`"utf-8`"?><configuration><packageSources><add key=`"GitHub`" value=`"https://nuget.pkg.github.com/microsoft/index.json`" /></packageSources><packageSourceCredentials><GitHub><add key=`"Username`" value=`"`" /><add key=`"ClearTextPassword`" value=`"`" /></GitHub></packageSourceCredentials></configuration>"
-[xml]$nugetConfigFileContent = [xml]$template
-$userEntry = $nugetConfigFileContent.configuration.packageSourceCredentials.GitHub.add | Where-Object {$_.key -eq "Username"} | Select-Object -First 1
-$userEntry.value = $username
-$tokenEntry = $nugetConfigFileContent.configuration.packageSourceCredentials.GitHub.add | Where-Object {$_.key -eq "ClearTextPassword"} | Select-Object -First 1
-$tokenEntry.value = $apiToken
-Set-Content -Path $nugetFileAbsolutePath -Value $nugetConfigFileContent.InnerXml -Encoding UTF8


### PR DESCRIPTION
Reduces amount of code needed by the pipeline (PowerShell script `scripts/updateNugetCredentials.ps1` isn't needed anymore)