### PR TITLE
Fixes a bug where Java and Go escaped model properties would not serialize properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug in Go where setters would be missing nil checks.
 - Fixes a bug where OData select query parameter would not be normalized
 - Fixes a bug in Go where empty collections would not be serialized.
+- Fixes a bug where Java generation would fail because of empty usings.
 
 ## [0.0.14] - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where OData select query parameter would not be normalized
 - Fixes a bug in Go where empty collections would not be serialized.
 - Fixes a bug where Java generation would fail because of empty usings.
+- Fixes a bug where Java and Go escaped model properties would not serialize properly.
 
 ## [0.0.14] - 2021-11-08
 

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -51,6 +51,7 @@ namespace Kiota.Builder
         public string Description {get; set;}
         public string SerializationName { get; set; }
         public string NamePrefix { get; set; }
+        public bool IsNameEscaped { get; set; }
         public bool IsOfKind(params CodePropertyKind[] kinds) {
             return kinds?.Contains(PropertyKind) ?? false;
         }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -187,21 +187,21 @@ namespace Kiota.Builder.Refiners {
                     currentProperty.Type is CodeType propertyType &&
                     !propertyType.IsExternal &&
                     provider.ReservedNames.Contains(currentProperty.Type.Name))
-            {
-                if(currentProperty.IsOfKind(CodePropertyKind.Custom)) {
-                    currentProperty.SerializationName = currentProperty.Name;
-                    currentProperty.IsNameEscaped = true;
-                }
                 propertyType.Name = replacement.Invoke(propertyType.Name);
-            }
             // Check if the current name meets the following conditions to be replaced
             // 1. In the list of reserved names
             // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
             // 3. There's not a very specific condition preventing from replacement
             if (provider.ReservedNames.Contains(current.Name) &&
                 isNotInExceptions &&
-                shouldReplace)
+                shouldReplace) {
+                if(current is CodeProperty currentProperty &&
+                    currentProperty.IsOfKind(CodePropertyKind.Custom)) {
+                    currentProperty.SerializationName = currentProperty.Name;
+                    currentProperty.IsNameEscaped = true;
+                }
                 current.Name = replacement.Invoke(current.Name);
+            }
 
             CrawlTree(current, x => ReplaceReservedNames(x, provider, replacement, codeElementExceptions, shouldReplaceCallback));
         }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -132,6 +132,10 @@ namespace Kiota.Builder.Writers.Go {
             var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
             var methodName = code.MethodKind switch {
                 CodeMethodKind.Constructor when parentClass.IsOfKind(CodeClassKind.RequestBuilder) => $"New{code.Parent.Name.ToFirstCharacterUpperCase()}Internal", // internal instantiation with url template parameters
+                CodeMethodKind.Getter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                    => $"Get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
+                CodeMethodKind.Setter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                    => $"Set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Getter => $"Get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Setter => $"Set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 _ when isConstructor => $"New{code.Parent.Name.ToFirstCharacterUpperCase()}",

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -132,9 +132,9 @@ namespace Kiota.Builder.Writers.Go {
             var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
             var methodName = code.MethodKind switch {
                 CodeMethodKind.Constructor when parentClass.IsOfKind(CodeClassKind.RequestBuilder) => $"New{code.Parent.Name.ToFirstCharacterUpperCase()}Internal", // internal instantiation with url template parameters
-                CodeMethodKind.Getter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                CodeMethodKind.Getter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
                     => $"Get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
-                CodeMethodKind.Setter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                CodeMethodKind.Setter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
                     => $"Set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Getter => $"Get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Setter => $"Set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -110,8 +110,10 @@ namespace Kiota.Builder.Writers.Go {
                 WriteReturnError(writer);
                 shouldDeclareErrorVar = false;
             }
-            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom))
-                WriteSerializationMethodCall(otherProp.Type, parentClass, otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase(), $"m.Get{otherProp.Name.ToFirstCharacterUpperCase()}()", shouldDeclareErrorVar, writer);
+            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
+                var accessorName = otherProp.IsNameEscaped && !string.IsNullOrEmpty(otherProp.SerializationName) ? otherProp.SerializationName : otherProp.Name.ToFirstCharacterLowerCase();
+                WriteSerializationMethodCall(otherProp.Type, parentClass, otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase(), $"m.Get{accessorName.ToFirstCharacterUpperCase()}()", shouldDeclareErrorVar, writer);
+            }
             if(additionalDataProperty != null) {
                 writer.WriteLine("{");
                 writer.IncreaseIndent();
@@ -305,7 +307,8 @@ namespace Kiota.Builder.Writers.Go {
             };
             if(property.Type.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None)
                 WriteCollectionCast(propertyTypeImportName, "val", "res", writer);
-            writer.WriteLine($"m.Set{property.Name.ToFirstCharacterUpperCase()}({valueArgument})");
+            var setterName = property.IsNameEscaped && !string.IsNullOrEmpty(property.SerializationName) ? property.SerializationName : property.Name;
+            writer.WriteLine($"m.Set{setterName.ToFirstCharacterUpperCase()}({valueArgument})");
             writer.CloseBlock();
             writer.WriteLine("return nil");
             writer.CloseBlock();

--- a/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
@@ -12,6 +12,7 @@ namespace Kiota.Builder.Writers.Java {
                 writer.WriteLine($"package {ns.Name};");
                 writer.WriteLine();
                 codeElement.Usings
+                    .Where(x => x.Declaration != null)
                     .Where(x => x.Declaration.IsExternal || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
                     .Select(x => x.Declaration.IsExternal ?
                                      $"import {x.Declaration.Name}.{x.Name.ToFirstCharacterUpperCase()};" :

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -325,6 +325,10 @@ namespace Kiota.Builder.Writers.Java {
             var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
             var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
             var methodName = code.MethodKind switch {
+                CodeMethodKind.Getter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                    => $"get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
+                CodeMethodKind.Setter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                    => $"set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Getter => $"get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Setter => $"set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 _ when isConstructor => code.Parent.Name.ToFirstCharacterUpperCase(),

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -325,9 +325,9 @@ namespace Kiota.Builder.Writers.Java {
             var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
             var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
             var methodName = code.MethodKind switch {
-                CodeMethodKind.Getter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                CodeMethodKind.Getter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
                     => $"get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
-                CodeMethodKind.Setter when code.AccessedProperty?.IsNameEscaped ?? false && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                CodeMethodKind.Setter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
                     => $"set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Getter => $"get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
                 CodeMethodKind.Setter => $"set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -51,6 +51,7 @@ namespace Kiota.Builder.Refiners.Tests {
             }).First();
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
             Assert.Equal("select", property.Name);
+            Assert.False(property.IsNameEscaped);
         }
         [Fact]
         public void EscapesPublicPropertiesReservedKeywordsForModels() {
@@ -65,6 +66,7 @@ namespace Kiota.Builder.Refiners.Tests {
             }).First();
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
             Assert.Equal("select_escaped", property.Name);
+            Assert.True(property.IsNameEscaped);
         }
         [Fact]
         public void ReplacesRequestBuilderPropertiesByMethods() {

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -15,6 +15,7 @@ namespace Kiota.Builder.Writers.Go.Tests {
         private readonly LanguageWriter writer;
         private readonly CodeMethod method;
         private readonly CodeClass parentClass;
+        private readonly CodeNamespace root;
         private const string MethodName = "methodName";
         private const string ReturnTypeName = "Somecustomtype";
         private const string MethodDescription = "some description";
@@ -25,7 +26,7 @@ namespace Kiota.Builder.Writers.Go.Tests {
             writer = LanguageWriter.GetLanguageWriter(GenerationLanguage.Go, DefaultPath, DefaultName);
             tw = new StringWriter();
             writer.SetTextWriter(tw);
-            var root = CodeNamespace.InitRootNamespace();
+            root = CodeNamespace.InitRootNamespace();
             parentClass = new CodeClass {
                 Name = "parentClass"
             };
@@ -592,6 +593,35 @@ namespace Kiota.Builder.Writers.Go.Tests {
             tempWriter.Write(method);
             var result = tw.ToString();
             Assert.Contains("EnableBackingStore", result);
+        }
+        [Fact]
+        public void AccessorsTargetingEscapedPropertiesAreNotEscapedThemselves() {
+            var model = root.AddClass(new CodeClass {
+                Name = "SomeClass",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            model.AddProperty(new CodeProperty {
+                Name = "select",
+                Type = new CodeType { Name = "string" },
+                Access = AccessModifier.Public,
+                PropertyKind = CodePropertyKind.Custom,
+            });
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+            var getter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Getter));
+            var setter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Setter));
+            var tempWriter = LanguageWriter.GetLanguageWriter(GenerationLanguage.Go, DefaultPath, DefaultName);
+            tempWriter.SetTextWriter(tw);
+            tempWriter.Write(getter);
+            var result = tw.ToString();
+            Assert.Contains("GetSelect", result);
+            Assert.DoesNotContain("GetSelect_escaped", result);
+            
+            using var tw2 = new StringWriter();
+            tempWriter.SetTextWriter(tw2);
+            tempWriter.Write(setter);
+            result = tw2.ToString();
+            Assert.Contains("SetSelect", result);
+            Assert.DoesNotContain("SetSelect_escaped", result);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where Java generation would fail because of empty usings
- Fixes a bug where Java and Go escaped model properties would not serialize properly

related https://github.com/microsoftgraph/msgraph-sdk-go/issues/46

Languages:
- Java : fixed.
- CSharp: not impacted as already using the serialization name and not using accessors.
- Go: fixed.
- Ruby: not fixed, other issues that need to be addressed (uses the field instead of the accessor in serialization/deserialization methods).
- TypeScript: not impacted as already using the serialization name and using a prefixed named for fields.

## Generation diff

https://github.com/microsoft/kiota-samples/pull/433
