### PR TITLE
Add PHP RetryHandler

### DIFF
--- a/.github/workflows/http-php-guzzle.yml
+++ b/.github/workflows/http-php-guzzle.yml
@@ -1,0 +1,32 @@
+﻿name: PHP Http
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths: ['http/php/guzzle/**', '.github/workflows/**']
+  pull_request:
+    paths: ['http/php/guzzle/**', '.github/workflows/**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./http/php/guzzle
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+      - name: Setup PHP and Xdebug for Code Coverage report
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install
+        working-directory: ${{ env.relativePath }}
+      - name: Run static analysis
+        run: ./vendor/bin/phpstan
+        working-directory: ${{ env.relativePath }}
+      - name: Run tests
+        run: ./vendor/bin/phpunit --coverage-text
+        working-directory: ${{ env.relativePath }}

--- a/http/php/guzzle/.editorconfig
+++ b/http/php/guzzle/.editorconfig
@@ -1,0 +1,27 @@
+# top-most EditorConfig file
+root = true
+
+# All PHP files MUST use the Unix LF (linefeed) line ending.
+# Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
+# All PHP files MUST end with a single blank line.
+# There MUST NOT be trailing whitespace at the end of non-blank lines.
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# PHP-Files, Composer.json, MD-Files
+[{*.php,composer.json,*.md}]
+indent_style = space
+indent_size = 4
+
+# HTML-Files LESS-Files SASS-Files CSS-Files JS-Files JSON-Files
+[{*.html,*.less,*.sass,*.css,*.js,*.json}]
+indent_style = tab
+indent_size = 4
+
+# Gitlab-CI, Travis-CI
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/http/php/guzzle/.gitattributes
+++ b/http/php/guzzle/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+*.{png,jpg,jpeg,gif,webp,woff,woff2} binary
+/coverage export-ignore
+/docs export-ignore
+/vendor export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/http/php/guzzle/.gitignore
+++ b/http/php/guzzle/.gitignore
@@ -1,0 +1,8 @@
+composer.phar
+composer.lock
+/vendor/
+/coverage
+.idea/
+tests/Functional/TestConstants.php
+.phpunit.result.cache
+.phpdoc/

--- a/http/php/guzzle/README.md
+++ b/http/php/guzzle/README.md
@@ -1,0 +1,10 @@
+# To-do
+
+![PHP](https://github.com/microsoft/kiota/actions/workflows/http-php-guzzle.yml/badge.svg)
+
+- [ ] Implement RequestAdapter
+- [ ] Implement Middleware
+
+## Using the Http Guzzle implementations
+
+1. Add the package using `composer require microsoft/kiota-http-guzzle`

--- a/http/php/guzzle/README.md
+++ b/http/php/guzzle/README.md
@@ -2,8 +2,10 @@
 
 ![PHP](https://github.com/microsoft/kiota/actions/workflows/http-php-guzzle.yml/badge.svg)
 
+- [ ] Add Abstractions package as dependency
 - [ ] Implement RequestAdapter
 - [ ] Implement Middleware
+- [ ] Ensure Middleware Options extend Abstractions RequestOption interface
 
 ## Using the Http Guzzle implementations
 

--- a/http/php/guzzle/composer.json
+++ b/http/php/guzzle/composer.json
@@ -9,8 +9,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.2"
-    },
+        "phpstan/phpstan": "^1.2",
+		"ext-json": "*"
+	},
     "license": "MIT",
     "authors": [
         {

--- a/http/php/guzzle/composer.json
+++ b/http/php/guzzle/composer.json
@@ -2,7 +2,8 @@
     "name": "microsoft/kiota-http-guzzle",
     "description": "Kiota Request Adapter implementation",
     "type": "library",
-    "require": {
+	"require": {
+		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug": "^2.2"
     },
@@ -16,5 +17,15 @@
             "name": "Microsoft Graph Client Tooling",
             "email": "graphtooling@service.microsoft.com"
         }
-    ]
+    ],
+	"autoload": {
+		"psr-4": {
+			"Microsoft\\Kiota\\Http\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Microsoft\\Kiota\\Http\\Test\\": "tests/"
+		}
+	}
 }

