### PR TITLE
Fix Argument Exception on unknown Enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug in Go where empty collections would not be serialized.
 - Fixes a bug where generation would fail because of empty usings.
 - Fixes a bug where Java and Go escaped model properties would not serialize properly.
+- Fixes a bug where null values would not be added to additionalData if there was no matching property in dotnet. 
+- Fixes a bug where deserialzation of enums would throw an ArgumentExcpetion if the member didn't exist in dotnet.
 
 ## [0.0.14] - 2021-11-08
 

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                             "        \"+1 412 555 0109\"\r\n" +
                                             "    ],\r\n" +
                                             "    \"displayName\": \"Megan Bowen\",\r\n" +
+                                            "    \"numbers\":\"one,two,thirtytwo\"," +
                                             "    \"givenName\": \"Megan\",\r\n" +
                                             "    \"accountEnabled\": true,\r\n" +
                                             "    \"createdDateTime\": \"2017 -07-29T03:07:25Z\",\r\n" +
@@ -45,6 +46,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.True(testEntity.AdditionalData.ContainsKey("mobilePhone"));
             Assert.Equal("Auditor", testEntity.AdditionalData["jobTitle"]);
             Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntity.Id);
+            Assert.Equal(TestEnum.One | TestEnum.Two, testEntity.Numbers ); // Unknown enum value is not included
         }
 
         [Fact]

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -90,17 +90,18 @@ namespace Microsoft.Kiota.Serialization.Json
         public T? GetEnumValue<T>() where T : struct, Enum
         {
             var rawValue = _jsonNode.GetString();
-            if(string.IsNullOrEmpty(rawValue)) return default;
+            if(string.IsNullOrEmpty(rawValue)) return null;
             if(typeof(T).GetCustomAttributes<FlagsAttribute>().Any())
             {
                 return (T)(object)rawValue
                     .Split(',')
-                    .Select(x => Enum.Parse<T>(x, true))
+                    .Select(x => Enum.TryParse<T>(x, true, out var result) ? result : (T?)null)
+                    .Where(x => !x.Equals(null))
                     .Select(x => (int)(object)x)
                     .Sum();
             }
             else
-                return Enum.Parse<T>(rawValue, true);
+                return Enum.TryParse<T>(rawValue, true,out var result) ? result : null;
         }
 
         /// <summary>

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
This PR 

- Fixes the `GetEnumValue` to return null when the enum value is empty as the return type is nullable yet an enum is not.
- Replaces the use of `Enum.Parse` with `Enum.TryParse` in order to be able to return a null default value rather than throwing an ArgumentException when an unknown Enum member is parsed. This is important as an API could be updated with a new Enum member and the user would experience breaking (exception throwing) code till he updates the library with a version that has the new Enum member included.