### PR TITLE
PHP - Compression Handler

### DIFF
--- a/http/php/guzzle/composer.json
+++ b/http/php/guzzle/composer.json
@@ -5,8 +5,9 @@
 	"require": {
 		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
-        "php-http/httplug": "^2.2"
-    },
+        "php-http/httplug": "^2.2",
+		"ext-zlib": "*"
+	},
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.2",

--- a/http/php/guzzle/src/Middleware/CompressionHandler.php
+++ b/http/php/guzzle/src/Middleware/CompressionHandler.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware;
+
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use Microsoft\Kiota\Http\Middleware\Options\CompressionOption;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class CompressionHandler
+ *
+ * Compresses a request body using the provided callbacks in {@link CompressionOption}
+ * Should the server return a 415, the CompressionHandler retries the request ONLY once with an uncompressed body
+ *
+ * @package Microsoft\Kiota\Http\Middleware
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class CompressionHandler
+{
+    private const COMPRESSION_RETRY_ATTEMPT = 'compressionRetryAttempt';
+
+    /**
+     * @var CompressionOption {@link CompressionOption}
+     */
+    private CompressionOption $compressionOption;
+
+    /**
+     * @var callable(RequestInterface, array): PromiseInterface
+     * Next handler to be called in the middleware pipeline
+     */
+    private $nextHandler;
+
+    /**
+     * @var RequestInterface Initial request with uncompressed body
+     */
+    private RequestInterface $originalRequest;
+
+    /**
+     * @param callable $nextHandler
+     * @param CompressionOption|null $compressionOption
+     */
+    public function __construct(callable $nextHandler, ?CompressionOption $compressionOption = null)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->compressionOption = ($compressionOption) ?: new CompressionOption();
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array $options
+     * @return PromiseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        $this->originalRequest = $request; // keep reference in case we have to retry with uncompressed body
+        if (!$this->shouldRetry($options)) {
+            $request = $this->compress($request);
+        }
+        $fn = $this->nextHandler;
+        return $fn($request, $options)->then(
+            $this->onFulfilled($request, $options),
+            $this->onRejected($request, $options)
+        );
+    }
+
+    /**
+     * if true, the request is retried with an uncompressed body
+     *
+     * @param $options
+     * @return bool
+     */
+    private function shouldRetry($options): bool
+    {
+        return (array_key_exists(self::COMPRESSION_RETRY_ATTEMPT, $options) && $options[self::COMPRESSION_RETRY_ATTEMPT] == 1);
+    }
+
+    /**
+     * Retries the request if 415 response was received
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     * @return callable
+     */
+    private function onFulfilled(RequestInterface $request, array $options): callable
+    {
+        return function (ResponseInterface $response) use ($request, $options) {
+            if ($response->getStatusCode() == 415 && !array_key_exists(self::COMPRESSION_RETRY_ATTEMPT, $options)) {
+                $options[self::COMPRESSION_RETRY_ATTEMPT] = 1;
+                return $this($this->originalRequest, $options);
+            }
+            return $response;
+        };
+    }
+
+    /**
+     * Retry only if guzzle BadResponseException was thrown with a 415 status code
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     * @return callable
+     */
+    private function onRejected(RequestInterface $request, array $options): callable
+    {
+        return function ($reason) use ($request, $options) {
+            // Only consider 415 BadResponseException in case guzzle http_errors = true
+            if (is_a($reason, \GuzzleHttp\Exception\BadResponseException::class)) {
+                if ($reason->getResponse()->getStatusCode() == 415 && !array_key_exists(self::COMPRESSION_RETRY_ATTEMPT, $options)) {
+                    $options[self::COMPRESSION_RETRY_ATTEMPT] = 1;
+                    return $this($this->originalRequest, $options);
+                }
+            }
+            return Create::rejectionFor($reason);
+        };
+    }
+
+    /**
+     * Applies compression callbacks provided in {@link CompressionOption} to the request
+     *
+     * @param RequestInterface $request
+     * @return RequestInterface
+     */
+    private function compress(RequestInterface $request): RequestInterface
+    {
+        foreach ($this->compressionOption->getCallbacks() as $callback) {
+            $request = $callback($request);
+        }
+        return $request;
+    }
+}

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -8,6 +8,7 @@
 
 namespace Microsoft\Kiota\Http\Middleware;
 
