### PR TITLE
- adds support for providing a custom transport under the middleware transport in go

### DIFF
--- a/http/go/nethttp/pipeline_test.go
+++ b/http/go/nethttp/pipeline_test.go
@@ -1,6 +1,7 @@
 package nethttplibrary
 
 import (
+	assert "github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 )
@@ -45,4 +46,27 @@ func TestCanInterceptMultipleRequests(t *testing.T) {
 	if expect != got2 {
 		t.Errorf("Expected: %v, but received: %v", expect, got2)
 	}
+}
+
+func TestItReturnsADefaultTransport(t *testing.T) {
+	transport := GetDefaultTransport()
+	assert.NotNil(t, transport)
+	defaultTransport, ok := transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.True(t, defaultTransport.ForceAttemptHTTP2)
+}
+
+func TestItAcceptsACustomizedTransport(t *testing.T) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ForceAttemptHTTP2 = false
+	customTransport := NewCustomTransportWithParentTransport(transport)
+	assert.NotNil(t, customTransport)
+	result, ok := customTransport.middlewarePipeline.transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.False(t, result.ForceAttemptHTTP2)
+}
+
+func TestItGetsADefaultTransportIfNoneIsProvided(t *testing.T) {
+	customTransport := NewCustomTransport()
+	assert.NotNil(t, customTransport.middlewarePipeline.transport)
 }


### PR DESCRIPTION
this pull request adds a GetDefaultTransport function to allow consumers to get the transport as it is configured for the kiota client (with default things like timeouts, and other configurations). This method clones the default transport provided by the Go runtime.
It also remove the inheritance of the custom transport from transport to avoid having two references (middleware), and provides a methods to configure the client with a third party transport should the consumer need to customize the transport used by the client.