### PR TITLE
TS - URL to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue where multiple api clients could run into racing conditions in Go.
 - Fixed a bug where empty additional data in Go would lead to invalid JSON payloads during serialization.
+- Modified the TypeScript RequestInformation URL paramater data type from URL to string.
 
 ## [0.0.15] - 2021-12-17
 

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/kiota-abstractions",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT",
       "dependencies": {
         "tinyduration": "^3.2.2",

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/src/requestInformation.ts
+++ b/abstractions/typescript/src/requestInformation.ts
@@ -3,26 +3,24 @@ import { ReadableStream } from 'web-streams-polyfill/es2018';
 import { Parsable } from "./serialization";
 import { RequestOption } from "./requestOption";
 import { RequestAdapter } from "./requestAdapter";
-import { URL } from "url";
 import * as urlTpl from "uri-template-lite";
 
 /** This class represents an abstract HTTP request. */
 export class RequestInformation {
     /** The URI of the request. */
-    private uri?: URL;
+    private uri?: string;
     /** The path parameters for the request. */
     public pathParameters: Map<string, unknown> = new Map<string, unknown>();
     /** The URL template for the request */
     public urlTemplate?: string;
     /** Gets the URL of the request  */
-    public get URL(): URL {
+    public get URL(): string {
         const rawUrl = this.pathParameters.get(RequestInformation.raw_url_key);
         if(this.uri) {
             return this.uri;
         } else if (rawUrl) {
-            const value = new URL(rawUrl as string);
-            this.URL = value;
-            return value;
+            this.URL = rawUrl as string;
+            return rawUrl as string;
         } else if(!this.queryParameters) {
             throw new Error("queryParameters cannot be undefined");
         } else if(!this.pathParameters) {
@@ -38,12 +36,11 @@ export class RequestInformation {
             this.pathParameters.forEach((v, k) => {
                 if(v) data[k] = v;
             });
-            const result = template.expand(data);
-            return new URL(result);
+            return template.expand(data);
         }   
     }
     /** Sets the URL of the request */
-    public set URL(url: URL) {
+    public set URL(url: string) {
         if(!url) throw new Error("URL cannot be undefined");
         this.uri = url;
         this.queryParameters.clear();

--- a/abstractions/typescript/src/requestInformation.ts
+++ b/abstractions/typescript/src/requestInformation.ts
@@ -15,12 +15,12 @@ export class RequestInformation {
     public urlTemplate?: string;
     /** Gets the URL of the request  */
     public get URL(): string {
-        const rawUrl = this.pathParameters.get(RequestInformation.raw_url_key);
+        const rawUrl = this.pathParameters.get(RequestInformation.raw_url_key) as string;
         if(this.uri) {
             return this.uri;
         } else if (rawUrl) {
-            this.URL = rawUrl as string;
-            return rawUrl as string;
+            this.URL = rawUrl;
+            return rawUrl;
         } else if(!this.queryParameters) {
             throw new Error("queryParameters cannot be undefined");
         } else if(!this.pathParameters) {

--- a/http/typescript/fetch/package-lock.json
+++ b/http/typescript/fetch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/kiota-http-fetchlibrary",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/kiota-http-fetchlibrary",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.23",

--- a/http/typescript/fetch/package.json
+++ b/http/typescript/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-http-fetchlibrary",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Kiota request adapter implementation with fetch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@microsoft/kiota-abstractions": "^1.0.23",
+    "@microsoft/kiota-abstractions": "^1.0.26",
     "cross-fetch": "^3.1.5",
     "web-streams-polyfill": "^3.2.0"
   },

--- a/http/typescript/fetch/src/fetchRequestAdapter.ts
+++ b/http/typescript/fetch/src/fetchRequestAdapter.ts
@@ -175,7 +175,7 @@ export class FetchRequestAdapter implements RequestAdapter {
         await this.authenticationProvider.authenticateRequest(requestInfo);
         
         const request = this.getRequestFromRequestInformation(requestInfo);
-        return await this.httpClient.fetch(requestInfo.URL.toString(), request);
+        return await this.httpClient.fetch(requestInfo.URL, request);
     }
     private getRequestFromRequestInformation = (requestInfo: RequestInformation): RequestInit => {
         requestInfo.pathParameters.set("baseurl", this.baseUrl);


### PR DESCRIPTION
fixes #773 

1. TS fails to compile when a node URL is set to a browser URL type. This is a problem with TS. 
2. Setting URL to string as suggested by @darrelmiller. This simplifies the problem to manage the URL object in TS isomorphically.