--- a/http/php/guzzle/composer.json
+++ b/http/php/guzzle/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "microsoft/kiota-http-guzzle",
+    "description": "Kiota Request Adapter implementation",
+    "type": "library",
+    "require": {
+        "php-http/guzzle7-adapter": "^1.0",
+        "php-http/httplug": "^2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.2"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Microsoft Graph Client Tooling",
+            "email": "graphtooling@service.microsoft.com"
+        }
+    ]
+}

--- a/http/php/guzzle/phpstan.neon
+++ b/http/php/guzzle/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+	level: 3
+	polluteScopeWithAlwaysIterableForeach: false
+	polluteScopeWithLoopInitialAssignments: false
+	paths:
+		- src
+		- tests

--- a/http/php/guzzle/phpunit.xml
+++ b/http/php/guzzle/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+	<testsuites>
+		<testsuite name="Kiota Guzzle Test Suite">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+	<coverage pathCoverage="true">
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+		<report>
+			<html outputDirectory="coverage"/>
+		</report>
+	</coverage>
+</phpunit>

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -29,7 +29,7 @@ class KiotaMiddleware
      * @param RetryOption|null $retryOption
      * @return callable
      */
-    public static function retry(?RetryOption $retryOption): callable
+    public static function retry(?RetryOption $retryOption = null): callable
     {
         return static function (callable $handler) use ($retryOption) : RetryHandler {
             return new RetryHandler($retryOption, $handler);

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware;
+
+use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
+
+/**
+ * Class KiotaMiddleware
+ *
+ * Utility methods to expose middleware components and easily add them to Guzzle's HandlerStack
+ *
+ * @package Microsoft\Kiota\Http\Middleware
+ * @copyright 2021 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class KiotaMiddleware
+{
+    /**
+     * Middleware that retries requests for 429,503 and 504 response status codes (by default) while respecting the Retry-After response header
+     * Configurable using {@link RetryOption}
+     *
+     * @param RetryOption|null $retryOption
+     * @return callable
+     */
+    public static function retry(?RetryOption $retryOption): callable
+    {
+        return static function (callable $handler) use ($retryOption) : RetryHandler {
+            return new RetryHandler($retryOption, $handler);
+        };
+    }
+}

--- a/http/php/guzzle/src/Middleware/Options/RetryOption.php
+++ b/http/php/guzzle/src/Middleware/Options/RetryOption.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware\Options;
+
+use Microsoft\Kiota\Http\Middleware\RetryHandler;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class RetryOption
+ *
+ * Options that configure {@link RetryHandler}
+ *
+ * @package Microsoft\Kiota\Http\Middleware\Options
+ * @copyright 2021 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class RetryOption
+{
+    /**
+     * Upper limit on {@link $maxRetries}
+     */
+    private const MAX_MAX_RETRIES = 10;
+    /**
+     * Upper limit on {@link $delaySeconds}
+     */
+    private const MAX_DELAY_SEC = 180;
+
+    /**
+     * @var int Max number of times a request can be resent
+     */
+    private int $maxRetries = 3;
+    /**
+     * @var int Minimum amount of time to wait before retrying
+     * This changes if the ResponseInterface contains a Retry-After header.
+     * If $delayMilliseconds < Retry-After value, delay is set to Retry-After value
+     */
+    private int $delaySeconds = 3;
+    /**
+     * @var \DateInterval Cumulative retry time (Retry-After + Retry request time) after which the previous failed response is returned
+     */
+    private \DateInterval $retriesTimeLimit;
+    /**
+     * @var callable(int, int, ResponseInterface):bool $sh Custom callback function to determine if request should be retried
+     * The callback should accept a delay time in seconds, number of retry attempts and a {@link ResponseInterface} and return a bool
+     */
+    private $shouldRetry;
+
+    public function __construct()
+    {
+        // Set defaults
+        $this->retriesTimeLimit = new \DateInterval("0");
+        $this->shouldRetry = function ($delaySec, $retries, $response) {
+            return true;
+        };
+    }
+
+    /**
+     * @param int $maxRetries
+     * @return RetryOption
+     */
+    public function setMaxRetries(int $maxRetries): self
+    {
+        if ($maxRetries > self::MAX_MAX_RETRIES) {
+            throw new \InvalidArgumentException("Max retries exceeded maximum limit of ".self::MAX_MAX_RETRIES);
+        }
+        $this->maxRetries = $maxRetries;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxRetries(): int
+    {
+        return $this->maxRetries;
+    }
+
+    /**
+     * @param int $delaySeconds
+     * @return RetryOption
+     */
+    public function setDelay(int $delaySeconds): self
+    {
+        if ($delaySeconds > self::MAX_DELAY_SEC) {
+            throw new \InvalidArgumentException("Delay exceeds max delay limit of ".self::MAX_DELAY_SEC);
+        }
+        $this->delaySeconds = $delaySeconds;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDelay(): int
+    {
+        return $this->delaySeconds;
+    }
+
+    /**
+     * @param \DateInterval $retriesTimeLimit {@link $retriesTimeLimit}
+     */
+    public function setRetriesTimeLimit(\DateInterval $retriesTimeLimit): self
+    {
+        $this->retriesTimeLimit = $retriesTimeLimit;
+        return $this;
+    }
+
+    /**
+     * @return \DateInterval
+     */
+    public function getRetriesTimeLimit(): \DateInterval
+    {
+        return $this->retriesTimeLimit;
+    }
+
+    /**
+     * @param callable(int, int, ResponseInterface):bool $shouldRetry {@link $shouldRetry}
+     */
+    public function setShouldRetry(callable $shouldRetry): self
+    {
+        $this->shouldRetry = $shouldRetry;
+        return $this;
+    }
+
+    /**
+     * @return callable(int, int, ResponseInterface):bool
+     */
+    public function getShouldRetry(): callable
+    {
+        return $this->shouldRetry;
+    }
+}

--- a/http/php/guzzle/src/Middleware/Options/RetryOption.php
+++ b/http/php/guzzle/src/Middleware/Options/RetryOption.php
@@ -124,9 +124,10 @@ class RetryOption
     /**
      * Default set to null
      *
-     * @param \DateInterval $retriesTimeLimit {@link $retriesTimeLimit}
+     * @param \DateInterval|null $retriesTimeLimit {@link $retriesTimeLimit}
+     * @return RetryOption
      */
-    public function setRetriesTimeLimit(\DateInterval $retriesTimeLimit): self
+    public function setRetriesTimeLimit(?\DateInterval $retriesTimeLimit): self
     {
         $this->retriesTimeLimit = $retriesTimeLimit;
         return $this;
@@ -142,6 +143,8 @@ class RetryOption
 
     /**
      * Default returns true
+     * Custom callback function to determine if request should be retried
+     * The callback should accept a delay time in seconds, number of retry attempts and a {@link ResponseInterface} and return a bool
      *
      * @param callable(int, int, ResponseInterface):bool $shouldRetry {@link $shouldRetry}
      */

--- a/http/php/guzzle/src/Middleware/RetryHandler.php
+++ b/http/php/guzzle/src/Middleware/RetryHandler.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class RetryHandler
+ *
+ * @package Microsoft\Kiota\Http\Middleware
+ * @copyright 2021 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class RetryHandler
+{
+    private const RETRY_AFTER_HEADER = "Retry-After";
+    private const RETRY_ATTEMPT_HEADER = "Retry-Attempt";
+
+    /**
+     * @var RetryOption configuration options for the middleware
+     */
+    private RetryOption $retryOption;
+    /**
+     * @var callable(RequestInterface, array): PromiseInterface
+     */
+    private $nextHandler;
+
+    /**
+     * @var int Seconds to delay after parsing Retry-After header and comparing it with $retryOption delay
+     */
+    private int $delaySecs;
+
+    /**
+     * @param RetryOption|null $retryOption
+     * @param callable $nextHandler
+     */
+    public function __construct(?RetryOption $retryOption, callable $nextHandler)
+    {
+        $this->retryOption = ($retryOption) ?: new RetryOption();
+        $this->nextHandler = $nextHandler;
+    }
+
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        $fn = $this->nextHandler;
+        return $fn($request, $options)->then(
+            $this->onFulfilled($request, $options),
+            function ($reason) {
+                throw $reason;
+            }
+        );
+    }
+
+    private function onFulfilled(RequestInterface $request, array $guzzleOptions): callable
+    {
+        return function (ResponseInterface $response) use ($request, $guzzleOptions) {
+            $startTimeSecs = (new \DateTime())->getTimestamp();
+            if (!$this->isRetryStatusCode($response->getStatusCode())
+                || (array_key_exists('retries', $guzzleOptions) &&  $guzzleOptions['retries'] > $this->retryOption->getMaxRetries())
+                || !$request->getBody()->isSeekable()
+            ) {
+                return $response;
+            }
+
+            $delayPromise = $this->delay($response, $guzzleOptions);
+
+            if (!$this->retryOption->getShouldRetry()($this->delaySecs, $guzzleOptions['retries'], $response)) {
+                $delayPromise->cancel();
+                return $response;
+            }
+
+            // Check retriesTimeLimit
+            $processingTimeSecs = (new \DateTime())->getTimestamp() - $startTimeSecs;
+            $retriesLimitSecs = date_create("@0")->add($this->retryOption->getRetriesTimeLimit())->getTimestamp();
+            if (($processingTimeSecs + $this->delaySecs) > $retriesLimitSecs) {
+                $delayPromise->cancel();
+                return $response;
+            }
+
+            if (array_key_exists('retries', $guzzleOptions)) {
+                $guzzleOptions['retries'] ++;
+            } else {
+                $guzzleOptions['retries'] = 1;
+            }
+            $request = $request->withAddedHeader(self::RETRY_ATTEMPT_HEADER, strval($guzzleOptions['retries']));
+            $request->getBody()->rewind();
+            $delayPromise->wait();
+            return $this($request, $guzzleOptions);
+        };
+    }
+
+    /**
+     * Returns true if Http Status Code warrants a retry
+     *
+     * @param int $httpStatusCode
+     * @return bool
+     */
+    private function isRetryStatusCode(int $httpStatusCode): bool
+    {
+        return ($httpStatusCode == 429 || $httpStatusCode == 503 || $httpStatusCode == 504);
+    }
+
+    /**
+     * Determines the correct delay period and sleeps
+     *
+     * @param ResponseInterface $response
+     * @param array $options
+     * @return PromiseInterface
+     */
+    private function delay(ResponseInterface $response, array $options): PromiseInterface
+    {
+        $this->delaySecs = $this->retryOption->getDelay();
+        if ($response->hasHeader(self::RETRY_AFTER_HEADER)) {
+            $retryAfterValue = $response->getHeader(self::RETRY_AFTER_HEADER)[0];
+            $retryAfterSeconds = $this->parseRetryAfterToSeconds($retryAfterValue);
+            $this->delaySecs = ($this->delaySecs > $retryAfterSeconds) ?: $retryAfterSeconds;
+        } else {
+            $this->delaySecs = $this->exponentialDelay($options['retries'] + 1);
+        }
+        return new Promise(
+            function () {
+                sleep($this->delaySecs);
+            }
+        );
+    }
+
+    /**
+     * Parses Http Retry-After values of type <http-date> of <delay-seconds>
+     *
+     * @param string $retryAfterValue Retry-After value formatted as <http-date> or <delay-seconds>
+     * @return int number of seconds
+     */
+    private function parseRetryAfterToSeconds(string $retryAfterValue): int
+    {
+        if (is_numeric($retryAfterValue)) {
+            return strval($retryAfterValue);
+        }
+        $retryAfterDateTime = \DateTime::createFromFormat(\DateTimeInterface::RFC7231, $retryAfterValue);
+        if (!$retryAfterDateTime) {
+            throw new \RuntimeException("Unable to parse Retry-After header value $retryAfterValue");
+        }
+        return $retryAfterDateTime->getTimestamp() - (new \DateTime())->getTimestamp();
+    }
+
+    /**
+     * Default exponential backoff delay function.
+     *
+     * @return int milliseconds.
+     */
+    private function exponentialDelay(int $retries): int
+    {
+        return (int) \pow(2, $retries - 1) * $this->retryOption->getDelay();
+    }
+}

--- a/http/php/guzzle/tests/Middleware/RetryHandlerTest.php
+++ b/http/php/guzzle/tests/Middleware/RetryHandlerTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Microsoft\Kiota\Http\Test\Middleware;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Middleware\KiotaMiddleware;
+use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
+use Microsoft\Kiota\Http\Middleware\RetryHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class RetryHandlerTest extends TestCase
+{
+
+    public function testRetryStatusCodes()
+    {
+        $requestIdHeader = "Request-Id";
+        $requestId = "123";
+        $requestRetried = false;
+        $responseCallback = function (RequestInterface $request, array $options) use ($requestIdHeader, $requestId, &$requestRetried) {
+            if ($request->hasHeader($requestIdHeader)
+                && $request->getHeader($requestIdHeader)[0] === $requestId) {
+                $requestRetried = true;
+            }
+            return new Response(200);
+        } ;
+
+        $mockResponses = [
+            new Response(429),
+            new Response(503),
+            new Response(504),
+            $responseCallback
+        ];
+        $this->executeMockRequestWithRetryHandler($mockResponses, null, ['headers' => [$requestIdHeader => $requestId]]);
+        $this->assertTrue($requestRetried);
+    }
+
+    public function testDelayUsingRetryOption()
+    {
+        $delaySecs = 5;
+        $retryOption = (new RetryOption())->setDelay($delaySecs);
+        $mockResponses = [
+            new Response(429),
+            function (RequestInterface $request, array $options) use ($delaySecs) {
+                if (array_key_exists('delay', $options) && $options['delay'] === $delaySecs) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Expected delay is not set");
+            }
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDelayUsingRetryAfterHeaderSecondsValue()
+    {
+        $retryOption = new RetryOption();
+        $retryAfterSecs = 120;
+        $mockResponses = [
+            new Response(429, ['Retry-After' => $retryAfterSecs]),
+            function (RequestInterface $request, array $options) use ($retryOption) {
+                if (array_key_exists('delay', $options) && $options['delay'] > $retryOption->getDelay()) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Expected delay is not set");
+            }
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRetryHandlerDelaysUsingRetryAfterHeaderDateValue()
+    {
+        $retryOption = new RetryOption();
+        $retryAfterSecs = (new \DateTime())->getTimestamp() + 120;
+        $retryAfterDate = new \DateTime("@$retryAfterSecs");
+        $mockResponses = [
+            new Response(429, ['Retry-After' => $retryAfterDate->format(\DateTimeInterface::RFC7231)]),
+            function (RequestInterface $request, array $options) use ($retryOption) {
+                if (array_key_exists('delay', $options) && $options['delay'] > $retryOption->getDelay()) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Expected delay is not set");
+            }
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRetryHandlerDelaysUsingExponentialBackoff()
+    {
+        $retryOption = new RetryOption();
+        $mockResponses = [
+            new Response(429),
+            new Response(429),
+            function (RequestInterface $request, array $options) use ($retryOption) {
+                if (array_key_exists('delay', $options)
+                    && $options['delay'] === RetryHandler::exponentialDelay(2, $retryOption->getDelay())) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Expected delay is not set");
+            }
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRetryAttemptHeaderIsAccurate()
+    {
+        $mockResponses = [
+            new Response(429),
+            function (RequestInterface $request, array $options) {
+                if ($request->hasHeader('Retry-Attempt')
+                    && $request->getHeader('Retry-Attempt')[0] == 1) {
+                    return new Response(429);
+                }
+                return new \RuntimeException("Wrong retry-attempt value found");
+            },
+            function (RequestInterface $request, array $options) {
+                if ($request->hasHeader('Retry-Attempt')
+                    && $request->getHeader('Retry-Attempt')[0] == 2) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Wrong retry-attempt value found");
+            }
+        ];
+
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRequestPayloadNotManipulatedDuringRetry()
+    {
+        $initialRequestBody = [
+            'userId' => 1
+        ];
+        $mockResponse = [
+            new Response(429),
+            function (RequestInterface $request, array $options) use ($initialRequestBody) {
+                $retryRequestBody = json_decode($request->getBody()->getContents(), true);
+                if ($initialRequestBody == $retryRequestBody) {
+                    return new Response(200);
+                }
+                return new \RuntimeException("Retry Request body has been manipulated");
+            }
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponse, new RetryOption(), ['body' => json_encode($initialRequestBody)]);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBadResponseExceptionsCauseRetry()
+    {
+        $mockResponses = [
+            new BadResponseException("429 returned", new Request("GET", "/"), new Response(429)),
+            new Response(200)
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, new RetryOption(), ['http_errors' => true]);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testNonBadResponseExceptionsDontRetry()
+    {
+        $this->expectException(NetworkExceptionInterface::class);
+        $mockResponses = [
+            $this->createMock(NetworkExceptionInterface::class)
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testShouldRetryCallbackIsConsidered()
+    {
+        $shouldRetry = function (int $delay, int $retries, ResponseInterface $response) {
+            return false;
+        };
+        $retryOption = (new RetryOption())->setShouldRetry($shouldRetry);
+        $mockResponses = [
+            new Response(429)
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+
+    public function testRetriesTimeLimitIsNotExceeded()
+    {
+        $retriesTimeLimit = new \DateInterval("PT20S");
+        $retryOption = (new RetryOption())->setDelay(100)->setRetriesTimeLimit($retriesTimeLimit);
+        $mockResponses = [
+            new Response(429)
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+
+    public function testMaxRetriesNotExceeded()
+    {
+        $retryOption = (new RetryOption())->setMaxRetries(1);
+        $mockResponses = [
+            new Response(429),
+            new Response(429),
+            new Response(429)
+        ];
+        $response = $this->executeMockRequestWithRetryHandler($mockResponses, $retryOption);
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+
+
+    private function executeMockRequestWithRetryHandler(array $mockResponses, ?RetryOption $retryOption = null, ?array $requestOptions = []) : ResponseInterface
+    {
+        $mockHandler = new MockHandler($mockResponses);
+        $handlerStack = new HandlerStack($mockHandler);
+        $retryOption = $retryOption ?: new RetryOption();
+        $handlerStack->push(KiotaMiddleware::retry($retryOption));
+
+        $guzzleClient = new Client(['handler' => $handlerStack, 'http_errors' => false]);
+        return $guzzleClient->get("/", $requestOptions);
+    }
+}


### PR DESCRIPTION
- Initialises PHP's HTTP Core package
- Implements a default RetryHandler that plugs into Guzzle's middleware pipeline

Pending for PR to be ready:
- [x] Unit tests

Addresses #596 
Part of #364 