+use Microsoft\Kiota\Http\Middleware\Options\CompressionOption;
 use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
 
 /**
@@ -33,6 +34,20 @@ class KiotaMiddleware
     {
         return static function (callable $handler) use ($retryOption) : RetryHandler {
             return new RetryHandler($retryOption, $handler);
+        };
+    }
+
+    /**
+     * Middleware that compresses a request body based on compression callbacks provided in {@link CompressionOption} and retries
+     * the initial request with an uncompressed body only once if a 415 response is received.
+     *
+     * @param CompressionOption|null $compressionOption
+     * @return callable
+     */
+    public static function compress(?CompressionOption $compressionOption = null): callable
+    {
+        return static function (callable $handler) use ($compressionOption): CompressionHandler {
+            return new CompressionHandler($handler, $compressionOption);
         };
     }
 }

--- a/http/php/guzzle/src/Middleware/Options/CompressionOption.php
+++ b/http/php/guzzle/src/Middleware/Options/CompressionOption.php
@@ -31,10 +31,15 @@ class CompressionOption
     private array $compressionCallbacks;
 
     /**
+     * Uses GZIP by default
+     *
      * @param callable[] $compressionCallbacks {@link $compressionCallbacks}
      */
-    public function __construct(array $compressionCallbacks = [CompressionOption::gzip()])
+    public function __construct(array $compressionCallbacks = [])
     {
+        if (empty($compressionCallbacks)) {
+            $compressionCallbacks[] = CompressionOption::gzip();
+        }
         $this->compressionCallbacks = $compressionCallbacks;
     }
 
