### PR TITLE
Serialization fixes in dotnet

### DIFF
--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                             "    \"displayName\": \"Megan Bowen\",\r\n" +
                                             "    \"givenName\": \"Megan\",\r\n" +
                                             "    \"accountEnabled\": true,\r\n" +
-                                            "    \"createdDateTime\": \"2017-07-29T03:07:25Z\",\r\n" +
+                                            "    \"createdDateTime\": \"2017 -07-29T03:07:25Z\",\r\n" +
                                             "    \"jobTitle\": \"Auditor\",\r\n" +
                                             "    \"mail\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
                                             "    \"mobilePhone\": null,\r\n" +

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.NotNull(testEntity);
             Assert.NotEmpty(testEntity.AdditionalData);
             Assert.True(testEntity.AdditionalData.ContainsKey("jobTitle"));
+            Assert.True(testEntity.AdditionalData.ContainsKey("mobilePhone"));
             Assert.Equal("Auditor", testEntity.AdditionalData["jobTitle"]);
             Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntity.Id);
         }

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         public string Id { get; set; }
         /// <summary>Read-only.</summary>
         public TestEnum? Numbers { get; set; }
+        /// <summary>Read-only.</summary>
+        public DateTimeOffset? CreatedDateTime { get; set; }
         /// <summary>
         /// Instantiates a new entity and sets the default values.
         /// </summary>
@@ -27,6 +29,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
             return new Dictionary<string, Action<T, IParseNode>> {
                 {"id", (o,n) => { (o as TestEntity).Id = n.GetStringValue(); } },
                 {"numbers", (o,n) => { (o as TestEntity).Numbers = n.GetEnumValue<TestEnum>(); } },
+                {"createdDateTime", (o,n) => { (o as TestEntity).CreatedDateTime = n.GetDateTimeOffsetValue(); } },
             };
         }
         /// <summary>
@@ -38,6 +41,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteStringValue("id", Id);
             writer.WriteEnumValue<TestEnum>("numbers",Numbers);
+            writer.WriteDateTimeOffsetValue("createdDateTime", CreatedDateTime);
             writer.WriteAdditionalData(AdditionalData);
         }
     }

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -73,7 +73,15 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the <see cref="DateTimeOffset"/> value from the json node
         /// </summary>
         /// <returns>A <see cref="DateTimeOffset"/> value</returns>
-        public DateTimeOffset? GetDateTimeOffsetValue() => _jsonNode.GetDateTimeOffset();
+        public DateTimeOffset? GetDateTimeOffsetValue() 
+        {
+            // JsonElement.GetDateTimeOffset is super strict so try to be more lenient if it fails(e.g. when we have whitespace or other variant formats).
+            // ref - https://docs.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support
+            if(!_jsonNode.TryGetDateTimeOffset(out var value))
+                value = DateTimeOffset.Parse(_jsonNode.GetString());
+
+            return value;
+        }
 
         /// <summary>
         /// Get the enumeration value of type <typeparam name="T"/>from the json node

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Kiota.Serialization.Json
             if(item.AdditionalData == null)
                 item.AdditionalData = new Dictionary<string, object>();
 
-            foreach(var fieldValue in _jsonNode.EnumerateObject().Where(x => x.Value.ValueKind != JsonValueKind.Null))
+            foreach(var fieldValue in _jsonNode.EnumerateObject())
             {
                 if(fieldDeserializers.ContainsKey(fieldValue.Name))
                 {

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
This PR fixes a couple of issue with regards to serialization in the dotnet serialization library.

Changes include.
- Changes `JsonParseNode.GetDateTimeOffset` to not call `JsonElement.GetDateTimeOffset` directly as `JsonElement.GetDateTimeOffset` is super strict and fails on variant dateTimeOffsets. Ref [here](https://docs.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support).
- Allows `JsonValueKind.Null` json types to be processed on deserialization to at least allow unknown null properties to be added to the additionalData.