### PR TITLE
Fix deserialization of null values in dotnet.

### DIFF
--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                             "    \"jobTitle\": \"Auditor\",\r\n" +
                                             "    \"mail\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
                                             "    \"mobilePhone\": null,\r\n" +
-                                            "    \"officeLocation\": \"12/1110\",\r\n" +
+                                            "    \"officeLocation\": null,\r\n" +
                                             "    \"preferredLanguage\": \"en-US\",\r\n" +
                                             "    \"surname\": \"Bowen\",\r\n" +
                                             "    \"userPrincipalName\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
@@ -39,6 +39,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var testEntity = jsonParseNode.GetObjectValue<TestEntity>();
             // Assert
             Assert.NotNull(testEntity);
+            Assert.Null(testEntity.OfficeLocation);
             Assert.NotEmpty(testEntity.AdditionalData);
             Assert.True(testEntity.AdditionalData.ContainsKey("jobTitle"));
             Assert.True(testEntity.AdditionalData.ContainsKey("mobilePhone"));

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         public TestEnum? Numbers { get; set; }
         /// <summary>Read-only.</summary>
         public DateTimeOffset? CreatedDateTime { get; set; }
+        /// <summary>Read-only.</summary>
+        public string OfficeLocation { get; set; }
         /// <summary>
         /// Instantiates a new entity and sets the default values.
         /// </summary>
@@ -30,6 +32,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
                 {"id", (o,n) => { (o as TestEntity).Id = n.GetStringValue(); } },
                 {"numbers", (o,n) => { (o as TestEntity).Numbers = n.GetEnumValue<TestEnum>(); } },
                 {"createdDateTime", (o,n) => { (o as TestEntity).CreatedDateTime = n.GetDateTimeOffsetValue(); } },
+                {"officeLocation", (o,n) => { (o as TestEntity).OfficeLocation = n.GetStringValue(); } },
             };
         }
         /// <summary>
@@ -42,6 +45,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
             writer.WriteStringValue("id", Id);
             writer.WriteEnumValue<TestEnum>("numbers",Numbers);
             writer.WriteDateTimeOffsetValue("createdDateTime", CreatedDateTime);
+            writer.WriteStringValue("officeLocation", OfficeLocation);
             writer.WriteAdditionalData(AdditionalData);
         }
     }

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -220,6 +220,9 @@ namespace Microsoft.Kiota.Serialization.Json
             {
                 if(fieldDeserializers.ContainsKey(fieldValue.Name))
                 {
+                    if(fieldValue.Value.ValueKind == JsonValueKind.Null)
+                        continue;// If the property is already null just continue. As calling functions like GetDouble,GetBoolValue do not process JsonValueKind.Null.
+
                     var fieldDeserializer = fieldDeserializers[fieldValue.Name];
                     Debug.WriteLine($"found property {fieldValue.Name} to deserialize");
                     fieldDeserializer.Invoke(item, new JsonParseNode(fieldValue.Value)

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
This PR fixes an issue created by changes in #997.

#997 Removed the filter that prevented json elements of kind `JsonValueKind.Null` from being processed during deserialization to enable null elements to be placed in the additional data. 

This fix had the side effect of creating paths where we could call functions like `GetDouble`, `GetDateTimeOffset` etc when the element kind is JsonValueKind.Null if the element has a matching field deserializer. This leads to the throwing of an InvalidOperation exception as opposed to just letting the value be null.

This PR fixes this side effect by adding the filter back but only when we have a match of the element key in the field deserializers so that we can still have the elements being added to the additionalData when there is no match.