@@ -81,7 +86,7 @@ class CompressionOption
         return static function (RequestInterface $request): RequestInterface {
             // Check if the request has a body
             if ($request->getBody()->getSize()) {
-                $compressedBody = gzinflate($request->getBody()->getContents());
+                $compressedBody = gzdeflate($request->getBody()->getContents());
                 return $request->withBody(Utils::streamFor($compressedBody))
                                 ->withAddedHeader('Content-Encoding', 'deflate');
             }

--- a/http/php/guzzle/src/Middleware/Options/CompressionOption.php
+++ b/http/php/guzzle/src/Middleware/Options/CompressionOption.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware\Options;
+
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class CompressionOption
+ *
+ * Configurations for a {@link CompressionHandler}
+ *
+ * @package Microsoft\Kiota\Http\Middleware\Options
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class CompressionOption
+{
+    /**
+     * @var callable[] compression algorithms to be applied in order of occurrence.
+     * Callable should take in a RequestInterface, compress the request body, set the Content-Encoding header and return the RequestInterface object
+     * callable(Psr\Http\Message\RequestInterface):Psr\Http\Message\RequestInterface
+     */
+    private array $compressionCallbacks;
+
+    /**
+     * @param callable[] $compressionCallbacks {@link $compressionCallbacks}
+     */
+    public function __construct(array $compressionCallbacks = [CompressionOption::gzip()])
+    {
+        $this->compressionCallbacks = $compressionCallbacks;
+    }
+
+    /**
+     * @param callable[] $callbacks {@link $compressionCallbacks}
+     */
+    public function setCallbacks(array $callbacks) {
+        $this->compressionCallbacks = $callbacks;
+    }
+
+    /**
+     * @return callable[] {@link $compressionCallbacks}
+     */
+    public function getCallbacks(): array {
+        return $this->compressionCallbacks;
+    }
+
+    /**
+     * Returns callback that applies GZIP compression to a RequestInterface body & adds the appropriate Content-Encoding header
+     *
+     * @return callable(RequestInterface):RequestInterface
+     */
+    public static function gzip(): callable
+    {
+        return static function (RequestInterface $request): RequestInterface {
+            // Check if the request has a body
+            if ($request->getBody()->getSize()) {
+                $compressedBody = gzencode($request->getBody()->getContents());
+                return $request->withBody(Utils::streamFor($compressedBody))
+                                ->withAddedHeader('Content-Encoding', 'gzip');
+            }
+            return $request;
+        };
+    }
+
+    /**
+     * Returns callback that applies DEFLATE compression to a RequestInterface body & adds the appropriate
+     * Content-Encoding header
+     *
+     * @return callable(RequestInterface):RequestInterface
+     */
+    public static function deflate(): callable
+    {
+        return static function (RequestInterface $request): RequestInterface {
+            // Check if the request has a body
+            if ($request->getBody()->getSize()) {
+                $compressedBody = gzinflate($request->getBody()->getContents());
+                return $request->withBody(Utils::streamFor($compressedBody))
+                                ->withAddedHeader('Content-Encoding', 'deflate');
+            }
+            return $request;
+        };
+    }
+}

--- a/http/php/guzzle/tests/Middleware/CompressionHandlerTest.php
+++ b/http/php/guzzle/tests/Middleware/CompressionHandlerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Microsoft\Kiota\Http\Test\Middleware;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Middleware\KiotaMiddleware;
+use Microsoft\Kiota\Http\Middleware\Options\CompressionOption;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class CompressionHandlerTest extends TestCase
+{
+    public function testGzipCompression()
+    {
+        $initialRequestBody = "body";
+        $mockResponse = [
+            function (RequestInterface $request, array $options) use ($initialRequestBody) {
+                $decompressedBody = gzdecode($request->getBody()->getContents());
+                if ($decompressedBody === $initialRequestBody
+                    && $request->hasHeader('Content-Encoding')
+                    && $request->getHeaderLine('Content-Encoding') === 'gzip') {
+                    return new Response(200);
+                }
+                throw new \RuntimeException("Decompressed body doesn't match initial request body");
+            }
+        ];
+
+        $response = $this->executeMockRequest($mockResponse, null, ['body' => $initialRequestBody]); // gzip is default
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDeflateCompression()
+    {
+        $initialRequestBody = "body";
+        $mockResponse = [
+            function (RequestInterface $request, array $options) use ($initialRequestBody) {
+                $decompressedBody = gzinflate($request->getBody()->getContents());
+                if ($decompressedBody === $initialRequestBody
+                    && $request->hasHeader('Content-Encoding')
+                    && $request->getHeaderLine('Content-Encoding') === 'deflate') {
+                    return new Response(200);
+                }
+                throw new \RuntimeException("Decompressed body doesn't match initial request body");
+            }
+        ];
+
+        $response = $this->executeMockRequest($mockResponse, new CompressionOption([CompressionOption::deflate()]), ['body' => $initialRequestBody]); // gzip is default
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testAtMostOneRetry()
+    {
+        $mockResponse = [
+            new Response(415),
+            new Response(200)
+        ];
+        $response = $this->executeMockRequest($mockResponse, null, ['body' => "Request body"]);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBadResponseExceptionCausesAtMostOneRetry()
+    {
+        $mockResponse = [
+            new Response(415),
+            new Response(200)
+        ];
+        $response = $this->executeMockRequest($mockResponse, null, ['body' => "Request body", 'http_errors' => true]);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testMultipleCompressionCallbacks()
+    {
+        $body = "payload";
+        $compressionOptions = [CompressionOption::gzip(), CompressionOption::deflate()];
+        $mockResponse = [
+            function (RequestInterface $request, array $options) use ($body) {
+                $decompressedBody = gzdecode(gzinflate($request->getBody()->getContents()));
+                if ($decompressedBody === $body
+                    && $request->hasHeader('Content-Encoding')
+                    && $request->getHeaderLine('Content-Encoding') === 'gzip, deflate') {
+                    return new Response(200);
+                }
+                throw new \RuntimeException("Decompressed body doesn't match initial request body");
+            }
+        ];
+        $response = $this->executeMockRequest($mockResponse, new CompressionOption($compressionOptions), ['body' => $body]);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    private function executeMockRequest(array $mockResponses, ?CompressionOption $compressionOption = null, ?array $requestOptions = [])
+    {
+        $mockHandler = new MockHandler($mockResponses);
+        $handlerStack = new HandlerStack($mockHandler);
+        $handlerStack->push(KiotaMiddleware::compress($compressionOption));
+
+        $guzzleClient = new Client(['handler' => $handlerStack, 'http_errors' => false]);
+        return $guzzleClient->get("/", $requestOptions);
+    }
+}


### PR DESCRIPTION
This implementation:
- allows the customer to provide callbacks to allow support for other algorithms e.g. `br` which has no built-in PHP implementation or well supported package on Packagist. Using it would require a customer to install a platform dependency alongside their PHP setup
- provides GZIP and DEFLATE implementations
- supports GZIP as the default
- allows chaining of multiple compression algorithms

part of #364, #598