### PR TITLE
adds support for date-only, time-only and duration in Kiota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to configure the underlying transport in Go. #1003
+- Added additional date time (date, time, duration) types in the generation process. #1017
 
 ### Changed
 

--- a/abstractions/dotnet/src/Date.cs
+++ b/abstractions/dotnet/src/Date.cs
@@ -1,0 +1,81 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    /// Model to represent only the date component of a DateTime
+    /// </summary>
+    public struct Date
+    {
+        /// <summary>
+        /// Create a new Date object from a <see cref="DateTime"/> object
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> object to use</param>
+        public Date(DateTime dateTime)
+        {
+            this.DateTime = dateTime;
+        }
+
+        /// <summary>
+        /// Create a new Date object from a year, month, and day.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <param name="month">The month.</param>
+        /// <param name="day">The day of the month.</param>
+        public Date(int year, int month, int day)
+            : this(new DateTime(year, month, day))
+        {
+        }
+
+        /// <summary>
+        /// The DateTime object.
+        /// </summary>
+        public DateTime DateTime { get; }
+
+        /// <summary>
+        /// The date's year.
+        /// </summary>
+        public int Year
+        {
+            get
+            {
+                return this.DateTime.Year;
+            }
+        }
+
+        /// <summary>
+        /// The date's month.
+        /// </summary>
+        public int Month
+        {
+            get
+            {
+                return this.DateTime.Month;
+            }
+        }
+
+        /// <summary>
+        /// The date's day.
+        /// </summary>
+        public int Day
+        {
+            get
+            {
+                return this.DateTime.Day;
+            }
+        }
+
+        /// <summary>
+        /// Convert the date to a string.
+        /// </summary>
+        /// <returns>The string value of the date in the format "yyyy-MM-dd".</returns>
+        public override string ToString()
+        {
+            return this.DateTime.ToString("yyyy-MM-dd");
+        }
+    }
+}

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.26</Version>
+    <Version>1.0.27</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/abstractions/dotnet/src/Time.cs
+++ b/abstractions/dotnet/src/Time.cs
@@ -1,0 +1,81 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    /// Model to represent only the date component of a DateTime
+    /// </summary>
+    public struct Time
+    {
+        /// <summary>
+        /// Create a new Time from hours, minutes, and seconds.
+        /// </summary>
+        /// <param name="hour">The hour.</param>
+        /// <param name="minute">The minute.</param>
+        /// <param name="second">The second.</param>
+        public Time(int hour, int minute, int second)
+            : this(new DateTime(1, 1, 1, hour, minute, second))
+        {
+        }
+
+        /// <summary>
+        /// Create a new Time from a <see cref="DateTime"/> object
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> object to create the object from.</param>
+        public Time(DateTime dateTime)
+        {
+            this.DateTime = dateTime;
+        }
+
+        /// <summary>
+        /// The <see cref="DateTime"/> representation of the class
+        /// </summary>
+        public DateTime DateTime { get; }
+
+        /// <summary>
+        /// The hour.
+        /// </summary>
+        public int Hour
+        {
+            get
+            {
+                return this.DateTime.Hour;
+            }
+        }
+
+        /// <summary>
+        /// The minute.
+        /// </summary>
+        public int Minute
+        {
+            get
+            {
+                return this.DateTime.Minute;
+            }
+        }
+
+        /// <summary>
+        /// The second.
+        /// </summary>
+        public int Second
+        {
+            get
+            {
+                return this.DateTime.Second;
+            }
+        }
+
+        /// <summary>
+        /// The time of day, formatted as "HH:mm:ss".
+        /// </summary>
+        /// <returns>The string time of day.</returns>
+        public override string ToString()
+        {
+            return this.DateTime.ToString("HH:mm:ss");
+        }
+    }
+}

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -58,6 +58,21 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// </summary>
         /// <returns>The DateTimeOffset value of the node.</returns>
         DateTimeOffset? GetDateTimeOffsetValue();
+        /// <summary>
+        /// Gets the TimeSpan value of the node.
+        /// </summary>
+        /// <returns>The TimeSpan value of the node.</returns>
+        TimeSpan? GetTimeSpanValue();
+        /// <summary>
+        /// Gets the Date value of the node.
+        /// </summary>
+        /// <returns>The Date value of the node.</returns>
+        Date? GetDateValue();
+        /// <summary>
+        /// Gets the Time value of the node.
+        /// </summary>
+        /// <returns>The Time value of the node.</returns>
+        Time? GetTimeValue();
         /// <summary>
         /// Gets the collection of primitive values of the node.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -61,6 +61,24 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The DateTimeOffset value to be written.</param>
         void WriteDateTimeOffsetValue(string key, DateTimeOffset? value);
+        /// <summary>
+        /// Writes the specified TimeSpan value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The TimeSpan value to be written.</param>
+        void WriteTimeSpanValue(string key, TimeSpan? value);
+        /// <summary>
+        /// Writes the specified Date value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The Date value to be written.</param>
+        void WriteDateValue(string key, Date? value);
+        /// <summary>
+        /// Writes the specified Time value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The Time value to be written.</param>
+        void WriteTimeValue(string key, Time? value);
         /// <summary>
         /// Writes the specified collection of primitive values to the stream with an optional given key.
         /// </summary>

--- a/abstractions/go/api_client_builder_test.go
+++ b/abstractions/go/api_client_builder_test.go
@@ -35,6 +35,15 @@ func (*mockSerializer) WriteByteArrayValue(key string, value []byte) error {
 func (*mockSerializer) WriteTimeValue(key string, value *time.Time) error {
 	return nil
 }
+func (*mockSerializer) WriteDurationValue(key string, value *time.Duration) error {
+	return nil
+}
+func (*mockSerializer) WriteDateOnlyValue(key string, value *serialization.DateOnly) error {
+	return nil
+}
+func (*mockSerializer) WriteTimeOnlyValue(key string, value *serialization.TimeOnly) error {
+	return nil
+}
 func (*mockSerializer) WriteUUIDValue(key string, value *uuid.UUID) error {
 	return nil
 }

--- a/abstractions/go/api_client_builder_test.go
+++ b/abstractions/go/api_client_builder_test.go
@@ -74,6 +74,15 @@ func (*mockSerializer) WriteCollectionOfFloat64Values(key string, collection []f
 func (*mockSerializer) WriteCollectionOfTimeValues(key string, collection []time.Time) error {
 	return nil
 }
+func (*mockSerializer) WriteCollectionOfDurationValues(key string, collection []time.Duration) error {
+	return nil
+}
+func (*mockSerializer) WriteCollectionOfDateOnlyValues(key string, collection []serialization.DateOnly) error {
+	return nil
+}
+func (*mockSerializer) WriteCollectionOfTimeOnlyValues(key string, collection []serialization.TimeOnly) error {
+	return nil
+}
 func (*mockSerializer) WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error {
 	return nil
 }

--- a/abstractions/go/api_client_builder_test.go
+++ b/abstractions/go/api_client_builder_test.go
@@ -35,7 +35,7 @@ func (*mockSerializer) WriteByteArrayValue(key string, value []byte) error {
 func (*mockSerializer) WriteTimeValue(key string, value *time.Time) error {
 	return nil
 }
-func (*mockSerializer) WriteDurationValue(key string, value *time.Duration) error {
+func (*mockSerializer) WriteISODurationValue(key string, value *serialization.ISODuration) error {
 	return nil
 }
 func (*mockSerializer) WriteDateOnlyValue(key string, value *serialization.DateOnly) error {
@@ -74,7 +74,7 @@ func (*mockSerializer) WriteCollectionOfFloat64Values(key string, collection []f
 func (*mockSerializer) WriteCollectionOfTimeValues(key string, collection []time.Time) error {
 	return nil
 }
-func (*mockSerializer) WriteCollectionOfDurationValues(key string, collection []time.Duration) error {
+func (*mockSerializer) WriteCollectionOfISODurationValues(key string, collection []serialization.ISODuration) error {
 	return nil
 }
 func (*mockSerializer) WriteCollectionOfDateOnlyValues(key string, collection []serialization.DateOnly) error {

--- a/abstractions/go/go.mod
+++ b/abstractions/go/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/cjlapao/common-go v0.0.16 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/abstractions/go/go.sum
+++ b/abstractions/go/go.sum
@@ -1,3 +1,5 @@
+github.com/cjlapao/common-go v0.0.16 h1:3CCMidbHuc+nvKHb1mX/rflMPrpeGQvoVk30b9CC/00=
+github.com/cjlapao/common-go v0.0.16/go.mod h1:zGdh2KmXnH4HTRfT7vPpY41cws776KULk44f09OPJgs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/abstractions/go/serialization/date_only.go
+++ b/abstractions/go/serialization/date_only.go
@@ -10,7 +10,7 @@ type DateOnly struct {
 	time time.Time
 }
 
-var dateOnlyFormat = "2006-01-02"
+const dateOnlyFormat = "2006-01-02"
 
 // String returns the date only as a string following the RFC3339 standard.
 func (t DateOnly) String() string {

--- a/abstractions/go/serialization/date_only.go
+++ b/abstractions/go/serialization/date_only.go
@@ -1,0 +1,39 @@
+package serialization
+
+import (
+	"strings"
+	"time"
+)
+
+// DateOnly is a struct that represents a date only from a date time (Time).
+type DateOnly struct {
+	time time.Time
+}
+
+var dateOnlyFormat = "2006-01-02"
+
+// String returns the date only as a string following the RFC3339 standard.
+func (t DateOnly) String() string {
+	return t.time.Format(dateOnlyFormat)
+}
+
+// ParseDateOnly parses a string into a DateOnly following the RFC3339 standard.
+func ParseDateOnly(s string) (*DateOnly, error) {
+	if len(strings.TrimSpace(s)) <= 0 {
+		return nil, nil
+	}
+	timeValue, err := time.Parse(dateOnlyFormat, s)
+	if err != nil {
+		return nil, err
+	}
+	return &DateOnly{
+		time: timeValue,
+	}, nil
+}
+
+// NewDateOnly creates a new DateOnly from a time.Time.
+func NewDateOnly(t time.Time) *DateOnly {
+	return &DateOnly{
+		time: t,
+	}
+}

--- a/abstractions/go/serialization/date_only_test.go
+++ b/abstractions/go/serialization/date_only_test.go
@@ -1,0 +1,23 @@
+package serialization
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestItParsesADateOnly(t *testing.T) {
+	dateOnly, err := ParseDateOnly("2020-01-04")
+	assert.Nil(t, err)
+	assert.Equal(t, "2020-01-04", dateOnly.String())
+}
+
+func TestItDoesntParseAFullDateADateOnly(t *testing.T) {
+	_, err := ParseDateOnly("2020-01-04T15:04:05.00000")
+	assert.NotNil(t, err)
+}
+
+func TestItCreateANewDateOnly(t *testing.T) {
+	dateOnly := NewDateOnly(time.Date(2020, 1, 4, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, "2020-01-04", dateOnly.String())
+}

--- a/abstractions/go/serialization/iso_duration.go
+++ b/abstractions/go/serialization/iso_duration.go
@@ -114,7 +114,7 @@ func (i ISODuration) String() string {
 
 // FromDuration returns an ISODuration from a time.Duration.
 func FromDuration(d time.Duration) *ISODuration {
-	return NewDuration(0, 0, 0, 0, 0, 0, int(d.Milliseconds()))
+	return NewDuration(0, 0, 0, 0, 0, int(d.Truncate(time.Second).Seconds()), int(d.Truncate(time.Millisecond).Milliseconds()))
 }
 
 // ToDuration returns the time.Duration representation of the ISODuration.

--- a/abstractions/go/serialization/iso_duration.go
+++ b/abstractions/go/serialization/iso_duration.go
@@ -1,0 +1,123 @@
+package serialization
+
+import (
+	"time"
+
+	cjl "github.com/cjlapao/common-go/duration"
+)
+
+// ISODuration represents an ISO 8601 duration
+type ISODuration struct {
+	duration cjl.Duration
+}
+
+// GetYears returns the number of years.
+func (i ISODuration) GetYears() int {
+	return i.duration.Years
+}
+
+// GetWeeks returns the number of weeks.
+func (i ISODuration) GetWeeks() int {
+	return i.duration.Weeks
+}
+
+// GetDays returns the number of days.
+func (i ISODuration) GetDays() int {
+	return i.duration.Days
+}
+
+// GetHours returns the number of hours.
+func (i ISODuration) GetHours() int {
+	return i.duration.Hours
+}
+
+// GetMinutes returns the number of minutes.
+func (i ISODuration) GetMinutes() int {
+	return i.duration.Minutes
+}
+
+// GetSeconds returns the number of seconds.
+func (i ISODuration) GetSeconds() int {
+	return i.duration.Seconds
+}
+
+// GetMilliSeconds returns the number of milliseconds.
+func (i ISODuration) GetMilliSeconds() int {
+	return i.duration.MilliSeconds
+}
+
+// SetYears sets the number of years.
+func (i ISODuration) SetYears(years int) {
+	i.duration.Years = years
+}
+
+// SetWeeks sets the number of weeks.
+func (i ISODuration) SetWeeks(weeks int) {
+	i.duration.Weeks = weeks
+}
+
+// SetDays sets the number of days.
+func (i ISODuration) SetDays(days int) {
+	i.duration.Days = days
+}
+
+// SetHours sets the number of hours.
+func (i ISODuration) SetHours(hours int) {
+	i.duration.Hours = hours
+}
+
+// SetMinutes sets the number of minutes.
+func (i ISODuration) SetMinutes(minutes int) {
+	i.duration.Minutes = minutes
+}
+
+// SetSeconds sets the number of seconds.
+func (i ISODuration) SetSeconds(seconds int) {
+	i.duration.Seconds = seconds
+}
+
+// SetMilliSeconds sets the number of milliseconds.
+func (i ISODuration) SetMilliSeconds(milliSeconds int) {
+	i.duration.MilliSeconds = milliSeconds
+}
+
+// ParseISODuration parses a string into an ISODuration following the ISO 8601 standard.
+func ParseISODuration(s string) (*ISODuration, error) {
+	d, err := cjl.FromString(s)
+	if err != nil {
+		return nil, err
+	}
+	return &ISODuration{
+		duration: *d,
+	}, nil
+}
+
+// NewISODuration creates a new ISODuration from primitive values.
+func NewDuration(years int, weeks int, days int, hours int, minutes int, seconds int, milliSeconds int) *ISODuration {
+	return &ISODuration{
+		duration: cjl.Duration{
+			Years:        years,
+			Weeks:        weeks,
+			Days:         days,
+			Hours:        hours,
+			Minutes:      minutes,
+			Seconds:      seconds,
+			MilliSeconds: milliSeconds,
+		},
+	}
+}
+
+// String returns the ISO 8601 representation of the duration.
+func (i ISODuration) String() string {
+	return i.duration.String()
+}
+
+// FromDuration returns an ISODuration from a time.Duration.
+func FromDuration(d time.Duration) *ISODuration {
+	return NewDuration(0, 0, 0, 0, 0, 0, int(d.Milliseconds()))
+}
+
+// ToDuration returns the time.Duration representation of the ISODuration.
+func (d ISODuration) ToDuration() time.Duration {
+	return d.duration.ToDuration()
+}

--- a/abstractions/go/serialization/iso_duration_test.go
+++ b/abstractions/go/serialization/iso_duration_test.go
@@ -1,0 +1,45 @@
+package serialization
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestItParsesADuration(t *testing.T) {
+	duration, err := ParseISODuration("PT1H")
+	assert.Nil(t, err)
+	assert.Equal(t, "PT1H", duration.String())
+}
+
+func TestItMakesAnISODurationFromATimeDurationFor1h(t *testing.T) {
+	duration := time.Duration(1) * time.Hour
+	isoDuration := FromDuration(duration)
+	assert.Equal(t, "PT3600S", isoDuration.String()) //TODO this is technically invalid and needs to be fixed in the dependency https://github.com/cjlapao/common-go/pull/11
+}
+
+func TestItMakesAnISODurationFromATimeDurationFor1d(t *testing.T) {
+	duration := time.Duration(24) * time.Hour
+	isoDuration := FromDuration(duration)
+	assert.Equal(t, "PT86400S", isoDuration.String()) //TODO this is technically invalid and needs to be fixed in the dependency https://github.com/cjlapao/common-go/pull/11
+}
+
+func TestItMakesAnNewISODurationFor1h(t *testing.T) {
+	isoDuration := NewDuration(0, 0, 0, 1, 0, 0, 0)
+	assert.Equal(t, "PT1H", isoDuration.String())
+}
+
+func TestItMakesAnNewISODurationFor1dAnd1h(t *testing.T) {
+	isoDuration := NewDuration(0, 0, 1, 1, 0, 0, 0)
+	assert.Equal(t, "P1DT1H", isoDuration.String())
+}
+
+func TestItMakesAnNewISODurationFor1wAnd1dAnd1h(t *testing.T) {
+	isoDuration := NewDuration(0, 1, 1, 1, 0, 0, 0)
+	assert.Equal(t, "P1W1DT1H", isoDuration.String())
+}
+
+func TestItMakesAnNewISODurationFor1y1wAnd1dAnd1h(t *testing.T) {
+	isoDuration := NewDuration(1, 1, 1, 1, 0, 0, 0)
+	assert.Equal(t, "P1Y1W1DT1H", isoDuration.String())
+}

--- a/abstractions/go/serialization/parse_node.go
+++ b/abstractions/go/serialization/parse_node.go
@@ -32,8 +32,8 @@ type ParseNode interface {
 	GetInt64Value() (*int64, error)
 	// GetTimeValue returns a Time value from the nodes.
 	GetTimeValue() (*time.Time, error)
-	// GetDurationValue returns a Duration value from the nodes.
-	GetDurationValue() (*time.Duration, error)
+	// GetISODurationValue returns a ISODuration value from the nodes.
+	GetISODurationValue() (*ISODuration, error)
 	// GetTimeOnlyValue returns a TimeOnly value from the nodes.
 	GetTimeOnlyValue() (*TimeOnly, error)
 	// GetDateOnlyValue returns a DateOnly value from the nodes.

--- a/abstractions/go/serialization/parse_node.go
+++ b/abstractions/go/serialization/parse_node.go
@@ -32,6 +32,12 @@ type ParseNode interface {
 	GetInt64Value() (*int64, error)
 	// GetTimeValue returns a Time value from the nodes.
 	GetTimeValue() (*time.Time, error)
+	// GetDurationValue returns a Duration value from the nodes.
+	GetDurationValue() (*time.Duration, error)
+	// GetTimeOnlyValue returns a TimeOnly value from the nodes.
+	GetTimeOnlyValue() (*TimeOnly, error)
+	// GetDateOnlyValue returns a DateOnly value from the nodes.
+	GetDateOnlyValue() (*DateOnly, error)
 	// GetUUIDValue returns a UUID value from the nodes.
 	GetUUIDValue() (*uuid.UUID, error)
 	// GetEnumValue returns a Enum value from the nodes.

--- a/abstractions/go/serialization/serialization_writer.go
+++ b/abstractions/go/serialization/serialization_writer.go
@@ -26,6 +26,12 @@ type SerializationWriter interface {
 	WriteByteArrayValue(key string, value []byte) error
 	// WriteTimeValue writes a Time value to underlying the byte array.
 	WriteTimeValue(key string, value *time.Time) error
+	// WriteTimeOnlyValue writes the time part of a Time value to underlying the byte array.
+	WriteTimeOnlyValue(key string, value *TimeOnly) error
+	// WriteDateOnlyValue writes the date part of a Time value to underlying the byte array.
+	WriteDateOnlyValue(key string, value *DateOnly) error
+	// WriteDurationValue writes a Duration value to underlying the byte array.
+	WriteDurationValue(key string, value *time.Duration) error
 	// WriteUUIDValue writes a UUID value to underlying the byte array.
 	WriteUUIDValue(key string, value *uuid.UUID) error
 	// WriteObjectValue writes a Parsable value to underlying the byte array.

--- a/abstractions/go/serialization/serialization_writer.go
+++ b/abstractions/go/serialization/serialization_writer.go
@@ -30,8 +30,8 @@ type SerializationWriter interface {
 	WriteTimeOnlyValue(key string, value *TimeOnly) error
 	// WriteDateOnlyValue writes the date part of a Time value to underlying the byte array.
 	WriteDateOnlyValue(key string, value *DateOnly) error
-	// WriteDurationValue writes a Duration value to underlying the byte array.
-	WriteDurationValue(key string, value *time.Duration) error
+	// WriteISODurationValue writes a ISODuration value to underlying the byte array.
+	WriteISODurationValue(key string, value *ISODuration) error
 	// WriteUUIDValue writes a UUID value to underlying the byte array.
 	WriteUUIDValue(key string, value *uuid.UUID) error
 	// WriteObjectValue writes a Parsable value to underlying the byte array.
@@ -52,8 +52,8 @@ type SerializationWriter interface {
 	WriteCollectionOfFloat64Values(key string, collection []float64) error
 	// WriteCollectionOfTimeValues writes a collection of Time values to underlying the byte array.
 	WriteCollectionOfTimeValues(key string, collection []time.Time) error
-	// WriteCollectionOfDurationValues writes a collection of Duration values to underlying the byte array.
-	WriteCollectionOfDurationValues(key string, collection []time.Duration) error
+	// WriteCollectionOfISODurationValues writes a collection of ISODuration values to underlying the byte array.
+	WriteCollectionOfISODurationValues(key string, collection []ISODuration) error
 	// WriteCollectionOfDateOnlyValues writes a collection of DateOnly values to underlying the byte array.
 	WriteCollectionOfDateOnlyValues(key string, collection []DateOnly) error
 	// WriteCollectionOfTimeOnlyValues writes a collection of TimeOnly values to underlying the byte array.

--- a/abstractions/go/serialization/serialization_writer.go
+++ b/abstractions/go/serialization/serialization_writer.go
@@ -52,6 +52,12 @@ type SerializationWriter interface {
 	WriteCollectionOfFloat64Values(key string, collection []float64) error
 	// WriteCollectionOfTimeValues writes a collection of Time values to underlying the byte array.
 	WriteCollectionOfTimeValues(key string, collection []time.Time) error
+	// WriteCollectionOfDurationValues writes a collection of Duration values to underlying the byte array.
+	WriteCollectionOfDurationValues(key string, collection []time.Duration) error
+	// WriteCollectionOfDateOnlyValues writes a collection of DateOnly values to underlying the byte array.
+	WriteCollectionOfDateOnlyValues(key string, collection []DateOnly) error
+	// WriteCollectionOfTimeOnlyValues writes a collection of TimeOnly values to underlying the byte array.
+	WriteCollectionOfTimeOnlyValues(key string, collection []TimeOnly) error
 	// WriteCollectionOfUUIDValues writes a collection of UUID values to underlying the byte array.
 	WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error
 	// GetSerializedContent returns the resulting byte array from the serialization writer.

--- a/abstractions/go/serialization/time_only.go
+++ b/abstractions/go/serialization/time_only.go
@@ -11,7 +11,7 @@ type TimeOnly struct {
 	time time.Time
 }
 
-var timeOnlyFormat = "15:04:05.000000000"
+const timeOnlyFormat = "15:04:05.000000000"
 
 var timeOnlyParsingFormats = map[int]string{
 	0: "15:04:05", //Go doesn't seem to support optional parameters in time.Parse, which is sad

--- a/abstractions/go/serialization/time_only.go
+++ b/abstractions/go/serialization/time_only.go
@@ -1,0 +1,62 @@
+package serialization
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// TimeOnly is represents the time part of a date time (time) value.
+type TimeOnly struct {
+	time time.Time
+}
+
+var timeOnlyFormat = "15:04:05.000000000"
+
+var timeOnlyParsingFormats = map[int]string{
+	0: "15:04:05", //Go doesn't seem to support optional parameters in time.Parse, which is sad
+	1: "15:04:05.0",
+	2: "15:04:05.00",
+	3: "15:04:05.000",
+	4: "15:04:05.0000",
+	5: "15:04:05.00000",
+	6: "15:04:05.000000",
+	7: "15:04:05.0000000",
+	8: "15:04:05.00000000",
+	9: timeOnlyFormat,
+}
+
+// String returns the time only as a string following the RFC3339 standard.
+func (t TimeOnly) String() string {
+	return t.time.Format(timeOnlyFormat)
+}
+
+// ParseTimeOnly parses a string into a TimeOnly following the RFC3339 standard.
+func ParseTimeOnly(s string) (*TimeOnly, error) {
+	if len(strings.TrimSpace(s)) <= 0 {
+		return nil, nil
+	}
+	splat := strings.Split(s, ".")
+	parsingFormat := timeOnlyParsingFormats[0]
+	if len(splat) > 1 {
+		dotSectionLen := len(splat[1])
+		if dotSectionLen >= len(timeOnlyParsingFormats) {
+			return nil, errors.New("too many decimal places in time only string")
+		}
+		parsingFormat = timeOnlyParsingFormats[dotSectionLen]
+	}
+	timeValue, err := time.Parse(parsingFormat, s)
+	if err != nil {
+		return nil, err
+	}
+	return &TimeOnly{
+		time: timeValue,
+	}, nil
+}
+
+// NewTimeOnly creates a new TimeOnly from a time.Time.
+func NewTimeOnly(t time.Time) *TimeOnly {
+	return &TimeOnly{
+		time: t,
+	}
+}

--- a/abstractions/go/serialization/time_only_test.go
+++ b/abstractions/go/serialization/time_only_test.go
@@ -30,5 +30,5 @@ func TestItDoesntParseAFullDateATimeOnly(t *testing.T) {
 
 func TestItCreateANewTimeOnly(t *testing.T) {
 	dateOnly := NewTimeOnly(time.Date(1, 1, 1, 16, 20, 21, 0, time.UTC))
-	assert.Equal(t, "16:20:21", dateOnly.String())
+	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
 }

--- a/abstractions/go/serialization/time_only_test.go
+++ b/abstractions/go/serialization/time_only_test.go
@@ -1,0 +1,34 @@
+package serialization
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestItParsesATimeOnly(t *testing.T) {
+	dateOnly, err := ParseTimeOnly("16:20:21.000")
+	assert.Nil(t, err)
+	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
+}
+
+func TestItParsesATimeOnlyNoDecimals(t *testing.T) {
+	dateOnly, err := ParseTimeOnly("16:20:21")
+	assert.Nil(t, err)
+	assert.Equal(t, "16:20:21.000000000", dateOnly.String())
+}
+
+func TestItDoesntParseATimeOnlyWithTooManyDecimals(t *testing.T) {
+	_, err := ParseTimeOnly("2020-01-04T15:04:05.00000000000000000000")
+	assert.NotNil(t, err)
+}
+
+func TestItDoesntParseAFullDateATimeOnly(t *testing.T) {
+	_, err := ParseTimeOnly("2020-01-04T15:04:05.00000")
+	assert.NotNil(t, err)
+}
+
+func TestItCreateANewTimeOnly(t *testing.T) {
+	dateOnly := NewTimeOnly(time.Date(1, 1, 1, 16, 20, 21, 0, time.UTC))
+	assert.Equal(t, "16:20:21", dateOnly.String())
+}

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -48,7 +48,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.23'
+            version '1.0.24'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNode.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/ParseNode.java
@@ -2,6 +2,9 @@ package com.microsoft.kiota.serialization;
 
 import java.lang.Enum;
 import java.time.OffsetDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Period;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -11,12 +14,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
+ * Interface for a deserialization node in a parse tree. This interface provides an abstraction layer over serialization formats, libraries and implementations.
  */
 public interface ParseNode {
     /**
      * Gets a new parse node for the given identifier.
-     * @param identitier the identifier of the current node property.
+     * @param identifier the identifier of the current node property.
      * @return a new parse node for the given identifier.
      */
     @Nonnull
@@ -69,6 +72,28 @@ public interface ParseNode {
      */
     @Nonnull
     OffsetDateTime getOffsetDateTimeValue();
+
+    /**
+     * Gets the LocalDate value of the node.
+     * @return the LocalDate value of the node.
+     */
+    @Nonnull
+    LocalDate getLocalDateValue();
+
+    /**
+     * Gets the LocalTime value of the node.
+     * @return the LocalTime value of the node.
+     */
+    @Nonnull
+    LocalTime getLocalTimeValue();
+
+    /**
+     * Gets the Period value of the node.
+     * @return the Period value of the node.
+     */
+    @Nonnull
+    Period getPeriodValue();
+
     /**
      * Gets the Enum value of the node.
      * @return the Enum value of the node.
@@ -112,7 +137,7 @@ public interface ParseNode {
     @Nullable
     Consumer<Parsable> getOnBeforeAssignFieldValues();
     /**
-     * Gets the callback called after the node is deseserialized.
+     * Gets the callback called after the node is deserialized.
      * @return the callback called after the node is deserialized.
      */
     @Nullable

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/SerializationWriter.java
@@ -2,7 +2,10 @@ package com.microsoft.kiota.serialization;
 
 import java.io.Closeable;
 import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.Period;
 import java.util.Map;
 import java.util.UUID;
 import java.util.EnumSet;
@@ -63,6 +66,24 @@ public interface SerializationWriter extends Closeable {
      * @param value the value to write to the stream.
      */
     void writeOffsetDateTimeValue(@Nullable final String key, @Nonnull final OffsetDateTime value);
+    /**
+     * Writes the specified LocalDate value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    void writeLocalDateValue(@Nullable final String key, @Nonnull final LocalDate value);
+    /**
+     * Writes the specified LocalTime value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    void writeLocalTimeValue(@Nullable final String key, @Nonnull final LocalTime value);
+    /**
+     * Writes the specified Period value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    void writePeriodValue(@Nullable final String key, @Nonnull final Period value);
     /**
      * Writes the specified collection of primitive values to the stream with an optional given key.
      * @param key the key to write the value with.

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/kiota-abstractions",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "MIT",
       "dependencies": {
         "tinyduration": "^3.2.2",

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.24",
       "license": "MIT",
       "dependencies": {
+        "tinyduration": "^3.2.2",
         "uri-template-lite": "^22.1.0",
         "uuid": "^8.3.2",
         "web-streams-polyfill": "^3.2.0"
@@ -37,6 +38,11 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
+    },
+    "node_modules/tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w=="
     },
     "node_modules/typescript": {
       "version": "4.5.4",
@@ -91,6 +97,11 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
+    },
+    "tinyduration": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.2.tgz",
+      "integrity": "sha512-eH6D0KIA4Xxje3ZRUnbsWfN28pAgTx3ZFQvgb0w9u8p9lxSX0eloxi4w165gv03GnvduR9m5JhToPxXvADHe+w=="
     },
     "typescript": {
       "version": "4.5.4",

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -32,6 +32,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
+    "tinyduration": "^3.2.2",
     "uri-template-lite": "^22.1.0",
     "uuid": "^8.3.2",
     "web-streams-polyfill": "^3.2.0"

--- a/abstractions/typescript/src/dateOnly.ts
+++ b/abstractions/typescript/src/dateOnly.ts
@@ -1,0 +1,97 @@
+/**
+ * Represents a date only. ISO 8601.
+ */
+export class DateOnly implements DateOnlyInterface {
+    /**
+     * Creates a new DateOnly from the given string.
+     * @returns The new DateOnly
+     * @throws An error if the year is invalid
+     * @throws An error if the month is invalid
+     * @throws An error if the day is invalid
+     */
+    public constructor(
+        {year = 0,
+        month = 1,
+        day = 1} : Partial<DateOnlyInterface>
+    ) {
+        if (year < 0)
+            throw new Error("Year must be positive");
+        if (month < 1 || month > 12)
+            throw new Error("Month must be between 1 and 12");
+        if (day < 1 || day > 31)
+            throw new Error("Day must be between 1 and 31");
+        this.year = year;
+        this.month = month;
+        this.day = day;
+    }
+    public year: number;
+    public month: number;
+    public day: number;
+    /**
+     * Creates a new DateOnly from the given date.
+     * @param date The date
+     * @returns The new DateOnly
+     * @throws An error if the date is invalid
+     */
+    public static fromDate(date: Date): DateOnly {
+        if (!date)
+            throw new Error("Date cannot be undefined");
+        return new DateOnly({year: date.getFullYear(), month: date.getMonth(), day: date.getDate()});
+    }
+    /**
+     * Parses a string into a DateOnly. The string can be of the ISO 8601 time only format or a number representing the ticks of a Date.
+     * @param value The value to parse
+     * @returns The parsed DateOnly.
+     * @throws An error if the value is invalid
+     */
+     public static parse(value: string): DateOnly {
+        if(!value)
+            throw new Error("Value cannot be undefined");
+        const ticks = Date.parse(value);
+        if (isNaN(ticks)) {
+            const exec = /^(?<year>\d{4,})-(?<month>0[1-9]|1[012])-(?<day>0[1-9]|[12]\d|3[01])$/gi.exec(value);
+            if(exec) {
+                const year = parseInt(exec.groups?.year ?? '');
+                const month = parseInt(exec.groups?.month ?? '');
+                const day = parseInt(exec.groups?.day ?? '');
+                return new DateOnly({year, month, day});
+            } else
+                throw new Error("Value is not a valid date-only representation");
+        } else {
+            const date = new Date(ticks);
+            return this.fromDate(date)
+        }
+    }
+    /**
+     *  Returns a string representation of the date in the format YYYY-MM-DD
+     * @returns The date in the format YYYY-MM-DD ISO 8601
+     */
+    public toString(): string {
+        return `${formatSegment(this.year, 4)}-${formatSegment(this.month)}-${formatSegment(this.day)}`;
+    }
+}
+interface DateOnlyInterface {
+    /**
+     * The year
+     * @default 0
+     * @minium 0
+     */
+    year: number;
+    /**
+     * The month
+     * @default 1
+     * @minium 1
+     * @maximum 12
+     */
+    month: number;
+    /**
+     * The day
+     * @default 1
+     * @minium 1
+     * @maximum 31
+     */
+    day: number;
+}
+export function formatSegment(segment: number, digits: number = 2): string {
+    return segment.toString().padStart(digits, "0");
+}

--- a/abstractions/typescript/src/dateOnly.ts
+++ b/abstractions/typescript/src/dateOnly.ts
@@ -44,9 +44,9 @@ export class DateOnly implements DateOnlyInterface {
      * @returns The parsed DateOnly.
      * @throws An error if the value is invalid
      */
-     public static parse(value: string): DateOnly {
-        if(!value)
-            throw new Error("Value cannot be undefined");
+     public static parse(value: string | undefined): DateOnly | undefined {
+        if(!value || value.length === 0)
+            return undefined;
         const ticks = Date.parse(value);
         if (isNaN(ticks)) {
             const exec = /^(?<year>\d{4,})-(?<month>0[1-9]|1[012])-(?<day>0[1-9]|[12]\d|3[01])$/gi.exec(value);

--- a/abstractions/typescript/src/dateOnly.ts
+++ b/abstractions/typescript/src/dateOnly.ts
@@ -14,19 +14,27 @@ export class DateOnly implements DateOnlyInterface {
         month = 1,
         day = 1} : Partial<DateOnlyInterface>
     ) {
-        if (year < 0)
-            throw new Error("Year must be positive");
-        if (month < 1 || month > 12)
-            throw new Error("Month must be between 1 and 12");
-        if (day < 1 || day > 31)
-            throw new Error("Day must be between 1 and 31");
-        this.year = year;
-        this.month = month;
-        this.day = day;
+        this.date = new Date(year, month - 1, day);
     }
-    public year: number;
-    public month: number;
-    public day: number;
+    private date: Date;
+    public get year(): number {
+        return this.date.getFullYear();
+    }
+    public set year(value: number) {
+        this.date.setFullYear(value);
+    }
+    public get month(): number {
+        return this.date.getMonth() + 1;
+    }
+    public set month(value: number) {
+        this.date.setMonth(value - 1);
+    }
+    public get day(): number {
+        return this.date.getDate();
+    }
+    public set day(value: number) {
+        this.date.setDate(value);
+    }
     /**
      * Creates a new DateOnly from the given date.
      * @param date The date
@@ -36,7 +44,9 @@ export class DateOnly implements DateOnlyInterface {
     public static fromDate(date: Date): DateOnly {
         if (!date)
             throw new Error("Date cannot be undefined");
-        return new DateOnly({year: date.getFullYear(), month: date.getMonth(), day: date.getDate()});
+        const result = new DateOnly({});
+        result.date = new Date(date);
+        return result;
     }
     /**
      * Parses a string into a DateOnly. The string can be of the ISO 8601 time only format or a number representing the ticks of a Date.

--- a/abstractions/typescript/src/duration.ts
+++ b/abstractions/typescript/src/duration.ts
@@ -1,0 +1,132 @@
+import { parse as parseDuration, serialize as serializeDuration } from "tinyduration";
+/**
+ * Represents a duration value. ISO 8601.
+ */
+export class Duration implements DurationInterface {
+    /**
+     * Creates a new Duration value from the given parameters.
+     * @returns The new Duration
+     * @throws An error if years is invalid
+     * @throws An error if months is invalid
+     * @throws An error if weeks is invalid
+     * @throws An error if days is invalid
+     * @throws An error if hours is invalid
+     * @throws An error if minutes is invalid
+     * @throws An error if seconds is invalid
+     * @throws An error if weeks is used in combination with years or months
+     */
+    public constructor (
+        {years = 0,
+        months = 0,
+        weeks = 0,
+        days = 0,
+        hours = 0,
+        minutes = 0,
+        seconds = 0,
+        negative = false} : Partial<DurationInterface>
+    ) {
+        if (years < 0 || years > 9999)
+            throw new Error("Year must be between 0 and 9999");
+        if (months < 0 || months > 11)
+            throw new Error("Month must be between 0 and 11");
+        if (weeks < 0 || weeks > 53)
+            throw new Error("Week must be between 0 and 53");
+        if (days < 0 || days > 6)
+            throw new Error("Day must be between 0 and 6");
+        if (hours < 0 || hours > 23)
+            throw new Error("Hour must be between 0 and 23");
+        if (minutes < 0 || minutes > 59)
+            throw new Error("Minute must be between 0 and 59");
+        if (seconds < 0 || seconds > 59)
+            throw new Error("Second must be between 0 and 59");
+        if ((years > 0 || months > 0) && weeks > 0)
+            throw new Error("Cannot have weeks and months or weeks and years");
+        this.years = years;
+        this.months = months;
+        this.weeks = weeks;
+        this.days = days;
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+        this.negative = negative;
+    }
+    public years: number;
+    public months: number;
+    public weeks: number;
+    public days: number;
+    public hours: number;
+    public minutes: number;
+    public seconds: number;
+    public negative: boolean;
+    /**
+     * Parses a string into a Duration. The string can be of the ISO 8601 duration format.
+     * @param value The value to parse
+     * @returns The parsed Duration.
+     * @throws An error if the value is invalid
+     */
+    public static parse(value: string): Duration {
+        if (!value)
+            throw new Error("Value cannot be undefined");
+        const duration = parseDuration(value);
+        return new Duration({
+            years: duration.years ?? 0,
+            months: duration.months ?? 0,
+            weeks: duration.weeks ?? 0,
+            days: duration.days ?? 0,
+            hours: duration.hours ?? 0,
+            minutes: duration.minutes ?? 0,
+            seconds: duration.seconds ?? 0,
+            negative: duration.negative ?? false
+        });
+    }
+    /**
+     * Serializes the duration to a string in the ISO 8601 duration format.
+     * @returns The serialized duration.
+     */
+    public toString(): string {
+        return serializeDuration(this);
+    }
+}
+
+interface DurationInterface {
+    /**
+     * Years of the duration
+     * @default 0
+     */
+    years: number;
+    /**
+     * Months of the duration
+     * @default 0
+     */
+    months: number;
+    /**
+     * Weeks of the duration, can't be used together with years or months
+     * @default 0
+     */
+    weeks: number;
+    /**
+     * Days of the duration
+     * @default 0
+     */
+    days: number;
+    /**
+     * Hours of the duration
+     * @default 0
+     */
+    hours: number;
+    /**
+     * Minutes of the duration
+     * @default 0
+     */
+    minutes: number;
+    /**
+     * Seconds of the duration
+     * @default 0
+     */
+    seconds: number;
+    /**
+     * Whether the duration is negative
+     * @default false
+     */
+    negative: boolean;
+}

--- a/abstractions/typescript/src/duration.ts
+++ b/abstractions/typescript/src/duration.ts
@@ -64,9 +64,9 @@ export class Duration implements DurationInterface {
      * @returns The parsed Duration.
      * @throws An error if the value is invalid
      */
-    public static parse(value: string): Duration {
-        if (!value)
-            throw new Error("Value cannot be undefined");
+    public static parse(value: string | undefined): Duration | undefined {
+        if (!value || value.length === 0)
+            return undefined;
         const duration = parseDuration(value);
         return new Duration({
             years: duration.years ?? 0,

--- a/abstractions/typescript/src/index.ts
+++ b/abstractions/typescript/src/index.ts
@@ -1,5 +1,7 @@
 export * from './apiClientBuilder';
 export * from './authentication';
+export * from './dateOnly';
+export * from './duration';
 export * from './getPathParameters';
 export * from './httpMethod';
 export * from './nativeResponseHandler';
@@ -10,4 +12,5 @@ export * from './requestOption';
 export * from './responseHandler';
 export * from './serialization';
 export * from './store';
+export * from './timeOnly';
 export * from './utils';

--- a/abstractions/typescript/src/serialization/parseNode.ts
+++ b/abstractions/typescript/src/serialization/parseNode.ts
@@ -1,7 +1,10 @@
+import { DateOnly } from "../dateOnly";
+import { Duration } from "../duration";
+import { TimeOnly } from "../timeOnly";
 import { Parsable } from "./parsable";
 
 /**
- * Interface for a deserialization node in a parse tree. This interace provides an abstraction layer over serialiation formats, libararies and implementations.
+ * Interface for a deserialization node in a parse tree. This interface provides an abstraction layer over serialization formats, libraries and implementations.
  */
 export interface ParseNode {
     /**
@@ -11,7 +14,7 @@ export interface ParseNode {
     getStringValue(): string;
     /**
      * Gets a new parse node for the given identifier.
-     * @param identitier the identifier of the current node property.
+     * @param identifier the identifier of the current node property.
      * @return a new parse node for the given identifier.
      */
     getChildNode(identifier: string): ParseNode;
@@ -35,6 +38,21 @@ export interface ParseNode {
      * @return the Date value of the node.
      */
     getDateValue(): Date;
+    /**
+     * Gets the Duration value of the node.
+     * @return the Duration value of the node.
+     */
+    getDurationValue(): Duration | undefined;
+     /**
+     * Gets the DateOnly value of the node.
+     * @return the DateOnly value of the node.
+     */
+    getDateOnlyValue(): DateOnly | undefined;
+    /**
+     * Gets the TimeOnly value of the node.
+     * @return the TimeOnly value of the node.
+     */
+    getTimeOnlyValue(): TimeOnly | undefined;
     /**
      * Gets the collection of primitive values of the node.
      * @return the collection of primitive values of the node.

--- a/abstractions/typescript/src/serialization/serializationWriter.ts
+++ b/abstractions/typescript/src/serialization/serializationWriter.ts
@@ -1,5 +1,8 @@
 import { Parsable } from "./parsable";
 import { ReadableStream } from 'web-streams-polyfill/es2018';
+import { Duration } from "../duration";
+import { TimeOnly } from "../timeOnly";
+import { DateOnly } from "../dateOnly";
 
 /** Defines an interface for serialization of objects to a stream. */
 export interface SerializationWriter {
@@ -33,6 +36,24 @@ export interface SerializationWriter {
      * @param value the value to write to the stream.
      */
     writeDateValue(key?: string | undefined, value?: Date | undefined): void;
+    /**
+     * Writes the specified Duration value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    writeDurationValue(key?: string | undefined, value?: Duration | undefined): void;
+    /**
+     * Writes the specified TimeOnly value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    writeTimeOnlyValue(key?: string | undefined, value?: TimeOnly | undefined): void;
+    /**
+     * Writes the specified DateOnly value to the stream with an optional given key.
+     * @param key the key to write the value with.
+     * @param value the value to write to the stream.
+     */
+    writeDateOnlyValue(key?: string | undefined, value?: DateOnly | undefined): void;
     /**
      * Writes the specified collection of primitive values to the stream with an optional given key.
      * @param key the key to write the value with.

--- a/abstractions/typescript/src/timeOnly.ts
+++ b/abstractions/typescript/src/timeOnly.ts
@@ -1,0 +1,110 @@
+import { formatSegment } from "./dateOnly";
+/*
+* Represents a time only. ISO 8601.
+*/
+export class TimeOnly implements TimeOnlyInterface {
+    /**
+     * Creates a new TimeOnly from the given parameters.
+     * @returns The new TimeOnly
+     * @throws An error if the milliseconds are invalid
+     * @throws An error if the seconds are invalid
+     * @throws An error if the minutes are invalid
+     * @throws An error if the hours are invalid
+     * @throws An error if the milliseconds are invalid
+     */
+    public constructor({hours = 0,
+                    minutes = 0,
+                    seconds = 0,
+                    picoseconds = 0} : Partial<TimeOnlyInterface>) {
+        if (hours < 0 || hours > 23)
+            throw new Error("Hour must be between 0 and 23");
+        if (minutes < 0 || minutes > 59)
+            throw new Error("Minute must be between 0 and 59");
+        if (seconds < 0 || seconds > 59)
+            throw new Error("Second must be between 0 and 59");
+        if (picoseconds < 0 || picoseconds > 999999999999)
+            throw new Error("Millisecond must be between 0 and 999999999999");
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+        this.picoseconds = picoseconds;
+    }
+    public hours: number;
+    public minutes: number;
+    public seconds: number;
+    public picoseconds: number;
+    /**
+     * Creates a new TimeOnly from the given date.
+     * @param date The date
+     * @returns The new TimeOnly
+     * @throws An error if the date is invalid
+     */
+    public static fromDate(date: Date): TimeOnly {
+        if (!date)
+            throw new Error("Date cannot be undefined");
+        return new TimeOnly({hours: date.getHours(), minutes: date.getMinutes(), seconds: date.getSeconds(), picoseconds: date.getMilliseconds() * 1000000000});
+    }
+    /**
+     * Parses a string into a TimeOnly. The string can be of the ISO 8601 time only format or a number representing the ticks of a Date.
+     * @param value The value to parse
+     * @returns The parsed TimeOnly.
+     * @throws An error if the value is invalid
+     */
+    public static parse(value: string): TimeOnly {
+        if(!value)
+            throw new Error("Value cannot be undefined");
+        const ticks = Date.parse(value);
+        if (isNaN(ticks)) {
+            const exec = /^(?<hours>[01]\d|2[0-3]):(?<minutes>[0-5]\d):(?<seconds>[0-5]\d)(?:[.](?<milliseconds>\d{1,12}))?$/gi.exec(value);
+            if(exec) {
+                const hours = parseInt(exec.groups?.hours ?? '');
+                const minutes = parseInt(exec.groups?.minutes ?? '');
+                const seconds = parseInt(exec.groups?.seconds ?? '');
+                const milliseconds = parseInt(exec.groups?.milliseconds ?? '0');
+                return new TimeOnly({hours, minutes, seconds, picoseconds: milliseconds});
+            } else
+                throw new Error("Value is not a valid time-only representation");
+        } else {
+            const date = new Date(ticks);
+            return this.fromDate(date)
+        }
+    }
+    /**
+     * Returns a string representation of the time in the format HH:MM:SS.SSSSSSSSSSSSSS
+     * @returns The time in the format HH:MM:SS.SSSSSSSSSSSSSS
+     * @throws An error if the time is invalid
+     */
+    public toString(): string {
+        return `${formatSegment(this.hours, 2)}:${formatSegment(this.minutes, 2)}:${formatSegment(this.seconds, 2)}.${formatSegment(this.picoseconds, 12)}`;
+    }
+}
+interface TimeOnlyInterface {
+    /**
+     * The hours
+     * @default 0
+     * @minimum 0
+     * @maximum 23
+     */
+    hours: number;
+    /**
+     * The minutes
+     * @default 0
+     * @minimum 0
+     * @maximum 59
+     */
+    minutes: number;
+    /**
+     * The seconds
+     * @default 0
+     * @minimum 0
+     * @maximum 59
+     */
+    seconds: number;
+    /**
+     * The milliseconds
+     * @default 0
+     * @minimum 0
+     * @maximum 999999999999
+     */
+    picoseconds: number;
+}

--- a/abstractions/typescript/src/timeOnly.ts
+++ b/abstractions/typescript/src/timeOnly.ts
@@ -50,9 +50,9 @@ export class TimeOnly implements TimeOnlyInterface {
      * @returns The parsed TimeOnly.
      * @throws An error if the value is invalid
      */
-    public static parse(value: string): TimeOnly {
-        if(!value)
-            throw new Error("Value cannot be undefined");
+    public static parse(value: string | undefined): TimeOnly | undefined {
+        if(!value || value.length === 0)
+            return undefined;
         const ticks = Date.parse(value);
         if (isNaN(ticks)) {
             const exec = /^(?<hours>[01]\d|2[0-3]):(?<minutes>[0-5]\d):(?<seconds>[0-5]\d)(?:[.](?<milliseconds>\d{1,12}))?$/gi.exec(value);

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.Json;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -24,7 +26,11 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                             "    \"officeLocation\": null,\r\n" +
                                             "    \"preferredLanguage\": \"en-US\",\r\n" +
                                             "    \"surname\": \"Bowen\",\r\n" +
+                                            "    \"workDuration\": \"PT1H\",\r\n" +
+                                            "    \"startWorkTime\": \"08:00:00.0000000\",\r\n" +
+                                            "    \"endWorkTime\": \"17:00:00.0000000\",\r\n" +
                                             "    \"userPrincipalName\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
+                                            "    \"birthDay\": \"2017-09-04\",\r\n" +
                                             "    \"id\": \"48d31887-5fad-4d73-a9f5-3c356e68a038\"\r\n" +
                                             "}";
 
@@ -47,6 +53,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal("Auditor", testEntity.AdditionalData["jobTitle"]);
             Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntity.Id);
             Assert.Equal(TestEnum.One | TestEnum.Two, testEntity.Numbers ); // Unknown enum value is not included
+            Assert.Equal(TimeSpan.FromHours(1), testEntity.WorkDuration); // Parses timespan values
+            Assert.Equal(new Time(8,0,0).ToString(),testEntity.StartWorkTime.ToString());// Parses time values
+            Assert.Equal(new Time(17, 0, 0).ToString(), testEntity.EndWorkTime.ToString());// Parses time values
+            Assert.Equal(new Date(2017,9,4).ToString(), testEntity.BirthDay.ToString());// Parses date values
         }
 
         [Fact]

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -16,6 +17,9 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var testEntity = new TestEntity()
             {
                 Id = "48d31887-5fad-4d73-a9f5-3c356e68a038",
+                WorkDuration = TimeSpan.FromHours(1),
+                StartWorkTime = new Time(8, 0, 0),
+                BirthDay = new Date(2017, 9, 4),
                 AdditionalData = new Dictionary<string, object>
                 {
                     {"mobilePhone",null}, // write null value
@@ -37,6 +41,9 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             // Assert
             var expectedString = "{" +
                                  "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
+                                 "\"workDuration\":\"PT1H\","+    // Serializes timespans
+                                 "\"birthDay\":\"2017-09-04\"," + // Serializes dates
+                                 "\"startWorkTime\":\"08:00:00\"," + //Serializes times
                                  "\"mobilePhone\":null," +
                                  "\"accountEnabled\":false," +
                                  "\"jobTitle\":\"Author\"," +

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
@@ -12,6 +13,14 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         public string Id { get; set; }
         /// <summary>Read-only.</summary>
         public TestEnum? Numbers { get; set; }
+        /// <summary>Read-only.</summary>
+        public TimeSpan? WorkDuration { get; set; }
+        /// <summary>Read-only.</summary>
+        public Date? BirthDay { get; set; }
+        /// <summary>Read-only.</summary>
+        public Time? StartWorkTime { get; set; }
+        /// <summary>Read-only.</summary>
+        public Time? EndWorkTime { get; set; }
         /// <summary>Read-only.</summary>
         public DateTimeOffset? CreatedDateTime { get; set; }
         /// <summary>Read-only.</summary>
@@ -33,6 +42,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
                 {"numbers", (o,n) => { (o as TestEntity).Numbers = n.GetEnumValue<TestEnum>(); } },
                 {"createdDateTime", (o,n) => { (o as TestEntity).CreatedDateTime = n.GetDateTimeOffsetValue(); } },
                 {"officeLocation", (o,n) => { (o as TestEntity).OfficeLocation = n.GetStringValue(); } },
+                {"workDuration", (o,n) => { (o as TestEntity).WorkDuration = n.GetTimeSpanValue(); } },
+                {"birthDay", (o,n) => { (o as TestEntity).BirthDay = n.GetDateValue(); } },
+                {"startWorkTime", (o,n) => { (o as TestEntity).StartWorkTime = n.GetTimeValue(); } },
+                {"endWorkTime", (o,n) => { (o as TestEntity).EndWorkTime = n.GetTimeValue(); } },
             };
         }
         /// <summary>
@@ -46,6 +59,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
             writer.WriteEnumValue<TestEnum>("numbers",Numbers);
             writer.WriteDateTimeOffsetValue("createdDateTime", CreatedDateTime);
             writer.WriteStringValue("officeLocation", OfficeLocation);
+            writer.WriteTimeSpanValue("workDuration", WorkDuration);
+            writer.WriteDateValue("birthDay", BirthDay);
+            writer.WriteTimeValue("startWorkTime", StartWorkTime);
+            writer.WriteTimeValue("endWorkTime", EndWorkTime);
             writer.WriteAdditionalData(AdditionalData);
         }
     }

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.Kiota.Abstractions.Serialization;
+using Microsoft.Kiota.Abstractions;
+using System.Xml;
 
 namespace Microsoft.Kiota.Serialization.Json
 {
@@ -84,6 +86,46 @@ namespace Microsoft.Kiota.Serialization.Json
         }
 
         /// <summary>
+        /// Get the <see cref="TimeSpan"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="TimeSpan"/> value</returns>
+        public TimeSpan? GetTimeSpanValue()
+        {
+            var jsonString = _jsonNode.GetString();
+            if(string.IsNullOrEmpty(jsonString))
+                return null;
+
+            // Parse an ISO8601 duration.http://en.wikipedia.org/wiki/ISO_8601#Durations to a TimeSpan
+            return XmlConvert.ToTimeSpan(jsonString);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Date"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="Date"/> value</returns>
+        public Date? GetDateValue()
+        {
+            var dateString = _jsonNode.GetString();
+            if(!DateTime.TryParse(dateString,out var result))
+                return null;
+
+            return new Date(result);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Time"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="Time"/> value</returns>
+        public Time? GetTimeValue()
+        {
+            var dateString = _jsonNode.GetString();
+            if(!DateTime.TryParse(dateString,out var result))
+                return null;
+
+            return new Time(result);
+        }
+
+        /// <summary>
         /// Get the enumeration value of type <typeparam name="T"/>from the json node
         /// </summary>
         /// <returns>An enumeration value or null</returns>
@@ -154,6 +196,9 @@ namespace Microsoft.Kiota.Serialization.Json
         private static Type doubleType = typeof(double?);
         private static Type guidType = typeof(Guid?);
         private static Type dateTimeOffsetType = typeof(DateTimeOffset?);
+        private static Type timeSpanType = typeof(TimeSpan?);
+        private static Type dateType = typeof(Date?);
+        private static Type timeType = typeof(Time?);
 
         /// <summary>
         /// Get the collection of primitives of type <typeparam name="T"/>from the json node
@@ -183,6 +228,12 @@ namespace Microsoft.Kiota.Serialization.Json
                     yield return (T)(object)currentParseNode.GetGuidValue();
                 else if(genericType == dateTimeOffsetType)
                     yield return (T)(object)currentParseNode.GetDateTimeOffsetValue();
+                else if(genericType == timeSpanType)
+                    yield return (T)(object)currentParseNode.GetTimeSpanValue();
+                else if(genericType == dateType)
+                    yield return (T)(object)currentParseNode.GetDateValue();
+                else if(genericType == timeType)
+                    yield return (T)(object)currentParseNode.GetTimeValue();
                 else
                     throw new InvalidOperationException($"unknown type for deserialization {genericType.FullName}");
             }

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -10,6 +10,8 @@ using Microsoft.Kiota.Abstractions.Serialization;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Kiota.Abstractions.Extensions;
+using Microsoft.Kiota.Abstractions;
+using System.Xml;
 
 namespace Microsoft.Kiota.Serialization.Json
 {
@@ -147,6 +149,39 @@ namespace Microsoft.Kiota.Serialization.Json
         {
             if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
             if(value.HasValue) writer.WriteStringValue(value.Value);
+        }
+
+        /// <summary>
+        /// Write the TimeSpan(An ISO8601 duration.For example, PT1M is "period time of 1 minute") value.
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The TimeSpan value</param>
+        public void WriteTimeSpanValue(string key, TimeSpan? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(XmlConvert.ToString(value.Value));
+        }
+
+        /// <summary>
+        /// Write the Date value
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The Date value</param>
+        public void WriteDateValue(string key, Date? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
+        }
+
+        /// <summary>
+        /// Write the Time value
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The Time value</param>
+        public void WriteTimeValue(string key, Time? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
         }
 
         /// <summary>
@@ -310,11 +345,20 @@ namespace Microsoft.Kiota.Serialization.Json
                 case DateTimeOffset dto:
                     WriteDateTimeOffsetValue(key, dto);
                     break;
+                case TimeSpan timeSpan:
+                    WriteTimeSpanValue(key, timeSpan);
+                    break;
                 case IEnumerable<object> coll:
                     WriteCollectionOfPrimitiveValues(key, coll);
                     break;
                 case IParsable parseable:
                     WriteObjectValue(key, parseable);
+                    break;
+                case Date date:
+                    WriteDateValue(key, date);
+                    break;
+                case Time time:
+                    WriteTimeValue(key, time);
                     break;
                 case object o:
                     WriteNonParsableObjectValue(key, o);

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.27" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/serialization/go/json/json_parse_node.go
+++ b/serialization/go/json/json_parse_node.go
@@ -244,8 +244,8 @@ func (n *JsonParseNode) getPrimitiveValue(targetType string) (interface{}, error
 		return n.GetTimeOnlyValue()
 	case "dateonly":
 		return n.GetDateOnlyValue()
-	case "duration":
-		return n.GetDurationValue()
+	case "isoduration":
+		return n.GetISODurationValue()
 	case "uuid":
 		return n.GetUUIDValue()
 	case "base64":
@@ -354,8 +354,8 @@ func (n *JsonParseNode) GetTimeValue() (*time.Time, error) {
 	return &parsed, err
 }
 
-// GetDurationValue returns a Duration value from the nodes.
-func (n *JsonParseNode) GetDurationValue() (*time.Duration, error) {
+// GetISODurationValue returns a ISODuration value from the nodes.
+func (n *JsonParseNode) GetISODurationValue() (*absser.ISODuration, error) {
 	v, err := n.GetStringValue()
 	if err != nil {
 		return nil, err
@@ -363,8 +363,7 @@ func (n *JsonParseNode) GetDurationValue() (*time.Duration, error) {
 	if v == nil {
 		return nil, nil
 	}
-	parsed, err := time.ParseDuration(*v)
-	return &parsed, err
+	return absser.ParseISODuration(*v)
 }
 
 // GetTimeOnlyValue returns a TimeOnly value from the nodes.

--- a/serialization/go/json/json_parse_node.go
+++ b/serialization/go/json/json_parse_node.go
@@ -376,8 +376,7 @@ func (n *JsonParseNode) GetTimeOnlyValue() (*absser.TimeOnly, error) {
 	if v == nil {
 		return nil, nil
 	}
-	parsed, err := absser.ParseTimeOnly(*v)
-	return &parsed, err
+	return absser.ParseTimeOnly(*v)
 }
 
 // GetDateOnlyValue returns a DateOnly value from the nodes.
@@ -389,8 +388,7 @@ func (n *JsonParseNode) GetDateOnlyValue() (*absser.DateOnly, error) {
 	if v == nil {
 		return nil, nil
 	}
-	parsed, err := absser.ParseDateOnly(*v)
-	return &parsed, err
+	return absser.ParseDateOnly(*v)
 }
 
 // GetUUIDValue returns a UUID value from the nodes.

--- a/serialization/go/json/json_parse_node.go
+++ b/serialization/go/json/json_parse_node.go
@@ -148,7 +148,7 @@ func (n *JsonParseNode) GetChildNode(index string) (absser.ParseNode, error) {
 // GetObjectValue returns the Parsable value from the node.
 func (n *JsonParseNode) GetObjectValue(ctor func() absser.Parsable) (absser.Parsable, error) {
 	if ctor == nil {
-		return nil, errors.New("constuctor is nil")
+		return nil, errors.New("constructor is nil")
 	}
 	if n == nil || n.value == nil {
 		return nil, nil
@@ -240,6 +240,12 @@ func (n *JsonParseNode) getPrimitiveValue(targetType string) (interface{}, error
 		return n.GetInt64Value()
 	case "time":
 		return n.GetTimeValue()
+	case "timeonly":
+		return n.GetTimeOnlyValue()
+	case "dateonly":
+		return n.GetDateOnlyValue()
+	case "duration":
+		return n.GetDurationValue()
 	case "uuid":
 		return n.GetUUIDValue()
 	case "base64":
@@ -345,6 +351,45 @@ func (n *JsonParseNode) GetTimeValue() (*time.Time, error) {
 		return nil, nil
 	}
 	parsed, err := time.Parse(time.RFC3339, *v)
+	return &parsed, err
+}
+
+// GetDurationValue returns a Duration value from the nodes.
+func (n *JsonParseNode) GetDurationValue() (*time.Duration, error) {
+	v, err := n.GetStringValue()
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+	parsed, err := time.ParseDuration(*v)
+	return &parsed, err
+}
+
+// GetTimeOnlyValue returns a TimeOnly value from the nodes.
+func (n *JsonParseNode) GetTimeOnlyValue() (*absser.TimeOnly, error) {
+	v, err := n.GetStringValue()
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+	parsed, err := absser.ParseTimeOnly(*v)
+	return &parsed, err
+}
+
+// GetDateOnlyValue returns a DateOnly value from the nodes.
+func (n *JsonParseNode) GetDateOnlyValue() (*absser.DateOnly, error) {
+	v, err := n.GetStringValue()
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+	parsed, err := absser.ParseDateOnly(*v)
 	return &parsed, err
 }
 

--- a/serialization/go/json/json_serialization_writer.go
+++ b/serialization/go/json/json_serialization_writer.go
@@ -141,6 +141,48 @@ func (w *JsonSerializationWriter) WriteTimeValue(key string, value *time.Time) e
 	return nil
 }
 
+// WriteDurationValue writes a Duration value to underlying the byte array.
+func (w *JsonSerializationWriter) WriteDurationValue(key string, value *time.Duration) error {
+	if key != "" && value != nil {
+		w.writePropertyName(key)
+	}
+	if value != nil {
+		w.writeRawValue((*value).String())
+	}
+	if key != "" && value != nil {
+		w.writePropertySeparator()
+	}
+	return nil
+}
+
+// WriteTimeOnlyValue writes a TimeOnly value to underlying the byte array.
+func (w *JsonSerializationWriter) WriteTimeOnlyValue(key string, value *absser.TimeOnly) error {
+	if key != "" && value != nil {
+		w.writePropertyName(key)
+	}
+	if value != nil {
+		w.writeRawValue((*value).String())
+	}
+	if key != "" && value != nil {
+		w.writePropertySeparator()
+	}
+	return nil
+}
+
+// WriteDateOnlyValue writes a DateOnly value to underlying the byte array.
+func (w *JsonSerializationWriter) WriteDateOnlyValue(key string, value *absser.DateOnly) error {
+	if key != "" && value != nil {
+		w.writePropertyName(key)
+	}
+	if value != nil {
+		w.writeRawValue((*value).String())
+	}
+	if key != "" && value != nil {
+		w.writePropertySeparator()
+	}
+	return nil
+}
+
 // WriteUUIDValue writes a UUID value to underlying the byte array.
 func (w *JsonSerializationWriter) WriteUUIDValue(key string, value *uuid.UUID) error {
 	if key != "" && value != nil {
@@ -353,6 +395,75 @@ func (w *JsonSerializationWriter) WriteCollectionOfTimeValues(key string, collec
 	return nil
 }
 
+// WriteCollectionOfDurationValues writes a collection of Duration values to underlying the byte array.
+func (w *JsonSerializationWriter) WriteCollectionOfDurationValues(key string, collection []time.Duration) error {
+	if collection != nil { // empty collections are meaningful
+		if key != "" {
+			w.writePropertyName(key)
+		}
+		w.writeArrayStart()
+		for _, item := range collection {
+			err := w.WriteDurationValue("", &item)
+			if err != nil {
+				return err
+			}
+			w.writePropertySeparator()
+		}
+		w.trimLastPropertySeparator()
+		w.writeArrayEnd()
+		if key != "" {
+			w.writePropertySeparator()
+		}
+	}
+	return nil
+}
+
+// WriteCollectionOfTimeOnlyValues writes a collection of TimeOnly values to underlying the byte array.
+func (w *JsonSerializationWriter) WriteCollectionOfTimeOnlyValues(key string, collection []absser.TimeOnly) error {
+	if collection != nil { // empty collections are meaningful
+		if key != "" {
+			w.writePropertyName(key)
+		}
+		w.writeArrayStart()
+		for _, item := range collection {
+			err := w.WriteTimeOnlyValue("", &item)
+			if err != nil {
+				return err
+			}
+			w.writePropertySeparator()
+		}
+		w.trimLastPropertySeparator()
+		w.writeArrayEnd()
+		if key != "" {
+			w.writePropertySeparator()
+		}
+	}
+	return nil
+}
+
+// WriteCollectionOfDateOnlyValues writes a collection of DateOnly values to underlying the byte array.
+func (w *JsonSerializationWriter) WriteCollectionOfDateOnlyValues(key string, collection []absser.DateOnly) error {
+	if collection != nil { // empty collections are meaningful
+		if key != "" {
+			w.writePropertyName(key)
+		}
+		w.writeArrayStart()
+		for _, item := range collection {
+			err := w.WriteDateOnlyValue("", &item)
+			if err != nil {
+				return err
+			}
+			w.writePropertySeparator()
+		}
+		w.trimLastPropertySeparator()
+		w.writeArrayEnd()
+		if key != "" {
+			w.writePropertySeparator()
+		}
+	}
+	return nil
+}
+
 // WriteCollectionOfUUIDValues writes a collection of UUID values to underlying the byte array.
 func (w *JsonSerializationWriter) WriteCollectionOfUUIDValues(key string, collection []uuid.UUID) error {
 	if collection != nil { // empty collections are meaningful
@@ -481,6 +592,38 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 				}
 				continue
 			}
+			tc, ok := value.([]time.Time)
+			if ok {
+				err := w.WriteCollectionOfTimeValues(key, tc)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			dc, ok := value.([]time.Duration)
+			if ok {
+				err := w.WriteCollectionOfDurationValues(key, dc)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			toc, ok := value.([]absser.TimeOnly)
+			if ok {
+				err := w.WriteCollectionOfTimeOnlyValues(key, toc)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			doc, ok := value.([]absser.DateOnly)
+			if ok {
+				err := w.WriteCollectionOfDateOnlyValues(key, doc)
+				if err != nil {
+					return err
+				}
+				continue
+			}
 			sv, ok := value.(*string)
 			if ok {
 				err := w.WriteStringValue(key, sv)
@@ -540,6 +683,30 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 			tv, ok := value.(*time.Time)
 			if ok {
 				err := w.WriteTimeValue(key, tv)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			dv, ok := value.(*time.Duration)
+			if ok {
+				err := w.WriteDurationValue(key, dv)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			tov, ok := value.(*absser.TimeOnly)
+			if ok {
+				err := w.WriteTimeOnlyValue(key, tov)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			dov, ok := value.(*absser.DateOnly)
+			if ok {
+				err := w.WriteDateOnlyValue(key, dov)
 				if err != nil {
 					return err
 				}

--- a/serialization/go/json/json_serialization_writer.go
+++ b/serialization/go/json/json_serialization_writer.go
@@ -141,8 +141,8 @@ func (w *JsonSerializationWriter) WriteTimeValue(key string, value *time.Time) e
 	return nil
 }
 
-// WriteDurationValue writes a Duration value to underlying the byte array.
-func (w *JsonSerializationWriter) WriteDurationValue(key string, value *time.Duration) error {
+// WriteISODurationValue writes a ISODuration value to underlying the byte array.
+func (w *JsonSerializationWriter) WriteISODurationValue(key string, value *absser.ISODuration) error {
 	if key != "" && value != nil {
 		w.writePropertyName(key)
 	}
@@ -395,15 +395,15 @@ func (w *JsonSerializationWriter) WriteCollectionOfTimeValues(key string, collec
 	return nil
 }
 
-// WriteCollectionOfDurationValues writes a collection of Duration values to underlying the byte array.
-func (w *JsonSerializationWriter) WriteCollectionOfDurationValues(key string, collection []time.Duration) error {
+// WriteCollectionOfISODurationValues writes a collection of ISODuration values to underlying the byte array.
+func (w *JsonSerializationWriter) WriteCollectionOfISODurationValues(key string, collection []absser.ISODuration) error {
 	if collection != nil { // empty collections are meaningful
 		if key != "" {
 			w.writePropertyName(key)
 		}
 		w.writeArrayStart()
 		for _, item := range collection {
-			err := w.WriteDurationValue("", &item)
+			err := w.WriteISODurationValue("", &item)
 			if err != nil {
 				return err
 			}
@@ -600,9 +600,9 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 				}
 				continue
 			}
-			dc, ok := value.([]time.Duration)
+			dc, ok := value.([]absser.ISODuration)
 			if ok {
-				err := w.WriteCollectionOfDurationValues(key, dc)
+				err := w.WriteCollectionOfISODurationValues(key, dc)
 				if err != nil {
 					return err
 				}
@@ -688,9 +688,9 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 				}
 				continue
 			}
-			dv, ok := value.(*time.Duration)
+			dv, ok := value.(*absser.ISODuration)
 			if ok {
-				err := w.WriteDurationValue(key, dv)
+				err := w.WriteISODurationValue(key, dv)
 				if err != nil {
 					return err
 				}

--- a/serialization/java/json/lib/build.gradle
+++ b/serialization/java/json/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:31.0.1-jre'
     api 'com.google.code.gson:gson:2.8.9'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.20'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.24'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-serialization-json'
-            version '1.0.5'
+            version '1.0.6'
             from(components.java)
         }
     }

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -9,7 +9,10 @@ import com.google.gson.JsonPrimitive;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.Period;
 import java.util.Base64;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -71,6 +74,15 @@ public class JsonParseNode implements ParseNode {
     public OffsetDateTime getOffsetDateTimeValue() {
         return OffsetDateTime.parse(currentNode.getAsString());
     }
+    public LocalDate getLocalDateValue() {
+        return LocalDate.parse(currentNode.getAsString());
+    }
+    public LocalTime getLocalTimeValue() {
+        return LocalTime.parse(currentNode.getAsString());
+    }
+    public Period getPeriodValue() {
+        return Period.parse(currentNode.getAsString());
+    }
     public <T> List<T> getCollectionOfPrimitiveValues(final Class<T> targetClass) {
         Objects.requireNonNull(targetClass, "parameter targetClass cannot be null");
         if(currentNode.isJsonArray()) {
@@ -109,6 +121,12 @@ public class JsonParseNode implements ParseNode {
                                 return (T)itemNode.getUUIDValue();
                             } else if(targetClass == OffsetDateTime.class) {
                                 return (T)itemNode.getOffsetDateTimeValue();
+                            } else if(targetClass == LocalDate.class) {
+                                return (T)itemNode.getLocalDateValue();
+                            } else if(targetClass == LocalTime.class) {
+                                return (T)itemNode.getLocalTimeValue();
+                            } else if(targetClass == Period.class) {
+                                return (T)itemNode.getPeriodValue();
                             } else {
                                 throw new RuntimeException("unknown type to deserialize " + targetClass.getName());
                             }

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
@@ -11,7 +11,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -120,6 +123,39 @@ public class JsonSerializationWriter implements SerializationWriter {
                     writer.name(key);
                 }
                 writer.value(value.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
+            } catch (IOException ex) {
+                throw new RuntimeException("could not serialize value", ex);
+            }
+    }
+    public void writeLocalDateValue(final String key, final LocalDate value) {
+        if(value != null)
+            try {
+                if(key != null && !key.isEmpty()) {
+                    writer.name(key);
+                }
+                writer.value(value.format(DateTimeFormatter.ISO_LOCAL_DATE));
+            } catch (IOException ex) {
+                throw new RuntimeException("could not serialize value", ex);
+            }
+    }
+    public void writeLocalTimeValue(final String key, final LocalTime value) {
+        if(value != null)
+            try {
+                if(key != null && !key.isEmpty()) {
+                    writer.name(key);
+                }
+                writer.value(value.format(DateTimeFormatter.ISO_LOCAL_TIME));
+            } catch (IOException ex) {
+                throw new RuntimeException("could not serialize value", ex);
+            }
+    }
+    public void writePeriodValue(final String key, final Period value) {
+        if(value != null)
+            try {
+                if(key != null && !key.isEmpty()) {
+                    writer.name(key);
+                }
+                writer.value(value.toString());
             } catch (IOException ex) {
                 throw new RuntimeException("could not serialize value", ex);
             }
@@ -277,6 +313,12 @@ public class JsonSerializationWriter implements SerializationWriter {
                 this.writeUUIDValue(key, (UUID)value);
             else if(valueClass.equals(OffsetDateTime.class))
                 this.writeOffsetDateTimeValue(key, (OffsetDateTime)value);
+            else if(valueClass.equals(LocalDate.class))
+                this.writeLocalDateValue(key, (LocalDate)value);
+            else if(valueClass.equals(LocalTime.class))
+                this.writeLocalTimeValue(key, (LocalTime)value);
+            else if(valueClass.equals(Period.class))
+                this.writePeriodValue(key, (Period)value);
             else if(value instanceof Iterable<?>)
                 this.writeCollectionOfPrimitiveValues(key, (Iterable<?>)value);
             else if(!valueClass.isPrimitive())

--- a/serialization/typescript/json/src/jsonParseNode.ts
+++ b/serialization/typescript/json/src/jsonParseNode.ts
@@ -1,4 +1,4 @@
-import { Parsable, ParseNode, toFirstCharacterUpper } from "@microsoft/kiota-abstractions";
+import { DateOnly, Duration, Parsable, ParseNode, TimeOnly, toFirstCharacterUpper } from "@microsoft/kiota-abstractions";
 
 export class JsonParseNode implements ParseNode {
     /**
@@ -15,6 +15,9 @@ export class JsonParseNode implements ParseNode {
     public getNumberValue = (): number => this._jsonNode as number;
     public getGuidValue = (): string => this._jsonNode as string;
     public getDateValue = (): Date => this._jsonNode as Date;
+    public getDateOnlyValue = () => DateOnly.parse(this.getStringValue());
+    public getTimeOnlyValue = () => TimeOnly.parse(this.getStringValue());
+    public getDurationValue = () => Duration.parse(this.getStringValue());
     public getCollectionOfPrimitiveValues = <T>(): T[] | undefined => {
         return (this._jsonNode as unknown[])
             .map(x => {
@@ -26,6 +29,12 @@ export class JsonParseNode implements ParseNode {
                 } else if (x instanceof Number) {
                     return currentParseNode.getNumberValue() as unknown as T;
                 } else if (x instanceof Date) {
+                    return currentParseNode.getDateValue() as unknown as T;
+                } else if (x instanceof DateOnly) {
+                    return currentParseNode.getDateValue() as unknown as T;
+                } else if (x instanceof TimeOnly) {
+                    return currentParseNode.getDateValue() as unknown as T;
+                } else if (x instanceof Duration) {
                     return currentParseNode.getDateValue() as unknown as T;
                 } else throw new Error(`encountered an unknown type during deserialization ${typeof x}`);
             });

--- a/serialization/typescript/json/src/jsonSerializationWriter.ts
+++ b/serialization/typescript/json/src/jsonSerializationWriter.ts
@@ -1,4 +1,4 @@
-import { Parsable, SerializationWriter } from "@microsoft/kiota-abstractions";
+import { DateOnly, Duration, Parsable, SerializationWriter, TimeOnly } from "@microsoft/kiota-abstractions";
 import { TextEncoder } from "util";
 import { ReadableStream } from 'web-streams-polyfill/es2018';
 
@@ -34,6 +34,21 @@ export class JsonSerializationWriter implements SerializationWriter {
     public writeDateValue = (key?: string, value?: Date): void => {
         key && value && this.writePropertyName(key);
         value && this.writer.push(`"${value.toISOString()}"`);
+        key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
+    }
+    public writeDateOnlyValue = (key?: string, value?: DateOnly): void => {
+        key && value && this.writePropertyName(key);
+        value && this.writer.push(`"${value.toString()}"`);
+        key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
+    }
+    public writeTimeOnlyValue = (key?: string, value?: TimeOnly): void => {
+        key && value && this.writePropertyName(key);
+        value && this.writer.push(`"${value.toString()}"`);
+        key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
+    }
+    public writeDurationValue = (key?: string, value?: Duration): void => {
+        key && value && this.writePropertyName(key);
+        value && this.writer.push(`"${value.toString()}"`);
         key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
     }
     public writeNullValue = (key?: string): void => {
@@ -126,6 +141,12 @@ export class JsonSerializationWriter implements SerializationWriter {
                 this.writeStringValue(key, value as any as string);
             } else if (value instanceof Date) {
                 this.writeDateValue(key, value as any as Date);
+            } else if (value instanceof DateOnly) {
+                this.writeDateOnlyValue(key, value as any as DateOnly);
+            } else if (value instanceof TimeOnly) {
+                this.writeTimeOnlyValue(key, value as any as TimeOnly);
+            } else if (value instanceof Duration) {
+                this.writeDurationValue(key, value as any as Duration);
             } else if (valueType === "number") {
                 this.writeNumberValue(key, value as any as number);
             } else if(Array.isArray(value)) {

--- a/src/Kiota.Builder/CodeDOM/CodeUsing.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeUsing.cs
@@ -1,15 +1,24 @@
-﻿namespace Kiota.Builder
+﻿using System;
+
+namespace Kiota.Builder;
+public class CodeUsing : CodeElement, ICloneable
 {
-    public class CodeUsing : CodeElement
+    private CodeType declaration;
+    public CodeType Declaration { get => declaration; set {
+        EnsureElementsAreChildren(declaration);
+        declaration = value;
+    } }
+    public bool IsExternal {
+        get => Declaration?.IsExternal ?? true;
+    }
+    public string Alias { get; set; }
+    public object Clone()
     {
-        private CodeType declaration;
-        public CodeType Declaration { get => declaration; set {
-            EnsureElementsAreChildren(declaration);
-            declaration = value;
-        } }
-        public bool IsExternal {
-            get => Declaration?.IsExternal ?? true;
-        }
-        public string Alias { get; set; }
+        return new CodeUsing {
+            Declaration = (CodeType)Declaration?.Clone(),
+            Alias = Alias,
+            Name = Name.Clone() as string,
+            Parent = Parent,
+        };
     }
 }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -525,6 +525,12 @@ namespace Kiota.Builder
                     isExternal = true;
                 if("date-time".Equals(format, StringComparison.OrdinalIgnoreCase))
                     typeName = "DateTimeOffset";
+                else if("duration".Equals(format, StringComparison.OrdinalIgnoreCase))
+                    typeName = "TimeSpan";
+                else if("date".Equals(format, StringComparison.OrdinalIgnoreCase))
+                    typeName = "DateOnly";
+                else if("time".Equals(format, StringComparison.OrdinalIgnoreCase))
+                    typeName = "TimeOnly";
                 else if ("base64url".Equals(format, StringComparison.OrdinalIgnoreCase))
                     typeName = "binary";
             } else if ("double".Equals(format, StringComparison.OrdinalIgnoreCase) || 

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -10,6 +10,7 @@ namespace Kiota.Builder.Refiners {
         public override void Refine(CodeNamespace generatedCode)
         {
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
             AddRawUrlConstructorOverload(generatedCode);
@@ -98,5 +99,41 @@ namespace Kiota.Builder.Refiners {
                 currentMethod.Name += "Async";
             CrawlTree(currentElement, AddAsyncSuffix);
         }
+        private static void CorrectPropertyType(CodeProperty currentProperty)
+        {
+            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+        }
+        private static void CorrectMethodType(CodeMethod currentMethod)
+        {
+            CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                                    .Select(x => x.Type)
+                                                    .Union(new CodeTypeBase[] { currentMethod.ReturnType })
+                                                    .ToArray());
+        }
+        private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
+        {
+            {
+                "DateOnly",("Date", new CodeUsing
+                    {
+                        Name = "Date",
+                        Declaration = new CodeType
+                        {
+                            Name = "Microsoft.Kiota.Abstractions",
+                            IsExternal = true,
+                        },
+                    })
+            },
+            {
+                "TimeOnly",("Time", new CodeUsing
+                    {
+                        Name = "Time",
+                        Declaration = new CodeType
+                        {
+                            Name = "Microsoft.Kiota.Abstractions",
+                            IsExternal = true,
+                        },
+                    })
+            },
+        };
     }
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -4,531 +4,540 @@ using System.Linq;
 using Kiota.Builder.Extensions;
 using static Kiota.Builder.CodeClass;
 
-namespace Kiota.Builder.Refiners {
-    public abstract class CommonLanguageRefiner : ILanguageRefiner
-    {
-        protected CommonLanguageRefiner(GenerationConfiguration configuration) {
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        }
-        public abstract void Refine(CodeNamespace generatedCode);
-        /// <summary>
-        ///     This method adds the imports for the default serializers and deserializers to the api client class.
-        ///     It also updates the module names to replace the fully qualified class name by the class name without the namespace.
-        /// </summary>
-        protected void AddSerializationModulesImport(CodeElement generatedCode, string[] serializationWriterFactoryInterfaceAndRegistrationFullName = default, string[] parseNodeFactoryInterfaceAndRegistrationFullName = default) {
-            if(serializationWriterFactoryInterfaceAndRegistrationFullName == null)
-                serializationWriterFactoryInterfaceAndRegistrationFullName = Array.Empty<string>();
-            if(parseNodeFactoryInterfaceAndRegistrationFullName == null)
-                parseNodeFactoryInterfaceAndRegistrationFullName = Array.Empty<string>();
-            if(generatedCode is CodeMethod currentMethod &&
-                currentMethod.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                currentMethod.Parent is CodeClass currentClass &&
-                currentClass.StartBlock is CodeClass.Declaration declaration) {
-                    var cumulatedSymbols = currentMethod.DeserializerModules
-                                                        .Union(currentMethod.SerializerModules)
-                                                        .Union(serializationWriterFactoryInterfaceAndRegistrationFullName)
-                                                        .Union(parseNodeFactoryInterfaceAndRegistrationFullName)
-                                                        .Where(x => !string.IsNullOrEmpty(x))
-                                                        .ToList();
-                    currentMethod.DeserializerModules = currentMethod.DeserializerModules.Select(x => x.Split('.').Last()).ToList();
-                    currentMethod.SerializerModules = currentMethod.SerializerModules.Select(x => x.Split('.').Last()).ToList();
-                    declaration.AddUsings(cumulatedSymbols.Select(x => new CodeUsing {
-                        Name = x.Split('.').Last(),
-                        Declaration = new CodeType {
-                            Name = x.Split('.').SkipLast(1).Aggregate((x, y) => $"{x}.{y}"),
-                            IsExternal = true,
-                        }
-                    }).ToArray());
-                    return;
-                }
-            CrawlTree(generatedCode, x => AddSerializationModulesImport(x, serializationWriterFactoryInterfaceAndRegistrationFullName, parseNodeFactoryInterfaceAndRegistrationFullName));
-        }
-        protected static void ReplaceDefaultSerializationModules(CodeElement generatedCode, params string[] moduleNames) {
-            if(ReplaceSerializationModules(generatedCode, x => x.SerializerModules, "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory", moduleNames))
-                return;
-            CrawlTree(generatedCode, (x) => ReplaceDefaultSerializationModules(x, moduleNames));
-        }
-        protected static void ReplaceDefaultDeserializationModules(CodeElement generatedCode, params string[] moduleNames) {
-            if(ReplaceSerializationModules(generatedCode, x => x.DeserializerModules, "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory", moduleNames))
-                return;
-            CrawlTree(generatedCode, (x) => ReplaceDefaultDeserializationModules(x, moduleNames));
-        }
-        private static bool ReplaceSerializationModules(CodeElement generatedCode, Func<CodeMethod, List<string>> propertyGetter, string initialName, params string[] moduleNames) {
-            if(generatedCode is CodeMethod currentMethod &&
-                currentMethod.IsOfKind(CodeMethodKind.ClientConstructor)) {
-                    var modules = propertyGetter.Invoke(currentMethod);
-                    if(modules.Count == 1 &&
-                        modules.Any(x => initialName.Equals(x, StringComparison.OrdinalIgnoreCase))) {
-                        modules.Clear();
-                        modules.AddRange(moduleNames);
-                        return true;
-                }
-            }
-
-            return false;
-        }
-        internal const string GetterPrefix = "get-";
-        internal const string SetterPrefix = "set-";
-        protected static void CorrectCoreTypesForBackingStore(CodeElement currentElement, string defaultPropertyValue) {
-            if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder)
-                && currentClass.StartBlock is CodeClass.Declaration currentDeclaration) {
-                var backedModelImplements = currentDeclaration.Implements.FirstOrDefault(x => "IBackedModel".Equals(x.Name, StringComparison.OrdinalIgnoreCase));
-                if(backedModelImplements != null)
-                    backedModelImplements.Name = backedModelImplements.Name[1..]; //removing the "I"
-                var backingStoreProperty = currentClass.GetPropertyOfKind(CodePropertyKind.BackingStore);
-                if(backingStoreProperty != null)
-                    backingStoreProperty.DefaultValue = defaultPropertyValue;
-                
-            }
-            CrawlTree(currentElement, (x) => CorrectCoreTypesForBackingStore(x, defaultPropertyValue));
-        }
-        private static bool DoesAnyParentHaveAPropertyWithDefaultValue(CodeClass current) {
-            if(current.StartBlock is Declaration currentDeclaration &&
-                currentDeclaration.Inherits?.TypeDefinition is CodeClass parentClass) {
-                    if(parentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)))
-                        return true;
-                    else
-                        return DoesAnyParentHaveAPropertyWithDefaultValue(parentClass);
-            } else
-                return false;
-        }
-        protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, bool removeProperty, bool parameterAsOptional) {
-            if(!(propertyKindsToAddAccessors?.Any() ?? true)) return;
-            if(current is CodeProperty currentProperty &&
-                propertyKindsToAddAccessors.Contains(currentProperty.PropertyKind) &&
-                current.Parent is CodeClass parentClass &&
-                !parentClass.IsOfKind(CodeClassKind.QueryParameters)) {
-                if(removeProperty && currentProperty.IsOfKind(CodePropertyKind.Custom, CodePropertyKind.AdditionalData)) // we never want to remove backing stores
-                    parentClass.RemoveChildElement(currentProperty);
-                else {
-                    currentProperty.Access = AccessModifier.Private;
-                    currentProperty.NamePrefix = "_";
-                }
-                var isSerializationNameNullOrEmpty = string.IsNullOrEmpty(currentProperty.SerializationName);
-                var propertyOriginalName = (isSerializationNameNullOrEmpty ? current.Name : currentProperty.SerializationName)
-                                            .ToFirstCharacterLowerCase();
-                var accessorName = (currentProperty.IsNameEscaped && !isSerializationNameNullOrEmpty ? currentProperty.SerializationName : current.Name)
-                                    .ToFirstCharacterUpperCase();
-                parentClass.AddMethod(new CodeMethod {
-                    Name = $"{GetterPrefix}{accessorName}",
-                    Access = AccessModifier.Public,
-                    IsAsync = false,
-                    MethodKind = CodeMethodKind.Getter,
-                    ReturnType = currentProperty.Type.Clone() as CodeTypeBase,
-                    Description = $"Gets the {propertyOriginalName} property value. {currentProperty.Description}",
-                    AccessedProperty = currentProperty,
-                });
-                if(!currentProperty.ReadOnly) {
-                    var setter = parentClass.AddMethod(new CodeMethod {
-                        Name = $"{SetterPrefix}{accessorName}",
-                        Access = AccessModifier.Public,
-                        IsAsync = false,
-                        MethodKind = CodeMethodKind.Setter,
-                        Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
-                        AccessedProperty = currentProperty,
-                        ReturnType = new CodeType {
-                            Name = "void",
-                            IsNullable = false,
-                        },
-                    }).First();
-                    
-                    setter.AddParameter(new CodeParameter {
-                        Name = "value",
-                        ParameterKind = CodeParameterKind.SetterValue,
-                        Description = $"Value to set for the {current.Name} property.",
-                        Optional = parameterAsOptional,
-                        Type = currentProperty.Type.Clone() as CodeTypeBase,
-                    });
-                }
-            }
-            CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional));
-        }
-        protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited) {
-            if(current is CodeClass currentClass &&
-                !currentClass.IsOfKind(CodeClassKind.RequestBuilder, CodeClassKind.QueryParameters) &&
-                (currentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)) ||
-                addIfInherited && DoesAnyParentHaveAPropertyWithDefaultValue(currentClass)) &&
-                !currentClass.Methods.Any(x => x.IsOfKind(CodeMethodKind.ClientConstructor)))
-                currentClass.AddMethod(new CodeMethod {
-                    Name = "constructor",
-                    MethodKind = CodeMethodKind.Constructor,
-                    ReturnType = new CodeType {
-                        Name = "void"
-                    },
-                    IsAsync = false,
-                    Description = $"Instantiates a new {current.Name} and sets the default values."
-                });
-            CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited));
-        }
-        protected static void ReplaceReservedNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement, HashSet<Type> codeElementExceptions = null, Func<CodeElement, bool> shouldReplaceCallback = null) {
-            var shouldReplace = shouldReplaceCallback?.Invoke(current) ?? true;
-            var isNotInExceptions = !codeElementExceptions?.Contains(current.GetType()) ?? true;
-            if(current is CodeClass currentClass && 
-                isNotInExceptions &&
-                shouldReplace &&
-                currentClass.StartBlock is Declaration currentDeclaration)
-                ReplaceReservedCodeUsings(currentDeclaration, provider, replacement);
-            else if(current is CodeNamespace currentNamespace &&
-                isNotInExceptions &&
-                shouldReplace &&
-                !string.IsNullOrEmpty(currentNamespace.Name))
-                ReplaceReservedNamespaceSegments(currentNamespace, provider, replacement);
-            else if(current is CodeMethod currentMethod &&
-                isNotInExceptions &&
-                shouldReplace) {
-                if(currentMethod.ReturnType is CodeType returnType &&
-                    !returnType.IsExternal &&
-                    provider.ReservedNames.Contains(returnType.Name))
-                    returnType.Name = replacement.Invoke(returnType.Name);
-                ReplaceReservedParameterNamesTypes(currentMethod, provider, replacement);
-            } else if (current is CodeProperty currentProperty &&
-                    isNotInExceptions &&
-                    shouldReplace &&
-                    currentProperty.Type is CodeType propertyType &&
-                    !propertyType.IsExternal &&
-                    provider.ReservedNames.Contains(currentProperty.Type.Name))
-                propertyType.Name = replacement.Invoke(propertyType.Name);
-            // Check if the current name meets the following conditions to be replaced
-            // 1. In the list of reserved names
-            // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
-            // 3. There's not a very specific condition preventing from replacement
-            if (provider.ReservedNames.Contains(current.Name) &&
-                isNotInExceptions &&
-                shouldReplace) {
-                if(current is CodeProperty currentProperty &&
-                    currentProperty.IsOfKind(CodePropertyKind.Custom)) {
-                    currentProperty.SerializationName = currentProperty.Name;
-                    currentProperty.IsNameEscaped = true;
-                }
-                current.Name = replacement.Invoke(current.Name);
-            }
-
-            CrawlTree(current, x => ReplaceReservedNames(x, provider, replacement, codeElementExceptions, shouldReplaceCallback));
-        }
-        private static void ReplaceReservedCodeUsings(Declaration currentDeclaration, IReservedNamesProvider provider, Func<string, string> replacement)
-        {
-            currentDeclaration.Usings
-                            .Select(x => x.Declaration)
-                            .Where(x => x != null && !x.IsExternal)
-                            .Join(provider.ReservedNames, x => x.Name, y => y, (x, y) => x)
-                            .ToList()
-                            .ForEach(x => {
-                                x.Name = replacement.Invoke(x.Name);
-                            });
-        }
-        private static void ReplaceReservedNamespaceSegments(CodeNamespace currentNamespace, IReservedNamesProvider provider, Func<string, string> replacement)
-        {
-            var segments = currentNamespace.Name.Split('.');
-            if(segments.Any(x => provider.ReservedNames.Contains(x)))
-                currentNamespace.Name = segments.Select(x => provider.ReservedNames.Contains(x) ?
-                                                                replacement.Invoke(x) :
-                                                                x)
-                                                .Aggregate((x, y) => $"{x}.{y}");
-        }
-        private static void ReplaceReservedParameterNamesTypes(CodeMethod currentMethod, IReservedNamesProvider provider, Func<string, string> replacement)
-        {
-            currentMethod.Parameters.Where(x => x.Type is CodeType parameterType &&
-                                                !parameterType.IsExternal &&
-                                                provider.ReservedNames.Contains(parameterType.Name))
-                                                .ToList()
-                                                .ForEach(x => {
-                                                    x.Type.Name = replacement.Invoke(x.Type.Name);
-                                                });
-        }
-        private static IEnumerable<CodeUsing> usingSelector(AdditionalUsingEvaluator x) =>
-        x.ImportSymbols.Select(y => 
-            new CodeUsing
-            {
-                Name = y,
-                Declaration = new CodeType { Name = x.NamespaceName, IsExternal = true },
-            });
-        protected static void AddDefaultImports(CodeElement current, IEnumerable<AdditionalUsingEvaluator> evaluators) {
-            var usingsToAdd = evaluators.Where(x => x.CodeElementEvaluator.Invoke(current))
-                            .SelectMany(x => usingSelector(x))
-                            .ToArray();
-            if(usingsToAdd.Any()) 
-                if(current is CodeEnum currentEnum) 
-                    currentEnum.AddUsings(usingsToAdd);
-                else {
-                    var parentClass = current.GetImmediateParentOfType<CodeClass>();
-                    var targetClass = parentClass.Parent is CodeClass parentClassParent ? parentClassParent : parentClass;
-                    targetClass.AddUsing(usingsToAdd);
-                }
-            CrawlTree(current, c => AddDefaultImports(c, evaluators));
-        }
-        private const string BinaryType = "binary";
-        protected static void ReplaceBinaryByNativeType(CodeElement currentElement, string symbol, string ns, bool addDeclaration = false) {
-            if(currentElement is CodeMethod currentMethod) {
-                var parentClass = currentMethod.Parent as CodeClass;
-                var shouldInsertUsing = false;
-                if(BinaryType.Equals(currentMethod.ReturnType?.Name)) {
-                    currentMethod.ReturnType.Name = symbol;
-                    shouldInsertUsing = true;
-                }
-                var binaryParameter = currentMethod.Parameters.FirstOrDefault(x => x.Type.Name.Equals(BinaryType));
-                if(binaryParameter != null) {
-                    binaryParameter.Type.Name = symbol;
-                    shouldInsertUsing = true;
-                }
-                if(shouldInsertUsing) {
-                    var newUsing = new CodeUsing {
-                        Name = addDeclaration ? symbol : ns,
-                    };
-                    if(addDeclaration)
-                        newUsing.Declaration = new CodeType {
-                            Name = ns,
-                            IsExternal = true,
-                        };
-                    parentClass.AddUsing(newUsing);
-                }
-            }
-            CrawlTree(currentElement, c => ReplaceBinaryByNativeType(c, symbol, ns, addDeclaration));
-        }
-        protected static void ConvertUnionTypesToWrapper(CodeElement currentElement, bool usesBackingStore) {
-            var parentClass = currentElement.Parent as CodeClass;
-            if(currentElement is CodeMethod currentMethod) {
-                if(currentMethod.ReturnType is CodeUnionType currentUnionType)
-                    currentMethod.ReturnType = ConvertUnionTypeToWrapper(parentClass, currentUnionType, usesBackingStore);
-                if(currentMethod.Parameters.Any(x => x.Type is CodeUnionType))
-                    foreach(var currentParameter in currentMethod.Parameters.Where(x => x.Type is CodeUnionType))
-                        currentParameter.Type = ConvertUnionTypeToWrapper(parentClass, currentParameter.Type as CodeUnionType, usesBackingStore);
-            }
-            else if (currentElement is CodeIndexer currentIndexer && currentIndexer.ReturnType is CodeUnionType currentUnionType)
-                currentIndexer.ReturnType = ConvertUnionTypeToWrapper(parentClass, currentUnionType, usesBackingStore);
-            else if(currentElement is CodeProperty currentProperty && currentProperty.Type is CodeUnionType currentPropUnionType)
-                currentProperty.Type = ConvertUnionTypeToWrapper(parentClass, currentPropUnionType, usesBackingStore);
-
-            CrawlTree(currentElement, x => ConvertUnionTypesToWrapper(x, usesBackingStore));
-        }
-        private static CodeTypeBase ConvertUnionTypeToWrapper(CodeClass codeClass, CodeUnionType codeUnionType, bool usesBackingStore)
-        {
-            if(codeClass == null) throw new ArgumentNullException(nameof(codeClass));
-            if(codeUnionType == null) throw new ArgumentNullException(nameof(codeUnionType));
-            var newClass = codeClass.AddInnerClass(new CodeClass {
-                Name = codeUnionType.Name,
-                Description = $"Union type wrapper for classes {codeUnionType.Types.Select(x => x.Name).Aggregate((x, y) => x + ", " + y)}"
-            }).First();
-            newClass.AddProperty(codeUnionType
-                                    .Types
-                                    .Select(x => new CodeProperty {
-                                        Name = x.Name,
-                                        Type = x,
-                                        Description = $"Union type representation for type {x.Name}"
-                                    }).ToArray());
-            if(codeUnionType.Types.All(x => x.TypeDefinition is CodeClass targetClass && targetClass.IsOfKind(CodeClassKind.Model) ||
-                                    x.TypeDefinition is CodeEnum)) {
-                KiotaBuilder.AddSerializationMembers(newClass, true, usesBackingStore);
-                newClass.ClassKind = CodeClassKind.Model;
-            }
-            return new CodeType {
-                Name = newClass.Name,
-                TypeDefinition = newClass,
-                CollectionKind = codeUnionType.CollectionKind,
-                IsNullable = codeUnionType.IsNullable,
-                ActionOf = codeUnionType.ActionOf,
-            };
-        }
-        protected static void MoveClassesWithNamespaceNamesUnderNamespace(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && 
-                !string.IsNullOrEmpty(currentClass.Name) &&
-                currentClass.Parent is CodeNamespace parentNamespace) {
-                var childNamespaceWithClassName = parentNamespace.GetChildElements(true)
-                                                                .OfType<CodeNamespace>()
-                                                                .FirstOrDefault(x => x.Name
-                                                                                    .EndsWith(currentClass.Name, StringComparison.OrdinalIgnoreCase));
-                if(childNamespaceWithClassName != null) {
-                    parentNamespace.RemoveChildElement(currentClass);
-                    childNamespaceWithClassName.AddClass(currentClass);
-                }
-            }
-            CrawlTree(currentElement, MoveClassesWithNamespaceNamesUnderNamespace);
-        }
-        protected static void ReplaceIndexersByMethodsWithParameter(CodeElement currentElement, CodeNamespace rootNamespace, bool parameterNullable, string methodNameSuffix = default) {
-            if(currentElement is CodeIndexer currentIndexer &&
-                currentElement.Parent is CodeClass currentParentClass) {
-                currentParentClass.RemoveChildElement(currentElement);
-                foreach(var returnType in currentIndexer.ReturnType.AllTypes)
-                    AddIndexerMethod(rootNamespace,
-                                    currentParentClass,
-                                    returnType.TypeDefinition as CodeClass,
-                                    methodNameSuffix,
-                                    parameterNullable,
-                                    currentIndexer);
-            }
-            CrawlTree(currentElement, c => ReplaceIndexersByMethodsWithParameter(c, rootNamespace, parameterNullable, methodNameSuffix));
-        }
-        private static void AddIndexerMethod(CodeElement currentElement, CodeClass targetClass, CodeClass indexerClass, string methodNameSuffix, bool parameterNullable, CodeIndexer currentIndexer) {
-            if(currentElement is CodeProperty currentProperty && currentProperty.Type.AllTypes.Any(x => x.TypeDefinition == targetClass)) {
-                var parentClass = currentElement.Parent as CodeClass;
-                var method = new CodeMethod {
-                    IsAsync = false,
-                    IsStatic = false,
-                    Access = AccessModifier.Public,
-                    MethodKind = CodeMethodKind.IndexerBackwardCompatibility,
-                    Name = currentIndexer.PathSegment + methodNameSuffix,
-                    Description = currentIndexer.Description,
-                    ReturnType = new CodeType {
-                        IsNullable = false,
-                        TypeDefinition = indexerClass,
-                        Name = indexerClass.Name,
-                    },
-                    OriginalIndexer = currentIndexer,
-                };
-                var parameter = new CodeParameter {
-                    Name = "id",
-                    Optional = false,
-                    ParameterKind = CodeParameterKind.Custom,
-                    Description = "Unique identifier of the item",
-                    Type = new CodeType {
-                        Name = "String",
-                        IsNullable = parameterNullable,
+namespace Kiota.Builder.Refiners;
+public abstract class CommonLanguageRefiner : ILanguageRefiner
+{
+    protected CommonLanguageRefiner(GenerationConfiguration configuration) {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+    public abstract void Refine(CodeNamespace generatedCode);
+    /// <summary>
+    ///     This method adds the imports for the default serializers and deserializers to the api client class.
+    ///     It also updates the module names to replace the fully qualified class name by the class name without the namespace.
+    /// </summary>
+    protected void AddSerializationModulesImport(CodeElement generatedCode, string[] serializationWriterFactoryInterfaceAndRegistrationFullName = default, string[] parseNodeFactoryInterfaceAndRegistrationFullName = default) {
+        if(serializationWriterFactoryInterfaceAndRegistrationFullName == null)
+            serializationWriterFactoryInterfaceAndRegistrationFullName = Array.Empty<string>();
+        if(parseNodeFactoryInterfaceAndRegistrationFullName == null)
+            parseNodeFactoryInterfaceAndRegistrationFullName = Array.Empty<string>();
+        if(generatedCode is CodeMethod currentMethod &&
+            currentMethod.IsOfKind(CodeMethodKind.ClientConstructor) &&
+            currentMethod.Parent is CodeClass currentClass &&
+            currentClass.StartBlock is CodeClass.Declaration declaration) {
+                var cumulatedSymbols = currentMethod.DeserializerModules
+                                                    .Union(currentMethod.SerializerModules)
+                                                    .Union(serializationWriterFactoryInterfaceAndRegistrationFullName)
+                                                    .Union(parseNodeFactoryInterfaceAndRegistrationFullName)
+                                                    .Where(x => !string.IsNullOrEmpty(x))
+                                                    .ToList();
+                currentMethod.DeserializerModules = currentMethod.DeserializerModules.Select(x => x.Split('.').Last()).ToList();
+                currentMethod.SerializerModules = currentMethod.SerializerModules.Select(x => x.Split('.').Last()).ToList();
+                declaration.AddUsings(cumulatedSymbols.Select(x => new CodeUsing {
+                    Name = x.Split('.').Last(),
+                    Declaration = new CodeType {
+                        Name = x.Split('.').SkipLast(1).Aggregate((x, y) => $"{x}.{y}"),
                         IsExternal = true,
+                    }
+                }).ToArray());
+                return;
+            }
+        CrawlTree(generatedCode, x => AddSerializationModulesImport(x, serializationWriterFactoryInterfaceAndRegistrationFullName, parseNodeFactoryInterfaceAndRegistrationFullName));
+    }
+    protected static void ReplaceDefaultSerializationModules(CodeElement generatedCode, params string[] moduleNames) {
+        if(ReplaceSerializationModules(generatedCode, x => x.SerializerModules, "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory", moduleNames))
+            return;
+        CrawlTree(generatedCode, (x) => ReplaceDefaultSerializationModules(x, moduleNames));
+    }
+    protected static void ReplaceDefaultDeserializationModules(CodeElement generatedCode, params string[] moduleNames) {
+        if(ReplaceSerializationModules(generatedCode, x => x.DeserializerModules, "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory", moduleNames))
+            return;
+        CrawlTree(generatedCode, (x) => ReplaceDefaultDeserializationModules(x, moduleNames));
+    }
+    private static bool ReplaceSerializationModules(CodeElement generatedCode, Func<CodeMethod, List<string>> propertyGetter, string initialName, params string[] moduleNames) {
+        if(generatedCode is CodeMethod currentMethod &&
+            currentMethod.IsOfKind(CodeMethodKind.ClientConstructor)) {
+                var modules = propertyGetter.Invoke(currentMethod);
+                if(modules.Count == 1 &&
+                    modules.Any(x => initialName.Equals(x, StringComparison.OrdinalIgnoreCase))) {
+                    modules.Clear();
+                    modules.AddRange(moduleNames);
+                    return true;
+            }
+        }
+
+        return false;
+    }
+    internal const string GetterPrefix = "get-";
+    internal const string SetterPrefix = "set-";
+    protected static void CorrectCoreTypesForBackingStore(CodeElement currentElement, string defaultPropertyValue) {
+        if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder)
+            && currentClass.StartBlock is CodeClass.Declaration currentDeclaration) {
+            var backedModelImplements = currentDeclaration.Implements.FirstOrDefault(x => "IBackedModel".Equals(x.Name, StringComparison.OrdinalIgnoreCase));
+            if(backedModelImplements != null)
+                backedModelImplements.Name = backedModelImplements.Name[1..]; //removing the "I"
+            var backingStoreProperty = currentClass.GetPropertyOfKind(CodePropertyKind.BackingStore);
+            if(backingStoreProperty != null)
+                backingStoreProperty.DefaultValue = defaultPropertyValue;
+            
+        }
+        CrawlTree(currentElement, (x) => CorrectCoreTypesForBackingStore(x, defaultPropertyValue));
+    }
+    private static bool DoesAnyParentHaveAPropertyWithDefaultValue(CodeClass current) {
+        if(current.StartBlock is Declaration currentDeclaration &&
+            currentDeclaration.Inherits?.TypeDefinition is CodeClass parentClass) {
+                if(parentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)))
+                    return true;
+                else
+                    return DoesAnyParentHaveAPropertyWithDefaultValue(parentClass);
+        } else
+            return false;
+    }
+    protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, bool removeProperty, bool parameterAsOptional) {
+        if(!(propertyKindsToAddAccessors?.Any() ?? true)) return;
+        if(current is CodeProperty currentProperty &&
+            propertyKindsToAddAccessors.Contains(currentProperty.PropertyKind) &&
+            current.Parent is CodeClass parentClass &&
+            !parentClass.IsOfKind(CodeClassKind.QueryParameters)) {
+            if(removeProperty && currentProperty.IsOfKind(CodePropertyKind.Custom, CodePropertyKind.AdditionalData)) // we never want to remove backing stores
+                parentClass.RemoveChildElement(currentProperty);
+            else {
+                currentProperty.Access = AccessModifier.Private;
+                currentProperty.NamePrefix = "_";
+            }
+            var isSerializationNameNullOrEmpty = string.IsNullOrEmpty(currentProperty.SerializationName);
+            var propertyOriginalName = (isSerializationNameNullOrEmpty ? current.Name : currentProperty.SerializationName)
+                                        .ToFirstCharacterLowerCase();
+            var accessorName = (currentProperty.IsNameEscaped && !isSerializationNameNullOrEmpty ? currentProperty.SerializationName : current.Name)
+                                .ToFirstCharacterUpperCase();
+            parentClass.AddMethod(new CodeMethod {
+                Name = $"{GetterPrefix}{accessorName}",
+                Access = AccessModifier.Public,
+                IsAsync = false,
+                MethodKind = CodeMethodKind.Getter,
+                ReturnType = currentProperty.Type.Clone() as CodeTypeBase,
+                Description = $"Gets the {propertyOriginalName} property value. {currentProperty.Description}",
+                AccessedProperty = currentProperty,
+            });
+            if(!currentProperty.ReadOnly) {
+                var setter = parentClass.AddMethod(new CodeMethod {
+                    Name = $"{SetterPrefix}{accessorName}",
+                    Access = AccessModifier.Public,
+                    IsAsync = false,
+                    MethodKind = CodeMethodKind.Setter,
+                    Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
+                    AccessedProperty = currentProperty,
+                    ReturnType = new CodeType {
+                        Name = "void",
+                        IsNullable = false,
                     },
+                }).First();
+                
+                setter.AddParameter(new CodeParameter {
+                    Name = "value",
+                    ParameterKind = CodeParameterKind.SetterValue,
+                    Description = $"Value to set for the {current.Name} property.",
+                    Optional = parameterAsOptional,
+                    Type = currentProperty.Type.Clone() as CodeTypeBase,
+                });
+            }
+        }
+        CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional));
+    }
+    protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited) {
+        if(current is CodeClass currentClass &&
+            !currentClass.IsOfKind(CodeClassKind.RequestBuilder, CodeClassKind.QueryParameters) &&
+            (currentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)) ||
+            addIfInherited && DoesAnyParentHaveAPropertyWithDefaultValue(currentClass)) &&
+            !currentClass.Methods.Any(x => x.IsOfKind(CodeMethodKind.ClientConstructor)))
+            currentClass.AddMethod(new CodeMethod {
+                Name = "constructor",
+                MethodKind = CodeMethodKind.Constructor,
+                ReturnType = new CodeType {
+                    Name = "void"
+                },
+                IsAsync = false,
+                Description = $"Instantiates a new {current.Name} and sets the default values."
+            });
+        CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited));
+    }
+    protected static void ReplaceReservedNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement, HashSet<Type> codeElementExceptions = null, Func<CodeElement, bool> shouldReplaceCallback = null) {
+        var shouldReplace = shouldReplaceCallback?.Invoke(current) ?? true;
+        var isNotInExceptions = !codeElementExceptions?.Contains(current.GetType()) ?? true;
+        if(current is CodeClass currentClass && 
+            isNotInExceptions &&
+            shouldReplace &&
+            currentClass.StartBlock is Declaration currentDeclaration)
+            ReplaceReservedCodeUsings(currentDeclaration, provider, replacement);
+        else if(current is CodeNamespace currentNamespace &&
+            isNotInExceptions &&
+            shouldReplace &&
+            !string.IsNullOrEmpty(currentNamespace.Name))
+            ReplaceReservedNamespaceSegments(currentNamespace, provider, replacement);
+        else if(current is CodeMethod currentMethod &&
+            isNotInExceptions &&
+            shouldReplace) {
+            if(currentMethod.ReturnType is CodeType returnType &&
+                !returnType.IsExternal &&
+                provider.ReservedNames.Contains(returnType.Name))
+                returnType.Name = replacement.Invoke(returnType.Name);
+            ReplaceReservedParameterNamesTypes(currentMethod, provider, replacement);
+        } else if (current is CodeProperty currentProperty &&
+                isNotInExceptions &&
+                shouldReplace &&
+                currentProperty.Type is CodeType propertyType &&
+                !propertyType.IsExternal &&
+                provider.ReservedNames.Contains(currentProperty.Type.Name))
+            propertyType.Name = replacement.Invoke(propertyType.Name);
+        // Check if the current name meets the following conditions to be replaced
+        // 1. In the list of reserved names
+        // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
+        // 3. There's not a very specific condition preventing from replacement
+        if (provider.ReservedNames.Contains(current.Name) &&
+            isNotInExceptions &&
+            shouldReplace) {
+            if(current is CodeProperty currentProperty &&
+                currentProperty.IsOfKind(CodePropertyKind.Custom)) {
+                currentProperty.SerializationName = currentProperty.Name;
+                currentProperty.IsNameEscaped = true;
+            }
+            current.Name = replacement.Invoke(current.Name);
+        }
+
+        CrawlTree(current, x => ReplaceReservedNames(x, provider, replacement, codeElementExceptions, shouldReplaceCallback));
+    }
+    private static void ReplaceReservedCodeUsings(Declaration currentDeclaration, IReservedNamesProvider provider, Func<string, string> replacement)
+    {
+        currentDeclaration.Usings
+                        .Select(x => x.Declaration)
+                        .Where(x => x != null && !x.IsExternal)
+                        .Join(provider.ReservedNames, x => x.Name, y => y, (x, y) => x)
+                        .ToList()
+                        .ForEach(x => {
+                            x.Name = replacement.Invoke(x.Name);
+                        });
+    }
+    private static void ReplaceReservedNamespaceSegments(CodeNamespace currentNamespace, IReservedNamesProvider provider, Func<string, string> replacement)
+    {
+        var segments = currentNamespace.Name.Split('.');
+        if(segments.Any(x => provider.ReservedNames.Contains(x)))
+            currentNamespace.Name = segments.Select(x => provider.ReservedNames.Contains(x) ?
+                                                            replacement.Invoke(x) :
+                                                            x)
+                                            .Aggregate((x, y) => $"{x}.{y}");
+    }
+    private static void ReplaceReservedParameterNamesTypes(CodeMethod currentMethod, IReservedNamesProvider provider, Func<string, string> replacement)
+    {
+        currentMethod.Parameters.Where(x => x.Type is CodeType parameterType &&
+                                            !parameterType.IsExternal &&
+                                            provider.ReservedNames.Contains(parameterType.Name))
+                                            .ToList()
+                                            .ForEach(x => {
+                                                x.Type.Name = replacement.Invoke(x.Type.Name);
+                                            });
+    }
+    private static IEnumerable<CodeUsing> usingSelector(AdditionalUsingEvaluator x) =>
+    x.ImportSymbols.Select(y => 
+        new CodeUsing
+        {
+            Name = y,
+            Declaration = new CodeType { Name = x.NamespaceName, IsExternal = true },
+        });
+    protected static void AddDefaultImports(CodeElement current, IEnumerable<AdditionalUsingEvaluator> evaluators) {
+        var usingsToAdd = evaluators.Where(x => x.CodeElementEvaluator.Invoke(current))
+                        .SelectMany(x => usingSelector(x))
+                        .ToArray();
+        if(usingsToAdd.Any()) 
+            if(current is CodeEnum currentEnum) 
+                currentEnum.AddUsings(usingsToAdd);
+            else {
+                var parentClass = current.GetImmediateParentOfType<CodeClass>();
+                var targetClass = parentClass.Parent is CodeClass parentClassParent ? parentClassParent : parentClass;
+                targetClass.AddUsing(usingsToAdd);
+            }
+        CrawlTree(current, c => AddDefaultImports(c, evaluators));
+    }
+    private const string BinaryType = "binary";
+    protected static void ReplaceBinaryByNativeType(CodeElement currentElement, string symbol, string ns, bool addDeclaration = false) {
+        if(currentElement is CodeMethod currentMethod) {
+            var parentClass = currentMethod.Parent as CodeClass;
+            var shouldInsertUsing = false;
+            if(BinaryType.Equals(currentMethod.ReturnType?.Name)) {
+                currentMethod.ReturnType.Name = symbol;
+                shouldInsertUsing = true;
+            }
+            var binaryParameter = currentMethod.Parameters.FirstOrDefault(x => x.Type.Name.Equals(BinaryType));
+            if(binaryParameter != null) {
+                binaryParameter.Type.Name = symbol;
+                shouldInsertUsing = true;
+            }
+            if(shouldInsertUsing) {
+                var newUsing = new CodeUsing {
+                    Name = addDeclaration ? symbol : ns,
                 };
-                method.AddParameter(parameter);
-                parentClass.AddMethod(method);
+                if(addDeclaration)
+                    newUsing.Declaration = new CodeType {
+                        Name = ns,
+                        IsExternal = true,
+                    };
+                parentClass.AddUsing(newUsing);
             }
-            CrawlTree(currentElement, c => AddIndexerMethod(c, targetClass, indexerClass, methodNameSuffix, parameterNullable, currentIndexer));
         }
-        internal void AddInnerClasses(CodeElement current, bool prefixClassNameWithParentName, string queryParametersBaseClassName = "QueryParametersBase") {
-            if(current is CodeClass currentClass) {
-                foreach(var innerClass in currentClass
-                                        .Methods
-                                        .SelectMany(x => x.Parameters)
-                                        .Where(x => x.Type.ActionOf && x.IsOfKind(CodeParameterKind.QueryParameter))
-                                        .SelectMany(x => x.Type.AllTypes)
-                                        .Select(x => x.TypeDefinition)
-                                        .OfType<CodeClass>()) {
-                    if(prefixClassNameWithParentName && !innerClass.Name.StartsWith(currentClass.Name, StringComparison.OrdinalIgnoreCase)) {
-                        innerClass.Name = $"{currentClass.Name}{innerClass.Name}";
-                        innerClass.StartBlock.Name = innerClass.Name;
-                    }
-                    
-                    if(currentClass.FindChildByName<CodeClass>(innerClass.Name) == null) {
-                        currentClass.AddInnerClass(innerClass);
-                    }
-                    if(!string.IsNullOrEmpty(queryParametersBaseClassName))
-                        (innerClass.StartBlock as Declaration).Inherits = new CodeType { Name = queryParametersBaseClassName, IsExternal = true };
-                }
-            }
-            CrawlTree(current, x => AddInnerClasses(x, prefixClassNameWithParentName, queryParametersBaseClassName));
+        CrawlTree(currentElement, c => ReplaceBinaryByNativeType(c, symbol, ns, addDeclaration));
+    }
+    protected static void ConvertUnionTypesToWrapper(CodeElement currentElement, bool usesBackingStore) {
+        var parentClass = currentElement.Parent as CodeClass;
+        if(currentElement is CodeMethod currentMethod) {
+            if(currentMethod.ReturnType is CodeUnionType currentUnionType)
+                currentMethod.ReturnType = ConvertUnionTypeToWrapper(parentClass, currentUnionType, usesBackingStore);
+            if(currentMethod.Parameters.Any(x => x.Type is CodeUnionType))
+                foreach(var currentParameter in currentMethod.Parameters.Where(x => x.Type is CodeUnionType))
+                    currentParameter.Type = ConvertUnionTypeToWrapper(parentClass, currentParameter.Type as CodeUnionType, usesBackingStore);
         }
-        private static readonly CodeUsingComparer usingComparerWithDeclarations = new(true);
-        private static readonly CodeUsingComparer usingComparerWithoutDeclarations = new(false);
-        protected readonly GenerationConfiguration _configuration;
+        else if (currentElement is CodeIndexer currentIndexer && currentIndexer.ReturnType is CodeUnionType currentUnionType)
+            currentIndexer.ReturnType = ConvertUnionTypeToWrapper(parentClass, currentUnionType, usesBackingStore);
+        else if(currentElement is CodeProperty currentProperty && currentProperty.Type is CodeUnionType currentPropUnionType)
+            currentProperty.Type = ConvertUnionTypeToWrapper(parentClass, currentPropUnionType, usesBackingStore);
 
-        protected static void AddPropertiesAndMethodTypesImports(CodeElement current, bool includeParentNamespaces, bool includeCurrentNamespace, bool compareOnDeclaration) {
-            if(current is CodeClass currentClass &&
-                currentClass.StartBlock is Declaration currentClassDeclaration) {
-                var currentClassNamespace = currentClass.GetImmediateParentOfType<CodeNamespace>();
-                var currentClassChildren = currentClass.GetChildElements(true);
-                var inheritTypes = currentClassDeclaration.Inherits?.AllTypes ?? Enumerable.Empty<CodeType>();
-                var propertiesTypes = currentClass
-                                    .Properties
-                                    .Select(x => x.Type)
-                                    .Distinct();
-                var methods = currentClass.Methods;
-                var methodsReturnTypes = methods
-                                    .Select(x => x.ReturnType)
-                                    .Distinct();
-                var methodsParametersTypes = methods
-                                    .SelectMany(x => x.Parameters)
-                                    .Where(x => x.IsOfKind(CodeParameterKind.Custom, CodeParameterKind.RequestBody))
-                                    .Select(x => x.Type)
-                                    .Distinct();
-                var indexerTypes = currentClassChildren
-                                    .OfType<CodeIndexer>()
-                                    .Select(x => x.ReturnType)
-                                    .Distinct();
-                var usingsToAdd = propertiesTypes
-                                    .Union(methodsParametersTypes)
-                                    .Union(methodsReturnTypes)
-                                    .Union(indexerTypes)
-                                    .Union(inheritTypes)
-                                    .Where(x => x != null)
-                                    .SelectMany(x => x?.AllTypes?.Select(y => new Tuple<CodeType, CodeNamespace>(y, y?.TypeDefinition?.GetImmediateParentOfType<CodeNamespace>())))
-                                    .Where(x => x.Item2 != null && (includeCurrentNamespace || x.Item2 != currentClassNamespace))
-                                    .Where(x => includeParentNamespaces || !currentClassNamespace.IsChildOf(x.Item2))
-                                    .Select(x => new CodeUsing { Name = x.Item2.Name, Declaration = x.Item1 })
-                                    .Where(x => x.Declaration?.TypeDefinition != current)
-                                    .Distinct(compareOnDeclaration ? usingComparerWithDeclarations : usingComparerWithoutDeclarations)
-                                    .ToArray();
-                if(usingsToAdd.Any())
-                    (currentClass.Parent is CodeClass parentClass ? parentClass : currentClass).AddUsing(usingsToAdd); //lots of languages do not support imports on nested classes
+        CrawlTree(currentElement, x => ConvertUnionTypesToWrapper(x, usesBackingStore));
+    }
+    private static CodeTypeBase ConvertUnionTypeToWrapper(CodeClass codeClass, CodeUnionType codeUnionType, bool usesBackingStore)
+    {
+        if(codeClass == null) throw new ArgumentNullException(nameof(codeClass));
+        if(codeUnionType == null) throw new ArgumentNullException(nameof(codeUnionType));
+        var newClass = codeClass.AddInnerClass(new CodeClass {
+            Name = codeUnionType.Name,
+            Description = $"Union type wrapper for classes {codeUnionType.Types.Select(x => x.Name).Aggregate((x, y) => x + ", " + y)}"
+        }).First();
+        newClass.AddProperty(codeUnionType
+                                .Types
+                                .Select(x => new CodeProperty {
+                                    Name = x.Name,
+                                    Type = x,
+                                    Description = $"Union type representation for type {x.Name}"
+                                }).ToArray());
+        if(codeUnionType.Types.All(x => x.TypeDefinition is CodeClass targetClass && targetClass.IsOfKind(CodeClassKind.Model) ||
+                                x.TypeDefinition is CodeEnum)) {
+            KiotaBuilder.AddSerializationMembers(newClass, true, usesBackingStore);
+            newClass.ClassKind = CodeClassKind.Model;
+        }
+        return new CodeType {
+            Name = newClass.Name,
+            TypeDefinition = newClass,
+            CollectionKind = codeUnionType.CollectionKind,
+            IsNullable = codeUnionType.IsNullable,
+            ActionOf = codeUnionType.ActionOf,
+        };
+    }
+    protected static void MoveClassesWithNamespaceNamesUnderNamespace(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && 
+            !string.IsNullOrEmpty(currentClass.Name) &&
+            currentClass.Parent is CodeNamespace parentNamespace) {
+            var childNamespaceWithClassName = parentNamespace.GetChildElements(true)
+                                                            .OfType<CodeNamespace>()
+                                                            .FirstOrDefault(x => x.Name
+                                                                                .EndsWith(currentClass.Name, StringComparison.OrdinalIgnoreCase));
+            if(childNamespaceWithClassName != null) {
+                parentNamespace.RemoveChildElement(currentClass);
+                childNamespaceWithClassName.AddClass(currentClass);
             }
-            CrawlTree(current, (x) => AddPropertiesAndMethodTypesImports(x, includeParentNamespaces, includeCurrentNamespace, compareOnDeclaration));
         }
-        protected static void PatchHeaderParametersType(CodeElement currentElement, string newTypeName) {
-            if(currentElement is CodeMethod currentMethod && currentMethod.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Headers)))
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Headers))
-                                        .ToList()
-                                        .ForEach(x => x.Type.Name = newTypeName);
-            CrawlTree(currentElement, (x) => PatchHeaderParametersType(x, newTypeName));
+        CrawlTree(currentElement, MoveClassesWithNamespaceNamesUnderNamespace);
+    }
+    protected static void ReplaceIndexersByMethodsWithParameter(CodeElement currentElement, CodeNamespace rootNamespace, bool parameterNullable, string methodNameSuffix = default) {
+        if(currentElement is CodeIndexer currentIndexer &&
+            currentElement.Parent is CodeClass currentParentClass) {
+            currentParentClass.RemoveChildElement(currentElement);
+            foreach(var returnType in currentIndexer.ReturnType.AllTypes)
+                AddIndexerMethod(rootNamespace,
+                                currentParentClass,
+                                returnType.TypeDefinition as CodeClass,
+                                methodNameSuffix,
+                                parameterNullable,
+                                currentIndexer);
         }
-        protected static void CrawlTree(CodeElement currentElement, Action<CodeElement> function) {
-            foreach(var childElement in currentElement.GetChildElements())
-                function.Invoke(childElement);
-        }
-        protected static void CorrectCoreType(CodeElement currentElement, Action<CodeMethod> correctMethodType, Action<CodeProperty> correctPropertyType) {
-            switch(currentElement) {
-                case CodeProperty property:
-                    correctPropertyType?.Invoke(property);
-                    break;
-                case CodeMethod method:
-                    correctMethodType?.Invoke(method);
-                    break;
-            }
-            CrawlTree(currentElement, x => CorrectCoreType(x, correctMethodType, correctPropertyType));
-        }
-        protected static void MakeModelPropertiesNullable(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass &&
-                currentClass.IsOfKind(CodeClassKind.Model))
-                currentClass.Properties
-                            .Where(x => x.IsOfKind(CodePropertyKind.Custom))
-                            .ToList()
-                            .ForEach(x => x.Type.IsNullable = true);
-            CrawlTree(currentElement, MakeModelPropertiesNullable);
-        }
-        protected static void AddRawUrlConstructorOverload(CodeElement currentElement) {
-            if(currentElement is CodeMethod currentMethod &&
-                currentMethod.IsOfKind(CodeMethodKind.Constructor) &&
-                currentElement.Parent is CodeClass parentClass &&
-                parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
-                var overloadCtor = currentMethod.Clone() as CodeMethod;
-                overloadCtor.MethodKind = CodeMethodKind.RawUrlConstructor;
-                overloadCtor.OriginalMethod = currentMethod;
-                overloadCtor.RemoveParametersByKind(CodeParameterKind.PathParameters, CodeParameterKind.Path);
-                overloadCtor.AddParameter(new CodeParameter {
-                    Name = "rawUrl",
-                    Type = new CodeType { Name = "string", IsExternal = true },
-                    Optional = false,
-                    Description = "The raw URL to use for the request builder.",
-                    ParameterKind = CodeParameterKind.RawUrl,
-                });
-                parentClass.AddMethod(overloadCtor);
-            }
-            CrawlTree(currentElement, AddRawUrlConstructorOverload);
-        }
-        protected static void RemoveCancellationParameter(CodeElement currentElement){
-            if (currentElement is CodeMethod currentMethod &&
-                currentMethod.IsOfKind(CodeMethodKind.RequestExecutor)){ 
-                currentMethod.RemoveParametersByKind(CodeParameterKind.Cancellation);
-            }
-            CrawlTree(currentElement, RemoveCancellationParameter);
-        }
-        
-        protected static void AddParsableInheritanceForModelClasses(CodeElement currentElement, string className) {
-            if(string.IsNullOrEmpty(className)) throw new ArgumentNullException(nameof(className));
-
-            if(currentElement is CodeClass currentClass &&
-               currentClass.IsOfKind(CodeClassKind.Model) &&
-               currentClass.StartBlock is CodeClass.Declaration declaration) {
-                declaration.AddImplements(new CodeType {
+        CrawlTree(currentElement, c => ReplaceIndexersByMethodsWithParameter(c, rootNamespace, parameterNullable, methodNameSuffix));
+    }
+    private static void AddIndexerMethod(CodeElement currentElement, CodeClass targetClass, CodeClass indexerClass, string methodNameSuffix, bool parameterNullable, CodeIndexer currentIndexer) {
+        if(currentElement is CodeProperty currentProperty && currentProperty.Type.AllTypes.Any(x => x.TypeDefinition == targetClass)) {
+            var parentClass = currentElement.Parent as CodeClass;
+            var method = new CodeMethod {
+                IsAsync = false,
+                IsStatic = false,
+                Access = AccessModifier.Public,
+                MethodKind = CodeMethodKind.IndexerBackwardCompatibility,
+                Name = currentIndexer.PathSegment + methodNameSuffix,
+                Description = currentIndexer.Description,
+                ReturnType = new CodeType {
+                    IsNullable = false,
+                    TypeDefinition = indexerClass,
+                    Name = indexerClass.Name,
+                },
+                OriginalIndexer = currentIndexer,
+            };
+            var parameter = new CodeParameter {
+                Name = "id",
+                Optional = false,
+                ParameterKind = CodeParameterKind.Custom,
+                Description = "Unique identifier of the item",
+                Type = new CodeType {
+                    Name = "String",
+                    IsNullable = parameterNullable,
                     IsExternal = true,
-                    Name = className
-                });
+                },
+            };
+            method.AddParameter(parameter);
+            parentClass.AddMethod(method);
+        }
+        CrawlTree(currentElement, c => AddIndexerMethod(c, targetClass, indexerClass, methodNameSuffix, parameterNullable, currentIndexer));
+    }
+    internal void AddInnerClasses(CodeElement current, bool prefixClassNameWithParentName, string queryParametersBaseClassName = "QueryParametersBase") {
+        if(current is CodeClass currentClass) {
+            foreach(var innerClass in currentClass
+                                    .Methods
+                                    .SelectMany(x => x.Parameters)
+                                    .Where(x => x.Type.ActionOf && x.IsOfKind(CodeParameterKind.QueryParameter))
+                                    .SelectMany(x => x.Type.AllTypes)
+                                    .Select(x => x.TypeDefinition)
+                                    .OfType<CodeClass>()) {
+                if(prefixClassNameWithParentName && !innerClass.Name.StartsWith(currentClass.Name, StringComparison.OrdinalIgnoreCase)) {
+                    innerClass.Name = $"{currentClass.Name}{innerClass.Name}";
+                    innerClass.StartBlock.Name = innerClass.Name;
+                }
+                
+                if(currentClass.FindChildByName<CodeClass>(innerClass.Name) == null) {
+                    currentClass.AddInnerClass(innerClass);
+                }
+                if(!string.IsNullOrEmpty(queryParametersBaseClassName))
+                    (innerClass.StartBlock as Declaration).Inherits = new CodeType { Name = queryParametersBaseClassName, IsExternal = true };
             }
-            CrawlTree(currentElement, c => AddParsableInheritanceForModelClasses(c, className));
+        }
+        CrawlTree(current, x => AddInnerClasses(x, prefixClassNameWithParentName, queryParametersBaseClassName));
+    }
+    private static readonly CodeUsingComparer usingComparerWithDeclarations = new(true);
+    private static readonly CodeUsingComparer usingComparerWithoutDeclarations = new(false);
+    protected readonly GenerationConfiguration _configuration;
+
+    protected static void AddPropertiesAndMethodTypesImports(CodeElement current, bool includeParentNamespaces, bool includeCurrentNamespace, bool compareOnDeclaration) {
+        if(current is CodeClass currentClass &&
+            currentClass.StartBlock is Declaration currentClassDeclaration) {
+            var currentClassNamespace = currentClass.GetImmediateParentOfType<CodeNamespace>();
+            var currentClassChildren = currentClass.GetChildElements(true);
+            var inheritTypes = currentClassDeclaration.Inherits?.AllTypes ?? Enumerable.Empty<CodeType>();
+            var propertiesTypes = currentClass
+                                .Properties
+                                .Select(x => x.Type)
+                                .Distinct();
+            var methods = currentClass.Methods;
+            var methodsReturnTypes = methods
+                                .Select(x => x.ReturnType)
+                                .Distinct();
+            var methodsParametersTypes = methods
+                                .SelectMany(x => x.Parameters)
+                                .Where(x => x.IsOfKind(CodeParameterKind.Custom, CodeParameterKind.RequestBody))
+                                .Select(x => x.Type)
+                                .Distinct();
+            var indexerTypes = currentClassChildren
+                                .OfType<CodeIndexer>()
+                                .Select(x => x.ReturnType)
+                                .Distinct();
+            var usingsToAdd = propertiesTypes
+                                .Union(methodsParametersTypes)
+                                .Union(methodsReturnTypes)
+                                .Union(indexerTypes)
+                                .Union(inheritTypes)
+                                .Where(x => x != null)
+                                .SelectMany(x => x?.AllTypes?.Select(y => new Tuple<CodeType, CodeNamespace>(y, y?.TypeDefinition?.GetImmediateParentOfType<CodeNamespace>())))
+                                .Where(x => x.Item2 != null && (includeCurrentNamespace || x.Item2 != currentClassNamespace))
+                                .Where(x => includeParentNamespaces || !currentClassNamespace.IsChildOf(x.Item2))
+                                .Select(x => new CodeUsing { Name = x.Item2.Name, Declaration = x.Item1 })
+                                .Where(x => x.Declaration?.TypeDefinition != current)
+                                .Distinct(compareOnDeclaration ? usingComparerWithDeclarations : usingComparerWithoutDeclarations)
+                                .ToArray();
+            if(usingsToAdd.Any())
+                (currentClass.Parent is CodeClass parentClass ? parentClass : currentClass).AddUsing(usingsToAdd); //lots of languages do not support imports on nested classes
+        }
+        CrawlTree(current, (x) => AddPropertiesAndMethodTypesImports(x, includeParentNamespaces, includeCurrentNamespace, compareOnDeclaration));
+    }
+    protected static void PatchHeaderParametersType(CodeElement currentElement, string newTypeName) {
+        if(currentElement is CodeMethod currentMethod && currentMethod.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Headers)))
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Headers))
+                                    .ToList()
+                                    .ForEach(x => x.Type.Name = newTypeName);
+        CrawlTree(currentElement, (x) => PatchHeaderParametersType(x, newTypeName));
+    }
+    protected static void CrawlTree(CodeElement currentElement, Action<CodeElement> function) {
+        foreach(var childElement in currentElement.GetChildElements())
+            function.Invoke(childElement);
+    }
+    protected static void CorrectCoreType(CodeElement currentElement, Action<CodeMethod> correctMethodType, Action<CodeProperty> correctPropertyType) {
+        switch(currentElement) {
+            case CodeProperty property:
+                correctPropertyType?.Invoke(property);
+                break;
+            case CodeMethod method:
+                correctMethodType?.Invoke(method);
+                break;
+        }
+        CrawlTree(currentElement, x => CorrectCoreType(x, correctMethodType, correctPropertyType));
+    }
+    protected static void MakeModelPropertiesNullable(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass &&
+            currentClass.IsOfKind(CodeClassKind.Model))
+            currentClass.Properties
+                        .Where(x => x.IsOfKind(CodePropertyKind.Custom))
+                        .ToList()
+                        .ForEach(x => x.Type.IsNullable = true);
+        CrawlTree(currentElement, MakeModelPropertiesNullable);
+    }
+    protected static void AddRawUrlConstructorOverload(CodeElement currentElement) {
+        if(currentElement is CodeMethod currentMethod &&
+            currentMethod.IsOfKind(CodeMethodKind.Constructor) &&
+            currentElement.Parent is CodeClass parentClass &&
+            parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
+            var overloadCtor = currentMethod.Clone() as CodeMethod;
+            overloadCtor.MethodKind = CodeMethodKind.RawUrlConstructor;
+            overloadCtor.OriginalMethod = currentMethod;
+            overloadCtor.RemoveParametersByKind(CodeParameterKind.PathParameters, CodeParameterKind.Path);
+            overloadCtor.AddParameter(new CodeParameter {
+                Name = "rawUrl",
+                Type = new CodeType { Name = "string", IsExternal = true },
+                Optional = false,
+                Description = "The raw URL to use for the request builder.",
+                ParameterKind = CodeParameterKind.RawUrl,
+            });
+            parentClass.AddMethod(overloadCtor);
+        }
+        CrawlTree(currentElement, AddRawUrlConstructorOverload);
+    }
+    protected static void RemoveCancellationParameter(CodeElement currentElement){
+        if (currentElement is CodeMethod currentMethod &&
+            currentMethod.IsOfKind(CodeMethodKind.RequestExecutor)){ 
+            currentMethod.RemoveParametersByKind(CodeParameterKind.Cancellation);
+        }
+        CrawlTree(currentElement, RemoveCancellationParameter);
+    }
+    
+    protected static void AddParsableInheritanceForModelClasses(CodeElement currentElement, string className) {
+        if(string.IsNullOrEmpty(className)) throw new ArgumentNullException(nameof(className));
+
+        if(currentElement is CodeClass currentClass &&
+            currentClass.IsOfKind(CodeClassKind.Model) &&
+            currentClass.StartBlock is CodeClass.Declaration declaration) {
+            declaration.AddImplements(new CodeType {
+                IsExternal = true,
+                Name = className
+            });
+        }
+        CrawlTree(currentElement, c => AddParsableInheritanceForModelClasses(c, className));
+    }
+    protected static void CorrectDateTypes(CodeClass parentClass, Dictionary<string, (string, CodeUsing)> dateTypesReplacements, params CodeTypeBase[] types) {
+        if(parentClass == null)
+            return;
+        foreach(var type in types.Where(x => x != null && dateTypesReplacements.ContainsKey(x.Name))) {
+            var replacement = dateTypesReplacements[type.Name];
+            if(replacement.Item1 != null)
+                type.Name = replacement.Item1;
+            parentClass.AddUsing(replacement.Item2.Clone() as CodeUsing);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -537,7 +537,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             var replacement = dateTypesReplacements[type.Name];
             if(replacement.Item1 != null)
                 type.Name = replacement.Item1;
-            parentClass.AddUsing(replacement.Item2.Clone() as CodeUsing);
+            if(replacement.Item2 != null)
+                parentClass.AddUsing(replacement.Item2.Clone() as CodeUsing);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -231,6 +231,13 @@ public class GoRefiner : CommonLanguageRefiner
         CrawlTree(currentElement, AddErrorImportForEnums);
     }
     private static readonly GoConventionService conventions = new();
+    private static readonly HashSet<string> typeToSkipStrConv = new(StringComparer.OrdinalIgnoreCase) {
+        "DateTimeOffset",
+        "Duration",
+        "TimeOnly",
+        "DateOnly",
+        "string"
+    };
     private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
             "github.com/microsoft/kiota/abstractions/go", "RequestAdapter"),
@@ -244,8 +251,7 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota/abstractions/go/serialization", "Parsable"),
         new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Constructor) &&
                     method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Path) &&
-                                            !x.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase) &&
-                                            !x.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase)),
+                                            !typeToSkipStrConv.Contains(x.Type.Name)),
             "strconv", "FormatBool"),
         new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
             "github.com/microsoft/kiota/abstractions/go/serialization", "SerializationWriter"),

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -4,317 +4,349 @@ using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Extensions;
 using Kiota.Builder.Writers.Go;
 
-namespace Kiota.Builder.Refiners {
-    public class GoRefiner : CommonLanguageRefiner
+namespace Kiota.Builder.Refiners;
+public class GoRefiner : CommonLanguageRefiner
+{
+    public GoRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public override void Refine(CodeNamespace generatedCode)
     {
-        public GoRefiner(GenerationConfiguration configuration) : base(configuration) {}
-        public override void Refine(CodeNamespace generatedCode)
-        {
-            AddInnerClasses(
-                generatedCode,
-                true,
-                null);
-            ReplaceIndexersByMethodsWithParameter(
-                generatedCode,
-                generatedCode,
-                false,
-                "ById");
-            RemoveCancellationParameter(generatedCode);
-            ReplaceRequestBuilderPropertiesByMethods(
-                generatedCode
-            );
-            ConvertUnionTypesToWrapper(
-                generatedCode,
-                _configuration.UsesBackingStore
-            );
-            AddNullCheckMethods(
-                generatedCode
-            );
-            AddRawUrlConstructorOverload(
-                generatedCode
-            );
-            MoveAllModelsToTopLevel(
-                generatedCode
-            );
-            ReplaceReservedNames(
-                generatedCode,
-                new GoReservedNamesProvider(),
-                x => $"{x}_escaped",
-                shouldReplaceCallback: x => x is not CodeProperty currentProp || 
-                                            !(currentProp.Parent is CodeClass parentClass &&
-                                            parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&
-                                            currentProp.Access == AccessModifier.Public)); // Go reserved keywords are all lowercase and public properties are uppercased when we don't provide accessors (models)
-            AddPropertiesAndMethodTypesImports(
-                generatedCode,
-                true,
-                false,
-                true);
-            AddDefaultImports(
-                generatedCode,
-                defaultUsingEvaluators);
-            CorrectCoreType(
-                generatedCode,
-                CorrectMethodType,
-                CorrectPropertyType);
-            PatchHeaderParametersType(
-                generatedCode,
-                "map[string]string");
-            AddGetterAndSetterMethods(
-                generatedCode, 
-                new () { 
-                    CodePropertyKind.AdditionalData,
-                    CodePropertyKind.Custom,
-                    CodePropertyKind.BackingStore }, 
-                _configuration.UsesBackingStore,
-                false);
-            AddConstructorsForDefaultValues(
-                generatedCode,
-                true);
-            MakeModelPropertiesNullable(
-                generatedCode);
-            AddErrorImportForEnums(
-                generatedCode);
-            ReplaceDefaultSerializationModules(
-                generatedCode,
-                "github.com/microsoft/kiota/serialization/go/json.JsonSerializationWriterFactory");
-            ReplaceDefaultDeserializationModules(
-                generatedCode,
-                "github.com/microsoft/kiota/serialization/go/json.JsonParseNodeFactory");
-            AddSerializationModulesImport(
-                generatedCode,
-                new string[] {"github.com/microsoft/kiota/abstractions/go/serialization.SerializationWriterFactory", "github.com/microsoft/kiota/abstractions/go.RegisterDefaultSerializer"},
-                new string[] {"github.com/microsoft/kiota/abstractions/go/serialization.ParseNodeFactory", "github.com/microsoft/kiota/abstractions/go.RegisterDefaultDeserializer"});
-            ReplaceExecutorAndGeneratorParametersByParameterSets(
-                generatedCode);
-        }
-        private static void ReplaceExecutorAndGeneratorParametersByParameterSets(CodeElement currentElement) {
-            if (currentElement is CodeMethod currentMethod &&
-                currentMethod.IsOfKind(CodeMethodKind.RequestExecutor) &&
-                currentMethod.Parameters.Any() &&
-                currentElement.Parent is CodeClass parentClass) {
-                    var parameterSetClass = parentClass.AddInnerClass(new CodeClass{
-                        Name = $"{parentClass.Name.ToFirstCharacterUpperCase()}{currentMethod.HttpMethod}Options",
-                        ClassKind = CodeClassKind.ParameterSet,
-                        Description = $"Options for {currentMethod.Name}",
-                    }).First();
-                    parameterSetClass.AddProperty(
-                        currentMethod.Parameters.Select(x => new CodeProperty{
-                            Name = x.Name,
-                            Type = x.Type,
-                            Description = x.Description,
-                            Access = AccessModifier.Public,
-                            PropertyKind = x.ParameterKind switch {
-                                CodeParameterKind.RequestBody => CodePropertyKind.RequestBody,
-                                CodeParameterKind.QueryParameter => CodePropertyKind.QueryParameter,
-                                CodeParameterKind.Headers => CodePropertyKind.Headers,
-                                CodeParameterKind.Options => CodePropertyKind.Options,
-                                CodeParameterKind.ResponseHandler => CodePropertyKind.ResponseHandler,
-                                _ => CodePropertyKind.Custom
-                            },
-                        }).ToArray());
-                    parameterSetClass.Properties.ToList().ForEach(x => {x.Type.ActionOf = false;});
-                    currentMethod.RemoveParametersByKind(CodeParameterKind.RequestBody,
-                                                        CodeParameterKind.QueryParameter,
-                                                        CodeParameterKind.Headers,
-                                                        CodeParameterKind.Options,
-                                                        CodeParameterKind.ResponseHandler);
-                    var parameterSetParameter = new CodeParameter{
-                        Name = "options",
-                        Type = new CodeType {
-                            Name = parameterSetClass.Name,
-                            ActionOf = false,
-                            IsNullable = true,
-                            TypeDefinition = parameterSetClass,
-                            IsExternal = false,
+        AddInnerClasses(
+            generatedCode,
+            true,
+            null);
+        ReplaceIndexersByMethodsWithParameter(
+            generatedCode,
+            generatedCode,
+            false,
+            "ById");
+        RemoveCancellationParameter(generatedCode);
+        ReplaceRequestBuilderPropertiesByMethods(
+            generatedCode
+        );
+        ConvertUnionTypesToWrapper(
+            generatedCode,
+            _configuration.UsesBackingStore
+        );
+        AddNullCheckMethods(
+            generatedCode
+        );
+        AddRawUrlConstructorOverload(
+            generatedCode
+        );
+        MoveAllModelsToTopLevel(
+            generatedCode
+        );
+        ReplaceReservedNames(
+            generatedCode,
+            new GoReservedNamesProvider(),
+            x => $"{x}_escaped",
+            shouldReplaceCallback: x => x is not CodeProperty currentProp || 
+                                        !(currentProp.Parent is CodeClass parentClass &&
+                                        parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&
+                                        currentProp.Access == AccessModifier.Public)); // Go reserved keywords are all lowercase and public properties are uppercased when we don't provide accessors (models)
+        AddPropertiesAndMethodTypesImports(
+            generatedCode,
+            true,
+            false,
+            true);
+        AddDefaultImports(
+            generatedCode,
+            defaultUsingEvaluators);
+        CorrectCoreType(
+            generatedCode,
+            CorrectMethodType,
+            CorrectPropertyType);
+        PatchHeaderParametersType(
+            generatedCode,
+            "map[string]string");
+        AddGetterAndSetterMethods(
+            generatedCode, 
+            new () { 
+                CodePropertyKind.AdditionalData,
+                CodePropertyKind.Custom,
+                CodePropertyKind.BackingStore }, 
+            _configuration.UsesBackingStore,
+            false);
+        AddConstructorsForDefaultValues(
+            generatedCode,
+            true);
+        MakeModelPropertiesNullable(
+            generatedCode);
+        AddErrorImportForEnums(
+            generatedCode);
+        ReplaceDefaultSerializationModules(
+            generatedCode,
+            "github.com/microsoft/kiota/serialization/go/json.JsonSerializationWriterFactory");
+        ReplaceDefaultDeserializationModules(
+            generatedCode,
+            "github.com/microsoft/kiota/serialization/go/json.JsonParseNodeFactory");
+        AddSerializationModulesImport(
+            generatedCode,
+            new string[] {"github.com/microsoft/kiota/abstractions/go/serialization.SerializationWriterFactory", "github.com/microsoft/kiota/abstractions/go.RegisterDefaultSerializer"},
+            new string[] {"github.com/microsoft/kiota/abstractions/go/serialization.ParseNodeFactory", "github.com/microsoft/kiota/abstractions/go.RegisterDefaultDeserializer"});
+        ReplaceExecutorAndGeneratorParametersByParameterSets(
+            generatedCode);
+    }
+    private static void ReplaceExecutorAndGeneratorParametersByParameterSets(CodeElement currentElement) {
+        if (currentElement is CodeMethod currentMethod &&
+            currentMethod.IsOfKind(CodeMethodKind.RequestExecutor) &&
+            currentMethod.Parameters.Any() &&
+            currentElement.Parent is CodeClass parentClass) {
+                var parameterSetClass = parentClass.AddInnerClass(new CodeClass{
+                    Name = $"{parentClass.Name.ToFirstCharacterUpperCase()}{currentMethod.HttpMethod}Options",
+                    ClassKind = CodeClassKind.ParameterSet,
+                    Description = $"Options for {currentMethod.Name}",
+                }).First();
+                parameterSetClass.AddProperty(
+                    currentMethod.Parameters.Select(x => new CodeProperty{
+                        Name = x.Name,
+                        Type = x.Type,
+                        Description = x.Description,
+                        Access = AccessModifier.Public,
+                        PropertyKind = x.ParameterKind switch {
+                            CodeParameterKind.RequestBody => CodePropertyKind.RequestBody,
+                            CodeParameterKind.QueryParameter => CodePropertyKind.QueryParameter,
+                            CodeParameterKind.Headers => CodePropertyKind.Headers,
+                            CodeParameterKind.Options => CodePropertyKind.Options,
+                            CodeParameterKind.ResponseHandler => CodePropertyKind.ResponseHandler,
+                            _ => CodePropertyKind.Custom
                         },
-                        Optional = false,
-                        Description = "Options for the request",
-                        ParameterKind = CodeParameterKind.ParameterSet,
-                    };
-                    currentMethod.AddParameter(parameterSetParameter);
-                    var generatorMethod = parentClass.GetMethodsOffKind(CodeMethodKind.RequestGenerator)
-                                                    .FirstOrDefault(x => x.HttpMethod == currentMethod.HttpMethod);
-                    if(!(generatorMethod?.Parameters.Any(x => x.IsOfKind(CodeParameterKind.ParameterSet)) ?? true)) {
-                        generatorMethod.RemoveParametersByKind(CodeParameterKind.RequestBody,
-                                                        CodeParameterKind.QueryParameter,
-                                                        CodeParameterKind.Headers,
-                                                        CodeParameterKind.Options);
-                        generatorMethod.AddParameter(parameterSetParameter);
-                    }
+                    }).ToArray());
+                parameterSetClass.Properties.ToList().ForEach(x => {x.Type.ActionOf = false;});
+                currentMethod.RemoveParametersByKind(CodeParameterKind.RequestBody,
+                                                    CodeParameterKind.QueryParameter,
+                                                    CodeParameterKind.Headers,
+                                                    CodeParameterKind.Options,
+                                                    CodeParameterKind.ResponseHandler);
+                var parameterSetParameter = new CodeParameter{
+                    Name = "options",
+                    Type = new CodeType {
+                        Name = parameterSetClass.Name,
+                        ActionOf = false,
+                        IsNullable = true,
+                        TypeDefinition = parameterSetClass,
+                        IsExternal = false,
+                    },
+                    Optional = false,
+                    Description = "Options for the request",
+                    ParameterKind = CodeParameterKind.ParameterSet,
+                };
+                currentMethod.AddParameter(parameterSetParameter);
+                var generatorMethod = parentClass.GetMethodsOffKind(CodeMethodKind.RequestGenerator)
+                                                .FirstOrDefault(x => x.HttpMethod == currentMethod.HttpMethod);
+                if(!(generatorMethod?.Parameters.Any(x => x.IsOfKind(CodeParameterKind.ParameterSet)) ?? true)) {
+                    generatorMethod.RemoveParametersByKind(CodeParameterKind.RequestBody,
+                                                    CodeParameterKind.QueryParameter,
+                                                    CodeParameterKind.Headers,
+                                                    CodeParameterKind.Options);
+                    generatorMethod.AddParameter(parameterSetParameter);
                 }
-            CrawlTree(currentElement, ReplaceExecutorAndGeneratorParametersByParameterSets);
+            }
+        CrawlTree(currentElement, ReplaceExecutorAndGeneratorParametersByParameterSets);
+    }
+    private static void AddNullCheckMethods(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model)) {
+            currentClass.AddMethod(new CodeMethod {
+                Name = "IsNil",
+                IsAsync = false,
+                MethodKind = CodeMethodKind.NullCheck,
+                ReturnType = new CodeType {
+                    Name = "boolean",
+                    IsExternal = true,
+                    IsNullable = false,
+                },
+            });
         }
-        private static void AddNullCheckMethods(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model)) {
-                currentClass.AddMethod(new CodeMethod {
-                    Name = "IsNil",
+        CrawlTree(currentElement, AddNullCheckMethods);
+    }
+    private static void MoveAllModelsToTopLevel(CodeElement currentElement, CodeNamespace targetNamespace = null) {
+        if(currentElement is CodeNamespace currentNamespace) {
+            if(targetNamespace == null) {
+                var rootModels = FindRootModelsNamespace(currentNamespace);
+                targetNamespace = FindFirstModelSubnamepaceWithClasses(rootModels);
+            }
+            if(currentNamespace != targetNamespace &&
+                !string.IsNullOrEmpty(currentNamespace.Name) &&
+                currentNamespace.Name.Contains(targetNamespace.Name, StringComparison.OrdinalIgnoreCase)) {
+                foreach (var codeClass in currentNamespace.Classes)
+                {
+                    currentNamespace.RemoveChildElement(codeClass);
+                    targetNamespace.AddClass(codeClass);
+                }
+            }
+            CrawlTree(currentElement, x => MoveAllModelsToTopLevel(x, targetNamespace));
+        }
+    }
+    private static CodeNamespace FindFirstModelSubnamepaceWithClasses(CodeNamespace currentNamespace) {
+        if(currentNamespace != null) {
+            if(currentNamespace.Classes.Any()) return currentNamespace;
+            else
+                foreach (var subNS in currentNamespace.Namespaces)
+                {
+                    var result = FindFirstModelSubnamepaceWithClasses(subNS);
+                    if (result != null) return result;
+                }
+        }
+        return null;
+    }
+    private static CodeNamespace FindRootModelsNamespace(CodeNamespace currentNamespace) {
+        if(currentNamespace != null) {
+            if(!string.IsNullOrEmpty(currentNamespace.Name) &&
+                currentNamespace.Name.EndsWith("Models", StringComparison.OrdinalIgnoreCase))
+                return currentNamespace;
+            else
+                foreach(var subNS in currentNamespace.Namespaces)
+                {
+                    var result = FindRootModelsNamespace(subNS);
+                    if(result != null)
+                        return result;
+                }
+        }
+        return null;
+    }
+    private static void ReplaceRequestBuilderPropertiesByMethods(CodeElement currentElement) {
+        if(currentElement is CodeProperty currentProperty &&
+            currentProperty.IsOfKind(CodePropertyKind.RequestBuilder) &&
+            currentElement.Parent is CodeClass parentClass) {
+                parentClass.RemoveChildElement(currentProperty);
+                currentProperty.Type.IsNullable = false;
+                parentClass.AddMethod(new CodeMethod {
+                    Name = currentProperty.Name,
+                    ReturnType = currentProperty.Type,
+                    Access = AccessModifier.Public,
+                    Description = currentProperty.Description,
                     IsAsync = false,
-                    MethodKind = CodeMethodKind.NullCheck,
-                    ReturnType = new CodeType {
-                        Name = "boolean",
+                    MethodKind = CodeMethodKind.RequestBuilderBackwardCompatibility,
+                });
+            }
+        CrawlTree(currentElement, ReplaceRequestBuilderPropertiesByMethods);
+    }
+    private static void AddErrorImportForEnums(CodeElement currentElement) {
+        if(currentElement is CodeEnum currentEnum) {
+            currentEnum.AddUsings(new CodeUsing {
+                Name = "errors",
+            });
+        }
+        CrawlTree(currentElement, AddErrorImportForEnums);
+    }
+    private static readonly GoConventionService conventions = new();
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            "github.com/microsoft/kiota/abstractions/go", "RequestAdapter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "github.com/microsoft/kiota/abstractions/go", "RequestInformation", "HttpMethod", "RequestOption"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "github.com/microsoft/kiota/abstractions/go", "ResponseHandler"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) &&
+                    !conventions.IsScalarType(method.ReturnType.Name) &&
+                    !conventions.IsPrimitiveType(method.ReturnType.Name),
+            "github.com/microsoft/kiota/abstractions/go/serialization", "Parsable"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Constructor) &&
+                    method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Path) &&
+                                            !x.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase) &&
+                                            !x.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase)),
+            "strconv", "FormatBool"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            "github.com/microsoft/kiota/abstractions/go/serialization", "SerializationWriter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "github.com/microsoft/kiota/abstractions/go/serialization", "ParseNode", "Parsable"),
+        new (x => x is CodeEnum num, "ToUpper", "strings"),
+    };//TODO add backing store types once we have them defined
+    private static void CorrectMethodType(CodeMethod currentMethod) {
+        var parentClass = currentMethod.Parent as CodeClass;
+        if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator) &&
+            parentClass != null) {
+            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
+                currentMethod.Parameters.Where(x => x.Type.Name.Equals("IResponseHandler")).ToList().ForEach(x => {
+                    x.Type.Name = "ResponseHandler";
+                    x.Type.IsNullable = false; //no pointers
+                });
+            else if(currentMethod.IsOfKind(CodeMethodKind.RequestGenerator))
+                currentMethod.ReturnType.IsNullable = true;
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => {
+                x.Type.IsNullable = false;
+                x.Type.Name = "RequestOption";
+                x.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+            });
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.QueryParameter)).ToList().ForEach(x => x.Type.Name = $"{parentClass.Name}{x.Type.Name}");
+        }
+        else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
+            currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
+        else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer)) {
+            currentMethod.ReturnType.Name = $"map[string]func(interface{{}}, {conventions.SerializationHash}.ParseNode)(error)";
+            currentMethod.Name = "getFieldDeserializers";
+        } else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {
+            var rawUrlParam = currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl);
+            if(rawUrlParam != null)
+                rawUrlParam.Type.IsNullable = false;
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter))
+                .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
+                .ToList()
+                .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
+        } else if(currentMethod.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility, CodeMethodKind.RequestBuilderWithParameters, CodeMethodKind.RequestBuilderBackwardCompatibility)) {
+            currentMethod.ReturnType.IsNullable = true;
+        }
+        CorrectDateTypes(parentClass, currentMethod.Parameters
+                                                .Select(x => x.Type)
+                                                .Union(new CodeTypeBase[] { currentMethod.ReturnType})
+                                                .ToArray());
+    }
+    private static void CorrectDateTypes(CodeClass parentClass, params CodeTypeBase[] types) {
+        if(parentClass == null)
+            return;
+        foreach(var type in types)
+            if("DateTimeOffset".Equals(type.Name, StringComparison.OrdinalIgnoreCase)) {
+                type.Name = "Time";
+                parentClass.AddUsing(new CodeUsing {
+                    Name = "Time",
+                    Declaration = new CodeType {
+                        Name = "time",
                         IsExternal = true,
-                        IsNullable = false,
+                    },
+                });
+            } else if("TimeSpan".Equals(type.Name, StringComparison.OrdinalIgnoreCase)) {
+                type.Name = "Duration";
+                parentClass.AddUsing(new CodeUsing {
+                    Name = "Duration",
+                    Declaration = new CodeType {
+                        Name = "time",
+                        IsExternal = true,
+                    },
+                });
+            } else if("DateOnly".Equals(type.Name, StringComparison.OrdinalIgnoreCase)) {
+                parentClass.AddUsing(new CodeUsing {
+                    Name = "DateOnly",
+                    Declaration = new CodeType {
+                        Name = "github.com/microsoft/kiota/abstractions/go/serialization",
+                        IsExternal = true,
+                    },
+                });
+            } else if("TimeOnly".Equals(type.Name, StringComparison.OrdinalIgnoreCase)) {
+                parentClass.AddUsing(new CodeUsing {
+                    Name = "TimeOnly",
+                    Declaration = new CodeType {
+                        Name = "github.com/microsoft/kiota/abstractions/go/serialization",
+                        IsExternal = true,
                     },
                 });
             }
-            CrawlTree(currentElement, AddNullCheckMethods);
-        }
-        private static void MoveAllModelsToTopLevel(CodeElement currentElement, CodeNamespace targetNamespace = null) {
-            if(currentElement is CodeNamespace currentNamespace) {
-                if(targetNamespace == null) {
-                    var rootModels = FindRootModelsNamespace(currentNamespace);
-                    targetNamespace = FindFirstModelSubnamepaceWithClasses(rootModels);
-                }
-                if(currentNamespace != targetNamespace &&
-                    !string.IsNullOrEmpty(currentNamespace.Name) &&
-                    currentNamespace.Name.Contains(targetNamespace.Name, StringComparison.OrdinalIgnoreCase)) {
-                    foreach (var codeClass in currentNamespace.Classes)
-                    {
-                        currentNamespace.RemoveChildElement(codeClass);
-                        targetNamespace.AddClass(codeClass);
-                    }
-                }
-                CrawlTree(currentElement, x => MoveAllModelsToTopLevel(x, targetNamespace));
-            }
-        }
-        private static CodeNamespace FindFirstModelSubnamepaceWithClasses(CodeNamespace currentNamespace) {
-            if(currentNamespace != null) {
-                if(currentNamespace.Classes.Any()) return currentNamespace;
-                else
-                    foreach (var subNS in currentNamespace.Namespaces)
-                    {
-                        var result = FindFirstModelSubnamepaceWithClasses(subNS);
-                        if (result != null) return result;
-                    }
-            }
-            return null;
-        }
-        private static CodeNamespace FindRootModelsNamespace(CodeNamespace currentNamespace) {
-            if(currentNamespace != null) {
-                if(!string.IsNullOrEmpty(currentNamespace.Name) &&
-                    currentNamespace.Name.EndsWith("Models", StringComparison.OrdinalIgnoreCase))
-                    return currentNamespace;
-                else
-                    foreach(var subNS in currentNamespace.Namespaces)
-                    {
-                        var result = FindRootModelsNamespace(subNS);
-                        if(result != null)
-                            return result;
-                    }
-            }
-            return null;
-        }
-        private static void ReplaceRequestBuilderPropertiesByMethods(CodeElement currentElement) {
-            if(currentElement is CodeProperty currentProperty &&
-                currentProperty.IsOfKind(CodePropertyKind.RequestBuilder) &&
-                currentElement.Parent is CodeClass parentClass) {
-                    parentClass.RemoveChildElement(currentProperty);
-                    currentProperty.Type.IsNullable = false;
-                    parentClass.AddMethod(new CodeMethod {
-                        Name = currentProperty.Name,
-                        ReturnType = currentProperty.Type,
-                        Access = AccessModifier.Public,
-                        Description = currentProperty.Description,
-                        IsAsync = false,
-                        MethodKind = CodeMethodKind.RequestBuilderBackwardCompatibility,
-                    });
-                }
-            CrawlTree(currentElement, ReplaceRequestBuilderPropertiesByMethods);
-        }
-        private static void AddErrorImportForEnums(CodeElement currentElement) {
-            if(currentElement is CodeEnum currentEnum) {
-                currentEnum.AddUsings(new CodeUsing {
-                    Name = "errors",
-                });
-            }
-            CrawlTree(currentElement, AddErrorImportForEnums);
-        }
-        private static readonly GoConventionService conventions = new();
-        private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "github.com/microsoft/kiota/abstractions/go", "RequestAdapter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "github.com/microsoft/kiota/abstractions/go", "RequestInformation", "HttpMethod", "RequestOption"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "github.com/microsoft/kiota/abstractions/go", "ResponseHandler"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) &&
-                        !conventions.IsScalarType(method.ReturnType.Name) &&
-                        !conventions.IsPrimitiveType(method.ReturnType.Name),
-                "github.com/microsoft/kiota/abstractions/go/serialization", "Parsable"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Constructor) &&
-                        method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Path) &&
-                                                !x.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase) &&
-                                                !x.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase)),
-                "strconv", "FormatBool"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "github.com/microsoft/kiota/abstractions/go/serialization", "SerializationWriter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "github.com/microsoft/kiota/abstractions/go/serialization", "ParseNode", "Parsable"),
-            new (x => x is CodeMethod method &&
-                method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.Path) && "DateTimeOffset".Equals(x.Type.Name, StringComparison.OrdinalIgnoreCase)),
-                "time", "Time"),
-            new (x => x is CodeEnum num, "ToUpper", "strings"),
-        };//TODO add backing store types once we have them defined
-        private static void CorrectMethodType(CodeMethod currentMethod) {
-            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator) &&
-                currentMethod.Parent is CodeClass parentClass) {
-                if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
-                    currentMethod.Parameters.Where(x => x.Type.Name.Equals("IResponseHandler")).ToList().ForEach(x => {
-                        x.Type.Name = "ResponseHandler";
-                        x.Type.IsNullable = false; //no pointers
-                    });
-                else if(currentMethod.IsOfKind(CodeMethodKind.RequestGenerator))
-                    currentMethod.ReturnType.IsNullable = true;
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => {
-                    x.Type.IsNullable = false;
-                    x.Type.Name = "RequestOption";
-                    x.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
-                });
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.QueryParameter)).ToList().ForEach(x => x.Type.Name = $"{parentClass.Name}{x.Type.Name}");
-            }
-            else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
-                currentMethod.Parameters.Where(x => x.Type.Name.Equals("ISerializationWriter")).ToList().ForEach(x => x.Type.Name = "SerializationWriter");
-            else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer)) {
-                currentMethod.ReturnType.Name = $"map[string]func(interface{{}}, {conventions.SerializationHash}.ParseNode)(error)";
-                currentMethod.Name = "getFieldDeserializers";
-            } else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {
-                var rawUrlParam = currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl);
-                if(rawUrlParam != null)
-                    rawUrlParam.Type.IsNullable = false;
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter))
-                    .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
-                    .ToList()
-                    .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
-            } else if(currentMethod.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility, CodeMethodKind.RequestBuilderWithParameters, CodeMethodKind.RequestBuilderBackwardCompatibility)) {
-                currentMethod.ReturnType.IsNullable = true;
-            }
-        }
-        private static void CorrectPropertyType(CodeProperty currentProperty) {
-            if (currentProperty.Type != null) {
-                if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
-                    currentProperty.Type.Name = "RequestAdapter";
-                else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
-                    currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
-                else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase)) {
-                    currentProperty.Type.Name = "Time";
-                    var nUsing = new CodeUsing {
-                        Name = "Time",
-                        Declaration = new CodeType {
-                            Name = "time",
-                            IsExternal = true,
-                        },
-                    };
-                    (currentProperty.Parent as CodeClass).AddUsing(nUsing);
-                } else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
-                    currentProperty.Type.Name = "map[string]interface{}";
+    }
+    private static void CorrectPropertyType(CodeProperty currentProperty) {
+        if (currentProperty.Type != null) {
+            if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
+                currentProperty.Type.Name = "RequestAdapter";
+            else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
+                currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
+            else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
+                currentProperty.Type.Name = "map[string]interface{}";
+                currentProperty.DefaultValue = $"make({currentProperty.Type.Name})";
+            } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
+                currentProperty.Type.IsNullable = true;
+                currentProperty.Type.Name = "map[string]string";
+                if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
                     currentProperty.DefaultValue = $"make({currentProperty.Type.Name})";
-                } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
-                    currentProperty.Type.IsNullable = true;
-                    currentProperty.Type.Name = "map[string]string";
-                    if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
-                        currentProperty.DefaultValue = $"make({currentProperty.Type.Name})";
-                }
-            }
+            } else
+                CorrectDateTypes(currentProperty.Parent as CodeClass, currentProperty.Type);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -293,7 +293,7 @@ public class GoRefiner : CommonLanguageRefiner
         } else if(currentMethod.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility, CodeMethodKind.RequestBuilderWithParameters, CodeMethodKind.RequestBuilderBackwardCompatibility)) {
             currentMethod.ReturnType.IsNullable = true;
         }
-        CorrectDateTypes(parentClass, currentMethod.Parameters
+        CorrectDateTypes(parentClass, DateTypesReplacements, currentMethod.Parameters
                                                 .Select(x => x.Type)
                                                 .Union(new CodeTypeBase[] { currentMethod.ReturnType})
                                                 .ToArray());
@@ -328,16 +328,6 @@ public class GoRefiner : CommonLanguageRefiner
                                 },
                             })},
     };
-    private static void CorrectDateTypes(CodeClass parentClass, params CodeTypeBase[] types) {
-        if(parentClass == null)
-            return;
-        foreach(var type in types.Where(x => DateTypesReplacements.ContainsKey(x.Name))) {
-            var replacement = DateTypesReplacements[type.Name];
-            if(replacement.Item1 != null)
-                type.Name = replacement.Item1;
-            parentClass.AddUsing(replacement.Item2.Clone() as CodeUsing);
-        }
-    }
     private static void CorrectPropertyType(CodeProperty currentProperty) {
         if (currentProperty.Type != null) {
             if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
@@ -353,7 +343,7 @@ public class GoRefiner : CommonLanguageRefiner
                 if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
                     currentProperty.DefaultValue = $"make({currentProperty.Type.Name})";
             } else
-                CorrectDateTypes(currentProperty.Parent as CodeClass, currentProperty.Type);
+                CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -306,10 +306,10 @@ public class GoRefiner : CommonLanguageRefiner
                                             IsExternal = true,
                                         },
                                     })},
-        {"TimeSpan", ("Duration", new CodeUsing {
-                                        Name = "Duration",
+        {"TimeSpan", ("ISODuration", new CodeUsing {
+                                        Name = "ISODuration",
                                         Declaration = new CodeType {
-                                            Name = "time",
+                                            Name = "github.com/microsoft/kiota/abstractions/go/serialization",
                                             IsExternal = true,
                                         },
                                     })},

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -1,218 +1,224 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Writers.Java;
 
-namespace Kiota.Builder.Refiners {
-    public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
+namespace Kiota.Builder.Refiners;
+public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
+{
+    public JavaRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public override void Refine(CodeNamespace generatedCode)
     {
-        public JavaRefiner(GenerationConfiguration configuration) : base(configuration) {}
-        public override void Refine(CodeNamespace generatedCode)
-        {
-            AddInnerClasses(generatedCode, false);
-            InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
-            ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
-            RemoveCancellationParameter(generatedCode);
-            ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
-            AddRawUrlConstructorOverload(generatedCode);
-            ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");
-            AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
-            AddDefaultImports(generatedCode, defaultUsingEvaluators);
-            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
-            PatchHeaderParametersType(generatedCode, "Map<String, String>");
-            AddParsableInheritanceForModelClasses(generatedCode, "Parsable");
-            ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
-            AddEnumSetImport(generatedCode);
-            AddGetterAndSetterMethods(generatedCode, new() {
-                                                    CodePropertyKind.Custom,
-                                                    CodePropertyKind.AdditionalData,
-                                                    CodePropertyKind.BackingStore,
-                                                }, _configuration.UsesBackingStore, true);
-            SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
-            AddConstructorsForDefaultValues(generatedCode, true);
-            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
-            ReplaceDefaultSerializationModules(generatedCode, "com.microsoft.kiota.serialization.JsonSerializationWriterFactory");
-            ReplaceDefaultDeserializationModules(generatedCode, "com.microsoft.kiota.serialization.JsonParseNodeFactory");
-            AddSerializationModulesImport(generatedCode,
-                                        new [] { "com.microsoft.kiota.ApiClientBuilder",
-                                                "com.microsoft.kiota.serialization.SerializationWriterFactoryRegistry" },
-                                        new [] { "com.microsoft.kiota.serialization.ParseNodeFactoryRegistry" });
-        }
-        private static void SetSetterParametersToNullable(CodeElement currentElement, params Tuple<CodeMethodKind, CodePropertyKind>[] accessorPairs) {
-            if(currentElement is CodeMethod method &&
-                accessorPairs.Any(x => method.IsOfKind(x.Item1) && (method.AccessedProperty?.IsOfKind(x.Item2) ?? false))) 
-                foreach(var param in method.Parameters)
-                    param.Type.IsNullable = true;
-            CrawlTree(currentElement, element => SetSetterParametersToNullable(element, accessorPairs));   
-        }
-        private static void AddEnumSetImport(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) &&
-                currentClass.Properties.Any(x => x.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags)) {
-                    var nUsing = new CodeUsing {
-                        Name = "EnumSet",
-                        Declaration = new CodeType { Name = "java.util", IsExternal = true },
-                    };
-                    currentClass.AddUsing(nUsing);
-                }
+        AddInnerClasses(generatedCode, false);
+        InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
+        ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
+        RemoveCancellationParameter(generatedCode);
+        ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
+        AddRawUrlConstructorOverload(generatedCode);
+        ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");
+        AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
+        AddDefaultImports(generatedCode, defaultUsingEvaluators);
+        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
+        PatchHeaderParametersType(generatedCode, "Map<String, String>");
+        AddParsableInheritanceForModelClasses(generatedCode, "Parsable");
+        ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
+        AddEnumSetImport(generatedCode);
+        AddGetterAndSetterMethods(generatedCode, new() {
+                                                CodePropertyKind.Custom,
+                                                CodePropertyKind.AdditionalData,
+                                                CodePropertyKind.BackingStore,
+                                            }, _configuration.UsesBackingStore, true);
+        SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
+        AddConstructorsForDefaultValues(generatedCode, true);
+        CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
+        ReplaceDefaultSerializationModules(generatedCode, "com.microsoft.kiota.serialization.JsonSerializationWriterFactory");
+        ReplaceDefaultDeserializationModules(generatedCode, "com.microsoft.kiota.serialization.JsonParseNodeFactory");
+        AddSerializationModulesImport(generatedCode,
+                                    new [] { "com.microsoft.kiota.ApiClientBuilder",
+                                            "com.microsoft.kiota.serialization.SerializationWriterFactoryRegistry" },
+                                    new [] { "com.microsoft.kiota.serialization.ParseNodeFactoryRegistry" });
+    }
+    private static void SetSetterParametersToNullable(CodeElement currentElement, params Tuple<CodeMethodKind, CodePropertyKind>[] accessorPairs) {
+        if(currentElement is CodeMethod method &&
+            accessorPairs.Any(x => method.IsOfKind(x.Item1) && (method.AccessedProperty?.IsOfKind(x.Item2) ?? false))) 
+            foreach(var param in method.Parameters)
+                param.Type.IsNullable = true;
+        CrawlTree(currentElement, element => SetSetterParametersToNullable(element, accessorPairs));   
+    }
+    private static void AddEnumSetImport(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) &&
+            currentClass.Properties.Any(x => x.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags)) {
+                var nUsing = new CodeUsing {
+                    Name = "EnumSet",
+                    Declaration = new CodeType { Name = "java.util", IsExternal = true },
+                };
+                currentClass.AddUsing(nUsing);
+            }
 
-            CrawlTree(currentElement, AddEnumSetImport);
+        CrawlTree(currentElement, AddEnumSetImport);
+    }
+    private static readonly JavaConventionService conventionService = new();
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            "com.microsoft.kiota", "RequestAdapter"),
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.PathParameters),
+            "java.util", "HashMap"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "com.microsoft.kiota", "RequestInformation", "RequestOption", "HttpMethod"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "java.net", "URISyntaxException"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "java.util", "Collection", "Map"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "com.microsoft.kiota", "ResponseHandler"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.QueryParameters),
+            "com.microsoft.kiota", "QueryParametersBase"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
+            "com.microsoft.kiota.serialization", "Parsable"),
+        new (x => x is CodeMethod method && method.Parameters.Any(x => !x.Optional),
+                "java.util", "Objects"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) && 
+                    method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) &&
+                                        x.Type.Name.Equals(conventionService.StreamTypeName, StringComparison.OrdinalIgnoreCase)),
+            "java.io", "InputStream"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            "com.microsoft.kiota.serialization", "SerializationWriter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "com.microsoft.kiota.serialization", "ParseNode"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "com.microsoft.kiota.serialization", "Parsable"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "java.util.function", "BiConsumer"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "java.util", "HashMap", "Map"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
+                    method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
+            "com.microsoft.kiota.store", "BackingStoreFactory", "BackingStoreFactorySingleton"),
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
+            "com.microsoft.kiota.store", "BackingStore", "BackedModel", "BackingStoreFactorySingleton"),
+    };
+    private static void CorrectPropertyType(CodeProperty currentProperty) {
+        if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter)) {
+            currentProperty.Type.Name = "RequestAdapter";
+            currentProperty.Type.IsNullable = true;
         }
-        private static readonly JavaConventionService conventionService = new();
-        private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "com.microsoft.kiota", "RequestAdapter"),
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.PathParameters),
-                "java.util", "HashMap"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "com.microsoft.kiota", "RequestInformation", "RequestOption", "HttpMethod"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "java.net", "URISyntaxException"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "java.util", "Collection", "Map"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "com.microsoft.kiota", "ResponseHandler"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.QueryParameters),
-                "com.microsoft.kiota", "QueryParametersBase"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
-                "com.microsoft.kiota.serialization", "Parsable"),
-            new (x => x is CodeMethod method && method.Parameters.Any(x => !x.Optional),
-                    "java.util", "Objects"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) && 
-                        method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) &&
-                                            x.Type.Name.Equals(conventionService.StreamTypeName, StringComparison.OrdinalIgnoreCase)),
-                "java.io", "InputStream"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "com.microsoft.kiota.serialization", "SerializationWriter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "com.microsoft.kiota.serialization", "ParseNode"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "com.microsoft.kiota.serialization", "Parsable"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "java.util.function", "BiConsumer"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "java.util", "HashMap", "Map"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                        method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
-                "com.microsoft.kiota.store", "BackingStoreFactory", "BackingStoreFactorySingleton"),
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
-                "com.microsoft.kiota.store", "BackingStore", "BackedModel", "BackingStoreFactorySingleton"),
-        };
-        private const string OriginalDateTimeOffsetType = "DateTimeOffset";
-        private const string JavaOffsetDateTimeType = "OffsetDateTime";
-        private const string JavaOffsetDateTimeTypePackage = "java.time";
-        private static void CorrectPropertyType(CodeProperty currentProperty) {
-            if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter)) {
-                currentProperty.Type.Name = "RequestAdapter";
-                currentProperty.Type.IsNullable = true;
-            }
-            else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
-                currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
-            else if(OriginalDateTimeOffsetType.Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase)) {
-                currentProperty.Type.Name = JavaOffsetDateTimeType;
-                var nUsing = new CodeUsing {
-                    Name = JavaOffsetDateTimeType,
-                    Declaration = new CodeType {
-                        Name = JavaOffsetDateTimeTypePackage,
-                        IsExternal = true,
-                    },
-                };
-                
-                (currentProperty.Parent as CodeClass).AddUsing(nUsing);
-            } else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
-                currentProperty.Type.Name = "Map<String, Object>";
+        else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
+            currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
+        else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
+            currentProperty.Type.Name = "Map<String, Object>";
+            currentProperty.DefaultValue = "new HashMap<>()";
+        } else if(currentProperty.IsOfKind(CodePropertyKind.UrlTemplate)) {
+            currentProperty.Type.IsNullable = true;
+        } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
+            currentProperty.Type.IsNullable = true;
+            currentProperty.Type.Name = "HashMap<String, Object>";
+            if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
                 currentProperty.DefaultValue = "new HashMap<>()";
-            } else if(currentProperty.IsOfKind(CodePropertyKind.UrlTemplate)) {
-                currentProperty.Type.IsNullable = true;
-            } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
-                currentProperty.Type.IsNullable = true;
-                currentProperty.Type.Name = "HashMap<String, Object>";
-                if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
-                    currentProperty.DefaultValue = "new HashMap<>()";
-            }
+        } else
+            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+    }
+    private static void CorrectMethodType(CodeMethod currentMethod) {
+        if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator)) {
+            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
+                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.ResponseHandler) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => x.Type.Name = "Collection<RequestOption>");
         }
-        private static void CorrectMethodType(CodeMethod currentMethod) {
-            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator)) {
-                if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
-                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.ResponseHandler) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => x.Type.Name = "Collection<RequestOption>");
-            }
-            else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Serializer)).ToList().ForEach(x => {
-                    x.Optional = false;
-                    x.Type.IsNullable = true;
-                    if(x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase))
-                        x.Type.Name = x.Type.Name[1..];
-                });
-            else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer)) {
-                currentMethod.ReturnType.Name = $"Map<String, BiConsumer<T, ParseNode>>";
-                currentMethod.Name = "getFieldDeserializers";
-            }
-            else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.BackingStore))
-                    .Where(x => x.Type.Name.StartsWith("I", StringComparison.OrdinalIgnoreCase))
-                    .ToList()
-                    .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.PathParameters))
-                    .ToList()
-                    .ForEach(x => x.Type.IsNullable = true);
-                var urlTplParams = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
-                if(urlTplParams != null) 
-                    urlTplParams.Type.Name = "HashMap<String, Object>";
-            }
-            if (currentMethod.IsOfKind(CodeMethodKind.RequestBuilderWithParameters, CodeMethodKind.Constructor) &&
-                    currentMethod.Parameters.Any(x => OriginalDateTimeOffsetType.Equals(x.Type.Name, StringComparison.OrdinalIgnoreCase)) &&
-                    currentMethod.Parent is CodeClass parentClass) {
-                currentMethod.Parameters.Where(x => OriginalDateTimeOffsetType.Equals(x.Type.Name, StringComparison.OrdinalIgnoreCase))
-                                        .ToList()
-                                        .ForEach(x => x.Type.Name = JavaOffsetDateTimeType);
-                var nUsing = new CodeUsing {
-                    Name = JavaOffsetDateTimeType,
-                    Declaration = new CodeType {
-                        Name = JavaOffsetDateTimeTypePackage,
-                        IsExternal = true,
-                    },
-                };
-                parentClass.AddUsing(nUsing);
-            }
+        else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Serializer)).ToList().ForEach(x => {
+                x.Optional = false;
+                x.Type.IsNullable = true;
+                if(x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase))
+                    x.Type.Name = x.Type.Name[1..];
+            });
+        else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer)) {
+            currentMethod.ReturnType.Name = $"Map<String, BiConsumer<T, ParseNode>>";
+            currentMethod.Name = "getFieldDeserializers";
         }
-        private static void InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass) {
-                var codeMethods = currentClass.Methods;
-                if(codeMethods.Any()) {
-                    var originalExecutorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
-                    var executorMethodsToAdd = originalExecutorMethods
-                                        .Select(x => GetMethodClone(x, CodeParameterKind.ResponseHandler))
-                                        .Union(originalExecutorMethods
-                                                .Select(x => GetMethodClone(x, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
-                                        .Union(originalExecutorMethods
-                                                .Select(x => GetMethodClone(x, CodeParameterKind.Headers, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
-                                        .Union(originalExecutorMethods
-                                                .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
-                                        .Where(x => x != null);
-                    var originalGeneratorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestGenerator));
-                    var generatorMethodsToAdd = originalGeneratorMethods
-                                        .Select(x => GetMethodClone(x, CodeParameterKind.Options))
-                                        .Union(originalGeneratorMethods
-                                                .Select(x => GetMethodClone(x, CodeParameterKind.Headers, CodeParameterKind.Options)))
-                                        .Union(originalGeneratorMethods
-                                                .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.Options)))
-                                        .Where(x => x != null);
-                    if(executorMethodsToAdd.Any() || generatorMethodsToAdd.Any())
-                        currentClass.AddMethod(executorMethodsToAdd
-                                                .Union(generatorMethodsToAdd)
+        else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.BackingStore))
+                .Where(x => x.Type.Name.StartsWith("I", StringComparison.OrdinalIgnoreCase))
+                .ToList()
+                .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.PathParameters))
+                .ToList()
+                .ForEach(x => x.Type.IsNullable = true);
+            var urlTplParams = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
+            if(urlTplParams != null) 
+                urlTplParams.Type.Name = "HashMap<String, Object>";
+        }
+        CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                                .Select(x => x.Type)
+                                                .Union(new CodeTypeBase[] { currentMethod.ReturnType})
                                                 .ToArray());
-                }
+    }
+    private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new (StringComparer.OrdinalIgnoreCase) {
+    {"DateTimeOffset", ("OffsetDateTime", new CodeUsing {
+                                    Name = "OffsetDateTime",
+                                    Declaration = new CodeType {
+                                        Name = "java.time",
+                                        IsExternal = true,
+                                    },
+                                })},
+    {"TimeSpan", ("Period", new CodeUsing {
+                                    Name = "Period",
+                                    Declaration = new CodeType {
+                                        Name = "java.time",
+                                        IsExternal = true,
+                                    },
+                                })},
+    {"DateOnly", ("LocalDate", new CodeUsing {
+                            Name = "LocalDate",
+                            Declaration = new CodeType {
+                                Name = "java.time",
+                                IsExternal = true,
+                            },
+                        })},
+    {"TimeOnly", ("LocalTime", new CodeUsing {
+                            Name = "LocalTime",
+                            Declaration = new CodeType {
+                                Name = "java.time",
+                                IsExternal = true,
+                            },
+                        })},
+    };
+    private static void InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass) {
+            var codeMethods = currentClass.Methods;
+            if(codeMethods.Any()) {
+                var originalExecutorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
+                var executorMethodsToAdd = originalExecutorMethods
+                                    .Select(x => GetMethodClone(x, CodeParameterKind.ResponseHandler))
+                                    .Union(originalExecutorMethods
+                                            .Select(x => GetMethodClone(x, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
+                                    .Union(originalExecutorMethods
+                                            .Select(x => GetMethodClone(x, CodeParameterKind.Headers, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
+                                    .Union(originalExecutorMethods
+                                            .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.Options, CodeParameterKind.ResponseHandler)))
+                                    .Where(x => x != null);
+                var originalGeneratorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestGenerator));
+                var generatorMethodsToAdd = originalGeneratorMethods
+                                    .Select(x => GetMethodClone(x, CodeParameterKind.Options))
+                                    .Union(originalGeneratorMethods
+                                            .Select(x => GetMethodClone(x, CodeParameterKind.Headers, CodeParameterKind.Options)))
+                                    .Union(originalGeneratorMethods
+                                            .Select(x => GetMethodClone(x, CodeParameterKind.QueryParameter, CodeParameterKind.Headers, CodeParameterKind.Options)))
+                                    .Where(x => x != null);
+                if(executorMethodsToAdd.Any() || generatorMethodsToAdd.Any())
+                    currentClass.AddMethod(executorMethodsToAdd
+                                            .Union(generatorMethodsToAdd)
+                                            .ToArray());
             }
-            
-            CrawlTree(currentElement, InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors);
         }
-        private static CodeMethod GetMethodClone(CodeMethod currentMethod, params CodeParameterKind[] parameterTypesToExclude) {
-            if(currentMethod.Parameters.Any(x => x.IsOfKind(parameterTypesToExclude))) {
-                var cloneMethod = currentMethod.Clone() as CodeMethod;
-                cloneMethod.RemoveParametersByKind(parameterTypesToExclude);
-                cloneMethod.OriginalMethod = currentMethod;
-                return cloneMethod;
-            }
-            else return null;
+        
+        CrawlTree(currentElement, InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors);
+    }
+    private static CodeMethod GetMethodClone(CodeMethod currentMethod, params CodeParameterKind[] parameterTypesToExclude) {
+        if(currentMethod.Parameters.Any(x => x.IsOfKind(parameterTypesToExclude))) {
+            var cloneMethod = currentMethod.Clone() as CodeMethod;
+            cloneMethod.RemoveParametersByKind(parameterTypesToExclude);
+            cloneMethod.OriginalMethod = currentMethod;
+            return cloneMethod;
         }
+        else return null;
     }
 }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -1,137 +1,165 @@
 ﻿using System.Linq;
 using System;
 using Kiota.Builder.Extensions;
+using System.Collections.Generic;
 
-namespace Kiota.Builder.Refiners {
-    public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
+namespace Kiota.Builder.Refiners;
+public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
+{
+    public TypeScriptRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public override void Refine(CodeNamespace generatedCode)
     {
-        public TypeScriptRefiner(GenerationConfiguration configuration) : base(configuration) {}
-        public override void Refine(CodeNamespace generatedCode)
-        {
-            AddDefaultImports(generatedCode, defaultUsingEvaluators);
-            ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
-            RemoveCancellationParameter(generatedCode);
-            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
-            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
-            AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
-            AliasUsingsWithSameSymbol(generatedCode);
-            AddParsableInheritanceForModelClasses(generatedCode, "Parsable");
-            ReplaceBinaryByNativeType(generatedCode, "ReadableStream", "web-streams-polyfill/es2018", true);
-            ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}_escaped");
-            AddGetterAndSetterMethods(generatedCode, new() {
-                                                    CodePropertyKind.Custom,
-                                                    CodePropertyKind.AdditionalData,
-                                                }, _configuration.UsesBackingStore, false);
-            AddConstructorsForDefaultValues(generatedCode, true);
-            ReplaceDefaultSerializationModules(generatedCode, "@microsoft/kiota-serialization-json.JsonSerializationWriterFactory");
-            ReplaceDefaultDeserializationModules(generatedCode, "@microsoft/kiota-serialization-json.JsonParseNodeFactory");
-            AddSerializationModulesImport(generatedCode,
-                new[] { "@microsoft/kiota-abstractions.registerDefaultSerializer", 
-                        "@microsoft/kiota-abstractions.enableBackingStoreForSerializationWriterFactory",
-                        "@microsoft/kiota-abstractions.SerializationWriterFactoryRegistry"},
-                new[] { "@microsoft/kiota-abstractions.registerDefaultDeserializer",
-                        "@microsoft/kiota-abstractions.ParseNodeFactoryRegistry" });
-        }
-        private static readonly CodeUsingDeclarationNameComparer usingComparer = new();
-        private static void AliasUsingsWithSameSymbol(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass &&
-                currentClass.StartBlock is CodeClass.Declaration currentDeclaration &&
-                currentDeclaration.Usings.Any(x => !x.IsExternal)) {
-                    var duplicatedSymbolsUsings = currentDeclaration.Usings.Where(x => !x.IsExternal)
-                                                                            .Distinct(usingComparer)
-                                                                            .GroupBy(x => x.Declaration.Name, StringComparer.OrdinalIgnoreCase)
-                                                                            .Where(x => x.Count() > 1)
-                                                                            .SelectMany(x => x)
-                                                                            .Union(currentDeclaration
-                                                                                    .Usings
-                                                                                    .Where(x => !x.IsExternal)
-                                                                                    .Where(x => x.Declaration
-                                                                                                    .Name
-                                                                                                    .Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase)));
-                    foreach(var usingElement in duplicatedSymbolsUsings)
-                            usingElement.Alias = (usingElement.Declaration
-                                                            .TypeDefinition
-                                                            .GetImmediateParentOfType<CodeNamespace>()
-                                                            .Name +
-                                                usingElement.Declaration
-                                                            .TypeDefinition
-                                                            .Name)
-                                                .GetNamespaceImportSymbol();
-                }
-            CrawlTree(currentElement, AliasUsingsWithSameSymbol);
-        }
-        private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "@microsoft/kiota-abstractions", "RequestAdapter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "@microsoft/kiota-abstractions", "HttpMethod", "RequestInformation", "RequestOption"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "@microsoft/kiota-abstractions", "ResponseHandler"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "@microsoft/kiota-abstractions", "SerializationWriter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "@microsoft/kiota-abstractions", "ParseNode"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.IndexerBackwardCompatibility),
-                "@microsoft/kiota-abstractions", "getPathParameters"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "@microsoft/kiota-abstractions", "Parsable"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
-                "@microsoft/kiota-abstractions", "Parsable"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                        method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
-                "@microsoft/kiota-abstractions", "BackingStoreFactory", "BackingStoreFactorySingleton"),
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
-                "@microsoft/kiota-abstractions", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
-        };
-        private static void CorrectPropertyType(CodeProperty currentProperty) {
-            if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
-                currentProperty.Type.Name = "RequestAdapter";
-            else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
-                currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
-            else if("DateTimeOffset".Equals(currentProperty.Type.Name, StringComparison.OrdinalIgnoreCase))
-                currentProperty.Type.Name = $"Date";
-            else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
-                currentProperty.Type.Name = "Map<string, unknown>";
-                currentProperty.DefaultValue = "new Map<string, unknown>()";
-            } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
-                currentProperty.Type.IsNullable = false;
-                currentProperty.Type.Name = "Map<string, unknown>";
-                if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
-                    currentProperty.DefaultValue = "new Map<string, unknown>()";
-            }
-        }
-        private static void CorrectMethodType(CodeMethod currentMethod) {
-            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator)) {
-                if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
-                    currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.ResponseHandler) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => x.Type.Name = "RequestOption[]");
-            }
-            else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Serializer) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
-            else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer))
-                currentMethod.ReturnType.Name = $"Map<string, (item: T, node: ParseNode) => void>";
-            else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor)) {
-                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.BackingStore))
-                    .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
-                    .ToList()
-                    .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
-                var urlTplParams = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
-                if(urlTplParams != null &&
-                    urlTplParams.Type is CodeType originalType) {
-                    originalType.Name = "Map<string, unknown>";
-                    urlTplParams.Description = "The raw url or the Url template parameters for the request.";
-                    var unionType = new CodeUnionType {
-                        Name = "rawUrlOrTemplateParameters",
-                        IsNullable = true,
-                    };
-                    unionType.AddType(originalType, new() {
-                        Name = "string",
-                        IsNullable = true,
-                        IsExternal = true,
-                    });
-                    urlTplParams.Type = unionType;
-                }
-            }
-        }
+        AddDefaultImports(generatedCode, defaultUsingEvaluators);
+        ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
+        RemoveCancellationParameter(generatedCode);
+        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
+        CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
+        AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
+        AliasUsingsWithSameSymbol(generatedCode);
+        AddParsableInheritanceForModelClasses(generatedCode, "Parsable");
+        ReplaceBinaryByNativeType(generatedCode, "ReadableStream", "web-streams-polyfill/es2018", true);
+        ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}_escaped");
+        AddGetterAndSetterMethods(generatedCode, new() {
+                                                CodePropertyKind.Custom,
+                                                CodePropertyKind.AdditionalData,
+                                            }, _configuration.UsesBackingStore, false);
+        AddConstructorsForDefaultValues(generatedCode, true);
+        ReplaceDefaultSerializationModules(generatedCode, "@microsoft/kiota-serialization-json.JsonSerializationWriterFactory");
+        ReplaceDefaultDeserializationModules(generatedCode, "@microsoft/kiota-serialization-json.JsonParseNodeFactory");
+        AddSerializationModulesImport(generatedCode,
+            new[] { $"{AbstractionsPackageName}.registerDefaultSerializer", 
+                    $"{AbstractionsPackageName}.enableBackingStoreForSerializationWriterFactory",
+                    $"{AbstractionsPackageName}.SerializationWriterFactoryRegistry"},
+            new[] { $"{AbstractionsPackageName}.registerDefaultDeserializer",
+                    $"{AbstractionsPackageName}.ParseNodeFactoryRegistry" });
     }
+    private static readonly CodeUsingDeclarationNameComparer usingComparer = new();
+    private static void AliasUsingsWithSameSymbol(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass &&
+            currentClass.StartBlock is CodeClass.Declaration currentDeclaration &&
+            currentDeclaration.Usings.Any(x => !x.IsExternal)) {
+                var duplicatedSymbolsUsings = currentDeclaration.Usings.Where(x => !x.IsExternal)
+                                                                        .Distinct(usingComparer)
+                                                                        .GroupBy(x => x.Declaration.Name, StringComparer.OrdinalIgnoreCase)
+                                                                        .Where(x => x.Count() > 1)
+                                                                        .SelectMany(x => x)
+                                                                        .Union(currentDeclaration
+                                                                                .Usings
+                                                                                .Where(x => !x.IsExternal)
+                                                                                .Where(x => x.Declaration
+                                                                                                .Name
+                                                                                                .Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase)));
+                foreach(var usingElement in duplicatedSymbolsUsings)
+                        usingElement.Alias = (usingElement.Declaration
+                                                        .TypeDefinition
+                                                        .GetImmediateParentOfType<CodeNamespace>()
+                                                        .Name +
+                                            usingElement.Declaration
+                                                        .TypeDefinition
+                                                        .Name)
+                                            .GetNamespaceImportSymbol();
+            }
+        CrawlTree(currentElement, AliasUsingsWithSameSymbol);
+    }
+    private const string AbstractionsPackageName = "@microsoft/kiota-abstractions";
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            AbstractionsPackageName, "RequestAdapter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            AbstractionsPackageName, "HttpMethod", "RequestInformation", "RequestOption"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            AbstractionsPackageName, "ResponseHandler"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            AbstractionsPackageName, "SerializationWriter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            AbstractionsPackageName, "ParseNode"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.IndexerBackwardCompatibility),
+            AbstractionsPackageName, "getPathParameters"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            AbstractionsPackageName, "Parsable"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
+            AbstractionsPackageName, "Parsable"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
+                    method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
+            AbstractionsPackageName, "BackingStoreFactory", "BackingStoreFactorySingleton"),
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
+            AbstractionsPackageName, "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
+    };
+    private static void CorrectPropertyType(CodeProperty currentProperty) {
+        if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
+            currentProperty.Type.Name = "RequestAdapter";
+        else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
+            currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
+        else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
+            currentProperty.Type.Name = "Map<string, unknown>";
+            currentProperty.DefaultValue = "new Map<string, unknown>()";
+        } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
+            currentProperty.Type.IsNullable = false;
+            currentProperty.Type.Name = "Map<string, unknown>";
+            if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
+                currentProperty.DefaultValue = "new Map<string, unknown>()";
+        } else
+            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+    }
+    private static void CorrectMethodType(CodeMethod currentMethod) {
+        if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator)) {
+            if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
+                currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.ResponseHandler) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Options)).ToList().ForEach(x => x.Type.Name = "RequestOption[]");
+        }
+        else if(currentMethod.IsOfKind(CodeMethodKind.Serializer))
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Serializer) && x.Type.Name.StartsWith("i", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Type.Name = x.Type.Name[1..]);
+        else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer))
+            currentMethod.ReturnType.Name = $"Map<string, (item: T, node: ParseNode) => void>";
+        else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor)) {
+            currentMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.BackingStore))
+                .Where(x => x.Type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
+                .ToList()
+                .ForEach(x => x.Type.Name = x.Type.Name[1..]); // removing the "I"
+            var urlTplParams = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
+            if(urlTplParams != null &&
+                urlTplParams.Type is CodeType originalType) {
+                originalType.Name = "Map<string, unknown>";
+                urlTplParams.Description = "The raw url or the Url template parameters for the request.";
+                var unionType = new CodeUnionType {
+                    Name = "rawUrlOrTemplateParameters",
+                    IsNullable = true,
+                };
+                unionType.AddType(originalType, new() {
+                    Name = "string",
+                    IsNullable = true,
+                    IsExternal = true,
+                });
+                urlTplParams.Type = unionType;
+            }
+        }
+        CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                                .Select(x => x.Type)
+                                                .Union(new CodeTypeBase[] { currentMethod.ReturnType})
+                                                .ToArray());
+    }
+    private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new (StringComparer.OrdinalIgnoreCase) {
+    {"DateTimeOffset", ("Date", null)},
+    {"TimeSpan", ("Duration", new CodeUsing {
+                                    Name = "Duration",
+                                    Declaration = new CodeType {
+                                        Name = AbstractionsPackageName,
+                                        IsExternal = true,
+                                    },
+                                })},
+    {"DateOnly", ( null, new CodeUsing {
+                            Name = "DateOnly",
+                            Declaration = new CodeType {
+                                Name = AbstractionsPackageName,
+                                IsExternal = true,
+                            },
+                        })},
+    {"TimeOnly", ( null, new CodeUsing {
+                            Name = "TimeOnly",
+                            Declaration = new CodeType {
+                                Name = AbstractionsPackageName,
+                                IsExternal = true,
+                            },
+                        })},
+    };
 }

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -9,7 +9,7 @@ namespace Kiota.Builder.Writers.CSharp {
         public override string StreamTypeName => "stream";
         public override string VoidTypeName => "void";
         public override string DocCommentPrefix => "/// ";
-        private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "bool", "float", "double", "decimal", "long", "Guid", "DateTimeOffset" };
+        private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "bool", "float", "double", "decimal", "long", "Guid", "DateTimeOffset", "TimeSpan", "Date","Time" };
         public static readonly char NullableMarker = '?';
         public static string NullableMarkerAsString => "?";
         public override string ParseNodeInterfaceName => "IParseNode";

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -2,167 +2,169 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
-using Kiota.Builder.Writers.Extensions;
 
-namespace Kiota.Builder.Writers.Go {
-    public class GoConventionService : CommonLanguageConventionService
+namespace Kiota.Builder.Writers.Go;
+public class GoConventionService : CommonLanguageConventionService
+{
+    public override string StreamTypeName => "[]byte";
+
+    public override string VoidTypeName => string.Empty;
+
+    public override string DocCommentPrefix => "// ";
+    public override string ParseNodeInterfaceName => "ParseNode";
+    #pragma warning disable CA1822 // Method should be static
+    public string AbstractionsHash => "ida96af0f171bb75f894a4013a6b3146a4397c58f11adb81a2b7cbea9314783a9";
+    public string SerializationHash => "i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55";
+    #pragma warning restore CA1822 // Method should be static
+    public override string GetAccessModifier(AccessModifier access)
     {
-        public override string StreamTypeName => "[]byte";
-
-        public override string VoidTypeName => string.Empty;
-
-        public override string DocCommentPrefix => "// ";
-        public override string ParseNodeInterfaceName => "ParseNode";
-        #pragma warning disable CA1822 // Method should be static
-        public string AbstractionsHash => "ida96af0f171bb75f894a4013a6b3146a4397c58f11adb81a2b7cbea9314783a9";
-        public string SerializationHash => "i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55";
-        #pragma warning restore CA1822 // Method should be static
-        public override string GetAccessModifier(AccessModifier access)
-        {
-            throw new InvalidOperationException("go uses a naming convention for access modifiers");
+        throw new InvalidOperationException("go uses a naming convention for access modifiers");
+    }
+    public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
+    {
+        return $"{parameter.Name.ToFirstCharacterLowerCase()} {GetTypeString(parameter.Type, targetElement)}";
+    }
+    public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true) =>
+        GetTypeString(code, targetElement, includeCollectionInformation, true);
+    public string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation, bool addPointerSymbol)
+    {
+        if(code is CodeUnionType) 
+            throw new InvalidOperationException($"Go does not support union types, the union type {code.Name} should have been filtered out by the refiner");
+        else if (code is CodeType currentType) {
+            var importSymbol = GetImportSymbol(code, targetElement);
+            if(!string.IsNullOrEmpty(importSymbol))
+                importSymbol += ".";
+            var typeName = TranslateType(currentType, true);
+            var nullableSymbol = addPointerSymbol && 
+                                currentType.IsNullable &&
+                                currentType.CollectionKind == CodeTypeBase.CodeTypeCollectionKind.None &&
+                                !IsScalarType(currentType.Name) ? "*"
+                                : string.Empty;
+            var collectionPrefix = currentType.CollectionKind switch {
+                CodeType.CodeTypeCollectionKind.Array or CodeType.CodeTypeCollectionKind.Complex when includeCollectionInformation => "[]",
+                _ => string.Empty,
+            };
+            if (currentType.ActionOf)
+                return $"func (value {nullableSymbol}{collectionPrefix}{importSymbol}{typeName}) (err error)";
+            else
+                return $"{nullableSymbol}{collectionPrefix}{importSymbol}{typeName}";
         }
-        public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
-        {
-            return $"{parameter.Name.ToFirstCharacterLowerCase()} {GetTypeString(parameter.Type, targetElement)}";
+        else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
+    }
+
+    public override string TranslateType(CodeType type) => throw new InvalidOperationException("use the overload instead.");
+    #pragma warning disable CA1822 // Method should be static
+    public string TranslateType(CodeTypeBase type, bool includeImportSymbol)
+    {
+        if(type.Name.StartsWith("map[")) return type.Name; //casing hack
+
+        return type.Name switch {
+            "void" => string.Empty,
+            "float" => "float32",
+            "integer" => "int32",
+            "long" => "int64",
+            "double" or "decimal" => "float64",
+            "boolean" => "bool",
+            "guid" when includeImportSymbol => "uuid.UUID",
+            "guid" when !includeImportSymbol => "UUID",
+            "DateTimeOffset" or "Time" when includeImportSymbol => "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time",
+            "DateTimeOffset" or "Time" when !includeImportSymbol => "Time",
+            "DateOnly" or "TimeOnly" when includeImportSymbol => $"{SerializationHash}.{type.Name}",
+            "DateOnly" or "TimeOnly" or "Duration" when !includeImportSymbol => type.Name,
+            "Duration" when includeImportSymbol => "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Duration",
+            "binary" => "[]byte",
+            "string" or "float32" or "float64" or "int32" or "int64" => type.Name,
+            "String" or "Int64" or "Int32" or "Float32" or "Float64" => type.Name.ToFirstCharacterLowerCase(), //casing hack
+            _ => type.Name.ToFirstCharacterUpperCase() ?? "Object",
+        };
+    }
+    public bool IsPrimitiveType(string typeName) {
+        return typeName.TrimCollectionAndPointerSymbols() switch {
+            "void" or "string" or "float" or "integer" or "long" or "double" or "boolean" or "guid" or "DateTimeOffset"
+            or "bool" or "int32" or "int64" or "float32" or "float64" or "UUID" or "Time" or "decimal" or "TimeOnly"
+            or "DateOnly" or "Duration" => true,
+            _ => false,
+        };
+    }
+    public bool IsScalarType(string typeName) {
+        if(typeName.StartsWith("map[")) return true;
+        return typeName.ToLowerInvariant() switch {
+            "binary" or "void" or "[]byte" => true,
+            _ => false,
+        };
+    }
+    #pragma warning restore CA1822 // Method should be static
+    private string GetImportSymbol(CodeTypeBase currentBaseType, CodeElement targetElement) {
+        if(currentBaseType == null || IsPrimitiveType(currentBaseType.Name)) return string.Empty;
+        var targetNamespace = targetElement.GetImmediateParentOfType<CodeNamespace>();
+        if(currentBaseType is CodeType currentType) {
+            if(currentType.TypeDefinition is CodeClass currentClassDefinition &&
+                currentClassDefinition.Parent is CodeNamespace classNS &&
+                targetNamespace != classNS)
+                    return classNS.GetNamespaceImportSymbol();
+            else if(currentType.TypeDefinition is CodeEnum currentEnumDefinition &&
+                currentEnumDefinition.Parent is CodeNamespace enumNS &&
+                targetNamespace != enumNS)
+                    return enumNS.GetNamespaceImportSymbol();
+            else if(currentType.TypeDefinition is null &&
+                    targetElement is CodeClass targetClass) {
+                        var symbolUsing = (targetClass.Parent is CodeClass parentClass ? parentClass : targetClass)
+                                                        .StartBlock
+                                                        .Usings
+                                                        .FirstOrDefault(x => currentBaseType.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase));
+                        return symbolUsing == null ? string.Empty : symbolUsing.Declaration.Name.GetNamespaceImportSymbol();
+                    }
         }
-        public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true) =>
-            GetTypeString(code, targetElement, includeCollectionInformation, true);
-        public string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation, bool addPointerSymbol)
-        {
-            if(code is CodeUnionType) 
-                throw new InvalidOperationException($"Go does not support union types, the union type {code.Name} should have been filtered out by the refiner");
-            else if (code is CodeType currentType) {
-                var importSymbol = GetImportSymbol(code, targetElement);
-                if(!string.IsNullOrEmpty(importSymbol))
-                    importSymbol += ".";
-                var typeName = TranslateType(currentType, true);
-                var nullableSymbol = addPointerSymbol && 
-                                    currentType.IsNullable &&
-                                    currentType.CollectionKind == CodeTypeBase.CodeTypeCollectionKind.None &&
-                                    !IsScalarType(currentType.Name) ? "*"
-                                    : string.Empty;
-                var collectionPrefix = currentType.CollectionKind switch {
-                    CodeType.CodeTypeCollectionKind.Array or CodeType.CodeTypeCollectionKind.Complex when includeCollectionInformation => "[]",
-                    _ => string.Empty,
-                };
-                if (currentType.ActionOf)
-                    return $"func (value {nullableSymbol}{collectionPrefix}{importSymbol}{typeName}) (err error)";
-                else
-                    return $"{nullableSymbol}{collectionPrefix}{importSymbol}{typeName}";
+        return string.Empty;
+    }
+
+    public override void WriteShortDescription(string description, LanguageWriter writer)
+    {
+        writer.WriteLine($"{DocCommentPrefix}{description}");
+    }
+    #pragma warning disable CA1822 // Method should be static
+    internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default)
+    {
+        var urlTemplateParamsProp = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        var urlTemplateParams = urlTemplateVarName ?? $"m.{urlTemplateParamsProp.Name}";
+        var splatImport = returnType.Split('.');
+        var constructorName = splatImport.Last().TrimCollectionAndPointerSymbols().ToFirstCharacterUpperCase();
+        var moduleName = splatImport.Length > 1 ? $"{splatImport.First().TrimStart('*')}." : string.Empty;
+        var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
+        writer.WriteLines($"return {moduleName}New{constructorName}Internal({urlTemplateParams}, m.{requestAdapterProp.Name}{pathParametersSuffix});");
+    }
+    public override string TempDictionaryVarName => "urlTplParams";
+    internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
+        if(pathParametersType == null) return;
+        var mapTypeName = pathParametersType.Name;
+        writer.WriteLine($"{TempDictionaryVarName} := make({mapTypeName})");
+        writer.WriteLine($"for idx, item := range {pathParametersReference} {{");
+        writer.IncreaseIndent();
+        writer.WriteLine($"{TempDictionaryVarName}[idx] = item");
+        writer.CloseBlock();
+        if(parameters.Any())
+            foreach(var p in parameters) {
+                var isStringStruct = !p.Item1.IsNullable && p.Item1.Name.Equals("string", StringComparison.OrdinalIgnoreCase);
+                var defaultValue = isStringStruct ? "\"\"" : "nil";
+                var pointerDereference = isStringStruct ? string.Empty : "*";
+                writer.WriteLines($"if {p.Item3} != {defaultValue} {{");
+                writer.IncreaseIndent();
+                writer.WriteLine($"{TempDictionaryVarName}[\"{p.Item2}\"] = {GetValueStringConversion(p.Item1.Name, pointerDereference+p.Item3)}");
+                writer.CloseBlock();
             }
-            else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
-        }
-
-        public override string TranslateType(CodeType type) => throw new InvalidOperationException("use the overload instead.");
-        #pragma warning disable CA1822 // Method should be static
-        public string TranslateType(CodeTypeBase type, bool includeImportSymbol)
-        {
-            if(type.Name.StartsWith("map[")) return type.Name; //casing hack
-
-            return type.Name switch {
-                "void" => string.Empty,
-                "float" => "float32",
-                "integer" => "int32",
-                "long" => "int64",
-                "double" or "decimal" => "float64",
-                "boolean" => "bool",
-                "guid" when includeImportSymbol => "uuid.UUID",
-                "guid" when !includeImportSymbol => "UUID",
-                "DateTimeOffset" or "Time" when includeImportSymbol => "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time",
-                "DateTimeOffset" or "Time" when !includeImportSymbol => "Time",
-                "binary" => "[]byte",
-                "string" or "float32" or "float64" or "int32" or "int64" => type.Name,
-                "String" or "Int64" or "Int32" or "Float32" or "Float64" => type.Name.ToFirstCharacterLowerCase(), //casing hack
-                _ => type.Name.ToFirstCharacterUpperCase() ?? "Object",
-            };
-        }
-        public bool IsPrimitiveType(string typeName) {
-            return typeName.TrimCollectionAndPointerSymbols() switch {
-                "void" or "string" or "float" or "integer" or "long" or "double" or "boolean" or "guid" or "DateTimeOffset"
-                or "bool" or "int32" or "int64" or "float32" or "float64" or "UUID" or "Time" or "decimal" => true,
-                _ => false,
-            };
-        }
-        public bool IsScalarType(string typeName) {
-            if(typeName.StartsWith("map[")) return true;
-            return typeName.ToLowerInvariant() switch {
-                "binary" or "void" or "[]byte" => true,
-                _ => false,
-            };
-        }
-        #pragma warning restore CA1822 // Method should be static
-        private string GetImportSymbol(CodeTypeBase currentBaseType, CodeElement targetElement) {
-            if(currentBaseType == null || IsPrimitiveType(currentBaseType.Name)) return string.Empty;
-            var targetNamespace = targetElement.GetImmediateParentOfType<CodeNamespace>();
-            if(currentBaseType is CodeType currentType) {
-                if(currentType.TypeDefinition is CodeClass currentClassDefinition &&
-                   currentClassDefinition.Parent is CodeNamespace classNS &&
-                   targetNamespace != classNS)
-                       return classNS.GetNamespaceImportSymbol();
-                else if(currentType.TypeDefinition is CodeEnum currentEnumDefinition &&
-                   currentEnumDefinition.Parent is CodeNamespace enumNS &&
-                   targetNamespace != enumNS)
-                       return enumNS.GetNamespaceImportSymbol();
-                else if(currentType.TypeDefinition is null &&
-                        targetElement is CodeClass targetClass) {
-                            var symbolUsing = (targetClass.Parent is CodeClass parentClass ? parentClass : targetClass)
-                                                            .StartBlock
-                                                            .Usings
-                                                            .FirstOrDefault(x => currentBaseType.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase));
-                            return symbolUsing == null ? string.Empty : symbolUsing.Declaration.Name.GetNamespaceImportSymbol();
-                        }
-            }
-            return string.Empty;
-        }
-
-        public override void WriteShortDescription(string description, LanguageWriter writer)
-        {
-            writer.WriteLine($"{DocCommentPrefix}{description}");
-        }
-        #pragma warning disable CA1822 // Method should be static
-        internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default)
-        {
-            var urlTemplateParamsProp = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            var urlTemplateParams = urlTemplateVarName ?? $"m.{urlTemplateParamsProp.Name}";
-            var splatImport = returnType.Split('.');
-            var constructorName = splatImport.Last().TrimCollectionAndPointerSymbols().ToFirstCharacterUpperCase();
-            var moduleName = splatImport.Length > 1 ? $"{splatImport.First().TrimStart('*')}." : string.Empty;
-            var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
-            writer.WriteLines($"return {moduleName}New{constructorName}Internal({urlTemplateParams}, m.{requestAdapterProp.Name}{pathParametersSuffix});");
-        }
-        public override string TempDictionaryVarName => "urlTplParams";
-        internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
-            if(pathParametersType == null) return;
-            var mapTypeName = pathParametersType.Name;
-            writer.WriteLine($"{TempDictionaryVarName} := make({mapTypeName})");
-            writer.WriteLine($"for idx, item := range {pathParametersReference} {{");
-            writer.IncreaseIndent();
-            writer.WriteLine($"{TempDictionaryVarName}[idx] = item");
-            writer.CloseBlock();
-            if(parameters.Any())
-                foreach(var p in parameters) {
-                    var isStringStruct = !p.Item1.IsNullable && p.Item1.Name.Equals("string", StringComparison.OrdinalIgnoreCase);
-                    var defaultValue = isStringStruct ? "\"\"" : "nil";
-                    var pointerDereference = isStringStruct ? string.Empty : "*";
-                    writer.WriteLines($"if {p.Item3} != {defaultValue} {{");
-                    writer.IncreaseIndent();
-                    writer.WriteLine($"{TempDictionaryVarName}[\"{p.Item2}\"] = {GetValueStringConversion(p.Item1.Name, pointerDereference+p.Item3)}");
-                    writer.CloseBlock();
-                }
-        }
-        #pragma warning restore CA1822 // Method should be static
-        private const string StrConvHash = "i53ac87e8cb3cc9276228f74d38694a208cacb99bb8ceb705eeae99fb88d4d274";
-        private static string GetValueStringConversion(string typeName, string reference) {
-            return typeName switch {
-                "boolean" => $"{StrConvHash}.FormatBool({reference})",
-                "int64" => $"{StrConvHash}.FormatInt({reference}, 10)",
-                "integer" or "int32" => $"{StrConvHash}.FormatInt(int64({reference}), 10)",
-                "long" => $"{StrConvHash}.FormatInt({reference}, 10)",
-                "float" or "double" or "decimal" or "float64" or "float32" => $"{StrConvHash}.FormatFloat({reference}, 'E', -1, 64)",
-                "DateTimeOffset" or "Time" => $"({reference}).String()",
-                _ => reference,
-            };
-        }
+    }
+    #pragma warning restore CA1822 // Method should be static
+    private const string StrConvHash = "i53ac87e8cb3cc9276228f74d38694a208cacb99bb8ceb705eeae99fb88d4d274";
+    private static string GetValueStringConversion(string typeName, string reference) {
+        return typeName switch {
+            "boolean" => $"{StrConvHash}.FormatBool({reference})",
+            "int64" => $"{StrConvHash}.FormatInt({reference}, 10)",
+            "integer" or "int32" => $"{StrConvHash}.FormatInt(int64({reference}), 10)",
+            "long" => $"{StrConvHash}.FormatInt({reference}, 10)",
+            "float" or "double" or "decimal" or "float64" or "float32" => $"{StrConvHash}.FormatFloat({reference}, 'E', -1, 64)",
+            "DateTimeOffset" or "Time" or "Duration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
+            _ => reference,
+        };
     }
 }

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -69,9 +69,8 @@ public class GoConventionService : CommonLanguageConventionService
             "guid" when !includeImportSymbol => "UUID",
             "DateTimeOffset" or "Time" when includeImportSymbol => "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time",
             "DateTimeOffset" or "Time" when !includeImportSymbol => "Time",
-            "DateOnly" or "TimeOnly" when includeImportSymbol => $"{SerializationHash}.{type.Name}",
-            "DateOnly" or "TimeOnly" or "Duration" when !includeImportSymbol => type.Name,
-            "Duration" when includeImportSymbol => "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Duration",
+            "DateOnly" or "TimeOnly" or "ISODuration" when includeImportSymbol => $"{SerializationHash}.{type.Name}",
+            "DateOnly" or "TimeOnly" or "ISODuration" when !includeImportSymbol => type.Name,
             "binary" => "[]byte",
             "string" or "float32" or "float64" or "int32" or "int64" => type.Name,
             "String" or "Int64" or "Int32" or "Float32" or "Float64" => type.Name.ToFirstCharacterLowerCase(), //casing hack
@@ -82,7 +81,7 @@ public class GoConventionService : CommonLanguageConventionService
         return typeName.TrimCollectionAndPointerSymbols() switch {
             "void" or "string" or "float" or "integer" or "long" or "double" or "boolean" or "guid" or "DateTimeOffset"
             or "bool" or "int32" or "int64" or "float32" or "float64" or "UUID" or "Time" or "decimal" or "TimeOnly"
-            or "DateOnly" or "Duration" => true,
+            or "DateOnly" or "ISODuration" => true,
             _ => false,
         };
     }
@@ -163,7 +162,7 @@ public class GoConventionService : CommonLanguageConventionService
             "integer" or "int32" => $"{StrConvHash}.FormatInt(int64({reference}), 10)",
             "long" => $"{StrConvHash}.FormatInt({reference}, 10)",
             "float" or "double" or "decimal" or "float64" or "float32" => $"{StrConvHash}.FormatFloat({reference}, 'E', -1, 64)",
-            "DateTimeOffset" or "Time" or "Duration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
+            "DateTimeOffset" or "Time" or "ISODuration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
             _ => reference,
         };
     }

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -4,402 +4,401 @@ using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Extensions;
 
-namespace Kiota.Builder.Writers.Java {
-    public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionService>
+namespace Kiota.Builder.Writers.Java;
+public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionService>
+{
+    public CodeMethodWriter(JavaConventionService conventionService) : base(conventionService){}
+    public override void WriteCodeElement(CodeMethod codeElement, LanguageWriter writer)
     {
-        public CodeMethodWriter(JavaConventionService conventionService) : base(conventionService){}
-        public override void WriteCodeElement(CodeMethod codeElement, LanguageWriter writer)
-        {
-            if(codeElement == null) throw new ArgumentNullException(nameof(codeElement));
-            if(codeElement.ReturnType == null) throw new InvalidOperationException($"{nameof(codeElement.ReturnType)} should not be null");
-            if(writer == null) throw new ArgumentNullException(nameof(writer));
-            if(!(codeElement.Parent is CodeClass)) throw new InvalidOperationException("the parent of a method should be a class");
+        if(codeElement == null) throw new ArgumentNullException(nameof(codeElement));
+        if(codeElement.ReturnType == null) throw new InvalidOperationException($"{nameof(codeElement.ReturnType)} should not be null");
+        if(writer == null) throw new ArgumentNullException(nameof(writer));
+        if(!(codeElement.Parent is CodeClass)) throw new InvalidOperationException("the parent of a method should be a class");
 
-            var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
-            WriteMethodDocumentation(codeElement, writer);
-            if(returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
-            {
-                if(codeElement.IsOfKind(CodeMethodKind.RequestExecutor))
-                    returnType = "Void"; //generic type for the future
-            } else if(!codeElement.IsAsync)
-                writer.WriteLine(codeElement.ReturnType.IsNullable && !codeElement.IsAsync ? "@javax.annotation.Nullable" : "@javax.annotation.Nonnull");
-            WriteMethodPrototype(codeElement, writer, returnType);
-            writer.IncreaseIndent();
-            var parentClass = codeElement.Parent as CodeClass;
-            var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-            var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
-            var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
-            var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);
-            var optionsParam = codeElement.Parameters.OfKind(CodeParameterKind.Options);
-            var requestParams = new RequestParams(requestBodyParam, queryStringParam, headersParam, optionsParam);
-            AddNullChecks(codeElement, writer);
-            switch(codeElement.MethodKind) {
-                case CodeMethodKind.Serializer:
-                    WriteSerializerBody(parentClass, codeElement, writer);
-                break;
-                case CodeMethodKind.Deserializer:
-                    WriteDeserializerBody(codeElement, codeElement, parentClass, writer);
-                break;
-                case CodeMethodKind.IndexerBackwardCompatibility:
-                    WriteIndexerBody(codeElement, parentClass, writer, returnType);
-                break;
-                case CodeMethodKind.RequestGenerator when codeElement.IsOverload:
-                    WriteGeneratorMethodCall(codeElement, requestParams, writer, "return ");
-                break;
-                case CodeMethodKind.RequestGenerator when !codeElement.IsOverload:
-                    WriteRequestGeneratorBody(codeElement, requestParams, parentClass, writer);
-                break;
-                case CodeMethodKind.RequestExecutor:
-                    WriteRequestExecutorBody(codeElement, requestParams, writer);
-                break;
-                case CodeMethodKind.Getter:
-                    WriteGetterBody(codeElement, writer, parentClass);
-                    break;
-                case CodeMethodKind.Setter:
-                    WriteSetterBody(codeElement, writer, parentClass);
-                    break;
-                case CodeMethodKind.ClientConstructor:
-                    WriteConstructorBody(parentClass, codeElement, writer, inherits);
-                    WriteApiConstructorBody(parentClass, codeElement, writer);
-                break;
-                case CodeMethodKind.Constructor when codeElement.IsOverload && parentClass.IsOfKind(CodeClassKind.RequestBuilder):
-                    WriteRequestBuilderConstructorCall(codeElement, writer);
-                break;
-                case CodeMethodKind.Constructor:
-                case CodeMethodKind.RawUrlConstructor:
-                    WriteConstructorBody(parentClass, codeElement, writer, inherits);
-                    break;
-                case CodeMethodKind.RequestBuilderWithParameters:
-                    WriteRequestBuilderBody(parentClass, codeElement, writer);
-                    break;
-                case CodeMethodKind.RequestBuilderBackwardCompatibility:
-                    throw new InvalidOperationException("RequestBuilderBackwardCompatibility is not supported as the request builders are implemented by properties.");
-                default:
-                    writer.WriteLine("return null;");
-                break;
-            }
-            writer.DecreaseIndent();
-            writer.WriteLine("}");
-        }
-        private void WriteRequestBuilderBody(CodeClass parentClass, CodeMethod codeElement, LanguageWriter writer)
+        var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
+        WriteMethodDocumentation(codeElement, writer);
+        if(returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
         {
-            var importSymbol = conventions.GetTypeString(codeElement.ReturnType, parentClass);
-            conventions.AddRequestBuilderBody(parentClass, importSymbol, writer, pathParameters: codeElement.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path)));
+            if(codeElement.IsOfKind(CodeMethodKind.RequestExecutor))
+                returnType = "Void"; //generic type for the future
+        } else if(!codeElement.IsAsync)
+            writer.WriteLine(codeElement.ReturnType.IsNullable && !codeElement.IsAsync ? "@javax.annotation.Nullable" : "@javax.annotation.Nonnull");
+        WriteMethodPrototype(codeElement, writer, returnType);
+        writer.IncreaseIndent();
+        var parentClass = codeElement.Parent as CodeClass;
+        var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
+        var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
+        var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
+        var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);
+        var optionsParam = codeElement.Parameters.OfKind(CodeParameterKind.Options);
+        var requestParams = new RequestParams(requestBodyParam, queryStringParam, headersParam, optionsParam);
+        AddNullChecks(codeElement, writer);
+        switch(codeElement.MethodKind) {
+            case CodeMethodKind.Serializer:
+                WriteSerializerBody(parentClass, codeElement, writer);
+            break;
+            case CodeMethodKind.Deserializer:
+                WriteDeserializerBody(codeElement, codeElement, parentClass, writer);
+            break;
+            case CodeMethodKind.IndexerBackwardCompatibility:
+                WriteIndexerBody(codeElement, parentClass, writer, returnType);
+            break;
+            case CodeMethodKind.RequestGenerator when codeElement.IsOverload:
+                WriteGeneratorMethodCall(codeElement, requestParams, writer, "return ");
+            break;
+            case CodeMethodKind.RequestGenerator when !codeElement.IsOverload:
+                WriteRequestGeneratorBody(codeElement, requestParams, parentClass, writer);
+            break;
+            case CodeMethodKind.RequestExecutor:
+                WriteRequestExecutorBody(codeElement, requestParams, writer);
+            break;
+            case CodeMethodKind.Getter:
+                WriteGetterBody(codeElement, writer, parentClass);
+                break;
+            case CodeMethodKind.Setter:
+                WriteSetterBody(codeElement, writer, parentClass);
+                break;
+            case CodeMethodKind.ClientConstructor:
+                WriteConstructorBody(parentClass, codeElement, writer, inherits);
+                WriteApiConstructorBody(parentClass, codeElement, writer);
+            break;
+            case CodeMethodKind.Constructor when codeElement.IsOverload && parentClass.IsOfKind(CodeClassKind.RequestBuilder):
+                WriteRequestBuilderConstructorCall(codeElement, writer);
+            break;
+            case CodeMethodKind.Constructor:
+            case CodeMethodKind.RawUrlConstructor:
+                WriteConstructorBody(parentClass, codeElement, writer, inherits);
+                break;
+            case CodeMethodKind.RequestBuilderWithParameters:
+                WriteRequestBuilderBody(parentClass, codeElement, writer);
+                break;
+            case CodeMethodKind.RequestBuilderBackwardCompatibility:
+                throw new InvalidOperationException("RequestBuilderBackwardCompatibility is not supported as the request builders are implemented by properties.");
+            default:
+                writer.WriteLine("return null;");
+            break;
         }
-        private static void AddNullChecks(CodeMethod codeElement, LanguageWriter writer) {
-            if(!codeElement.IsOverload)
-                foreach(var parameter in codeElement.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name))
-                    writer.WriteLine($"Objects.requireNonNull({parameter.Name.ToFirstCharacterLowerCase()});");
+        writer.DecreaseIndent();
+        writer.WriteLine("}");
+    }
+    private void WriteRequestBuilderBody(CodeClass parentClass, CodeMethod codeElement, LanguageWriter writer)
+    {
+        var importSymbol = conventions.GetTypeString(codeElement.ReturnType, parentClass);
+        conventions.AddRequestBuilderBody(parentClass, importSymbol, writer, pathParameters: codeElement.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path)));
+    }
+    private static void AddNullChecks(CodeMethod codeElement, LanguageWriter writer) {
+        if(!codeElement.IsOverload)
+            foreach(var parameter in codeElement.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name))
+                writer.WriteLine($"Objects.requireNonNull({parameter.Name.ToFirstCharacterLowerCase()});");
+    }
+    private static void WriteRequestBuilderConstructorCall(CodeMethod codeElement, LanguageWriter writer)
+    {
+        var requestAdapterParameter = codeElement.Parameters.OfKind(CodeParameterKind.RequestAdapter);
+        var urlTemplateParamsParameter = codeElement.Parameters.OfKind(CodeParameterKind.PathParameters);
+        var pathParameters = codeElement.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path));
+        var pathParametersRef = pathParameters.Any() ? (", " + pathParameters.Select(x => x.Name).Aggregate((x, y) => $"{x}, {y}")) : string.Empty;
+        writer.WriteLine($"this({urlTemplateParamsParameter.Name}, {requestAdapterParameter.Name}{pathParametersRef});");
+    }
+    private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
+        var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        var backingStoreParameter = method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.BackingStore));
+        var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
+        WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
+        WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
+        writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
+        if(backingStoreParameter != null)
+            writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
+    }
+    private static void WriteSerializationRegistration(List<string> serializationModules, LanguageWriter writer, string methodName) {
+        if(serializationModules != null)
+            foreach(var module in serializationModules)
+                writer.WriteLine($"ApiClientBuilder.{methodName}({module}.class);");
+    }
+    private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
+        if(inherits)
+            writer.WriteLine("super();");
+        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.BackingStore,
+                                                                        CodePropertyKind.RequestBuilder,
+                                                                        CodePropertyKind.UrlTemplate,
+                                                                        CodePropertyKind.PathParameters)
+                                        .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderBy(x => x.Name)) {
+            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
         }
-        private static void WriteRequestBuilderConstructorCall(CodeMethod codeElement, LanguageWriter writer)
-        {
-            var requestAdapterParameter = codeElement.Parameters.OfKind(CodeParameterKind.RequestAdapter);
-            var urlTemplateParamsParameter = codeElement.Parameters.OfKind(CodeParameterKind.PathParameters);
-            var pathParameters = codeElement.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path));
-            var pathParametersRef = pathParameters.Any() ? (", " + pathParameters.Select(x => x.Name).Aggregate((x, y) => $"{x}, {y}")) : string.Empty;
-            writer.WriteLine($"this({urlTemplateParamsParameter.Name}, {requestAdapterParameter.Name}{pathParametersRef});");
+        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData) //additional data and backing Store rely on accessors
+                                        .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderBy(x => x.Name)) {
+            writer.WriteLine($"this.set{propWithDefault.Name.ToFirstCharacterUpperCase()}({propWithDefault.DefaultValue});");
         }
-        private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
-            var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            var backingStoreParameter = method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.BackingStore));
-            var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
-            WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
-            WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
-            writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
-            if(backingStoreParameter != null)
-                writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
-        }
-        private static void WriteSerializationRegistration(List<string> serializationModules, LanguageWriter writer, string methodName) {
-            if(serializationModules != null)
-                foreach(var module in serializationModules)
-                    writer.WriteLine($"ApiClientBuilder.{methodName}({module}.class);");
-        }
-        private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
-            if(inherits)
-                writer.WriteLine("super();");
-            foreach(var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.BackingStore,
-                                                                            CodePropertyKind.RequestBuilder,
-                                                                            CodePropertyKind.UrlTemplate,
-                                                                            CodePropertyKind.PathParameters)
-                                            .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
-                                            .OrderBy(x => x.Name)) {
-                writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
+        if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
+            if(currentMethod.IsOfKind(CodeMethodKind.Constructor)) {
+                var pathParametersParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
+                conventions.AddParametersAssignment(writer, 
+                                                    pathParametersParam.Type,
+                                                    pathParametersParam.Name.ToFirstCharacterLowerCase(),
+                                                    currentMethod.Parameters
+                                                                .Where(x => x.IsOfKind(CodeParameterKind.Path))
+                                                                .Select(x => (x.Type, x.UrlTemplateParameterName, x.Name.ToFirstCharacterLowerCase()))
+                                                                .ToArray());
+                AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
             }
-            foreach(var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData) //additional data and backing Store rely on accessors
-                                            .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
-                                            .OrderBy(x => x.Name)) {
-                writer.WriteLine($"this.set{propWithDefault.Name.ToFirstCharacterUpperCase()}({propWithDefault.DefaultValue});");
+            else if(currentMethod.IsOfKind(CodeMethodKind.RawUrlConstructor)) {
+                var pathParametersProp = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+                var rawUrlParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.RawUrl));
+                conventions.AddParametersAssignment(writer,
+                                                    pathParametersProp.Type,
+                                                    string.Empty,
+                                                    (rawUrlParam.Type, Constants.RawUrlParameterName, rawUrlParam.Name.ToFirstCharacterLowerCase()));
+                AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
             }
-            if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
-                if(currentMethod.IsOfKind(CodeMethodKind.Constructor)) {
-                    var pathParametersParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
-                    conventions.AddParametersAssignment(writer, 
-                                                        pathParametersParam.Type,
-                                                        pathParametersParam.Name.ToFirstCharacterLowerCase(),
-                                                        currentMethod.Parameters
-                                                                    .Where(x => x.IsOfKind(CodeParameterKind.Path))
-                                                                    .Select(x => (x.Type, x.UrlTemplateParameterName, x.Name.ToFirstCharacterLowerCase()))
-                                                                    .ToArray());
-                    AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
-                }
-                else if(currentMethod.IsOfKind(CodeMethodKind.RawUrlConstructor)) {
-                    var pathParametersProp = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-                    var rawUrlParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.RawUrl));
-                    conventions.AddParametersAssignment(writer,
-                                                        pathParametersProp.Type,
-                                                        string.Empty,
-                                                        (rawUrlParam.Type, Constants.RawUrlParameterName, rawUrlParam.Name.ToFirstCharacterLowerCase()));
-                    AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
-                }
-                AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.RequestAdapter, CodePropertyKind.RequestAdapter, writer);
-            }
+            AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.RequestAdapter, CodePropertyKind.RequestAdapter, writer);
         }
-        private static void AssignPropertyFromParameter(CodeClass parentClass, CodeMethod currentMethod, CodeParameterKind parameterKind, CodePropertyKind propertyKind, LanguageWriter writer, string variableName = default) {
-            var property = parentClass.GetPropertyOfKind(propertyKind);
-            if(property != null) {
-                var parameter = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(parameterKind));
-                if(!string.IsNullOrEmpty(variableName))
-                    writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {variableName};");
-                else if (parameter != null)
-                    writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {parameter.Name};");
-            }
+    }
+    private static void AssignPropertyFromParameter(CodeClass parentClass, CodeMethod currentMethod, CodeParameterKind parameterKind, CodePropertyKind propertyKind, LanguageWriter writer, string variableName = default) {
+        var property = parentClass.GetPropertyOfKind(propertyKind);
+        if(property != null) {
+            var parameter = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(parameterKind));
+            if(!string.IsNullOrEmpty(variableName))
+                writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {variableName};");
+            else if (parameter != null)
+                writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {parameter.Name};");
         }
-        private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
-            var backingStore = parentClass.GetBackingStoreProperty();
-            if(backingStore == null)
-                writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
-            else
-                writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value);");
-        }
-        private void WriteGetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
-            var backingStore = parentClass.GetBackingStoreProperty();
-            if(backingStore == null || (codeElement.AccessedProperty?.IsOfKind(CodePropertyKind.BackingStore) ?? false))
-                writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()};");
-            else 
-                if(!(codeElement.AccessedProperty?.Type?.IsNullable ?? true) &&
-                   !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
-                    !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue)) {
-                    writer.WriteLines($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\");",
-                        "if(value == null) {");
-                    writer.IncreaseIndent();
-                    writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
-                        $"this.set{codeElement.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}(value);");
-                    writer.DecreaseIndent();
-                    writer.WriteLines("}", "return value;");
-                } else
-                    writer.WriteLine($"return this.get{backingStore.Name.ToFirstCharacterUpperCase()}().get(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\");");
-
-        }
-        private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType) {
-            var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            conventions.AddParametersAssignment(writer, pathParametersProperty.Type, $"this.{pathParametersProperty.Name}",
-                (codeElement.OriginalIndexer.IndexType, codeElement.OriginalIndexer.ParameterName, "id"));
-            conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName);
-        }
-        private void WriteDeserializerBody(CodeMethod codeElement, CodeMethod method, CodeClass parentClass, LanguageWriter writer) {
-            var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-            var fieldToSerialize = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom);
-            writer.WriteLine($"return new HashMap<>({(inherits ? "super." + codeElement.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())}) {{{{");
-            if(fieldToSerialize.Any()) {
+    }
+    private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
+        var backingStore = parentClass.GetBackingStoreProperty();
+        if(backingStore == null)
+            writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
+        else
+            writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value);");
+    }
+    private void WriteGetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
+        var backingStore = parentClass.GetBackingStoreProperty();
+        if(backingStore == null || (codeElement.AccessedProperty?.IsOfKind(CodePropertyKind.BackingStore) ?? false))
+            writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()};");
+        else 
+            if(!(codeElement.AccessedProperty?.Type?.IsNullable ?? true) &&
+                !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
+                !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue)) {
+                writer.WriteLines($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\");",
+                    "if(value == null) {");
                 writer.IncreaseIndent();
-                fieldToSerialize
-                        .OrderBy(x => x.Name)
-                        .Select(x => {
-                            var setterName = x.IsNameEscaped && !string.IsNullOrEmpty(x.SerializationName) ? x.SerializationName : x.Name;
-                            return $"this.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (o, n) -> {{ (({parentClass.Name.ToFirstCharacterUpperCase()})o).set{setterName.ToFirstCharacterUpperCase()}({GetDeserializationMethodName(x.Type, method)}); }});";
-                        })
-                        .ToList()
-                        .ForEach(x => writer.WriteLine(x));
+                writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
+                    $"this.set{codeElement.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}(value);");
                 writer.DecreaseIndent();
-            }
-            writer.WriteLine("}};");
-        }
-        private void WriteRequestExecutorBody(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer) {
-            if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
-            var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement, false);
-            writer.WriteLine("try {");
+                writer.WriteLines("}", "return value;");
+            } else
+                writer.WriteLine($"return this.get{backingStore.Name.ToFirstCharacterUpperCase()}().get(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\");");
+
+    }
+    private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType) {
+        var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        conventions.AddParametersAssignment(writer, pathParametersProperty.Type, $"this.{pathParametersProperty.Name}",
+            (codeElement.OriginalIndexer.IndexType, codeElement.OriginalIndexer.ParameterName, "id"));
+        conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName);
+    }
+    private void WriteDeserializerBody(CodeMethod codeElement, CodeMethod method, CodeClass parentClass, LanguageWriter writer) {
+        var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
+        var fieldToSerialize = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom);
+        writer.WriteLine($"return new HashMap<>({(inherits ? "super." + codeElement.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())}) {{{{");
+        if(fieldToSerialize.Any()) {
             writer.IncreaseIndent();
-            WriteGeneratorMethodCall(codeElement, requestParams, writer, $"final RequestInformation {RequestInfoVarName} = ");
-            var sendMethodName = GetSendRequestMethodName(codeElement.ReturnType.IsCollection, returnType);
-            var responseHandlerParam = codeElement.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.ResponseHandler));
-            if(codeElement.Parameters.Any(x => x.IsOfKind(CodeParameterKind.ResponseHandler)))
-                writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {returnType}.class, {responseHandlerParam.Name});");
-            else
-                writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {returnType}.class, null);");
+            fieldToSerialize
+                    .OrderBy(x => x.Name)
+                    .Select(x => {
+                        var setterName = x.IsNameEscaped && !string.IsNullOrEmpty(x.SerializationName) ? x.SerializationName : x.Name;
+                        return $"this.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (o, n) -> {{ (({parentClass.Name.ToFirstCharacterUpperCase()})o).set{setterName.ToFirstCharacterUpperCase()}({GetDeserializationMethodName(x.Type, method)}); }});";
+                    })
+                    .ToList()
+                    .ForEach(x => writer.WriteLine(x));
             writer.DecreaseIndent();
-            writer.WriteLine("} catch (URISyntaxException ex) {");
+        }
+        writer.WriteLine("}};");
+    }
+    private void WriteRequestExecutorBody(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer) {
+        if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+        var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement, false);
+        writer.WriteLine("try {");
+        writer.IncreaseIndent();
+        WriteGeneratorMethodCall(codeElement, requestParams, writer, $"final RequestInformation {RequestInfoVarName} = ");
+        var sendMethodName = GetSendRequestMethodName(codeElement.ReturnType.IsCollection, returnType);
+        var responseHandlerParam = codeElement.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.ResponseHandler));
+        if(codeElement.Parameters.Any(x => x.IsOfKind(CodeParameterKind.ResponseHandler)))
+            writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {returnType}.class, {responseHandlerParam.Name});");
+        else
+            writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {returnType}.class, null);");
+        writer.DecreaseIndent();
+        writer.WriteLine("} catch (URISyntaxException ex) {");
+        writer.IncreaseIndent();
+        writer.WriteLine("return java.util.concurrent.CompletableFuture.failedFuture(ex);");
+        writer.DecreaseIndent();
+        writer.WriteLine("}");
+    }
+    private string GetSendRequestMethodName(bool isCollection, string returnType) {
+        if(conventions.PrimitiveTypes.Contains(returnType)) 
+            if(isCollection)
+                return "sendPrimitiveCollectionAsync";
+            else
+                return $"sendPrimitiveAsync";
+        else if(isCollection) return $"sendCollectionAsync";
+        else return $"sendAsync";
+    }
+    private const string RequestInfoVarName = "requestInfo";
+    private static void WriteGeneratorMethodCall(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer, string prefix) {
+        var generatorMethodName = (codeElement.Parent as CodeClass)
+                                            .Methods
+                                            .FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod)
+                                            ?.Name
+                                            ?.ToFirstCharacterLowerCase();
+        var paramsList = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options };
+        var requestInfoParameters = paramsList.Where(x => x != null)
+                                            .Select(x => x.Name)
+                                            .ToList();
+        var skipIndex = requestParams.requestBody == null ? 1 : 0;
+        if(codeElement.IsOverload && !codeElement.OriginalMethod.Parameters.Any(x => x.IsOfKind(CodeParameterKind.QueryParameter)) || // we're on an overload and the original method has no query parameters
+            !codeElement.IsOverload && requestParams.queryString == null) // we're on the original method and there is no query string parameter
+            skipIndex++;// we skip the query string parameter null value
+        requestInfoParameters.AddRange(paramsList.Where(x => x == null).Skip(skipIndex).Select(x => "null"));
+        var paramsCall = requestInfoParameters.Any() ? requestInfoParameters.Aggregate((x,y) => $"{x}, {y}") : string.Empty;
+        writer.WriteLine($"{prefix}{generatorMethodName}({paramsCall});");
+    }
+    private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {
+        if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+        
+        var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
+        var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation() {{{{");
+        writer.IncreaseIndent();
+        writer.WriteLine($"httpMethod = HttpMethod.{codeElement.HttpMethod?.ToString().ToUpperInvariant()};");
+        writer.DecreaseIndent();
+        writer.WriteLine("}};");
+        writer.WriteLines($"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "\"\"")};",
+                        $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "null")};");
+        if(requestParams.requestBody != null)
+            if(requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
+                writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name});");
+            else
+                writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable({requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.ContentType}\", {requestParams.requestBody.Name});");
+        if(requestParams.queryString != null) {
+            var httpMethodPrefix = codeElement.HttpMethod.ToString().ToFirstCharacterUpperCase();
+            writer.WriteLine($"if ({requestParams.queryString.Name} != null) {{");
             writer.IncreaseIndent();
-            writer.WriteLine("return java.util.concurrent.CompletableFuture.failedFuture(ex);");
+            writer.WriteLines($"final {httpMethodPrefix}QueryParameters qParams = new {httpMethodPrefix}QueryParameters();",
+                        $"{requestParams.queryString.Name}.accept(qParams);",
+                        $"qParams.AddQueryParameters({RequestInfoVarName}.queryParameters);");
             writer.DecreaseIndent();
             writer.WriteLine("}");
         }
-        private string GetSendRequestMethodName(bool isCollection, string returnType) {
-            if(conventions.PrimitiveTypes.Contains(returnType)) 
-                if(isCollection)
-                    return "sendPrimitiveCollectionAsync";
-                else
-                    return $"sendPrimitiveAsync";
-            else if(isCollection) return $"sendCollectionAsync";
-            else return $"sendAsync";
+        if(requestParams.headers != null) {
+            writer.WriteLine($"if ({requestParams.headers.Name} != null) {{");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{requestParams.headers.Name}.accept({RequestInfoVarName}.headers);");
+            writer.DecreaseIndent();
+            writer.WriteLine("}");
         }
-        private const string RequestInfoVarName = "requestInfo";
-        private static void WriteGeneratorMethodCall(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer, string prefix) {
-            var generatorMethodName = (codeElement.Parent as CodeClass)
-                                                .Methods
-                                                .FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod)
-                                                ?.Name
-                                                ?.ToFirstCharacterLowerCase();
-            var paramsList = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options };
-            var requestInfoParameters = paramsList.Where(x => x != null)
-                                                .Select(x => x.Name)
-                                                .ToList();
-            var skipIndex = requestParams.requestBody == null ? 1 : 0;
-            if(codeElement.IsOverload && !codeElement.OriginalMethod.Parameters.Any(x => x.IsOfKind(CodeParameterKind.QueryParameter)) || // we're on an overload and the original method has no query parameters
-                !codeElement.IsOverload && requestParams.queryString == null) // we're on the original method and there is no query string parameter
-                skipIndex++;// we skip the query string parameter null value
-            requestInfoParameters.AddRange(paramsList.Where(x => x == null).Skip(skipIndex).Select(x => "null"));
-            var paramsCall = requestInfoParameters.Any() ? requestInfoParameters.Aggregate((x,y) => $"{x}, {y}") : string.Empty;
-            writer.WriteLine($"{prefix}{generatorMethodName}({paramsCall});");
+        if(requestParams.options != null) {
+            writer.WriteLine($"if ({requestParams.options.Name} != null) {{");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{RequestInfoVarName}.addRequestOptions({requestParams.options.Name}.toArray(new RequestOption[0]));");
+            writer.DecreaseIndent();
+            writer.WriteLine("}");
         }
-        private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {
-            if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+        writer.WriteLine($"return {RequestInfoVarName};");
+    }
+    private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"{property.Name.ToFirstCharacterLowerCase()}";
+    private void WriteSerializerBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
+        var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
+        if((parentClass.StartBlock as CodeClass.Declaration).Inherits != null)
+            writer.WriteLine("super.serialize(writer);");
+        foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
+            var accessorName = otherProp.IsNameEscaped && !string.IsNullOrEmpty(otherProp.SerializationName) ? otherProp.SerializationName : otherProp.Name.ToFirstCharacterLowerCase();
+            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}(\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", this.get{accessorName.ToFirstCharacterUpperCase()}());");
+        }
+        if(additionalDataProperty != null)
+            writer.WriteLine($"writer.writeAdditionalData(this.get{additionalDataProperty.Name.ToFirstCharacterUpperCase()}());");
+    }
+    private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+    private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType) {
+        var accessModifier = conventions.GetAccessModifier(code.Access);
+        var genericTypeParameterDeclaration = code.IsOfKind(CodeMethodKind.Deserializer) ? " <T>": string.Empty;
+        var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
+        var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
+        var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
+        var methodName = code.MethodKind switch {
+            CodeMethodKind.Getter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                => $"get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
+            CodeMethodKind.Setter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
+                => $"set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
+            CodeMethodKind.Getter => $"get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
+            CodeMethodKind.Setter => $"set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
+            _ when isConstructor => code.Parent.Name.ToFirstCharacterUpperCase(),
+            _ => code.Name.ToFirstCharacterLowerCase()
+        };
+        var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p=> conventions.GetParameterSignature(p, code)).ToList());
+        var throwableDeclarations = code.IsOfKind(CodeMethodKind.RequestGenerator) ? "throws URISyntaxException ": string.Empty;
+        var collectionCorrectedReturnType = code.ReturnType.IsArray && code.IsOfKind(CodeMethodKind.RequestExecutor) ?
+                                            $"Iterable<{returnType.StripArraySuffix()}>" :
+                                            returnType;
+        var finalReturnType = isConstructor ? string.Empty : $" {returnTypeAsyncPrefix}{collectionCorrectedReturnType}{returnTypeAsyncSuffix}";
+        writer.WriteLine($"{accessModifier}{genericTypeParameterDeclaration}{finalReturnType} {methodName}({parameters}) {throwableDeclarations}{{");
+    }
+    private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer) {
+        var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
+        var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
+        if (isDescriptionPresent || parametersWithDescription.Any()) {
+            writer.WriteLine(conventions.DocCommentStart);
+            if(isDescriptionPresent)
+                writer.WriteLine($"{conventions.DocCommentPrefix}{JavaConventionService.RemoveInvalidDescriptionCharacters(code.Description)}");
+            foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
+                writer.WriteLine($"{conventions.DocCommentPrefix}@param {paramWithDescription.Name} {JavaConventionService.RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
             
-            var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
-            var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation() {{{{");
-            writer.IncreaseIndent();
-            writer.WriteLine($"httpMethod = HttpMethod.{codeElement.HttpMethod?.ToString().ToUpperInvariant()};");
-            writer.DecreaseIndent();
-            writer.WriteLine("}};");
-            writer.WriteLines($"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "\"\"")};",
-                            $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "null")};");
-            if(requestParams.requestBody != null)
-                if(requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
-                    writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name});");
+            if(code.IsAsync)
+                writer.WriteLine($"{conventions.DocCommentPrefix}@return a CompletableFuture of {code.ReturnType.Name}");
+            else
+                writer.WriteLine($"{conventions.DocCommentPrefix}@return a {code.ReturnType.Name}");
+            writer.WriteLine(conventions.DocCommentEnd);
+        }
+    }
+    private string GetDeserializationMethodName(CodeTypeBase propType, CodeMethod method) {
+        var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
+        var propertyType = conventions.GetTypeString(propType, method, false);
+        if(propType is CodeType currentType) {
+            if(isCollection)
+                if(currentType.TypeDefinition == null)
+                    return $"n.getCollectionOfPrimitiveValues({propertyType.ToFirstCharacterUpperCase()}.class)";
+                else if (currentType.TypeDefinition is CodeEnum enumType)
+                    return $"n.getCollectionOfEnumValues({enumType.Name.ToFirstCharacterUpperCase()}.class)";
                 else
-                    writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable({requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.ContentType}\", {requestParams.requestBody.Name});");
-            if(requestParams.queryString != null) {
-                var httpMethodPrefix = codeElement.HttpMethod.ToString().ToFirstCharacterUpperCase();
-                writer.WriteLine($"if ({requestParams.queryString.Name} != null) {{");
-                writer.IncreaseIndent();
-                writer.WriteLines($"final {httpMethodPrefix}QueryParameters qParams = new {httpMethodPrefix}QueryParameters();",
-                            $"{requestParams.queryString.Name}.accept(qParams);",
-                            $"qParams.AddQueryParameters({RequestInfoVarName}.queryParameters);");
-                writer.DecreaseIndent();
-                writer.WriteLine("}");
-            }
-            if(requestParams.headers != null) {
-                writer.WriteLine($"if ({requestParams.headers.Name} != null) {{");
-                writer.IncreaseIndent();
-                writer.WriteLine($"{requestParams.headers.Name}.accept({RequestInfoVarName}.headers);");
-                writer.DecreaseIndent();
-                writer.WriteLine("}");
-            }
-            if(requestParams.options != null) {
-                writer.WriteLine($"if ({requestParams.options.Name} != null) {{");
-                writer.IncreaseIndent();
-                writer.WriteLine($"{RequestInfoVarName}.addRequestOptions({requestParams.options.Name}.toArray(new RequestOption[0]));");
-                writer.DecreaseIndent();
-                writer.WriteLine("}");
-            }
-            writer.WriteLine($"return {RequestInfoVarName};");
+                    return $"n.getCollectionOfObjectValues({propertyType.ToFirstCharacterUpperCase()}.class)";
+            else if (currentType.TypeDefinition is CodeEnum currentEnum)
+                return $"n.getEnum{(currentEnum.Flags ? "Set" : string.Empty)}Value({propertyType.ToFirstCharacterUpperCase()}.class)";
         }
-        private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"{property.Name.ToFirstCharacterLowerCase()}";
-        private void WriteSerializerBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
-            var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
-            if((parentClass.StartBlock as CodeClass.Declaration).Inherits != null)
-                writer.WriteLine("super.serialize(writer);");
-            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
-                var accessorName = otherProp.IsNameEscaped && !string.IsNullOrEmpty(otherProp.SerializationName) ? otherProp.SerializationName : otherProp.Name.ToFirstCharacterLowerCase();
-                writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}(\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", this.get{accessorName.ToFirstCharacterUpperCase()}());");
-            }
-            if(additionalDataProperty != null)
-                writer.WriteLine($"writer.writeAdditionalData(this.get{additionalDataProperty.Name.ToFirstCharacterUpperCase()}());");
-        }
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
-        private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType) {
-            var accessModifier = conventions.GetAccessModifier(code.Access);
-            var genericTypeParameterDeclaration = code.IsOfKind(CodeMethodKind.Deserializer) ? " <T>": string.Empty;
-            var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
-            var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
-            var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
-            var methodName = code.MethodKind switch {
-                CodeMethodKind.Getter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
-                    => $"get{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
-                CodeMethodKind.Setter when (code.AccessedProperty?.IsNameEscaped ?? false) && !string.IsNullOrEmpty(code.AccessedProperty?.SerializationName)
-                    => $"set{code.AccessedProperty.SerializationName.ToFirstCharacterUpperCase()}",
-                CodeMethodKind.Getter => $"get{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
-                CodeMethodKind.Setter => $"set{code.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}",
-                _ when isConstructor => code.Parent.Name.ToFirstCharacterUpperCase(),
-                _ => code.Name.ToFirstCharacterLowerCase()
-            };
-            var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p=> conventions.GetParameterSignature(p, code)).ToList());
-            var throwableDeclarations = code.IsOfKind(CodeMethodKind.RequestGenerator) ? "throws URISyntaxException ": string.Empty;
-            var collectionCorrectedReturnType = code.ReturnType.IsArray && code.IsOfKind(CodeMethodKind.RequestExecutor) ?
-                                                $"Iterable<{returnType.StripArraySuffix()}>" :
-                                                returnType;
-            var finalReturnType = isConstructor ? string.Empty : $" {returnTypeAsyncPrefix}{collectionCorrectedReturnType}{returnTypeAsyncSuffix}";
-            writer.WriteLine($"{accessModifier}{genericTypeParameterDeclaration}{finalReturnType} {methodName}({parameters}) {throwableDeclarations}{{");
-        }
-        private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer) {
-            var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
-            var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
-            if (isDescriptionPresent || parametersWithDescription.Any()) {
-                writer.WriteLine(conventions.DocCommentStart);
-                if(isDescriptionPresent)
-                    writer.WriteLine($"{conventions.DocCommentPrefix}{JavaConventionService.RemoveInvalidDescriptionCharacters(code.Description)}");
-                foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
-                    writer.WriteLine($"{conventions.DocCommentPrefix}@param {paramWithDescription.Name} {JavaConventionService.RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
-                
-                if(code.IsAsync)
-                    writer.WriteLine($"{conventions.DocCommentPrefix}@return a CompletableFuture of {code.ReturnType.Name}");
+        return propertyType switch
+        {
+            "byte[]" => "n.getByteArrayValue()",
+            _ when conventions.PrimitiveTypes.Contains(propertyType) => $"n.get{propertyType}Value()",
+            _ => $"n.getObjectValue({propertyType.ToFirstCharacterUpperCase()}.class)",
+        };
+    }
+    private string GetSerializationMethodName(CodeTypeBase propType, CodeMethod method) {
+        var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
+        var propertyType = conventions.GetTypeString(propType, method, false);
+        if(propType is CodeType currentType) {
+            if(isCollection)
+                if(currentType.TypeDefinition == null)
+                    return $"writeCollectionOfPrimitiveValues";
+                else if(currentType.TypeDefinition is CodeEnum)
+                    return $"writeCollectionOfEnumValues";
                 else
-                    writer.WriteLine($"{conventions.DocCommentPrefix}@return a {code.ReturnType.Name}");
-                writer.WriteLine(conventions.DocCommentEnd);
-            }
+                    return $"writeCollectionOfObjectValues";
+            else if (currentType.TypeDefinition is CodeEnum currentEnum)
+                return $"writeEnum{(currentEnum.Flags ? "Set" : string.Empty)}Value";
         }
-        private string GetDeserializationMethodName(CodeTypeBase propType, CodeMethod method) {
-            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-            var propertyType = conventions.GetTypeString(propType, method, false);
-            if(propType is CodeType currentType) {
-                if(isCollection)
-                    if(currentType.TypeDefinition == null)
-                        return $"n.getCollectionOfPrimitiveValues({propertyType.ToFirstCharacterUpperCase()}.class)";
-                    else if (currentType.TypeDefinition is CodeEnum enumType)
-                        return $"n.getCollectionOfEnumValues({enumType.Name.ToFirstCharacterUpperCase()}.class)";
-                    else
-                        return $"n.getCollectionOfObjectValues({propertyType.ToFirstCharacterUpperCase()}.class)";
-                else if (currentType.TypeDefinition is CodeEnum currentEnum)
-                    return $"n.getEnum{(currentEnum.Flags ? "Set" : string.Empty)}Value({propertyType.ToFirstCharacterUpperCase()}.class)";
-            }
-            return propertyType switch
-            {
-                "byte[]" => "n.getByteArrayValue()",
-                "String" or "Boolean" or "Integer" or "Float" or "Long" or "Guid" or "OffsetDateTime" or "Double" => $"n.get{propertyType}Value()",
-                _ => $"n.getObjectValue({propertyType.ToFirstCharacterUpperCase()}.class)",
-            };
-        }
-        private string GetSerializationMethodName(CodeTypeBase propType, CodeMethod method) {
-            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-            var propertyType = conventions.GetTypeString(propType, method, false);
-            if(propType is CodeType currentType) {
-                if(isCollection)
-                    if(currentType.TypeDefinition == null)
-                        return $"writeCollectionOfPrimitiveValues";
-                    else if(currentType.TypeDefinition is CodeEnum)
-                        return $"writeCollectionOfEnumValues";
-                    else
-                        return $"writeCollectionOfObjectValues";
-                else if (currentType.TypeDefinition is CodeEnum currentEnum)
-                    return $"writeEnum{(currentEnum.Flags ? "Set" : string.Empty)}Value";
-            }
-            return propertyType switch
-            {
-                "byte[]" => "writeByteArrayValue",
-                "String" or "Boolean" or "Integer" or "Float" or "Long" or "Guid" or "OffsetDateTime" or "Double" => $"write{propertyType}Value",
-                _ => $"writeObjectValue",
-            };
-        }
+        return propertyType switch
+        {
+            "byte[]" => "writeByteArrayValue",
+            _ when conventions.PrimitiveTypes.Contains(propertyType) => $"write{propertyType}Value",
+            _ => $"writeObjectValue",
+        };
     }
 }

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -4,99 +4,98 @@ using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Refiners;
 
-namespace Kiota.Builder.Writers.Java {
-    public class JavaConventionService : CommonLanguageConventionService
+namespace Kiota.Builder.Writers.Java;
+public class JavaConventionService : CommonLanguageConventionService
+{
+    private const string InternalStreamTypeName = "InputStream";
+    public override string StreamTypeName => InternalStreamTypeName;
+    private const string InternalVoidTypeName = "Void";
+    public override string VoidTypeName => InternalVoidTypeName;
+    public override string DocCommentPrefix => " * ";
+    internal HashSet<string> PrimitiveTypes = new() {"String", "Boolean", "Integer", "Float", "Long", "Guid", "Double", "OffsetDateTime", "LocalDate", "LocalTime", "Period", InternalVoidTypeName, InternalStreamTypeName };
+    public override string ParseNodeInterfaceName => "ParseNode";
+    internal string DocCommentStart = "/**";
+    internal string DocCommentEnd = " */";
+    public override string GetAccessModifier(AccessModifier access)
     {
-        private const string InternalStreamTypeName = "InputStream";
-        public override string StreamTypeName => InternalStreamTypeName;
-        private const string InternalVoidTypeName = "Void";
-        public override string VoidTypeName => InternalVoidTypeName;
-        public override string DocCommentPrefix => " * ";
-        internal HashSet<string> PrimitiveTypes = new() {"String", "Boolean", "Integer", "Float", "Long", "Guid", "OffsetDateTime", InternalVoidTypeName, InternalStreamTypeName };
-        public override string ParseNodeInterfaceName => "ParseNode";
-        internal string DocCommentStart = "/**";
-        internal string DocCommentEnd = " */";
-        public override string GetAccessModifier(AccessModifier access)
-        {
-            return access switch {
-                AccessModifier.Public => "public",
-                AccessModifier.Protected => "protected",
-                _ => "private",
-            };
-        }
-
-        public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
-        {
-            var nullKeyword = parameter.Optional ? "Nullable" : "Nonnull";
-            var nullAnnotation = parameter.Type.IsNullable ? $"@javax.annotation.{nullKeyword} " : string.Empty;
-            return $"{nullAnnotation}final {GetTypeString(parameter.Type, targetElement)} {parameter.Name.ToFirstCharacterLowerCase()}";
-        }
-
-        public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true)
-        {
-            if(code is CodeUnionType) 
-                throw new InvalidOperationException($"Java does not support union types, the union type {code.Name} should have been filtered out by the refiner");
-            else if (code is CodeType currentType) {
-                var typeName = TranslateType(currentType);
-                if(!currentType.IsExternal && IsSymbolDuplicated(typeName, targetElement))
-                    typeName = $"{currentType.TypeDefinition.GetImmediateParentOfType<CodeNamespace>().Name}.{typeName}";
-
-                var collectionPrefix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex && includeCollectionInformation ? "java.util.List<" : string.Empty;
-                var collectionSuffix = currentType.CollectionKind switch {
-                    CodeType.CodeTypeCollectionKind.Complex when includeCollectionInformation => ">",
-                    CodeType.CodeTypeCollectionKind.Array when includeCollectionInformation => "[]",
-                    _ => string.Empty,
-                };
-                if (currentType.ActionOf)
-                    return $"java.util.function.Consumer<{collectionPrefix}{typeName}{collectionSuffix}>";
-                else
-                    return $"{collectionPrefix}{typeName}{collectionSuffix}";
-            }
-            else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
-        }
-        private static readonly CodeUsingDeclarationNameComparer usingDeclarationComparer = new();
-        private static bool IsSymbolDuplicated(string symbol, CodeElement targetElement) {
-            var targetClass = targetElement as CodeClass ?? targetElement.GetImmediateParentOfType<CodeClass>();
-            if (targetClass.Parent is CodeClass parentClass) 
-                targetClass = parentClass;
-            return (targetClass.StartBlock as CodeClass.Declaration)
-                            ?.Usings
-                            ?.Where(x => !x.IsExternal && symbol.Equals(x.Declaration.TypeDefinition.Name, StringComparison.OrdinalIgnoreCase))
-                            ?.Distinct(usingDeclarationComparer)
-                            ?.Count() > 1;
-        }
-        public override string TranslateType(CodeType type) {
-            return type.Name switch {
-                "int64" => "Long",
-                "void" or "boolean" when !type.IsNullable => type.Name, //little casing hack
-                "binary" => "byte[]",
-                _ => type.Name.ToFirstCharacterUpperCase() ?? "Object",
-            };
-        }
-        public override void WriteShortDescription(string description, LanguageWriter writer)
-        {
-            if(!string.IsNullOrEmpty(description))
-                writer.WriteLine($"{DocCommentStart} {RemoveInvalidDescriptionCharacters(description)} {DocCommentEnd}");
-        }
-        internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
-        #pragma warning disable CA1822 // Method should be static
-        internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default) {
-            var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            var urlTemplateParams = urlTemplateVarName ?? pathParametersProperty.Name;
-            var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
-            writer.WriteLines($"return new {returnType}({urlTemplateParams}, {requestAdapterProp.Name}{pathParametersSuffix});");
-        }
-        public override string TempDictionaryVarName => "urlTplParams";
-        internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
-            if(pathParametersType == null) return;
-            var mapTypeName = pathParametersType.Name;
-            writer.WriteLine($"var {TempDictionaryVarName} = new {mapTypeName}({pathParametersReference});");
-            if(parameters.Any())
-                writer.WriteLines(parameters.Select(p =>
-                    $"{TempDictionaryVarName}.put(\"{p.Item2}\", {p.Item3});"
-                ).ToArray());
-        }
-        #pragma warning restore CA1822 // Method should be static
+        return access switch {
+            AccessModifier.Public => "public",
+            AccessModifier.Protected => "protected",
+            _ => "private",
+        };
     }
+
+    public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
+    {
+        var nullKeyword = parameter.Optional ? "Nullable" : "Nonnull";
+        var nullAnnotation = parameter.Type.IsNullable ? $"@javax.annotation.{nullKeyword} " : string.Empty;
+        return $"{nullAnnotation}final {GetTypeString(parameter.Type, targetElement)} {parameter.Name.ToFirstCharacterLowerCase()}";
+    }
+
+    public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true)
+    {
+        if(code is CodeUnionType) 
+            throw new InvalidOperationException($"Java does not support union types, the union type {code.Name} should have been filtered out by the refiner");
+        else if (code is CodeType currentType) {
+            var typeName = TranslateType(currentType);
+            if(!currentType.IsExternal && IsSymbolDuplicated(typeName, targetElement))
+                typeName = $"{currentType.TypeDefinition.GetImmediateParentOfType<CodeNamespace>().Name}.{typeName}";
+
+            var collectionPrefix = currentType.CollectionKind == CodeType.CodeTypeCollectionKind.Complex && includeCollectionInformation ? "java.util.List<" : string.Empty;
+            var collectionSuffix = currentType.CollectionKind switch {
+                CodeType.CodeTypeCollectionKind.Complex when includeCollectionInformation => ">",
+                CodeType.CodeTypeCollectionKind.Array when includeCollectionInformation => "[]",
+                _ => string.Empty,
+            };
+            if (currentType.ActionOf)
+                return $"java.util.function.Consumer<{collectionPrefix}{typeName}{collectionSuffix}>";
+            else
+                return $"{collectionPrefix}{typeName}{collectionSuffix}";
+        }
+        else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
+    }
+    private static readonly CodeUsingDeclarationNameComparer usingDeclarationComparer = new();
+    private static bool IsSymbolDuplicated(string symbol, CodeElement targetElement) {
+        var targetClass = targetElement as CodeClass ?? targetElement.GetImmediateParentOfType<CodeClass>();
+        if (targetClass.Parent is CodeClass parentClass) 
+            targetClass = parentClass;
+        return (targetClass.StartBlock as CodeClass.Declaration)
+                        ?.Usings
+                        ?.Where(x => !x.IsExternal && symbol.Equals(x.Declaration.TypeDefinition.Name, StringComparison.OrdinalIgnoreCase))
+                        ?.Distinct(usingDeclarationComparer)
+                        ?.Count() > 1;
+    }
+    public override string TranslateType(CodeType type) {
+        return type.Name switch {
+            "int64" => "Long",
+            "void" or "boolean" when !type.IsNullable => type.Name, //little casing hack
+            "binary" => "byte[]",
+            _ => type.Name.ToFirstCharacterUpperCase() ?? "Object",
+        };
+    }
+    public override void WriteShortDescription(string description, LanguageWriter writer)
+    {
+        if(!string.IsNullOrEmpty(description))
+            writer.WriteLine($"{DocCommentStart} {RemoveInvalidDescriptionCharacters(description)} {DocCommentEnd}");
+    }
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
+    #pragma warning disable CA1822 // Method should be static
+    internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default) {
+        var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        var urlTemplateParams = urlTemplateVarName ?? pathParametersProperty.Name;
+        var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
+        writer.WriteLines($"return new {returnType}({urlTemplateParams}, {requestAdapterProp.Name}{pathParametersSuffix});");
+    }
+    public override string TempDictionaryVarName => "urlTplParams";
+    internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
+        if(pathParametersType == null) return;
+        var mapTypeName = pathParametersType.Name;
+        writer.WriteLine($"var {TempDictionaryVarName} = new {mapTypeName}({pathParametersReference});");
+        if(parameters.Any())
+            writer.WriteLines(parameters.Select(p =>
+                $"{TempDictionaryVarName}.put(\"{p.Item2}\", {p.Item3});"
+            ).ToArray());
+    }
+    #pragma warning restore CA1822 // Method should be static
 }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -4,350 +4,349 @@ using System.Linq;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Extensions;
 
-namespace Kiota.Builder.Writers.TypeScript {
-    public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventionService>
+namespace Kiota.Builder.Writers.TypeScript;
+public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventionService>
+{
+    public CodeMethodWriter(TypeScriptConventionService conventionService) : base(conventionService){}
+    private TypeScriptConventionService localConventions;
+    public override void WriteCodeElement(CodeMethod codeElement, LanguageWriter writer)
     {
-        public CodeMethodWriter(TypeScriptConventionService conventionService) : base(conventionService){}
-        private TypeScriptConventionService localConventions;
-        public override void WriteCodeElement(CodeMethod codeElement, LanguageWriter writer)
-        {
-            if(codeElement == null) throw new ArgumentNullException(nameof(codeElement));
-            if(codeElement.ReturnType == null) throw new InvalidOperationException($"{nameof(codeElement.ReturnType)} should not be null");
-            if(writer == null) throw new ArgumentNullException(nameof(writer));
-            if(!(codeElement.Parent is CodeClass)) throw new InvalidOperationException("the parent of a method should be a class");
+        if(codeElement == null) throw new ArgumentNullException(nameof(codeElement));
+        if(codeElement.ReturnType == null) throw new InvalidOperationException($"{nameof(codeElement.ReturnType)} should not be null");
+        if(writer == null) throw new ArgumentNullException(nameof(writer));
+        if(!(codeElement.Parent is CodeClass)) throw new InvalidOperationException("the parent of a method should be a class");
 
-            localConventions = new TypeScriptConventionService(writer); //because we allow inline type definitions for methods parameters
-            var returnType = localConventions.GetTypeString(codeElement.ReturnType, codeElement);
-            var isVoid = "void".Equals(returnType, StringComparison.OrdinalIgnoreCase);
-            WriteMethodDocumentation(codeElement, writer, isVoid);
-            WriteMethodPrototype(codeElement, writer, returnType, isVoid);
-            writer.IncreaseIndent();
-            var parentClass = codeElement.Parent as CodeClass;
-            var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-            var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
-            var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
-            var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);
-            var optionsParam = codeElement.Parameters.OfKind(CodeParameterKind.Options);
-            var requestParams = new RequestParams(requestBodyParam, queryStringParam, headersParam, optionsParam);
-            if(!codeElement.IsOfKind(CodeMethodKind.Setter))
-                foreach(var parameter in codeElement.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name)) {
-                    var parameterName = parameter.Name.ToFirstCharacterLowerCase();
-                    writer.WriteLine($"if(!{parameterName}) throw new Error(\"{parameterName} cannot be undefined\");");
-                }
-            switch(codeElement.MethodKind) {
-                case CodeMethodKind.IndexerBackwardCompatibility:
-                    WriteIndexerBody(codeElement, parentClass, returnType, writer);
-                    break;
-                case CodeMethodKind.Deserializer:
-                    WriteDeserializerBody(codeElement, parentClass, writer);
-                    break;
-                case CodeMethodKind.Serializer:
-                    WriteSerializerBody(inherits, parentClass, writer);
-                    break;
-                case CodeMethodKind.RequestGenerator:
-                    WriteRequestGeneratorBody(codeElement, requestParams, parentClass, writer);
+        localConventions = new TypeScriptConventionService(writer); //because we allow inline type definitions for methods parameters
+        var returnType = localConventions.GetTypeString(codeElement.ReturnType, codeElement);
+        var isVoid = "void".Equals(returnType, StringComparison.OrdinalIgnoreCase);
+        WriteMethodDocumentation(codeElement, writer, isVoid);
+        WriteMethodPrototype(codeElement, writer, returnType, isVoid);
+        writer.IncreaseIndent();
+        var parentClass = codeElement.Parent as CodeClass;
+        var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
+        var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
+        var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
+        var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);
+        var optionsParam = codeElement.Parameters.OfKind(CodeParameterKind.Options);
+        var requestParams = new RequestParams(requestBodyParam, queryStringParam, headersParam, optionsParam);
+        if(!codeElement.IsOfKind(CodeMethodKind.Setter))
+            foreach(var parameter in codeElement.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name)) {
+                var parameterName = parameter.Name.ToFirstCharacterLowerCase();
+                writer.WriteLine($"if(!{parameterName}) throw new Error(\"{parameterName} cannot be undefined\");");
+            }
+        switch(codeElement.MethodKind) {
+            case CodeMethodKind.IndexerBackwardCompatibility:
+                WriteIndexerBody(codeElement, parentClass, returnType, writer);
                 break;
-                case CodeMethodKind.RequestExecutor:
-                    WriteRequestExecutorBody(codeElement, requestParams, isVoid, returnType, writer);
-                    break;
-                case CodeMethodKind.Getter:
-                    WriteGetterBody(codeElement, writer, parentClass);
-                    break;
-                case CodeMethodKind.Setter:
-                    WriteSetterBody(codeElement, writer, parentClass);
-                    break;
-                case CodeMethodKind.ClientConstructor:
-                    WriteConstructorBody(parentClass, codeElement, writer, inherits);
-                    WriteApiConstructorBody(parentClass, codeElement, writer);
+            case CodeMethodKind.Deserializer:
+                WriteDeserializerBody(codeElement, parentClass, writer);
                 break;
-                case CodeMethodKind.Constructor:
-                    WriteConstructorBody(parentClass, codeElement, writer, inherits);
-                    break;
-                case CodeMethodKind.RequestBuilderWithParameters:
-                    WriteRequestBuilderWithParametersBody(codeElement, parentClass, returnType, writer);
-                    break;
-                case CodeMethodKind.RawUrlConstructor:
-                    throw new InvalidOperationException("RawUrlConstructor is not supported as typescript relies on union types.");
-                case CodeMethodKind.RequestBuilderBackwardCompatibility:
-                    throw new InvalidOperationException("RequestBuilderBackwardCompatibility is not supported as the request builders are implemented by properties.");
-                default:
-                    WriteDefaultMethodBody(codeElement, writer);
-                    break;
+            case CodeMethodKind.Serializer:
+                WriteSerializerBody(inherits, parentClass, writer);
+                break;
+            case CodeMethodKind.RequestGenerator:
+                WriteRequestGeneratorBody(codeElement, requestParams, parentClass, writer);
+            break;
+            case CodeMethodKind.RequestExecutor:
+                WriteRequestExecutorBody(codeElement, requestParams, isVoid, returnType, writer);
+                break;
+            case CodeMethodKind.Getter:
+                WriteGetterBody(codeElement, writer, parentClass);
+                break;
+            case CodeMethodKind.Setter:
+                WriteSetterBody(codeElement, writer, parentClass);
+                break;
+            case CodeMethodKind.ClientConstructor:
+                WriteConstructorBody(parentClass, codeElement, writer, inherits);
+                WriteApiConstructorBody(parentClass, codeElement, writer);
+            break;
+            case CodeMethodKind.Constructor:
+                WriteConstructorBody(parentClass, codeElement, writer, inherits);
+                break;
+            case CodeMethodKind.RequestBuilderWithParameters:
+                WriteRequestBuilderWithParametersBody(codeElement, parentClass, returnType, writer);
+                break;
+            case CodeMethodKind.RawUrlConstructor:
+                throw new InvalidOperationException("RawUrlConstructor is not supported as typescript relies on union types.");
+            case CodeMethodKind.RequestBuilderBackwardCompatibility:
+                throw new InvalidOperationException("RequestBuilderBackwardCompatibility is not supported as the request builders are implemented by properties.");
+            default:
+                WriteDefaultMethodBody(codeElement, writer);
+                break;
+        }
+        writer.DecreaseIndent();
+        writer.WriteLine("};");
+    }
+    private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, string returnType, LanguageWriter writer) {
+        var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        localConventions.AddParametersAssignment(writer, pathParametersProperty.Type, $"this.{pathParametersProperty.Name}",
+            (codeElement.OriginalIndexer.IndexType, codeElement.OriginalIndexer.ParameterName, "id"));
+        localConventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName);
+    }
+    private void WriteRequestBuilderWithParametersBody(CodeMethod codeElement, CodeClass parentClass, string returnType, LanguageWriter writer)
+    {
+        var codePathParameters = codeElement.Parameters
+                                                    .Where(x => x.IsOfKind(CodeParameterKind.Path));
+        localConventions.AddRequestBuilderBody(parentClass, returnType, writer, pathParameters: codePathParameters);
+    }
+    private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
+        var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        var backingStoreParameter = method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.BackingStore));
+        var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
+        WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
+        WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
+        writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = \"{method.BaseUrl}\";");
+        if(backingStoreParameter != null)
+            writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
+    }
+    private static void WriteSerializationRegistration(List<string> serializationModules, LanguageWriter writer, string methodName) {
+        if(serializationModules != null)
+            foreach(var module in serializationModules)
+                writer.WriteLine($"{methodName}({module});");
+    }
+    private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
+        if(inherits)
+            writer.WriteLine("super();");
+        var propertiesWithDefaultValues = new List<CodePropertyKind> {
+            CodePropertyKind.AdditionalData,
+            CodePropertyKind.BackingStore,
+            CodePropertyKind.RequestBuilder,
+            CodePropertyKind.UrlTemplate,
+            CodePropertyKind.PathParameters,
+        };
+        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(propertiesWithDefaultValues.ToArray())
+                                        .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderByDescending(x => x.PropertyKind)
+                                        .ThenBy(x => x.Name)) {
+            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
+        }
+        if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
+            if(currentMethod.IsOfKind(CodeMethodKind.Constructor)) {
+                var pathParametersParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
+                localConventions.AddParametersAssignment(writer, 
+                                                    pathParametersParam.Type.AllTypes.OfType<CodeType>().FirstOrDefault(),
+                                                    pathParametersParam.Name.ToFirstCharacterLowerCase(),
+                                                    currentMethod.Parameters
+                                                                .Where(x => x.IsOfKind(CodeParameterKind.Path))
+                                                                .Select(x => (x.Type, x.UrlTemplateParameterName, x.Name.ToFirstCharacterLowerCase()))
+                                                                .ToArray());
+                AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
             }
-            writer.DecreaseIndent();
-            writer.WriteLine("};");
+            AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.RequestAdapter, CodePropertyKind.RequestAdapter, writer);
         }
-        private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, string returnType, LanguageWriter writer) {
-            var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            localConventions.AddParametersAssignment(writer, pathParametersProperty.Type, $"this.{pathParametersProperty.Name}",
-                (codeElement.OriginalIndexer.IndexType, codeElement.OriginalIndexer.ParameterName, "id"));
-            localConventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName);
+    }
+    private static void AssignPropertyFromParameter(CodeClass parentClass, CodeMethod currentMethod, CodeParameterKind parameterKind, CodePropertyKind propertyKind, LanguageWriter writer, string variableName = default) {
+        var property = parentClass.GetPropertyOfKind(propertyKind);
+        if(property != null) {
+            var parameter = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(parameterKind));
+            if(!string.IsNullOrEmpty(variableName))
+                writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {variableName};");
+            else if(parameter != null)
+                writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {parameter.Name};");
         }
-        private void WriteRequestBuilderWithParametersBody(CodeMethod codeElement, CodeClass parentClass, string returnType, LanguageWriter writer)
-        {
-            var codePathParameters = codeElement.Parameters
-                                                        .Where(x => x.IsOfKind(CodeParameterKind.Path));
-            localConventions.AddRequestBuilderBody(parentClass, returnType, writer, pathParameters: codePathParameters);
-        }
-        private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer) {
-            var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            var backingStoreParameter = method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.BackingStore));
-            var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
-            WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
-            WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
-            writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = \"{method.BaseUrl}\";");
-            if(backingStoreParameter != null)
-                writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
-        }
-        private static void WriteSerializationRegistration(List<string> serializationModules, LanguageWriter writer, string methodName) {
-            if(serializationModules != null)
-                foreach(var module in serializationModules)
-                    writer.WriteLine($"{methodName}({module});");
-        }
-        private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
-            if(inherits)
-                writer.WriteLine("super();");
-            var propertiesWithDefaultValues = new List<CodePropertyKind> {
-                CodePropertyKind.AdditionalData,
-                CodePropertyKind.BackingStore,
-                CodePropertyKind.RequestBuilder,
-                CodePropertyKind.UrlTemplate,
-                CodePropertyKind.PathParameters,
-            };
-            foreach(var propWithDefault in parentClass.GetPropertiesOfKind(propertiesWithDefaultValues.ToArray())
-                                            .Where(x => !string.IsNullOrEmpty(x.DefaultValue))
-                                            .OrderByDescending(x => x.PropertyKind)
-                                            .ThenBy(x => x.Name)) {
-                writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
-            }
-            if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
-                if(currentMethod.IsOfKind(CodeMethodKind.Constructor)) {
-                    var pathParametersParam = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
-                    localConventions.AddParametersAssignment(writer, 
-                                                        pathParametersParam.Type.AllTypes.OfType<CodeType>().FirstOrDefault(),
-                                                        pathParametersParam.Name.ToFirstCharacterLowerCase(),
-                                                        currentMethod.Parameters
-                                                                    .Where(x => x.IsOfKind(CodeParameterKind.Path))
-                                                                    .Select(x => (x.Type, x.UrlTemplateParameterName, x.Name.ToFirstCharacterLowerCase()))
-                                                                    .ToArray());
-                    AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
-                }
-                AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.RequestAdapter, CodePropertyKind.RequestAdapter, writer);
-            }
-        }
-        private static void AssignPropertyFromParameter(CodeClass parentClass, CodeMethod currentMethod, CodeParameterKind parameterKind, CodePropertyKind propertyKind, LanguageWriter writer, string variableName = default) {
-            var property = parentClass.GetPropertyOfKind(propertyKind);
-            if(property != null) {
-                var parameter = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(parameterKind));
-                if(!string.IsNullOrEmpty(variableName))
-                    writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {variableName};");
-                else if(parameter != null)
-                    writer.WriteLine($"this.{property.Name.ToFirstCharacterLowerCase()} = {parameter.Name};");
-            }
-        }
-        private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
-            var backingStore = parentClass.GetBackingStoreProperty();
-            if(backingStore == null)
-                writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
-            else
-                writer.WriteLine($"this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value);");
-        }
-        private void WriteGetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
-            var backingStore = parentClass.GetBackingStoreProperty();
-            if(backingStore == null)
-                writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()};");
-            else 
-                if(!(codeElement.AccessedProperty?.Type?.IsNullable ?? true) &&
-                    !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
-                    !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue)) {
-                    writer.WriteLines($"let value = this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get<{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)}>(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\");",
-                        "if(!value) {");
-                    writer.IncreaseIndent();
-                    writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
-                        $"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
-                    writer.DecreaseIndent();
-                    writer.WriteLines("}", "return value;");
-                } else
-                    writer.WriteLine($"return this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\");");
-
-        }
-        private static void WriteDefaultMethodBody(CodeMethod codeElement, LanguageWriter writer) {
-            var promisePrefix = codeElement.IsAsync ? "Promise.resolve(" : string.Empty;
-            var promiseSuffix = codeElement.IsAsync ? ")" : string.Empty;
-            writer.WriteLine($"return {promisePrefix}{(codeElement.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{promiseSuffix};");
-        }
-        private void WriteDeserializerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer) {
-            var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
-            writer.WriteLine($"return new Map<string, (item: T, node: {localConventions.ParseNodeInterfaceName}) => void>([{(inherits ? $"...super.{codeElement.Name.ToFirstCharacterLowerCase()}()," : string.Empty)}");
-            writer.IncreaseIndent();
-            var parentClassName = parentClass.Name.ToFirstCharacterUpperCase();
-            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
-                writer.WriteLine($"[\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ (o as unknown as {parentClassName}).{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
-            }
-            writer.DecreaseIndent();
-            writer.WriteLine("]);");
-        }
-        private void WriteRequestExecutorBody(CodeMethod codeElement, RequestParams requestParams, bool isVoid, string returnType, LanguageWriter writer) {
-            if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
-
-            var generatorMethodName = (codeElement.Parent as CodeClass)
-                                                .Methods
-                                                .FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod)
-                                                ?.Name
-                                                ?.ToFirstCharacterLowerCase();
-            writer.WriteLine($"const requestInfo = this.{generatorMethodName}(");
-            var requestInfoParameters = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options }
-                	                        .Select(x => x?.Name).Where(x => x != null);
-            if(requestInfoParameters.Any()) {
+    }
+    private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
+        var backingStore = parentClass.GetBackingStoreProperty();
+        if(backingStore == null)
+            writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
+        else
+            writer.WriteLine($"this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value);");
+    }
+    private void WriteGetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass) {
+        var backingStore = parentClass.GetBackingStoreProperty();
+        if(backingStore == null)
+            writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()};");
+        else 
+            if(!(codeElement.AccessedProperty?.Type?.IsNullable ?? true) &&
+                !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
+                !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue)) {
+                writer.WriteLines($"let value = this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get<{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)}>(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\");",
+                    "if(!value) {");
                 writer.IncreaseIndent();
-                writer.WriteLine(requestInfoParameters.Aggregate((x,y) => $"{x}, {y}"));
+                writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
+                    $"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = value;");
                 writer.DecreaseIndent();
+                writer.WriteLines("}", "return value;");
+            } else
+                writer.WriteLine($"return this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\");");
+
+    }
+    private static void WriteDefaultMethodBody(CodeMethod codeElement, LanguageWriter writer) {
+        var promisePrefix = codeElement.IsAsync ? "Promise.resolve(" : string.Empty;
+        var promiseSuffix = codeElement.IsAsync ? ")" : string.Empty;
+        writer.WriteLine($"return {promisePrefix}{(codeElement.ReturnType.Name.Equals("string") ? "''" : "{} as any")}{promiseSuffix};");
+    }
+    private void WriteDeserializerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer) {
+        var inherits = (parentClass.StartBlock as CodeClass.Declaration).Inherits != null;
+        writer.WriteLine($"return new Map<string, (item: T, node: {localConventions.ParseNodeInterfaceName}) => void>([{(inherits ? $"...super.{codeElement.Name.ToFirstCharacterLowerCase()}()," : string.Empty)}");
+        writer.IncreaseIndent();
+        var parentClassName = parentClass.Name.ToFirstCharacterUpperCase();
+        foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
+            writer.WriteLine($"[\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", (o, n) => {{ (o as unknown as {parentClassName}).{otherProp.Name.ToFirstCharacterLowerCase()} = n.{GetDeserializationMethodName(otherProp.Type)}; }}],");
+        }
+        writer.DecreaseIndent();
+        writer.WriteLine("]);");
+    }
+    private void WriteRequestExecutorBody(CodeMethod codeElement, RequestParams requestParams, bool isVoid, string returnType, LanguageWriter writer) {
+        if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+
+        var generatorMethodName = (codeElement.Parent as CodeClass)
+                                            .Methods
+                                            .FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod)
+                                            ?.Name
+                                            ?.ToFirstCharacterLowerCase();
+        writer.WriteLine($"const requestInfo = this.{generatorMethodName}(");
+        var requestInfoParameters = new CodeParameter[] { requestParams.requestBody, requestParams.queryString, requestParams.headers, requestParams.options }
+                                        .Select(x => x?.Name).Where(x => x != null);
+        if(requestInfoParameters.Any()) {
+            writer.IncreaseIndent();
+            writer.WriteLine(requestInfoParameters.Aggregate((x,y) => $"{x}, {y}"));
+            writer.DecreaseIndent();
+        }
+        writer.WriteLine(");");
+        var isStream = localConventions.StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
+        var returnTypeWithoutCollectionSymbol = GetReturnTypeWithoutCollectionSymbol(codeElement, returnType);
+        var genericTypeForSendMethod = GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnTypeWithoutCollectionSymbol);
+        var newFactoryParameter = GetTypeFactory(isVoid, isStream, returnTypeWithoutCollectionSymbol);
+        writer.WriteLine($"return this.requestAdapter?.{genericTypeForSendMethod}(requestInfo,{newFactoryParameter} responseHandler) ?? Promise.reject(new Error('http core is null'));");
+    }
+    private string GetReturnTypeWithoutCollectionSymbol(CodeMethod codeElement, string fullTypeName) {
+        if(!codeElement.ReturnType.IsCollection) return fullTypeName;
+        var clone = codeElement.ReturnType.Clone() as CodeTypeBase;
+        clone.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.None;
+        return conventions.GetTypeString(clone, codeElement);
+    }
+    private const string RequestInfoVarName = "requestInfo";
+    private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {
+        if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+        
+        var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
+        var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        writer.WriteLines($"const {RequestInfoVarName} = new RequestInformation();",
+                            $"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "''")};",
+                            $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "''")};",
+                            $"{RequestInfoVarName}.httpMethod = HttpMethod.{codeElement.HttpMethod.ToString().ToUpperInvariant()};");
+        if(requestParams.headers != null)
+            writer.WriteLine($"{requestParams.headers.Name} && {RequestInfoVarName}.setHeadersFromRawObject(h);");
+        if(requestParams.queryString != null)
+            writer.WriteLines($"{requestParams.queryString.Name} && {RequestInfoVarName}.setQueryStringParametersFromRawObject(q);");
+        if(requestParams.requestBody != null) {
+            if(requestParams.requestBody.Type.Name.Equals(localConventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
+                writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name});");
+            else {
+                var spreadOperator = requestParams.requestBody.Type.AllTypes.First().IsCollection ? "..." : string.Empty;
+                writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable(this.{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.ContentType}\", {spreadOperator}{requestParams.requestBody.Name});");
             }
-            writer.WriteLine(");");
-            var isStream = localConventions.StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
-            var returnTypeWithoutCollectionSymbol = GetReturnTypeWithoutCollectionSymbol(codeElement, returnType);
-            var genericTypeForSendMethod = GetSendRequestMethodName(isVoid, isStream, codeElement.ReturnType.IsCollection, returnTypeWithoutCollectionSymbol);
-            var newFactoryParameter = GetTypeFactory(isVoid, isStream, returnTypeWithoutCollectionSymbol);
-            writer.WriteLine($"return this.requestAdapter?.{genericTypeForSendMethod}(requestInfo,{newFactoryParameter} responseHandler) ?? Promise.reject(new Error('http core is null'));");
         }
-        private string GetReturnTypeWithoutCollectionSymbol(CodeMethod codeElement, string fullTypeName) {
-            if(!codeElement.ReturnType.IsCollection) return fullTypeName;
-            var clone = codeElement.ReturnType.Clone() as CodeTypeBase;
-            clone.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.None;
-            return conventions.GetTypeString(clone, codeElement);
+        if(requestParams.options != null)
+            writer.WriteLine($"{requestParams.options.Name} && {RequestInfoVarName}.addRequestOptions(...{requestParams.options.Name});");
+        writer.WriteLine($"return {RequestInfoVarName};");
+    }
+    private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"this.{property.Name}";
+    private void WriteSerializerBody(bool inherits, CodeClass parentClass, LanguageWriter writer) {
+        var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
+        if(inherits)
+            writer.WriteLine("super.serialize(writer);");
+        foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
+            var isCollectionOfEnum = otherProp.Type is CodeType cType && cType.IsCollection && cType.TypeDefinition is CodeEnum;
+            var spreadOperator = isCollectionOfEnum ? "..." : string.Empty;
+            var otherPropName = otherProp.Name.ToFirstCharacterLowerCase();
+            var undefinedPrefix = isCollectionOfEnum ? $"this.{otherPropName} && " : string.Empty;
+            writer.WriteLine($"{undefinedPrefix}writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.SerializationName ?? otherPropName}\", {spreadOperator}this.{otherPropName});");
         }
-        private const string RequestInfoVarName = "requestInfo";
-        private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, CodeClass currentClass, LanguageWriter writer) {
-            if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
+        if(additionalDataProperty != null)
+            writer.WriteLine($"writer.writeAdditionalData(this.{additionalDataProperty.Name.ToFirstCharacterLowerCase()});");
+    }
+    private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer, bool isVoid) {
+        var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
+        var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
+        if (isDescriptionPresent || parametersWithDescription.Any()) {
+            writer.WriteLine(localConventions.DocCommentStart);
+            if(isDescriptionPresent)
+                writer.WriteLine($"{localConventions.DocCommentPrefix}{TypeScriptConventionService.RemoveInvalidDescriptionCharacters(code.Description)}");
+            foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
+                writer.WriteLine($"{localConventions.DocCommentPrefix}@param {paramWithDescription.Name} {TypeScriptConventionService.RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
             
-            var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
-            var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            writer.WriteLines($"const {RequestInfoVarName} = new RequestInformation();",
-                                $"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "''")};",
-                                $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "''")};",
-                                $"{RequestInfoVarName}.httpMethod = HttpMethod.{codeElement.HttpMethod.ToString().ToUpperInvariant()};");
-            if(requestParams.headers != null)
-                writer.WriteLine($"{requestParams.headers.Name} && {RequestInfoVarName}.setHeadersFromRawObject(h);");
-            if(requestParams.queryString != null)
-                writer.WriteLines($"{requestParams.queryString.Name} && {RequestInfoVarName}.setQueryStringParametersFromRawObject(q);");
-            if(requestParams.requestBody != null) {
-                if(requestParams.requestBody.Type.Name.Equals(localConventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
-                    writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name});");
-                else {
-                    var spreadOperator = requestParams.requestBody.Type.AllTypes.First().IsCollection ? "..." : string.Empty;
-                    writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable(this.{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.ContentType}\", {spreadOperator}{requestParams.requestBody.Name});");
-                }
-            }
-            if(requestParams.options != null)
-                writer.WriteLine($"{requestParams.options.Name} && {RequestInfoVarName}.addRequestOptions(...{requestParams.options.Name});");
-            writer.WriteLine($"return {RequestInfoVarName};");
+            if(!isVoid)
+                if(code.IsAsync)
+                    writer.WriteLine($"{localConventions.DocCommentPrefix}@returns a Promise of {code.ReturnType.Name.ToFirstCharacterUpperCase()}");
+                else
+                    writer.WriteLine($"{localConventions.DocCommentPrefix}@returns a {code.ReturnType.Name}");
+            writer.WriteLine(localConventions.DocCommentEnd);
         }
-        private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"this.{property.Name}";
-        private void WriteSerializerBody(bool inherits, CodeClass parentClass, LanguageWriter writer) {
-            var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
-            if(inherits)
-                writer.WriteLine("super.serialize(writer);");
-            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
-                var isCollectionOfEnum = otherProp.Type is CodeType cType && cType.IsCollection && cType.TypeDefinition is CodeEnum;
-                var spreadOperator = isCollectionOfEnum ? "..." : string.Empty;
-                var otherPropName = otherProp.Name.ToFirstCharacterLowerCase();
-                var undefinedPrefix = isCollectionOfEnum ? $"this.{otherPropName} && " : string.Empty;
-                writer.WriteLine($"{undefinedPrefix}writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.SerializationName ?? otherPropName}\", {spreadOperator}this.{otherPropName});");
-            }
-            if(additionalDataProperty != null)
-                writer.WriteLine($"writer.writeAdditionalData(this.{additionalDataProperty.Name.ToFirstCharacterLowerCase()});");
-        }
-        private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer, bool isVoid) {
-            var isDescriptionPresent = !string.IsNullOrEmpty(code.Description);
-            var parametersWithDescription = code.Parameters.Where(x => !string.IsNullOrEmpty(code.Description));
-            if (isDescriptionPresent || parametersWithDescription.Any()) {
-                writer.WriteLine(localConventions.DocCommentStart);
-                if(isDescriptionPresent)
-                    writer.WriteLine($"{localConventions.DocCommentPrefix}{TypeScriptConventionService.RemoveInvalidDescriptionCharacters(code.Description)}");
-                foreach(var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
-                    writer.WriteLine($"{localConventions.DocCommentPrefix}@param {paramWithDescription.Name} {TypeScriptConventionService.RemoveInvalidDescriptionCharacters(paramWithDescription.Description)}");
-                
-                if(!isVoid)
-                    if(code.IsAsync)
-                        writer.WriteLine($"{localConventions.DocCommentPrefix}@returns a Promise of {code.ReturnType.Name.ToFirstCharacterUpperCase()}");
-                    else
-                        writer.WriteLine($"{localConventions.DocCommentPrefix}@returns a {code.ReturnType.Name}");
-                writer.WriteLine(localConventions.DocCommentEnd);
-            }
-        }
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
-        private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool isVoid) {
-            var accessModifier = localConventions.GetAccessModifier(code.Access);
-            var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor);
-            var methodName = (code.MethodKind switch {
-                _ when code.IsAccessor => code.AccessedProperty?.Name,
-                _ when isConstructor => "constructor",
-                _ => code.Name,
-            })?.ToFirstCharacterLowerCase();
-            var asyncPrefix = code.IsAsync && code.MethodKind != CodeMethodKind.RequestExecutor ? " async ": string.Empty;
-            var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p=> localConventions.GetParameterSignature(p, code)).ToList());
-            var asyncReturnTypePrefix = code.IsAsync ? "Promise<": string.Empty;
-            var asyncReturnTypeSuffix = code.IsAsync ? ">": string.Empty;
-            var nullableSuffix = code.ReturnType.IsNullable && !isVoid ? " | undefined" : string.Empty;
-            var accessorPrefix = code.MethodKind switch {
-                    CodeMethodKind.Getter => "get ",
-                    CodeMethodKind.Setter => "set ",
-                    _ => string.Empty
-                };
-            var shouldHaveTypeSuffix = !code.IsAccessor && !isConstructor;
-            var returnTypeSuffix = shouldHaveTypeSuffix ? $" : {asyncReturnTypePrefix}{returnType}{nullableSuffix}{asyncReturnTypeSuffix}" : string.Empty;
-            writer.WriteLine($"{accessModifier} {accessorPrefix}{methodName}{asyncPrefix}({parameters}){returnTypeSuffix} {{");
-        }
-        private string GetDeserializationMethodName(CodeTypeBase propType) {
-            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-            var propertyType = localConventions.TranslateType(propType);
-            if(propType is CodeType currentType) {
-                if(currentType.TypeDefinition is CodeEnum currentEnum)
-                    return $"getEnumValue{(currentEnum.Flags || isCollection ? "s" : string.Empty)}<{currentEnum.Name.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})";
-                else if(isCollection)
-                    if(currentType.TypeDefinition == null)
-                        return $"getCollectionOfPrimitiveValues<{propertyType.ToFirstCharacterLowerCase()}>()";
-                    else
-                        return $"getCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})";
-            }
-            return propertyType switch
-            {
-                "string" or "boolean" or "number" or "Guid" or "Date" => $"get{propertyType.ToFirstCharacterUpperCase()}Value()",
-                _ => $"getObjectValue<{propertyType.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})",
+    }
+    private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+    private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool isVoid) {
+        var accessModifier = localConventions.GetAccessModifier(code.Access);
+        var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor);
+        var methodName = (code.MethodKind switch {
+            _ when code.IsAccessor => code.AccessedProperty?.Name,
+            _ when isConstructor => "constructor",
+            _ => code.Name,
+        })?.ToFirstCharacterLowerCase();
+        var asyncPrefix = code.IsAsync && code.MethodKind != CodeMethodKind.RequestExecutor ? " async ": string.Empty;
+        var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p=> localConventions.GetParameterSignature(p, code)).ToList());
+        var asyncReturnTypePrefix = code.IsAsync ? "Promise<": string.Empty;
+        var asyncReturnTypeSuffix = code.IsAsync ? ">": string.Empty;
+        var nullableSuffix = code.ReturnType.IsNullable && !isVoid ? " | undefined" : string.Empty;
+        var accessorPrefix = code.MethodKind switch {
+                CodeMethodKind.Getter => "get ",
+                CodeMethodKind.Setter => "set ",
+                _ => string.Empty
             };
+        var shouldHaveTypeSuffix = !code.IsAccessor && !isConstructor;
+        var returnTypeSuffix = shouldHaveTypeSuffix ? $" : {asyncReturnTypePrefix}{returnType}{nullableSuffix}{asyncReturnTypeSuffix}" : string.Empty;
+        writer.WriteLine($"{accessModifier} {accessorPrefix}{methodName}{asyncPrefix}({parameters}){returnTypeSuffix} {{");
+    }
+    private string GetDeserializationMethodName(CodeTypeBase propType) {
+        var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
+        var propertyType = localConventions.TranslateType(propType);
+        if(propType is CodeType currentType) {
+            if(currentType.TypeDefinition is CodeEnum currentEnum)
+                return $"getEnumValue{(currentEnum.Flags || isCollection ? "s" : string.Empty)}<{currentEnum.Name.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})";
+            else if(isCollection)
+                if(currentType.TypeDefinition == null)
+                    return $"getCollectionOfPrimitiveValues<{propertyType.ToFirstCharacterLowerCase()}>()";
+                else
+                    return $"getCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})";
         }
-        private string GetSerializationMethodName(CodeTypeBase propType) {
-            var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-            var propertyType = localConventions.TranslateType(propType);
-            if(propType is CodeType currentType) {
-                if(currentType.TypeDefinition is CodeEnum currentEnum)
-                    return $"writeEnumValue<{currentEnum.Name.ToFirstCharacterUpperCase()}>";
-                else if(isCollection)
-                    if(currentType.TypeDefinition == null)
-                        return $"writeCollectionOfPrimitiveValues<{propertyType.ToFirstCharacterLowerCase()}>";
-                    else
-                        return $"writeCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>";
-            }
-            return propertyType switch
-            {
-                "string" or "boolean" or "number" or "Guid" or "Date" => $"write{propertyType.ToFirstCharacterUpperCase()}Value",
-                _ => $"writeObjectValue<{propertyType.ToFirstCharacterUpperCase()}>",
-            };
+        return propertyType switch
+        {
+            "string" or "boolean" or "number" or "Guid" or "Date" or "DateOnly" or "TimeOnly" or "Duration" => $"get{propertyType.ToFirstCharacterUpperCase()}Value()",
+            _ => $"getObjectValue<{propertyType.ToFirstCharacterUpperCase()}>({propertyType.ToFirstCharacterUpperCase()})",
+        };
+    }
+    private string GetSerializationMethodName(CodeTypeBase propType) {
+        var isCollection = propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
+        var propertyType = localConventions.TranslateType(propType);
+        if(propType is CodeType currentType) {
+            if(currentType.TypeDefinition is CodeEnum currentEnum)
+                return $"writeEnumValue<{currentEnum.Name.ToFirstCharacterUpperCase()}>";
+            else if(isCollection)
+                if(currentType.TypeDefinition == null)
+                    return $"writeCollectionOfPrimitiveValues<{propertyType.ToFirstCharacterLowerCase()}>";
+                else
+                    return $"writeCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>";
         }
-        private string GetTypeFactory(bool isVoid, bool isStream, string returnType) {
-            if(isVoid) return string.Empty;
-            else if(isStream || conventions.IsPrimitiveType(returnType)) return $" \"{returnType}\",";
-            else return $" {returnType},";
+        return propertyType switch
+        {
+            "string" or "boolean" or "number" or "Guid" or "Date" or "DateOnly" or "TimeOnly" or "Duration" => $"write{propertyType.ToFirstCharacterUpperCase()}Value",
+            _ => $"writeObjectValue<{propertyType.ToFirstCharacterUpperCase()}>",
+        };
+    }
+    private string GetTypeFactory(bool isVoid, bool isStream, string returnType) {
+        if(isVoid) return string.Empty;
+        else if(isStream || conventions.IsPrimitiveType(returnType)) return $" \"{returnType}\",";
+        else return $" {returnType},";
+    }
+    private string GetSendRequestMethodName(bool isVoid, bool isStream, bool isCollection, string returnType) {
+        if(isVoid) return "sendNoResponseContentAsync";
+        else if(isCollection) {
+            if(conventions.IsPrimitiveType(returnType)) return $"sendCollectionOfPrimitiveAsync<{returnType}>";
+            else return $"sendCollectionAsync<{returnType}>";
         }
-        private string GetSendRequestMethodName(bool isVoid, bool isStream, bool isCollection, string returnType) {
-            if(isVoid) return "sendNoResponseContentAsync";
-            else if(isCollection) {
-                if(conventions.IsPrimitiveType(returnType)) return $"sendCollectionOfPrimitiveAsync<{returnType}>";
-                else return $"sendCollectionAsync<{returnType}>";
-            }
-            else if(isStream || conventions.IsPrimitiveType(returnType)) return $"sendPrimitiveAsync<{returnType}>";
-            else return $"sendAsync<{returnType}>";
-        }
+        else if(isStream || conventions.IsPrimitiveType(returnType)) return $"sendPrimitiveAsync<{returnType}>";
+        else return $"sendAsync<{returnType}>";
     }
 }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -4,125 +4,123 @@ using System.Linq;
 using Kiota.Builder.Extensions;
 using static Kiota.Builder.CodeTypeBase;
 
-namespace Kiota.Builder.Writers.TypeScript {
-    public class TypeScriptConventionService : CommonLanguageConventionService
+namespace Kiota.Builder.Writers.TypeScript;
+public class TypeScriptConventionService : CommonLanguageConventionService
+{
+    public TypeScriptConventionService(LanguageWriter languageWriter)
     {
-        public TypeScriptConventionService(LanguageWriter languageWriter)
-        {
-            writer = languageWriter;
-        }
-        private readonly LanguageWriter writer;
-        public override string StreamTypeName => "ReadableStream";
+        writer = languageWriter;
+    }
+    private readonly LanguageWriter writer;
+    public override string StreamTypeName => "ReadableStream";
 
-        public override string VoidTypeName => throw new System.NotImplementedException();
+    public override string VoidTypeName => throw new NotImplementedException();
 
-        public override string DocCommentPrefix => " * ";
-        public override string ParseNodeInterfaceName => "ParseNode";
-        internal string DocCommentStart = "/**";
-        internal string DocCommentEnd = " */";
-        #pragma warning disable CA1822 // Method should be static
-        internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default) {
-            var codePathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
-            var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
-            var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-            var urlTemplateParams = urlTemplateVarName ?? $"this.{pathParametersProperty.Name}";
-            writer.WriteLines($"return new {returnType}({urlTemplateParams}, this.{requestAdapterProp.Name}{codePathParametersSuffix});");
-        }
-        public override string TempDictionaryVarName => "urlTplParams";
-        internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
-            if(pathParametersType == null) return;
-            writer.WriteLine($"const {TempDictionaryVarName} = getPathParameters({pathParametersReference});");
-            if(parameters.Any())
-                writer.WriteLines(parameters.Select(p => 
-                    $"{p.Item3} && {TempDictionaryVarName}.set(\"{p.Item2}\", {p.Item3});"
-                ).ToArray());
-        }
-        #pragma warning restore CA1822 // Method should be static
-        public override string GetAccessModifier(AccessModifier access)
-        {
-            return access switch {
-                AccessModifier.Public => "public",
-                AccessModifier.Protected => "protected",
-                _ => "private",
-            };
-        }
+    public override string DocCommentPrefix => " * ";
+    public override string ParseNodeInterfaceName => "ParseNode";
+    internal string DocCommentStart = "/**";
+    internal string DocCommentEnd = " */";
+    #pragma warning disable CA1822 // Method should be static
+    internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string urlTemplateVarName = default, IEnumerable<CodeParameter> pathParameters = default) {
+        var codePathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
+        var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
+        var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
+        var urlTemplateParams = urlTemplateVarName ?? $"this.{pathParametersProperty.Name}";
+        writer.WriteLines($"return new {returnType}({urlTemplateParams}, this.{requestAdapterProp.Name}{codePathParametersSuffix});");
+    }
+    public override string TempDictionaryVarName => "urlTplParams";
+    internal void AddParametersAssignment(LanguageWriter writer, CodeTypeBase pathParametersType, string pathParametersReference, params (CodeTypeBase, string, string)[] parameters) {
+        if(pathParametersType == null) return;
+        writer.WriteLine($"const {TempDictionaryVarName} = getPathParameters({pathParametersReference});");
+        if(parameters.Any())
+            writer.WriteLines(parameters.Select(p => 
+                $"{p.Item3} && {TempDictionaryVarName}.set(\"{p.Item2}\", {p.Item3});"
+            ).ToArray());
+    }
+    #pragma warning restore CA1822 // Method should be static
+    public override string GetAccessModifier(AccessModifier access)
+    {
+        return access switch {
+            AccessModifier.Public => "public",
+            AccessModifier.Protected => "protected",
+            _ => "private",
+        };
+    }
 
-        public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
-        {
-            var defaultValueSuffiix = string.IsNullOrEmpty(parameter.DefaultValue) ? string.Empty : $" = {parameter.DefaultValue}";
-            return $"{parameter.Name.ToFirstCharacterLowerCase()}{(parameter.Optional && parameter.Type.IsNullable ? "?" : string.Empty)}: {GetTypeString(parameter.Type, targetElement)}{(parameter.Type.IsNullable ? " | undefined": string.Empty)}{defaultValueSuffiix}";
-        }
-        public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true) {
-            if(code is null)
-                return null;
-            var collectionSuffix = code.CollectionKind == CodeTypeCollectionKind.None && includeCollectionInformation ? string.Empty : "[]";
-            if(code is CodeUnionType currentUnion && currentUnion.Types.Any())
-                return currentUnion.Types.Select(x => GetTypeString(x, targetElement)).Aggregate((x, y) => $"{x} | {y}") + collectionSuffix;
-            else if(code is CodeType currentType) {
-                var typeName = GetTypeAlias(currentType, targetElement) ?? TranslateType(currentType);
-                if (code.ActionOf)
-                    return WriteInlineDeclaration(currentType, targetElement);
-                else
-                    return $"{typeName}{collectionSuffix}";
-            }
-            else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
-        }
-        private static string GetTypeAlias(CodeType targetType, CodeElement targetElement) {
-            var parentClass = targetElement.GetImmediateParentOfType<CodeClass>();
-            if(parentClass != null && parentClass.StartBlock is CodeClass.Declaration currentDeclaration) {
-                var aliasedUsing = currentDeclaration.Usings
-                                                    .FirstOrDefault(x => !x.IsExternal &&
-                                                                    x.Declaration.TypeDefinition == targetType.TypeDefinition &&
-                                                                    !string.IsNullOrEmpty(x.Alias));
-                return aliasedUsing?.Alias;
-            }
+    public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement)
+    {
+        var defaultValueSuffiix = string.IsNullOrEmpty(parameter.DefaultValue) ? string.Empty : $" = {parameter.DefaultValue}";
+        return $"{parameter.Name.ToFirstCharacterLowerCase()}{(parameter.Optional && parameter.Type.IsNullable ? "?" : string.Empty)}: {GetTypeString(parameter.Type, targetElement)}{(parameter.Type.IsNullable ? " | undefined": string.Empty)}{defaultValueSuffiix}";
+    }
+    public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true) {
+        if(code is null)
             return null;
-        }
-        private string WriteInlineDeclaration(CodeType currentType, CodeElement targetElement) {
-            writer.IncreaseIndent(4);
-            var childElements = (currentType?.TypeDefinition as CodeClass)
-                                        ?.Properties
-                                        ?.OrderBy(x => x.Name)
-                                        ?.Select(x => $"{x.Name}?: {GetTypeString(x.Type, targetElement)}");
-            var innerDeclaration = childElements?.Any() ?? false ? 
-                                            LanguageWriter.NewLine +
-                                            writer.GetIndent() +
-                                            childElements
-                                            .Aggregate((x, y) => $"{x};{LanguageWriter.NewLine}{writer.GetIndent()}{y}")
-                                            .Replace(';', ',') +
-                                            LanguageWriter.NewLine +
-                                            writer.GetIndent()
-                                        : string.Empty;
-            writer.DecreaseIndent();
-            if(string.IsNullOrEmpty(innerDeclaration))
-                return "object";
+        var collectionSuffix = code.CollectionKind == CodeTypeCollectionKind.None && includeCollectionInformation ? string.Empty : "[]";
+        if(code is CodeUnionType currentUnion && currentUnion.Types.Any())
+            return currentUnion.Types.Select(x => GetTypeString(x, targetElement)).Aggregate((x, y) => $"{x} | {y}") + collectionSuffix;
+        else if(code is CodeType currentType) {
+            var typeName = GetTypeAlias(currentType, targetElement) ?? TranslateType(currentType);
+            if (code.ActionOf)
+                return WriteInlineDeclaration(currentType, targetElement);
             else
-                return $"{{{innerDeclaration}}}";
+                return $"{typeName}{collectionSuffix}";
         }
+        else throw new InvalidOperationException($"type of type {code.GetType()} is unknown");
+    }
+    private static string GetTypeAlias(CodeType targetType, CodeElement targetElement) {
+        var parentClass = targetElement.GetImmediateParentOfType<CodeClass>();
+        if(parentClass != null && parentClass.StartBlock is CodeClass.Declaration currentDeclaration) {
+            var aliasedUsing = currentDeclaration.Usings
+                                                .FirstOrDefault(x => !x.IsExternal &&
+                                                                x.Declaration.TypeDefinition == targetType.TypeDefinition &&
+                                                                !string.IsNullOrEmpty(x.Alias));
+            return aliasedUsing?.Alias;
+        }
+        return null;
+    }
+    private string WriteInlineDeclaration(CodeType currentType, CodeElement targetElement) {
+        writer.IncreaseIndent(4);
+        var childElements = (currentType?.TypeDefinition as CodeClass)
+                                    ?.Properties
+                                    ?.OrderBy(x => x.Name)
+                                    ?.Select(x => $"{x.Name}?: {GetTypeString(x.Type, targetElement)}");
+        var innerDeclaration = childElements?.Any() ?? false ? 
+                                        LanguageWriter.NewLine +
+                                        writer.GetIndent() +
+                                        childElements
+                                        .Aggregate((x, y) => $"{x};{LanguageWriter.NewLine}{writer.GetIndent()}{y}")
+                                        .Replace(';', ',') +
+                                        LanguageWriter.NewLine +
+                                        writer.GetIndent()
+                                    : string.Empty;
+        writer.DecreaseIndent();
+        if(string.IsNullOrEmpty(innerDeclaration))
+            return "object";
+        else
+            return $"{{{innerDeclaration}}}";
+    }
 
-        public override string TranslateType(CodeType type)
-        {
-            return type.Name switch  {
-                "integer" or "int64" or "float" or "double" => "number",
-                "binary" => "string",
-                "DateTimeOffset" => "Date",
-                "String" or "Object" or "Boolean" or "Void" or "string" or "object" or "boolean" or "void" => type.Name.ToFirstCharacterLowerCase(), // little casing hack
-                _ => type.Name.ToFirstCharacterUpperCase() ?? "object",
-            };
-        }
-        #pragma warning disable CA1822 // Method should be static
-        public bool IsPrimitiveType(string typeName) {
-            return typeName switch {
-                "number" or "string" or "byte[]" or "boolean" or "void" => true,
-                _ => false,
-            };
-        }
-        #pragma warning restore CA1822 // Method should be static
-        internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
-        public override void WriteShortDescription(string description, LanguageWriter writer)
-        {
-            if(!string.IsNullOrEmpty(description))
-                writer.WriteLine($"{DocCommentStart} {RemoveInvalidDescriptionCharacters(description)} {DocCommentEnd}");
-        }
+    public override string TranslateType(CodeType type)
+    {
+        return type.Name switch  {
+            "integer" or "int64" or "float" or "double" => "number",
+            "binary" => "string",
+            "String" or "Object" or "Boolean" or "Void" or "string" or "object" or "boolean" or "void" => type.Name.ToFirstCharacterLowerCase(), // little casing hack
+            _ => type.Name.ToFirstCharacterUpperCase() ?? "object",
+        };
+    }
+    #pragma warning disable CA1822 // Method should be static
+    public bool IsPrimitiveType(string typeName) {
+        return typeName switch {
+            "number" or "string" or "byte[]" or "boolean" or "void" => true,
+            _ => false,
+        };
+    }
+    #pragma warning restore CA1822 // Method should be static
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription?.Replace("\\", "/");
+    public override void WriteShortDescription(string description, LanguageWriter writer)
+    {
+        if(!string.IsNullOrEmpty(description))
+            writer.WriteLine($"{DocCommentStart} {RemoveInvalidDescriptionCharacters(description)} {DocCommentEnd}");
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -10,114 +10,112 @@ using System.Threading.Tasks;
 using System.IO;
 using System;
 
-namespace Kiota.Builder.Tests
+namespace Kiota.Builder.Tests;
+public class KiotaBuilderTests
 {
-    public class KiotaBuilderTests
+    [Fact]
+    public async Task ThrowsOnMissingServer() {
+        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+        await File.WriteAllLinesAsync(tempFilePath, new string[] {"openapi: 3.0.0", "info:", "  title: \"Todo API\"", "  version: \"1.0.0\""});
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.GenerateSDK());
+        File.Delete(tempFilePath);
+    }
+    [Fact]
+    public async Task DoesntThrowOnMissingServerForV2() {
+        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+        await File.WriteAllLinesAsync(tempFilePath, new string[] {"swagger: 2.0", "title: \"Todo API\"", "version: \"1.0.0\"", "host: mytodos.doesntexit", "basePath: v2", "schemes:", " - https"," - http"});
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
+        await builder.GenerateSDK();
+        File.Delete(tempFilePath);
+    }
+    [Fact]
+    public void Single_root_node_creates_single_request_builder_class()
     {
-        [Fact]
-        public async Task ThrowsOnMissingServer() {
-            var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
-            await File.WriteAllLinesAsync(tempFilePath, new string[] {"openapi: 3.0.0", "info:", "  title: \"Todo API\"", "  version: \"1.0.0\""});
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
-            await Assert.ThrowsAsync<InvalidOperationException>(() => builder.GenerateSDK());
-            File.Delete(tempFilePath);
-        }
-        [Fact]
-        public async Task DoesntThrowOnMissingServerForV2() {
-            var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
-            await File.WriteAllLinesAsync(tempFilePath, new string[] {"swagger: 2.0", "title: \"Todo API\"", "version: \"1.0.0\"", "host: mytodos.doesntexit", "basePath: v2", "schemes:", " - https"," - http"});
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
-            await builder.GenerateSDK();
-            File.Delete(tempFilePath);
-        }
-        [Fact]
-        public void Single_root_node_creates_single_request_builder_class()
-        {
-            var node = OpenApiUrlTreeNode.Create();
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            var codeModel = builder.CreateSourceModel(node);
+        var node = OpenApiUrlTreeNode.Create();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
 
-            Assert.Single(codeModel.GetChildElements(true));
-        }
-        [Fact]
-        public void Single_path_with_get_collection()
-        {
-            var node = OpenApiUrlTreeNode.Create();
-            node.Attach("tasks", new OpenApiPathItem() {
-                Operations = {
-                    [OperationType.Get] = new OpenApiOperation() { 
-                        Responses = new OpenApiResponses
+        Assert.Single(codeModel.GetChildElements(true));
+    }
+    [Fact]
+    public void Single_path_with_get_collection()
+    {
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem() {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation() { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse()
                         {
-                            ["200"] = new OpenApiResponse()
+                            Content =
                             {
-                                Content =
+                                ["application/json"] = new OpenApiMediaType()
                                 {
-                                    ["application/json"] = new OpenApiMediaType()
+                                    Schema = new OpenApiSchema
                                     {
-                                        Schema = new OpenApiSchema
+                                        Type = "array",
+                                        Items = new OpenApiSchema
                                         {
-                                            Type = "array",
-                                            Items = new OpenApiSchema
-                                            {
-                                                Type = "int"
-                                            }
+                                            Type = "int"
                                         }
                                     }
                                 }
                             }
                         }
                     }
-                } 
-            }, "default");
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            var codeModel = builder.CreateSourceModel(node);
+                }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
 
-            var rootNamespace = codeModel.GetChildElements(true).Single();
-            var rootBuilder = rootNamespace.GetChildElements(true).OfType<CodeClass>().Single(e => e.Name == "Graph");
-            var tasksProperty = rootBuilder.Properties.Single(e => e.Name.Equals("Tasks", StringComparison.OrdinalIgnoreCase));
-            var tasksRequestBuilder = tasksProperty.Type as CodeType;
-            Assert.NotNull(tasksRequestBuilder);
-            var getMethod = (tasksRequestBuilder.TypeDefinition as CodeClass).Methods.Single(e => e.Name == "Get");
-            var returnType = getMethod.ReturnType;
-            Assert.Equal(CodeTypeBase.CodeTypeCollectionKind.Array, returnType.CollectionKind);
-        }
-        [Fact]
-        public void OData_doubles_as_any_of(){
-            var node = OpenApiUrlTreeNode.Create();
-            node.Attach("tasks", new OpenApiPathItem() {
-                Operations = {
-                    [OperationType.Get] = new OpenApiOperation() { 
-                        Responses = new OpenApiResponses
+        var rootNamespace = codeModel.GetChildElements(true).Single();
+        var rootBuilder = rootNamespace.GetChildElements(true).OfType<CodeClass>().Single(e => e.Name == "Graph");
+        var tasksProperty = rootBuilder.Properties.Single(e => e.Name.Equals("Tasks", StringComparison.OrdinalIgnoreCase));
+        var tasksRequestBuilder = tasksProperty.Type as CodeType;
+        Assert.NotNull(tasksRequestBuilder);
+        var getMethod = (tasksRequestBuilder.TypeDefinition as CodeClass).Methods.Single(e => e.Name == "Get");
+        var returnType = getMethod.ReturnType;
+        Assert.Equal(CodeTypeBase.CodeTypeCollectionKind.Array, returnType.CollectionKind);
+    }
+    [Fact]
+    public void OData_doubles_as_any_of(){
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem() {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation() { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse()
                         {
-                            ["200"] = new OpenApiResponse()
+                            Content =
                             {
-                                Content =
+                                ["application/json"] = new OpenApiMediaType()
                                 {
-                                    ["application/json"] = new OpenApiMediaType()
+                                    Schema = new OpenApiSchema
                                     {
-                                        Schema = new OpenApiSchema
-                                        {
-                                            Type = "object",
-                                            Properties = new Dictionary<string, OpenApiSchema> {
-                                                {
-                                                    "progress", new OpenApiSchema{
-                                                        AnyOf = new List<OpenApiSchema>{
-                                                            new OpenApiSchema{
-                                                                Type = "number"
-                                                            },
-                                                            new OpenApiSchema{
-                                                                Type = "string"
-                                                            },
-                                                            new OpenApiSchema {
-                                                                Enum = new List<IOpenApiAny> { new OpenApiString("-INF"), new OpenApiString("INF"), new OpenApiString("NaN") }
-                                                            }
+                                        Type = "object",
+                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                            {
+                                                "progress", new OpenApiSchema{
+                                                    AnyOf = new List<OpenApiSchema>{
+                                                        new OpenApiSchema{
+                                                            Type = "number"
                                                         },
-                                                        Format = "double"
-                                                    }
+                                                        new OpenApiSchema{
+                                                            Type = "string"
+                                                        },
+                                                        new OpenApiSchema {
+                                                            Enum = new List<IOpenApiAny> { new OpenApiString("-INF"), new OpenApiString("INF"), new OpenApiString("NaN") }
+                                                        }
+                                                    },
+                                                    Format = "double"
                                                 }
                                             }
                                         }
@@ -126,52 +124,52 @@ namespace Kiota.Builder.Tests
                             }
                         }
                     }
-                } 
-            }, "default");
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            var codeModel = builder.CreateSourceModel(node);
-            var progressProp = codeModel.FindChildByName<CodeProperty>("progress", true);
-            Assert.Equal("double", progressProp.Type.Name);
-        }
-        [Fact]
-        public void Object_Arrays_are_supported() {
-            var userSchema = new OpenApiSchema {
-                Type = "object",
-                Properties = new Dictionary<string, OpenApiSchema> {
-                    {
-                        "id", new OpenApiSchema {
-                            Type = "string"
-                        }
-                    },
-                    {
-                        "displayName", new OpenApiSchema {
-                            Type = "string"
-                        }
+                }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var progressProp = codeModel.FindChildByName<CodeProperty>("progress", true);
+        Assert.Equal("double", progressProp.Type.Name);
+    }
+    [Fact]
+    public void Object_Arrays_are_supported() {
+        var userSchema = new OpenApiSchema {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema> {
+                {
+                    "id", new OpenApiSchema {
+                        Type = "string"
                     }
                 },
-                Reference = new OpenApiReference() {
-                    Id = "#/components/schemas/microsoft.graph.user"
-                },
-                UnresolvedReference = false
-            };
-            var document = new OpenApiDocument() {
-                Paths = new OpenApiPaths() {
-                    ["users/{id}"] = new OpenApiPathItem() {
-                        Operations = {
-                            [OperationType.Get] = new OpenApiOperation() {
-                                Responses = new OpenApiResponses {
-                                    ["200"] = new OpenApiResponse() {
-                                        Content = {
-                                            ["application/json"] = new OpenApiMediaType() {
-                                                Schema = new OpenApiSchema {
-                                                    Type = "object",
-                                                    Properties = new Dictionary<string, OpenApiSchema> {
-                                                        {
-                                                            "value", new OpenApiSchema {
-                                                                Type = "array",
-                                                                Items = userSchema
-                                                            }
+                {
+                    "displayName", new OpenApiSchema {
+                        Type = "string"
+                    }
+                }
+            },
+            Reference = new OpenApiReference() {
+                Id = "#/components/schemas/microsoft.graph.user"
+            },
+            UnresolvedReference = false
+        };
+        var document = new OpenApiDocument() {
+            Paths = new OpenApiPaths() {
+                ["users/{id}"] = new OpenApiPathItem() {
+                    Operations = {
+                        [OperationType.Get] = new OpenApiOperation() {
+                            Responses = new OpenApiResponses {
+                                ["200"] = new OpenApiResponse() {
+                                    Content = {
+                                        ["application/json"] = new OpenApiMediaType() {
+                                            Schema = new OpenApiSchema {
+                                                Type = "object",
+                                                Properties = new Dictionary<string, OpenApiSchema> {
+                                                    {
+                                                        "value", new OpenApiSchema {
+                                                            Type = "array",
+                                                            Items = userSchema
                                                         }
                                                     }
                                                 }
@@ -181,95 +179,95 @@ namespace Kiota.Builder.Tests
                                 }
                             }
                         }
-                    },
+                    }
                 },
-                Components = new OpenApiComponents() {
-                    Schemas = new Dictionary<string, OpenApiSchema> {
-                        {
-                            "microsoft.graph.user", userSchema
+            },
+            Components = new OpenApiComponents() {
+                Schemas = new Dictionary<string, OpenApiSchema> {
+                    {
+                        "microsoft.graph.user", userSchema
+                    }
+                }
+            }
+        };
+        var node = OpenApiUrlTreeNode.Create(document, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        builder.CreateUriSpace(document);//needed so the component index exists
+        var codeModel = builder.CreateSourceModel(node);
+        var userClass = codeModel.FindNamespaceByName("ApiSdk.models").FindChildByName<CodeClass>("user");
+        Assert.NotNull(userClass);
+    }
+    [Fact]
+    public void Supports_Path_Parameters() {
+        var resourceActionSchema = new OpenApiSchema {
+            Type = "object",
+            Title = "resourceAction",
+            Properties = new Dictionary<string, OpenApiSchema> {
+                {
+                    "allowedResourceActions", new OpenApiSchema {
+                        Type = "array",
+                        Items = new OpenApiSchema {
+                            Type = "string"
+                        }
+                    }
+                },
+                {
+                    "notAllowedResourceActions", new OpenApiSchema {
+                        Type = "array",
+                        Items = new OpenApiSchema {
+                            Type = "string"
                         }
                     }
                 }
-            };
-            var node = OpenApiUrlTreeNode.Create(document, "default");
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            builder.CreateUriSpace(document);//needed so the component index exists
-            var codeModel = builder.CreateSourceModel(node);
-            var userClass = codeModel.FindNamespaceByName("ApiSdk.models").FindChildByName<CodeClass>("user");
-            Assert.NotNull(userClass);
-        }
-        [Fact]
-        public void Supports_Path_Parameters() {
-            var resourceActionSchema = new OpenApiSchema {
-                Type = "object",
-                Title = "resourceAction",
-                Properties = new Dictionary<string, OpenApiSchema> {
-                    {
-                        "allowedResourceActions", new OpenApiSchema {
-                            Type = "array",
-                            Items = new OpenApiSchema {
+            },
+            Reference = new OpenApiReference() {
+                Id = "#/components/schemas/microsoft.graph.resourceAction"
+            },
+            UnresolvedReference = false
+        };
+        var permissionSchema = new OpenApiSchema {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema> {
+                {
+                    "resourceActions", new OpenApiSchema {
+                        Type = "array",
+                        Items = new OpenApiSchema {
+                            AnyOf = new List<OpenApiSchema> {
+                                resourceActionSchema,
+                            }
+                        }
+                    }
+                }
+            },
+            Reference = new OpenApiReference() {
+                Id = "#/components/schemas/microsoft.graph.rolePermission"
+            },
+            UnresolvedReference = false
+        };
+        var document = new OpenApiDocument() {
+            Paths = new OpenApiPaths() {
+                ["/deviceManagement/microsoft.graph.getEffectivePermissions(scope='{scope}')"] = new OpenApiPathItem() {
+                    Parameters = {
+                        new OpenApiParameter() {
+                            Name = "scope",
+                            In = ParameterLocation.Path,
+                            Required = true,
+                            Schema = new OpenApiSchema {
                                 Type = "string"
                             }
                         }
                     },
-                    {
-                        "notAllowedResourceActions", new OpenApiSchema {
-                            Type = "array",
-                            Items = new OpenApiSchema {
-                                Type = "string"
-                            }
-                        }
-                    }
-                },
-                Reference = new OpenApiReference() {
-                    Id = "#/components/schemas/microsoft.graph.resourceAction"
-                },
-                UnresolvedReference = false
-            };
-            var permissionSchema = new OpenApiSchema {
-                Type = "object",
-                Properties = new Dictionary<string, OpenApiSchema> {
-                    {
-                        "resourceActions", new OpenApiSchema {
-                            Type = "array",
-                            Items = new OpenApiSchema {
-                                AnyOf = new List<OpenApiSchema> {
-                                    resourceActionSchema,
-                                }
-                            }
-                        }
-                    }
-                },
-                Reference = new OpenApiReference() {
-                    Id = "#/components/schemas/microsoft.graph.rolePermission"
-                },
-                UnresolvedReference = false
-            };
-            var document = new OpenApiDocument() {
-                Paths = new OpenApiPaths() {
-                    ["/deviceManagement/microsoft.graph.getEffectivePermissions(scope='{scope}')"] = new OpenApiPathItem() {
-                        Parameters = {
-                            new OpenApiParameter() {
-                                Name = "scope",
-                                In = ParameterLocation.Path,
-                                Required = true,
-                                Schema = new OpenApiSchema {
-                                    Type = "string"
-                                }
-                            }
-                        },
-                        Operations = {
-                            [OperationType.Get] = new OpenApiOperation() {
-                                Responses = new OpenApiResponses {
-                                    ["200"] = new OpenApiResponse() {
-                                        Content = {
-                                            ["application/json"] = new OpenApiMediaType() {
-                                                Schema = new OpenApiSchema {
-                                                    Type = "array",
-                                                    AnyOf = new List<OpenApiSchema> {
-                                                        permissionSchema,
-                                                    }
+                    Operations = {
+                        [OperationType.Get] = new OpenApiOperation() {
+                            Responses = new OpenApiResponses {
+                                ["200"] = new OpenApiResponse() {
+                                    Content = {
+                                        ["application/json"] = new OpenApiMediaType() {
+                                            Schema = new OpenApiSchema {
+                                                Type = "array",
+                                                AnyOf = new List<OpenApiSchema> {
+                                                    permissionSchema,
                                                 }
                                             }
                                         }
@@ -277,83 +275,83 @@ namespace Kiota.Builder.Tests
                                 }
                             }
                         }
-                    },
+                    }
                 },
-                Components = new OpenApiComponents() {
-                    Schemas = new Dictionary<string, OpenApiSchema> {
-                        { "microsoft.graph.rolePermission", permissionSchema },
-                        { "microsoft.graph.resourceAction", resourceActionSchema },
+            },
+            Components = new OpenApiComponents() {
+                Schemas = new Dictionary<string, OpenApiSchema> {
+                    { "microsoft.graph.rolePermission", permissionSchema },
+                    { "microsoft.graph.resourceAction", resourceActionSchema },
+                }
+            }
+        };
+        var node = OpenApiUrlTreeNode.Create(document, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        builder.CreateUriSpace(document);//needed so the component index exists
+        var codeModel = builder.CreateSourceModel(node);
+        var deviceManagementNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement");
+        Assert.NotNull(deviceManagementNS);
+        var deviceManagementRequestBuilder = deviceManagementNS.FindChildByName<CodeClass>("DeviceManagementRequestBuilder");
+        Assert.NotNull(deviceManagementRequestBuilder);
+        var getEffectivePermissionsMethod = deviceManagementRequestBuilder.FindChildByName<CodeMethod>("getEffectivePermissionsWithScope");
+        Assert.NotNull(getEffectivePermissionsMethod);
+        Assert.Single(getEffectivePermissionsMethod.Parameters);
+        var getEffectivePermissionsNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement.getEffectivePermissionsWithScope");
+        Assert.NotNull(getEffectivePermissionsNS);
+        var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("GetEffectivePermissionsWithScopeRequestBuilder");
+        Assert.NotNull(getEffectivePermissionsRequestBuilder);
+        var constructorMethod = getEffectivePermissionsRequestBuilder.FindChildByName<CodeMethod>("constructor");
+        Assert.NotNull(constructorMethod);
+        Assert.Single(constructorMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path)));
+    }
+    [Fact]
+    public void Inline_Property_Inheritance_Is_Supported() {
+        var resourceSchema = new OpenApiSchema {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema> {
+                {
+                    "info", new OpenApiSchema {
+                        Type = "string",
                     }
                 }
-            };
-            var node = OpenApiUrlTreeNode.Create(document, "default");
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            builder.CreateUriSpace(document);//needed so the component index exists
-            var codeModel = builder.CreateSourceModel(node);
-            var deviceManagementNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement");
-            Assert.NotNull(deviceManagementNS);
-            var deviceManagementRequestBuilder = deviceManagementNS.FindChildByName<CodeClass>("DeviceManagementRequestBuilder");
-            Assert.NotNull(deviceManagementRequestBuilder);
-            var getEffectivePermissionsMethod = deviceManagementRequestBuilder.FindChildByName<CodeMethod>("getEffectivePermissionsWithScope");
-            Assert.NotNull(getEffectivePermissionsMethod);
-            Assert.Single(getEffectivePermissionsMethod.Parameters);
-            var getEffectivePermissionsNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement.getEffectivePermissionsWithScope");
-            Assert.NotNull(getEffectivePermissionsNS);
-            var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("GetEffectivePermissionsWithScopeRequestBuilder");
-            Assert.NotNull(getEffectivePermissionsRequestBuilder);
-            var constructorMethod = getEffectivePermissionsRequestBuilder.FindChildByName<CodeMethod>("constructor");
-            Assert.NotNull(constructorMethod);
-            Assert.Single(constructorMethod.Parameters.Where(x => x.IsOfKind(CodeParameterKind.Path)));
-        }
-        [Fact]
-        public void Inline_Property_Inheritance_Is_Supported() {
-            var resourceSchema = new OpenApiSchema {
-                Type = "object",
-                Properties = new Dictionary<string, OpenApiSchema> {
-                    {
-                        "info", new OpenApiSchema {
-                            Type = "string",
-                        }
-                    }
-                },
-                Reference = new OpenApiReference() {
-                    Id = "resource"
-                },
-                UnresolvedReference = false
-            };
-            var document = new OpenApiDocument() {
-                Paths = new OpenApiPaths() {
-                    ["resource/{id}"] = new OpenApiPathItem() {
-                        Operations = {
-                            [OperationType.Get] = new OpenApiOperation() {
-                                Responses = new OpenApiResponses {
-                                    ["200"] = new OpenApiResponse() {
-                                        Content = {
-                                            ["application/json"] = new OpenApiMediaType() {
-                                                Schema = new OpenApiSchema {
-                                                    Type = "object",
-                                                    Properties = new Dictionary<string, OpenApiSchema> {
-                                                        {
-                                                            "derivedResource", new OpenApiSchema {
-                                                                Type = "object",
-                                                                Properties = new Dictionary<string, OpenApiSchema> {
-                                                                    {
-                                                                        "info", new OpenApiSchema {
-                                                                            Type = "object",
-                                                                            Properties = new Dictionary<string, OpenApiSchema> {
-                                                                                {
-                                                                                    "title", new OpenApiSchema {
-                                                                                        Type = "string",
-                                                                                    }
+            },
+            Reference = new OpenApiReference() {
+                Id = "resource"
+            },
+            UnresolvedReference = false
+        };
+        var document = new OpenApiDocument() {
+            Paths = new OpenApiPaths() {
+                ["resource/{id}"] = new OpenApiPathItem() {
+                    Operations = {
+                        [OperationType.Get] = new OpenApiOperation() {
+                            Responses = new OpenApiResponses {
+                                ["200"] = new OpenApiResponse() {
+                                    Content = {
+                                        ["application/json"] = new OpenApiMediaType() {
+                                            Schema = new OpenApiSchema {
+                                                Type = "object",
+                                                Properties = new Dictionary<string, OpenApiSchema> {
+                                                    {
+                                                        "derivedResource", new OpenApiSchema {
+                                                            Type = "object",
+                                                            Properties = new Dictionary<string, OpenApiSchema> {
+                                                                {
+                                                                    "info", new OpenApiSchema {
+                                                                        Type = "object",
+                                                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                                                            {
+                                                                                "title", new OpenApiSchema {
+                                                                                    Type = "string",
                                                                                 }
                                                                             }
                                                                         }
                                                                     }
-                                                                },
-                                                                AllOf = new List<OpenApiSchema> {
-                                                                    resourceSchema,
                                                                 }
+                                                            },
+                                                            AllOf = new List<OpenApiSchema> {
+                                                                resourceSchema,
                                                             }
                                                         }
                                                     }
@@ -364,33 +362,150 @@ namespace Kiota.Builder.Tests
                                 }
                             }
                         }
-                    },
+                    }
                 },
-                Components = new OpenApiComponents() {
-                    Schemas = new Dictionary<string, OpenApiSchema> {
+            },
+            Components = new OpenApiComponents() {
+                Schemas = new Dictionary<string, OpenApiSchema> {
+                    {
+                        "#/components/resource", resourceSchema
+                    }
+                }
+            }
+        };
+        var node = OpenApiUrlTreeNode.Create(document, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        builder.CreateUriSpace(document);//needed so the component index exists
+        var codeModel = builder.CreateSourceModel(node);
+        var resourceClass = codeModel.FindNamespaceByName("ApiSdk.models").FindChildByName<CodeClass>("resource");
+        var responseClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse");
+        var derivedResourceClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse_derivedResource");
+        var derivedResourceInfoClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse_derivedResource_info");
+
+        
+        Assert.NotNull(resourceClass);
+        Assert.NotNull(derivedResourceClass);
+        Assert.NotNull(derivedResourceClass.StartBlock);
+        Assert.Equal((derivedResourceClass.StartBlock as CodeClass.Declaration).Inherits.TypeDefinition, resourceClass);
+        Assert.NotNull(derivedResourceInfoClass);
+        Assert.NotNull(responseClass);
+    }
+    [Fact]
+    public void MapsTime(){
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem() {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation() { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse()
                         {
-                            "#/components/resource", resourceSchema
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType()
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "object",
+                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                            {
+                                                "progress", new OpenApiSchema{
+                                                    Type = "string",
+                                                    Format = "time"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            };
-            var node = OpenApiUrlTreeNode.Create(document, "default");
-            var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-            var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
-            builder.CreateUriSpace(document);//needed so the component index exists
-            var codeModel = builder.CreateSourceModel(node);
-            var resourceClass = codeModel.FindNamespaceByName("ApiSdk.models").FindChildByName<CodeClass>("resource");
-            var responseClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse");
-            var derivedResourceClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse_derivedResource");
-            var derivedResourceInfoClass = codeModel.FindNamespaceByName("ApiSdk.resource.item").FindChildByName<CodeClass>("WithResponse_derivedResource_info");
-
-            
-            Assert.NotNull(resourceClass);
-            Assert.NotNull(derivedResourceClass);
-            Assert.NotNull(derivedResourceClass.StartBlock);
-            Assert.Equal((derivedResourceClass.StartBlock as CodeClass.Declaration).Inherits.TypeDefinition, resourceClass);
-            Assert.NotNull(derivedResourceInfoClass);
-            Assert.NotNull(responseClass);
-        }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var progressProp = codeModel.FindChildByName<CodeProperty>("progress", true);
+        Assert.Equal("TimeOnly", progressProp.Type.Name);
+    }
+    [Fact]
+    public void MapsDate(){
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem() {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation() { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse()
+                        {
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType()
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "object",
+                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                            {
+                                                "progress", new OpenApiSchema{
+                                                    Type = "string",
+                                                    Format = "date"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var progressProp = codeModel.FindChildByName<CodeProperty>("progress", true);
+        Assert.Equal("DateOnly", progressProp.Type.Name);
+    }
+    [Fact]
+    public void MapsDuration(){
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem() {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation() { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse()
+                        {
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType()
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "object",
+                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                            {
+                                                "progress", new OpenApiSchema{
+                                                    Type = "string",
+                                                    Format = "duration"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var progressProp = codeModel.FindChildByName<CodeProperty>("progress", true);
+        Assert.Equal("TimeSpan", progressProp.Type.Name);
     }
 }

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -145,6 +145,46 @@ namespace Kiota.Builder.Refiners.Tests {
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
             Assert.Equal(serializationName, propToAdd.SerializationName);
         }
+        [Fact]
+        public void ReplacesDateOnlyByNativeType()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "method",
+                ReturnType = new CodeType
+                {
+                    Name = "DateOnly"
+                },
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+            Assert.NotEmpty(model.StartBlock.Usings);
+            Assert.Equal("Date", method.ReturnType.Name);
+        }
+        [Fact]
+        public void ReplacesTimeOnlyByNativeType()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "method",
+                ReturnType = new CodeType
+                {
+                    Name = "TimeOnly"
+                },
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+            Assert.NotEmpty(model.StartBlock.Usings);
+            Assert.Equal("Time", method.ReturnType.Name);
+        }
         #endregion
     }
 }

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -1,211 +1,274 @@
 ﻿using System.Linq;
 using Xunit;
 
-namespace Kiota.Builder.Refiners.Tests {
-    public class GoLanguageRefinerTests {
-        private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
-        #region CommonLangRefinerTests
-        [Fact]
-        public void DoesNotKeepCancellationParametersInRequestExecutors()
+namespace Kiota.Builder.Refiners.Tests;
+public class GoLanguageRefinerTests {
+    private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
+    #region CommonLangRefinerTests
+    [Fact]
+    public void DoesNotKeepCancellationParametersInRequestExecutors()
+    {
+        var model = root.AddClass(new CodeClass
         {
-            var model = root.AddClass(new CodeClass
+            Name = "model",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        var method = model.AddMethod(new CodeMethod
+        {
+            Name = "getMethod",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType
             {
-                Name = "model",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            var method = model.AddMethod(new CodeMethod
-            {
-                Name = "getMethod",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType
-                {
-                    Name = "string"
-                }
-            }).First();
-            var cancellationParam = new CodeParameter
-            {
-                Name = "cancelletionToken",
-                Optional = true,
-                ParameterKind = CodeParameterKind.Cancellation,
-                Description = "Cancellation token to use when cancelling requests",
-                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
-            };
-            method.AddParameter(cancellationParam);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root); //using CSharp so the cancelletionToken doesn't get removed
-            Assert.False(method.Parameters.Any());
-            Assert.DoesNotContain(cancellationParam, method.Parameters);
-        }
-        #endregion
-
-        #region GoRefinerTests
-        [Fact]
-        public void DoesNotEscapePublicPropertiesReservedKeywordsForQueryParameters() {
-            var model = root.AddClass(new CodeClass {
-                Name = "SomeClass",
-                ClassKind = CodeClassKind.QueryParameters
-            }).First();
-            var property = model.AddProperty(new CodeProperty {
-                Name = "select",
-                Type = new CodeType { Name = "string" },
-                Access = AccessModifier.Public,
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Equal("select", property.Name);
-            Assert.False(property.IsNameEscaped);
-        }
-        [Fact]
-        public void EscapesPublicPropertiesReservedKeywordsForModels() {
-            var model = root.AddClass(new CodeClass {
-                Name = "SomeClass",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var property = model.AddProperty(new CodeProperty {
-                Name = "select",
-                Type = new CodeType { Name = "string" },
-                Access = AccessModifier.Public,
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Equal("select_escaped", property.Name);
-            Assert.True(property.IsNameEscaped);
-        }
-        [Fact]
-        public void ReplacesRequestBuilderPropertiesByMethods() {
-            var model = root.AddClass(new CodeClass {
-                Name = "someModel",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            var rb = model.AddProperty(new CodeProperty {
-                Name = "someProperty",
-                PropertyKind = CodePropertyKind.RequestBuilder,
-            }).First();
-            rb.Type = new CodeType {
-                Name = "someType",
-            };
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Empty(model.Properties);
-            Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.RequestBuilderBackwardCompatibility)));
-        }
-        [Fact]
-        public void AddsErrorImportForEnums() {
-            var testEnum = root.AddEnum(new CodeEnum {
-                Name = "TestEnum",
-
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Single(testEnum.Usings.Where(x => x.Name == "errors"));
-        }
-        [Fact]
-        public void CorrectsCoreType() {
-            const string requestAdapterDefaultName = "IRequestAdapter";
-            const string factoryDefaultName = "ISerializationWriterFactory";
-            const string deserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
-            const string dateTimeOffsetDefaultName = "DateTimeOffset";
-            const string addiationalDataDefaultName = "new Dictionary<string, object>()";
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            model.AddProperty(new () {
-                Name = "core",
-                PropertyKind = CodePropertyKind.RequestAdapter,
-                Type = new CodeType {
-                    Name = requestAdapterDefaultName
-                }
-            }, new () {
-                Name = "someDate",
-                PropertyKind = CodePropertyKind.Custom,
-                Type = new CodeType {
-                    Name = dateTimeOffsetDefaultName,
-                }
-            }, new () {
-                Name = "additionalData",
-                PropertyKind = CodePropertyKind.AdditionalData,
-                Type = new CodeType {
-                    Name = addiationalDataDefaultName
-                }
-            });
-            const string handlerDefaultName = "IResponseHandler";
-            const string headersDefaultName = "IDictionary<string, string>";
-            var executorMethod = model.AddMethod(new CodeMethod {
-                Name = "executor",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }, new () {
-                Name = "deserializeFields",
-                ReturnType = new CodeType {
-                    Name = deserializeDefaultName,
-                },
-                MethodKind = CodeMethodKind.Deserializer
-            }).First();
-            executorMethod.AddParameter(new () {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.ResponseHandler,
-                Type = new CodeType {
-                    Name = handlerDefaultName,
-                }
-            }, new () {
-                Name = "headers",
-                ParameterKind = CodeParameterKind.Headers,
-                Type = new CodeType {
-                    Name = headersDefaultName
-                }
-            });
-            const string serializerDefaultName = "ISerializationWriter";
-            var serializationMethod = model.AddMethod(new CodeMethod {
-                Name = "seriailization",
-                MethodKind = CodeMethodKind.Serializer,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            serializationMethod.AddParameter(new CodeParameter {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.Serializer,
-                Type = new CodeType {
-                    Name = serializerDefaultName,
-                }
-            });
-            var constructorMethod = model.AddMethod(new CodeMethod {
-                Name = "constructor",
-                MethodKind = CodeMethodKind.Constructor,
-                ReturnType = new CodeType {
-                    Name = "void"
-                }
-            }).First();
-            var rawUrlParam = new CodeParameter {
-                Name = "rawUrl",
-                ParameterKind = CodeParameterKind.RawUrl,
-                Type = new CodeType {
-                    Name = "string",
-                    IsNullable = true,
-                    IsExternal = true
-                }
-            };
-            constructorMethod.AddParameter(rawUrlParam);
-            var pathParamsProp = model.AddProperty(new CodeProperty {
-                Name = "name",
-                Type = new CodeType {
-                    Name = "string",
-                    IsExternal = true
-                },
-                PropertyKind = CodePropertyKind.PathParameters,
-                DefaultValue = "wrongDefaultValue"
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-            Assert.Empty(model.Properties.Where(x => requestAdapterDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => factoryDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
-            Assert.Equal("make(map[string]string)", pathParamsProp.DefaultValue);
-            Assert.Equal("map[string]string", pathParamsProp.Type.Name);
-            Assert.False(rawUrlParam.Type.IsNullable);
-        }
-        #endregion
+                Name = "string"
+            }
+        }).First();
+        var cancellationParam = new CodeParameter
+        {
+            Name = "cancelletionToken",
+            Optional = true,
+            ParameterKind = CodeParameterKind.Cancellation,
+            Description = "Cancellation token to use when cancelling requests",
+            Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+        };
+        method.AddParameter(cancellationParam);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root); //using CSharp so the cancelletionToken doesn't get removed
+        Assert.False(method.Parameters.Any());
+        Assert.DoesNotContain(cancellationParam, method.Parameters);
     }
+    [Fact]
+    public void ReplacesDateTimeOffsetByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateTimeOffset"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Time", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDateOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("DateOnly", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesTimeOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("TimeOnly", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDurationByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeSpan"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("ISODuration", method.ReturnType.Name);
+    }
+    #endregion
+
+    #region GoRefinerTests
+    [Fact]
+    public void DoesNotEscapePublicPropertiesReservedKeywordsForQueryParameters() {
+        var model = root.AddClass(new CodeClass {
+            Name = "SomeClass",
+            ClassKind = CodeClassKind.QueryParameters
+        }).First();
+        var property = model.AddProperty(new CodeProperty {
+            Name = "select",
+            Type = new CodeType { Name = "string" },
+            Access = AccessModifier.Public,
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Equal("select", property.Name);
+        Assert.False(property.IsNameEscaped);
+    }
+    [Fact]
+    public void EscapesPublicPropertiesReservedKeywordsForModels() {
+        var model = root.AddClass(new CodeClass {
+            Name = "SomeClass",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var property = model.AddProperty(new CodeProperty {
+            Name = "select",
+            Type = new CodeType { Name = "string" },
+            Access = AccessModifier.Public,
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Equal("select_escaped", property.Name);
+        Assert.True(property.IsNameEscaped);
+    }
+    [Fact]
+    public void ReplacesRequestBuilderPropertiesByMethods() {
+        var model = root.AddClass(new CodeClass {
+            Name = "someModel",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        var rb = model.AddProperty(new CodeProperty {
+            Name = "someProperty",
+            PropertyKind = CodePropertyKind.RequestBuilder,
+        }).First();
+        rb.Type = new CodeType {
+            Name = "someType",
+        };
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Empty(model.Properties);
+        Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.RequestBuilderBackwardCompatibility)));
+    }
+    [Fact]
+    public void AddsErrorImportForEnums() {
+        var testEnum = root.AddEnum(new CodeEnum {
+            Name = "TestEnum",
+
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Single(testEnum.Usings.Where(x => x.Name == "errors"));
+    }
+    [Fact]
+    public void CorrectsCoreType() {
+        const string requestAdapterDefaultName = "IRequestAdapter";
+        const string factoryDefaultName = "ISerializationWriterFactory";
+        const string deserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
+        const string dateTimeOffsetDefaultName = "DateTimeOffset";
+        const string addiationalDataDefaultName = "new Dictionary<string, object>()";
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        model.AddProperty(new () {
+            Name = "core",
+            PropertyKind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType {
+                Name = requestAdapterDefaultName
+            }
+        }, new () {
+            Name = "someDate",
+            PropertyKind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = dateTimeOffsetDefaultName,
+            }
+        }, new () {
+            Name = "additionalData",
+            PropertyKind = CodePropertyKind.AdditionalData,
+            Type = new CodeType {
+                Name = addiationalDataDefaultName
+            }
+        });
+        const string handlerDefaultName = "IResponseHandler";
+        const string headersDefaultName = "IDictionary<string, string>";
+        var executorMethod = model.AddMethod(new CodeMethod {
+            Name = "executor",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }, new () {
+            Name = "deserializeFields",
+            ReturnType = new CodeType {
+                Name = deserializeDefaultName,
+            },
+            MethodKind = CodeMethodKind.Deserializer
+        }).First();
+        executorMethod.AddParameter(new () {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.ResponseHandler,
+            Type = new CodeType {
+                Name = handlerDefaultName,
+            }
+        }, new () {
+            Name = "headers",
+            ParameterKind = CodeParameterKind.Headers,
+            Type = new CodeType {
+                Name = headersDefaultName
+            }
+        });
+        const string serializerDefaultName = "ISerializationWriter";
+        var serializationMethod = model.AddMethod(new CodeMethod {
+            Name = "seriailization",
+            MethodKind = CodeMethodKind.Serializer,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        serializationMethod.AddParameter(new CodeParameter {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.Serializer,
+            Type = new CodeType {
+                Name = serializerDefaultName,
+            }
+        });
+        var constructorMethod = model.AddMethod(new CodeMethod {
+            Name = "constructor",
+            MethodKind = CodeMethodKind.Constructor,
+            ReturnType = new CodeType {
+                Name = "void"
+            }
+        }).First();
+        var rawUrlParam = new CodeParameter {
+            Name = "rawUrl",
+            ParameterKind = CodeParameterKind.RawUrl,
+            Type = new CodeType {
+                Name = "string",
+                IsNullable = true,
+                IsExternal = true
+            }
+        };
+        constructorMethod.AddParameter(rawUrlParam);
+        var pathParamsProp = model.AddProperty(new CodeProperty {
+            Name = "name",
+            Type = new CodeType {
+                Name = "string",
+                IsExternal = true
+            },
+            PropertyKind = CodePropertyKind.PathParameters,
+            DefaultValue = "wrongDefaultValue"
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Empty(model.Properties.Where(x => requestAdapterDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => factoryDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
+        Assert.Equal("make(map[string]string)", pathParamsProp.DefaultValue);
+        Assert.Equal("map[string]string", pathParamsProp.Type.Name);
+        Assert.False(rawUrlParam.Type.IsNullable);
+    }
+    #endregion
 }

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -258,7 +258,7 @@ public class JavaLanguageRefinerTests {
         const string factoryDefaultName = "ISerializationWriterFactory";
         const string deserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
         const string dateTimeOffsetDefaultName = "DateTimeOffset";
-        const string addiationalDataDefaultName = "new Dictionary<string, object>()";
+        const string additionalDataDefaultName = "new Dictionary<string, object>()";
         var model = root.AddClass(new CodeClass {
             Name = "model",
             ClassKind = CodeClassKind.Model
@@ -279,7 +279,7 @@ public class JavaLanguageRefinerTests {
             Name = "additionalData",
             PropertyKind = CodePropertyKind.AdditionalData,
             Type = new CodeType {
-                Name = addiationalDataDefaultName
+                Name = additionalDataDefaultName
             }
         });
         const string handlerDefaultName = "IResponseHandler";
@@ -329,7 +329,7 @@ public class JavaLanguageRefinerTests {
         Assert.Empty(model.Properties.Where(x => requestAdapterDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Properties.Where(x => factoryDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Properties.Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
-        Assert.Empty(model.Properties.Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => additionalDataDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Methods.Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -1,346 +1,409 @@
 ﻿using System.Linq;
 using Xunit;
 
-namespace Kiota.Builder.Refiners.Tests {
-    public class JavaLanguageRefinerTests {
-        private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
-        #region CommonLanguageRefinerTests
-        [Fact]
-        public void EscapesReservedKeywordsInInternalDeclaration() {
-            var model = root.AddClass(new CodeClass {
-                Name = "break",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var nUsing = new CodeUsing {
-                Name = "some.ns",
-            };
-            nUsing.Declaration = new CodeType {
-                Name = "break",
-                IsExternal = false,
-            };
-            model.AddUsing(nUsing);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.NotEqual("break", nUsing.Declaration.Name);
-            Assert.Contains("escaped", nUsing.Declaration.Name);
-        }
-        [Fact]
-        public void EscapesReservedKeywords() {
-            var model = root.AddClass(new CodeClass {
-                Name = "break",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.NotEqual("break", model.Name);
-            Assert.Contains("escaped", model.Name);
-        }
-        [Fact]
-        public void AddsDefaultImports() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var requestBuilder = root.AddClass(new CodeClass {
-                Name = "rb",
-                ClassKind = CodeClassKind.RequestBuilder,
-            }).First();
-            requestBuilder.AddMethod(new CodeMethod {
-                Name = "get",
-                MethodKind = CodeMethodKind.RequestExecutor,
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.NotEmpty(requestBuilder.StartBlock.Usings);
-        }
-        [Fact]
-        public void ReplacesBinaryByNativeType() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method",
-                ReturnType = new CodeType {
-                   Name = "binary"
-                },
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.NotEqual("binary", method.ReturnType.Name);
-        }
-        [Fact]
-        public void ReplacesIndexersByMethodsWithParameter() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var requestBuilder = root.AddClass(new CodeClass {
-                Name = "requestBuilder",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            requestBuilder.AddProperty(new CodeProperty {
-                Name = "urlTemplate",
-                DefaultValue = "path",
-                PropertyKind = CodePropertyKind.UrlTemplate,
-                Type = new CodeType {
-                    Name = "string",
-                }
-            });
-            requestBuilder.SetIndexer(new CodeIndexer {
-                Name = "idx",
-                ReturnType = new CodeType {
-                    Name = "model",
-                    TypeDefinition = model,
-                },
-            });
-            var collectionRequestBuilder = root.AddClass(new CodeClass {
-                Name = "CollectionRequestBUilder",
-            }).First();
-            collectionRequestBuilder.AddProperty(new CodeProperty {
-                Name = "collection",
-                Type = new CodeType {
-                    Name = "requestBuilder",
-                    TypeDefinition = requestBuilder,
-                },
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.Single(requestBuilder.Properties);
-            Assert.Empty(requestBuilder.GetChildElements(true).OfType<CodeIndexer>());
-            Assert.Single(collectionRequestBuilder.Methods.Where(x => x.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility)));
-            Assert.Single(collectionRequestBuilder.Properties);
-        }
-        [Fact]
-        public void AddsInnerClasses() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method1",
-                ReturnType = new CodeType {
-                    Name = "string",
-                    IsExternal = true
-                }
-            }).First();
-            var parameter = new CodeParameter {
-                Name = "param1",
-                ParameterKind = CodeParameterKind.QueryParameter,
-                Type = new CodeType {
-                    Name = "SomeCustomType",
-                    ActionOf = true,
-                    TypeDefinition = new CodeClass {
-                        Name = "SomeCustomType"
-                    }
-                }
-            };
-            method.AddParameter(parameter);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.Equal(2, model.GetChildElements(true).Count());
-        }
-        [Fact]
-        public void DoesNotKeepCancellationParametersInRequestExecutors()
-        {
-            var model = root.AddClass(new CodeClass
-            {
-                Name = "model",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            var method = model.AddMethod(new CodeMethod
-            {
-                Name = "getMethod",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType
-                {
-                    Name = "string"
-                }
-            }).First();
-            var cancellationParam = new CodeParameter
-            {
-                Name = "cancelletionToken",
-                Optional = true,
-                ParameterKind = CodeParameterKind.Cancellation,
-                Description = "Cancellation token to use when cancelling requests",
-                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
-            };
-            method.AddParameter(cancellationParam);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root); //using CSharp so the cancelletionToken doesn't get removed
-            Assert.False(method.Parameters.Any());
-            Assert.DoesNotContain(cancellationParam, method.Parameters);
-        }
-        #endregion
-        #region JavaLanguageRefinerTests
-        [Fact]
-        public void AddsEnumSetImport() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            model.AddProperty(new CodeProperty{
-                Name = "prop1",
-                Type = new CodeType {
-                    Name = "SomeEnum",
-                    TypeDefinition = new CodeEnum {
-                        Name = "SomeEnum",
-                        Flags = true,
-                        Parent = root,
-                    }
-                }
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.NotEmpty((model.StartBlock as CodeClass.Declaration).Usings.Where(x => "EnumSet".Equals(x.Name)));
-        }
-        [Fact]
-        public void CorrectsCoreType() {
-            const string requestAdapterDefaultName = "IRequestAdapter";
-            const string factoryDefaultName = "ISerializationWriterFactory";
-            const string deserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
-            const string dateTimeOffsetDefaultName = "DateTimeOffset";
-            const string addiationalDataDefaultName = "new Dictionary<string, object>()";
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            model.AddProperty(new () {
-                Name = "core",
-                PropertyKind = CodePropertyKind.RequestAdapter,
-                Type = new CodeType {
-                    Name = requestAdapterDefaultName
-                }
-            }, new () {
-                Name = "someDate",
-                PropertyKind = CodePropertyKind.Custom,
-                Type = new CodeType {
-                    Name = dateTimeOffsetDefaultName,
-                }
-            }, new () {
-                Name = "additionalData",
-                PropertyKind = CodePropertyKind.AdditionalData,
-                Type = new CodeType {
-                    Name = addiationalDataDefaultName
-                }
-            });
-            const string handlerDefaultName = "IResponseHandler";
-            const string headersDefaultName = "IDictionary<string, string>";
-            var executorMethod = model.AddMethod(new CodeMethod {
-                Name = "executor",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }, new () {
-                Name = "deserializeFields",
-                ReturnType = new CodeType {
-                    Name = deserializeDefaultName,
-                },
-                MethodKind = CodeMethodKind.Deserializer
-            }).First();
-            executorMethod.AddParameter(new () {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.ResponseHandler,
-                Type = new CodeType {
-                    Name = handlerDefaultName,
-                }
-            }, new () {
-                Name = "headers",
-                ParameterKind = CodeParameterKind.Headers,
-                Type = new CodeType() {
-                    Name = headersDefaultName
-                }
-            });
-            const string serializerDefaultName = "ISerializationWriter";
-            var serializationMethod = model.AddMethod(new CodeMethod {
-                Name = "seriailization",
-                MethodKind = CodeMethodKind.Serializer,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            serializationMethod.AddParameter(new CodeParameter {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.Serializer,
-                Type = new CodeType {
-                    Name = serializerDefaultName,
-                }
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            Assert.Empty(model.Properties.Where(x => requestAdapterDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => factoryDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
-        }
-        [Fact]
-        public void AddsMethodsOverloads() {
-            var builder = root.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            var executor = builder.AddMethod(new CodeMethod {
-                Name = "executor",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            executor.AddParameter(new CodeParameter {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.ResponseHandler,
-                Type = new CodeType {
-                    Name = "string"
-                }
-            });
-            executor.AddParameter(new CodeParameter {
-                Name = "headers",
-                ParameterKind = CodeParameterKind.Headers,
-                Type = new CodeType {
-                    Name = "string"
-                }
-            });
-            executor.AddParameter(new CodeParameter {
-                Name = "query",
-                ParameterKind = CodeParameterKind.QueryParameter,
-                Type = new CodeType {
-                    Name = "string"
-                }
-            });
-            executor.AddParameter(new CodeParameter {
-                Name = "body",
-                ParameterKind = CodeParameterKind.RequestBody,
-                Type = new CodeType {
-                    Name = "string"
-                }
-            });
-            executor.AddParameter(new CodeParameter {
-                Name = "options",
-                ParameterKind = CodeParameterKind.Options,
-                Type = new CodeType {
-                    Name = "string"
-                }
-            });
-            var generator = builder.AddMethod(new CodeMethod {
-                Name = "generator",
-                MethodKind = CodeMethodKind.RequestGenerator,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            generator.AddParameter(executor.Parameters.Where(x => !x.IsOfKind(CodeParameterKind.ResponseHandler)).ToArray());
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-            var childMethods = builder.Methods;
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 1);//only the body
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 1);//only the body
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 2);// body + query params
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 2);// body + query params
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 3);// body + query params + headers
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 3);// body + query params + headers
-            Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 4);// body + query params + headers + options
-            Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 4);// body + query params + headers + options
-            Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 5);// body + query params + headers + options + response handler
-            Assert.Equal(9, childMethods.Count());
-            Assert.Equal(7, childMethods.Count(x => x.IsOverload));
-        }
-        #endregion
+namespace Kiota.Builder.Refiners.Tests;
+public class JavaLanguageRefinerTests {
+    private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
+    #region CommonLanguageRefinerTests
+    [Fact]
+    public void EscapesReservedKeywordsInInternalDeclaration() {
+        var model = root.AddClass(new CodeClass {
+            Name = "break",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var nUsing = new CodeUsing {
+            Name = "some.ns",
+        };
+        nUsing.Declaration = new CodeType {
+            Name = "break",
+            IsExternal = false,
+        };
+        model.AddUsing(nUsing);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEqual("break", nUsing.Declaration.Name);
+        Assert.Contains("escaped", nUsing.Declaration.Name);
     }
+    [Fact]
+    public void EscapesReservedKeywords() {
+        var model = root.AddClass(new CodeClass {
+            Name = "break",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEqual("break", model.Name);
+        Assert.Contains("escaped", model.Name);
+    }
+    [Fact]
+    public void AddsDefaultImports() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var requestBuilder = root.AddClass(new CodeClass {
+            Name = "rb",
+            ClassKind = CodeClassKind.RequestBuilder,
+        }).First();
+        requestBuilder.AddMethod(new CodeMethod {
+            Name = "get",
+            MethodKind = CodeMethodKind.RequestExecutor,
+        });
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.NotEmpty(requestBuilder.StartBlock.Usings);
+    }
+    [Fact]
+    public void ReplacesDateTimeOffsetByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateTimeOffset"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("OffsetDateTime", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDateOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("LocalDate", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesTimeOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("LocalTime", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDurationByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeSpan"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Period", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesBinaryByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "binary"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.NotEqual("binary", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesIndexersByMethodsWithParameter() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var requestBuilder = root.AddClass(new CodeClass {
+            Name = "requestBuilder",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        requestBuilder.AddProperty(new CodeProperty {
+            Name = "urlTemplate",
+            DefaultValue = "path",
+            PropertyKind = CodePropertyKind.UrlTemplate,
+            Type = new CodeType {
+                Name = "string",
+            }
+        });
+        requestBuilder.SetIndexer(new CodeIndexer {
+            Name = "idx",
+            ReturnType = new CodeType {
+                Name = "model",
+                TypeDefinition = model,
+            },
+        });
+        var collectionRequestBuilder = root.AddClass(new CodeClass {
+            Name = "CollectionRequestBUilder",
+        }).First();
+        collectionRequestBuilder.AddProperty(new CodeProperty {
+            Name = "collection",
+            Type = new CodeType {
+                Name = "requestBuilder",
+                TypeDefinition = requestBuilder,
+            },
+        });
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.Single(requestBuilder.Properties);
+        Assert.Empty(requestBuilder.GetChildElements(true).OfType<CodeIndexer>());
+        Assert.Single(collectionRequestBuilder.Methods.Where(x => x.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility)));
+        Assert.Single(collectionRequestBuilder.Properties);
+    }
+    [Fact]
+    public void AddsInnerClasses() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method1",
+            ReturnType = new CodeType {
+                Name = "string",
+                IsExternal = true
+            }
+        }).First();
+        var parameter = new CodeParameter {
+            Name = "param1",
+            ParameterKind = CodeParameterKind.QueryParameter,
+            Type = new CodeType {
+                Name = "SomeCustomType",
+                ActionOf = true,
+                TypeDefinition = new CodeClass {
+                    Name = "SomeCustomType"
+                }
+            }
+        };
+        method.AddParameter(parameter);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.Equal(2, model.GetChildElements(true).Count());
+    }
+    [Fact]
+    public void DoesNotKeepCancellationParametersInRequestExecutors()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "model",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        var method = model.AddMethod(new CodeMethod
+        {
+            Name = "getMethod",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var cancellationParam = new CodeParameter
+        {
+            Name = "cancelletionToken",
+            Optional = true,
+            ParameterKind = CodeParameterKind.Cancellation,
+            Description = "Cancellation token to use when cancelling requests",
+            Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+        };
+        method.AddParameter(cancellationParam);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root); //using CSharp so the cancelletionToken doesn't get removed
+        Assert.False(method.Parameters.Any());
+        Assert.DoesNotContain(cancellationParam, method.Parameters);
+    }
+    #endregion
+    #region JavaLanguageRefinerTests
+    [Fact]
+    public void AddsEnumSetImport() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        model.AddProperty(new CodeProperty{
+            Name = "prop1",
+            Type = new CodeType {
+                Name = "SomeEnum",
+                TypeDefinition = new CodeEnum {
+                    Name = "SomeEnum",
+                    Flags = true,
+                    Parent = root,
+                }
+            }
+        });
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.NotEmpty((model.StartBlock as CodeClass.Declaration).Usings.Where(x => "EnumSet".Equals(x.Name)));
+    }
+    [Fact]
+    public void CorrectsCoreType() {
+        const string requestAdapterDefaultName = "IRequestAdapter";
+        const string factoryDefaultName = "ISerializationWriterFactory";
+        const string deserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
+        const string dateTimeOffsetDefaultName = "DateTimeOffset";
+        const string addiationalDataDefaultName = "new Dictionary<string, object>()";
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        model.AddProperty(new () {
+            Name = "core",
+            PropertyKind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType {
+                Name = requestAdapterDefaultName
+            }
+        }, new () {
+            Name = "someDate",
+            PropertyKind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = dateTimeOffsetDefaultName,
+            }
+        }, new () {
+            Name = "additionalData",
+            PropertyKind = CodePropertyKind.AdditionalData,
+            Type = new CodeType {
+                Name = addiationalDataDefaultName
+            }
+        });
+        const string handlerDefaultName = "IResponseHandler";
+        const string headersDefaultName = "IDictionary<string, string>";
+        var executorMethod = model.AddMethod(new CodeMethod {
+            Name = "executor",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }, new () {
+            Name = "deserializeFields",
+            ReturnType = new CodeType {
+                Name = deserializeDefaultName,
+            },
+            MethodKind = CodeMethodKind.Deserializer
+        }).First();
+        executorMethod.AddParameter(new () {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.ResponseHandler,
+            Type = new CodeType {
+                Name = handlerDefaultName,
+            }
+        }, new () {
+            Name = "headers",
+            ParameterKind = CodeParameterKind.Headers,
+            Type = new CodeType() {
+                Name = headersDefaultName
+            }
+        });
+        const string serializerDefaultName = "ISerializationWriter";
+        var serializationMethod = model.AddMethod(new CodeMethod {
+            Name = "seriailization",
+            MethodKind = CodeMethodKind.Serializer,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        serializationMethod.AddParameter(new CodeParameter {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.Serializer,
+            Type = new CodeType {
+                Name = serializerDefaultName,
+            }
+        });
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.Empty(model.Properties.Where(x => requestAdapterDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => factoryDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => dateTimeOffsetDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => addiationalDataDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.Where(x => deserializeDefaultName.Equals(x.ReturnType.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
+    }
+    [Fact]
+    public void AddsMethodsOverloads() {
+        var builder = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        var executor = builder.AddMethod(new CodeMethod {
+            Name = "executor",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        executor.AddParameter(new CodeParameter {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.ResponseHandler,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        executor.AddParameter(new CodeParameter {
+            Name = "headers",
+            ParameterKind = CodeParameterKind.Headers,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        executor.AddParameter(new CodeParameter {
+            Name = "query",
+            ParameterKind = CodeParameterKind.QueryParameter,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        executor.AddParameter(new CodeParameter {
+            Name = "body",
+            ParameterKind = CodeParameterKind.RequestBody,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        executor.AddParameter(new CodeParameter {
+            Name = "options",
+            ParameterKind = CodeParameterKind.Options,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        var generator = builder.AddMethod(new CodeMethod {
+            Name = "generator",
+            MethodKind = CodeMethodKind.RequestGenerator,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        generator.AddParameter(executor.Parameters.Where(x => !x.IsOfKind(CodeParameterKind.ResponseHandler)).ToArray());
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        var childMethods = builder.Methods;
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 1);//only the body
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 1);//only the body
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 2);// body + query params
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 2);// body + query params
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 3);// body + query params + headers
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 3);// body + query params + headers
+        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 4);// body + query params + headers + options
+        Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 4);// body + query params + headers + options
+        Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 5);// body + query params + headers + options + response handler
+        Assert.Equal(9, childMethods.Count());
+        Assert.Equal(7, childMethods.Count(x => x.IsOverload));
+    }
+    #endregion
 }

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -1,196 +1,259 @@
 using System.Linq;
 using Xunit;
 
-namespace Kiota.Builder.Refiners.Tests {
-    public class TypeScriptLanguageRefinerTests {
-        private readonly CodeNamespace root;
-        private readonly CodeNamespace graphNS;
-        private readonly CodeClass parentClass;
-        public TypeScriptLanguageRefinerTests() {
-            root = CodeNamespace.InitRootNamespace();
-            graphNS = root.AddNamespace("graph");
-            parentClass = new () {
-                Name = "parentClass"
-            };
-            graphNS.AddClass(parentClass);
-        }
-#region typescript
-        private const string HttpCoreDefaultName = "IRequestAdapter";
-        private const string FactoryDefaultName = "ISerializationWriterFactory";
-        private const string DeserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
-        private const string PathParametersDefaultName = "Dictionary<string, object>";
-        private const string PathParametersDefaultValue = "new Dictionary<string, object>";
-        private const string DateTimeOffsetDefaultName = "DateTimeOffset";
-        private const string AddiationalDataDefaultName = "new Dictionary<string, object>()";
-        private const string HandlerDefaultName = "IResponseHandler";
-        [Fact]
-        public void EscapesReservedKeywords() {
-            var model = root.AddClass(new CodeClass {
-                Name = "break",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
-            Assert.NotEqual("break", model.Name);
-            Assert.Contains("escaped", model.Name);
-        }
-        [Fact]
-        public void CorrectsCoreType() {
-
-            var model = root.AddClass(new CodeClass () {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            model.AddProperty(new CodeProperty() {
-                Name = "core",
-                PropertyKind = CodePropertyKind.RequestAdapter,
-                Type = new CodeType {
-                    Name = HttpCoreDefaultName
-                }
-            }, new () {
-                Name = "someDate",
-                PropertyKind = CodePropertyKind.Custom,
-                Type = new CodeType {
-                    Name = DateTimeOffsetDefaultName,
-                }
-            }, new () {
-                Name = "additionalData",
-                PropertyKind = CodePropertyKind.AdditionalData,
-                Type = new CodeType {
-                    Name = AddiationalDataDefaultName
-                }
-            }, new () {
-                Name = "pathParameters",
-                PropertyKind = CodePropertyKind.PathParameters,
-                Type = new CodeType {
-                    Name = PathParametersDefaultName
-                },
-                DefaultValue = PathParametersDefaultValue
-            });
-            var executorMethod = model.AddMethod(new CodeMethod {
-                Name = "executor",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            executorMethod.AddParameter(new CodeParameter {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.ResponseHandler,
-                Type = new CodeType {
-                    Name = HandlerDefaultName,
-                }
-            });
-            const string serializerDefaultName = "ISerializationWriter";
-            var serializationMethod = model.AddMethod(new CodeMethod {
-                Name = "seriailization",
-                MethodKind = CodeMethodKind.Serializer,
-                ReturnType = new CodeType {
-                    Name = "string"
-                }
-            }).First();
-            serializationMethod.AddParameter(new CodeParameter {
-                Name = "handler",
-                ParameterKind = CodeParameterKind.Serializer,
-                Type = new CodeType {
-                    Name = serializerDefaultName,
-                }
-            });
-            var constructorMethod = model.AddMethod(new CodeMethod {
-                Name = "constructor",
-                MethodKind = CodeMethodKind.Constructor,
-                ReturnType = new CodeType {
-                    Name = "void"
-                }
-            }).First();
-            constructorMethod.AddParameter(new CodeParameter {
-                Name = "pathParameters",
-                ParameterKind = CodeParameterKind.PathParameters,
-                Type = new CodeType {
-                    Name = PathParametersDefaultName
-                },
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration{ Language = GenerationLanguage.TypeScript }, root);
-            Assert.Empty(model.Properties.Where(x => HttpCoreDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => FactoryDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => DateTimeOffsetDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => AddiationalDataDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => PathParametersDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Properties.Where(x => PathParametersDefaultValue.Equals(x.DefaultValue)));
-            Assert.Empty(model.Methods.Where(x => DeserializeDefaultName.Equals(x.ReturnType.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => HandlerDefaultName.Equals(x.Type.Name)));
-            Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
-            Assert.Single(constructorMethod.Parameters.Where(x => x.Type is CodeUnionType));
-        }
-        [Fact]
-        public void AliasesDuplicateUsingSymbols() {
-            var model = graphNS.AddClass(new CodeClass {
-                Name = "model",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var modelsNS = graphNS.AddNamespace($"{graphNS.Name}.models");
-            var source1 = modelsNS.AddClass(new CodeClass {
-                Name = "source",
-                ClassKind = CodeClassKind.Model
-            }).First();
-            var submodelsNS = modelsNS.AddNamespace($"{modelsNS.Name}.submodels");
-            var source2 = submodelsNS.AddClass(new CodeClass {
-                Name = "source",
-                ClassKind = CodeClassKind.Model
-            }).First();
-
-            var using1 = new CodeUsing {
-               Name = modelsNS.Name,
-               Declaration = new CodeType {
-                   Name = source1.Name,
-                   TypeDefinition = source1,
-                   IsExternal = false,
-               }
-            };
-            var using2 = new CodeUsing {
-               Name = submodelsNS.Name,
-               Declaration = new CodeType {
-                   Name = source2.Name,
-                   TypeDefinition = source2,
-                   IsExternal = false,
-               }
-            };
-            model.AddUsing(using1);
-            model.AddUsing(using2);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
-            Assert.NotEmpty(using1.Alias);
-            Assert.NotEmpty(using2.Alias);
-            Assert.NotEqual(using1.Alias, using2.Alias);
-        }
-        [Fact]
-        public void DoesNotKeepCancellationParametersInRequestExecutors()
-        {
-            var model = root.AddClass(new CodeClass
-            {
-                Name = "model",
-                ClassKind = CodeClassKind.RequestBuilder
-            }).First();
-            var method = model.AddMethod(new CodeMethod
-            {
-                Name = "getMethod",
-                MethodKind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType
-                {
-                    Name = "string"
-                }
-            }).First();
-            var cancellationParam = new CodeParameter
-            {
-                Name = "cancelletionToken",
-                Optional = true,
-                ParameterKind = CodeParameterKind.Cancellation,
-                Description = "Cancellation token to use when cancelling requests",
-                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
-            };
-            method.AddParameter(cancellationParam);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
-            Assert.False(method.Parameters.Any());
-            Assert.DoesNotContain(cancellationParam, method.Parameters);
-        }
-#endregion
+namespace Kiota.Builder.Refiners.Tests;
+public class TypeScriptLanguageRefinerTests {
+    private readonly CodeNamespace root;
+    private readonly CodeNamespace graphNS;
+    private readonly CodeClass parentClass;
+    public TypeScriptLanguageRefinerTests() {
+        root = CodeNamespace.InitRootNamespace();
+        graphNS = root.AddNamespace("graph");
+        parentClass = new () {
+            Name = "parentClass"
+        };
+        graphNS.AddClass(parentClass);
     }
+#region typescript
+    private const string HttpCoreDefaultName = "IRequestAdapter";
+    private const string FactoryDefaultName = "ISerializationWriterFactory";
+    private const string DeserializeDefaultName = "IDictionary<string, Action<Model, IParseNode>>";
+    private const string PathParametersDefaultName = "Dictionary<string, object>";
+    private const string PathParametersDefaultValue = "new Dictionary<string, object>";
+    private const string DateTimeOffsetDefaultName = "DateTimeOffset";
+    private const string AddiationalDataDefaultName = "new Dictionary<string, object>()";
+    private const string HandlerDefaultName = "IResponseHandler";
+    [Fact]
+    public void EscapesReservedKeywords() {
+        var model = root.AddClass(new CodeClass {
+            Name = "break",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEqual("break", model.Name);
+        Assert.Contains("escaped", model.Name);
+    }
+    [Fact]
+    public void CorrectsCoreType() {
+
+        var model = root.AddClass(new CodeClass () {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        model.AddProperty(new CodeProperty() {
+            Name = "core",
+            PropertyKind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType {
+                Name = HttpCoreDefaultName
+            }
+        }, new () {
+            Name = "someDate",
+            PropertyKind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = DateTimeOffsetDefaultName,
+            }
+        }, new () {
+            Name = "additionalData",
+            PropertyKind = CodePropertyKind.AdditionalData,
+            Type = new CodeType {
+                Name = AddiationalDataDefaultName
+            }
+        }, new () {
+            Name = "pathParameters",
+            PropertyKind = CodePropertyKind.PathParameters,
+            Type = new CodeType {
+                Name = PathParametersDefaultName
+            },
+            DefaultValue = PathParametersDefaultValue
+        });
+        var executorMethod = model.AddMethod(new CodeMethod {
+            Name = "executor",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        executorMethod.AddParameter(new CodeParameter {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.ResponseHandler,
+            Type = new CodeType {
+                Name = HandlerDefaultName,
+            }
+        });
+        const string serializerDefaultName = "ISerializationWriter";
+        var serializationMethod = model.AddMethod(new CodeMethod {
+            Name = "seriailization",
+            MethodKind = CodeMethodKind.Serializer,
+            ReturnType = new CodeType {
+                Name = "string"
+            }
+        }).First();
+        serializationMethod.AddParameter(new CodeParameter {
+            Name = "handler",
+            ParameterKind = CodeParameterKind.Serializer,
+            Type = new CodeType {
+                Name = serializerDefaultName,
+            }
+        });
+        var constructorMethod = model.AddMethod(new CodeMethod {
+            Name = "constructor",
+            MethodKind = CodeMethodKind.Constructor,
+            ReturnType = new CodeType {
+                Name = "void"
+            }
+        }).First();
+        constructorMethod.AddParameter(new CodeParameter {
+            Name = "pathParameters",
+            ParameterKind = CodeParameterKind.PathParameters,
+            Type = new CodeType {
+                Name = PathParametersDefaultName
+            },
+        });
+        ILanguageRefiner.Refine(new GenerationConfiguration{ Language = GenerationLanguage.TypeScript }, root);
+        Assert.Empty(model.Properties.Where(x => HttpCoreDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => FactoryDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => DateTimeOffsetDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => AddiationalDataDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => PathParametersDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Properties.Where(x => PathParametersDefaultValue.Equals(x.DefaultValue)));
+        Assert.Empty(model.Methods.Where(x => DeserializeDefaultName.Equals(x.ReturnType.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => HandlerDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
+        Assert.Single(constructorMethod.Parameters.Where(x => x.Type is CodeUnionType));
+    }
+    [Fact]
+    public void ReplacesDateTimeOffsetByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateTimeOffset"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Date", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDateOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("DateOnly", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesTimeOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeOnly"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("TimeOnly", method.ReturnType.Name);
+    }
+    [Fact]
+    public void ReplacesDurationByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeSpan"
+            },
+        }).First();
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Duration", method.ReturnType.Name);
+    }
+    [Fact]
+    public void AliasesDuplicateUsingSymbols() {
+        var model = graphNS.AddClass(new CodeClass {
+            Name = "model",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var modelsNS = graphNS.AddNamespace($"{graphNS.Name}.models");
+        var source1 = modelsNS.AddClass(new CodeClass {
+            Name = "source",
+            ClassKind = CodeClassKind.Model
+        }).First();
+        var submodelsNS = modelsNS.AddNamespace($"{modelsNS.Name}.submodels");
+        var source2 = submodelsNS.AddClass(new CodeClass {
+            Name = "source",
+            ClassKind = CodeClassKind.Model
+        }).First();
+
+        var using1 = new CodeUsing {
+            Name = modelsNS.Name,
+            Declaration = new CodeType {
+                Name = source1.Name,
+                TypeDefinition = source1,
+                IsExternal = false,
+            }
+        };
+        var using2 = new CodeUsing {
+            Name = submodelsNS.Name,
+            Declaration = new CodeType {
+                Name = source2.Name,
+                TypeDefinition = source2,
+                IsExternal = false,
+            }
+        };
+        model.AddUsing(using1);
+        model.AddUsing(using2);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        Assert.NotEmpty(using1.Alias);
+        Assert.NotEmpty(using2.Alias);
+        Assert.NotEqual(using1.Alias, using2.Alias);
+    }
+    [Fact]
+    public void DoesNotKeepCancellationParametersInRequestExecutors()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "model",
+            ClassKind = CodeClassKind.RequestBuilder
+        }).First();
+        var method = model.AddMethod(new CodeMethod
+        {
+            Name = "getMethod",
+            MethodKind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var cancellationParam = new CodeParameter
+        {
+            Name = "cancelletionToken",
+            Optional = true,
+            ParameterKind = CodeParameterKind.Cancellation,
+            Description = "Cancellation token to use when cancelling requests",
+            Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
+        };
+        method.AddParameter(cancellationParam);
+        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
+        Assert.False(method.Parameters.Any());
+        Assert.DoesNotContain(cancellationParam, method.Parameters);
+    }
+#endregion
 }


### PR DESCRIPTION
fixes #1004

This PR adds improves generation to add new date types: date only, time only and duration. Some platforms have those types natively (Java), some platform have recently added those new types and for compatibility we're adding our own (CSharp), and some platforms don't have native types for these and we added our own custom types (Go, TypeScript).