### PR TITLE
Rename HttpMethod in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixes name collisions in dotnet by renaming "HttpMethod" enum to "Method" in dotnet abstractions
 - Add support for PHP Generation.
 - Migrated generator to dotnet 6 #815
 - Fixes a bug where json deserialization would fail in go

--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             var anonymousAuthenticationProvider = new AnonymousAuthenticationProvider();
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             Assert.Empty(testRequest.Headers); // header collection is empty
@@ -39,7 +39,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             var testAuthProvider = mockBaseBearerTokenAuthenticationProvider.Object;
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             Assert.Empty(testRequest.Headers); // header collection is empty

--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/QueryParametersBaseTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/QueryParametersBaseTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Arrange as the request builders would
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 UrlTemplate = "http://localhost/me?select={select}"
             };
             Action<GetQueryParameters> q = x => x.Select = new[] { "id", "displayName" };

--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Arrange
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 UrlTemplate = "http://localhost/{path}/me?foo={foo}"
             };
             // Act
@@ -33,7 +33,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Arrange
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var testRequestOption = new Mock<IRequestOption>().Object;

--- a/abstractions/dotnet/src/Method.cs
+++ b/abstractions/dotnet/src/Method.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -7,7 +7,7 @@ namespace Microsoft.Kiota.Abstractions
     /// <summary>
     ///     Represents the HTTP method used by a request.
     /// </summary>
-    public enum HttpMethod
+    public enum Method
     {
         /// <summary>
         ///     The HTTP GET method.

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.25</Version>
+    <Version>1.0.26</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/abstractions/dotnet/src/RequestInformation.cs
+++ b/abstractions/dotnet/src/RequestInformation.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         ///  The <see cref="HttpMethod">HTTP method</see> of the request.
         /// </summary>
-        public HttpMethod HttpMethod { get; set; }
+        public Method HttpMethod { get; set; }
         /// <summary>
         /// The Query Parameters of the request.
         /// </summary>

--- a/abstractions/dotnet/src/RequestInformation.cs
+++ b/abstractions/dotnet/src/RequestInformation.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Kiota.Abstractions
         /// </summary>
         public IDictionary<string, object> PathParameters { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         /// <summary>
-        ///  The <see cref="HttpMethod">HTTP method</see> of the request.
+        ///  The <see cref="Method">HTTP method</see> of the request.
         /// </summary>
         public Method HttpMethod { get; set; }
         /// <summary>

--- a/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
+++ b/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Kiota.Authentication.Azure.Tests
             var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object, null);
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
 
@@ -52,7 +52,7 @@ namespace Microsoft.Kiota.Authentication.Azure.Tests
             var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object,"User.Read");
             var testRequest = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             Assert.Empty(testRequest.Headers); // header collection is empty

--- a/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/authentication/dotnet/azure/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
   </ItemGroup>
 
 </Project>

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Xunit;
-using HttpMethod = Microsoft.Kiota.Abstractions.HttpMethod;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
 {
@@ -25,7 +24,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             // Arrange
             var requestInfo = new RequestInformation()
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var redirectHandlerOption = new RedirectHandlerOption()
@@ -47,7 +46,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
         {
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var originalRequest = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
@@ -64,7 +63,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
         {
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             requestInfo.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes("contents")));
@@ -86,7 +85,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
         {
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var redirectHandlerOption = new RedirectHandlerOption()
@@ -113,7 +112,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var originalRequest = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
@@ -128,7 +127,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.POST,
+                HttpMethod = Method.POST,
                 URI = new Uri("http://localhost")
             };
             var originalRequest = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
@@ -144,7 +143,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             byte[] data = new byte[] { 1, 2, 3, 4, 5 };
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.POST,
+                HttpMethod = Method.POST,
                 URI = new Uri("http://localhost"),
                 Content = new MemoryStream(data)
             };

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/TelemetryHandlerTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/TelemetryHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Abstractions.HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             // Act and get a request message
@@ -53,7 +53,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Abstractions.HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
             var telemetryHandlerOption = new TelemetryHandlerOption
@@ -101,7 +101,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var invoker = new HttpMessageInvoker(handler);
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Abstractions.HttpMethod.GET,
+                HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
 

--- a/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
+++ b/http/dotnet/httpclient/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.GET,
+                HttpMethod = Method.GET,
                 UrlTemplate = "http://localhost/me{?top,skip,search,filter,count,orderby,select}"
             };
             requestInfo.QueryParameters.Add(queryParam, queryParamObject);
@@ -73,7 +73,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             // Arrange
             var requestInfo = new RequestInformation
             {
-                HttpMethod = HttpMethod.PUT,
+                HttpMethod = Method.PUT,
                 UrlTemplate = "https://sn3302.up.1drv.com/up/fe6987415ace7X4e1eF866337"
             };
             requestInfo.Headers.Add("Content-Length", "26");

--- a/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/http/dotnet/httpclient/src/Extensions/HttpRequestMessageExtensions.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions;
-using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
 {

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             requestInfo.PathParameters.Add("baseurl", BaseUrl);
             var message = new HttpRequestMessage
             {
-                Method = new System.Net.Http.HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),
+                Method = new HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),
                 RequestUri = requestInfo.URI,
             };
 

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.16</Version>
+    <Version>1.0.17</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.25" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -59,7 +59,7 @@ namespace Kiota.Builder.Refiners {
             new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
                 "Microsoft.Kiota.Abstractions", "IRequestAdapter"),
             new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "Microsoft.Kiota.Abstractions", "HttpMethod", "RequestInformation", "IRequestOption"),
+                "Microsoft.Kiota.Abstractions", "Method", "RequestInformation", "IRequestOption"),
             new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
                 "Microsoft.Kiota.Abstractions", "IResponseHandler"),
             new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -190,7 +190,7 @@ namespace Kiota.Builder.Writers.CSharp {
             var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
             writer.WriteLine($"var {RequestInfoVarName} = new RequestInformation {{");
             writer.IncreaseIndent();
-            writer.WriteLines($"HttpMethod = HttpMethod.{operationName?.ToUpperInvariant()},",
+            writer.WriteLines($"HttpMethod = Method.{operationName?.ToUpperInvariant()},",
                             $"UrlTemplate = {GetPropertyCall(urlTemplateProperty, "string.Empty")},",
                             $"PathParameters = {GetPropertyCall(urlTemplateParamsProperty, "string.Empty")},");
             writer.DecreaseIndent();

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -184,7 +184,7 @@ namespace Kiota.Builder.Writers.CSharp.Tests {
             writer.Write(method);
             var result = tw.ToString();
             Assert.Contains("var requestInfo = new RequestInformation", result);
-            Assert.Contains("HttpMethod = HttpMethod.GET", result);
+            Assert.Contains("HttpMethod = Method.GET", result);
             Assert.Contains("UrlTemplate = ", result);
             Assert.Contains("PathParameters = ", result);
             Assert.Contains("h?.Invoke", result);


### PR DESCRIPTION
This PR closes #940 

Samples generation available at https://github.com/microsoft/kiota-samples/pull/442

Changes include
- rename the enum to Method
- update abstractions and http libs
- update the usings added by the CSharp refiner
- update the code method writer to use the new name
- update tests accordingly

TODO
- [x] Validate and test everything works okay