### PR TITLE
PHP - Telemetry & Chaos Handlers

### DIFF
--- a/http/php/guzzle/src/Middleware/ChaosHandler.php
+++ b/http/php/guzzle/src/Middleware/ChaosHandler.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware;
+
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Middleware\Options\ChaosOption;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class ChaosHandler
+ *
+ * Middleware that selects a chaos response (configured via {@link ChaosOption}) at random x% of the time
+ * If criteria is not met for a chaos response, the request is forwarded down the middleware chain
+ *
+ * @package Microsoft\Kiota\Http\Middleware
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class ChaosHandler
+{
+    /**
+     * Key to use to set request specific {@link ChaosOption}'s within Guzzle's request options
+     */
+    public const CHAOS_GUZZLE_CONFIG = 'kiota_chaos_option';
+
+    /**
+     * @var callable Next handler in the middleware pipeline
+     */
+    private $nextHandler;
+
+    /**
+     * @var ChaosOption {@link ChaosOption}
+     */
+    private ChaosOption $chaosOption;
+
+    /**
+     * @param callable $nextHandler
+     * @param ChaosOption|null $chaosOption
+     */
+    public function __construct(callable $nextHandler, ?ChaosOption $chaosOption = null)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->chaosOption = ($chaosOption) ?: new ChaosOption();
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array $options
+     * @return PromiseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        if (array_key_exists(self::CHAOS_GUZZLE_CONFIG, $options)) {
+            $this->chaosOption = $options[self::CHAOS_GUZZLE_CONFIG];
+        }
+
+        $randomPercentage = rand(0, ChaosOption::MAX_CHAOS_PERCENTAGE);
+        if ($randomPercentage < $this->chaosOption->getChaosPercentage()) {
+            $response = $this->randomChaosResponse($request, $options);
+            if ($response) {
+                return Create::promiseFor($response);
+            }
+        }
+        $fn = $this->nextHandler;
+        return $fn($request, $options);
+    }
+
+    /**
+     * Selects a chaos response from ChaosOptions at random or falls back to selecting a random response
+     * from pre-configured possible responses per HTTP request method
+     *
+     * @param RequestInterface $request
+     * @param array $options
+     * @return ResponseInterface|null
+     */
+    private function randomChaosResponse(RequestInterface $request, array $options): ?ResponseInterface
+    {
+        $chaosResponses = $this->chaosOption->getChaosResponses();
+        if (empty($chaosResponses)) {
+            $chaosResponses = $this->getRandomResponsesByRequestMethod($request->getMethod());
+        }
+        if (!$chaosResponses) {
+            return null;
+        }
+        $randomIndex = rand(0, sizeof($chaosResponses) - 1);
+        $chaosResponse = $chaosResponses[$randomIndex];
+        return is_callable($chaosResponse) ? $chaosResponse($request, $options) : $chaosResponse;
+    }
+
+    /**
+     * Returns list of possible responses by HTTP request method
+     *
+     * @param string $httpMethod
+     * @return Response[]|null
+     */
+    private function getRandomResponsesByRequestMethod(string $httpMethod): ?array
+    {
+        $randomResponses = [
+            'GET' => [
+                new Response(200),
+                new Response(301),
+                new Response(307),
+                new Response(400),
+                new Response(401),
+                new Response(403),
+                new Response(404),
+                new Response(405),
+                new Response(429),
+                new Response(500),
+                new Response(502),
+                new Response(503),
+                new Response(504)
+            ],
+            'POST' => [
+                new Response(200),
+                new Response(201),
+                new Response(204),
+                new Response(307),
+                new Response(400),
+                new Response(401),
+                new Response(403),
+                new Response(404),
+                new Response(405),
+                new Response(429),
+                new Response(500),
+                new Response(502),
+                new Response(503),
+                new Response(504),
+                new Response(507)
+            ],
+            'PUT' => [
+                new Response(200),
+                new Response(201),
+                new Response(400),
+                new Response(401),
+                new Response(403),
+                new Response(404),
+                new Response(405),
+                new Response(409),
+                new Response(429),
+                new Response(500),
+                new Response(502),
+                new Response(503),
+                new Response(504),
+                new Response(507)
+            ],
+            'PATCH' => [
+                new Response(200),
+                new Response(204),
+                new Response(400),
+                new Response(401),
+                new Response(403),
+                new Response(404),
+                new Response(405),
+                new Response(429),
+                new Response(500),
+                new Response(502),
+                new Response(503),
+                new Response(504)
+            ],
+            'DELETE' => [
+                new Response(200),
+                new Response(204),
+                new Response(400),
+                new Response(401),
+                new Response(403),
+                new Response(404),
+                new Response(405),
+                new Response(429),
+                new Response(500),
+                new Response(502),
+                new Response(503),
+                new Response(504),
+                new Response(507)
+            ]
+        ];
+
+        if (!array_key_exists(strtoupper($httpMethod), $randomResponses)) {
+            return null;
+        }
+        return $randomResponses[strtoupper($httpMethod)];
+    }
+}

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -8,6 +8,7 @@
 
 namespace Microsoft\Kiota\Http\Middleware;
 
+use Microsoft\Kiota\Http\Middleware\Options\ChaosOption;
 use Microsoft\Kiota\Http\Middleware\Options\CompressionOption;
 use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
 use Microsoft\Kiota\Http\Middleware\Options\TelemetryOption;
@@ -45,7 +46,7 @@ class KiotaMiddleware
      * @param CompressionOption|null $compressionOption
      * @return callable
      */
-    public static function compress(?CompressionOption $compressionOption = null): callable
+    public static function compression(?CompressionOption $compressionOption = null): callable
     {
         return static function (callable $handler) use ($compressionOption): CompressionHandler {
             return new CompressionHandler($handler, $compressionOption);
@@ -62,6 +63,19 @@ class KiotaMiddleware
     {
         return static function (callable $handler) use ($telemetryOption): TelemetryHandler {
             return new TelemetryHandler($handler, $telemetryOption);
+        };
+    }
+
+    /**
+     * Middleware that selects a chaos response (configured via {@link ChaosOption}) at random x% of the time
+     * If criteria is not met for a chaos response, the request is forwarded down the middleware chain
+     * @param ChaosOption|null $chaosOption
+     * @return callable
+     */
+    public static function chaos(?ChaosOption $chaosOption = null): callable
+    {
+        return static function (callable $handler) use ($chaosOption): ChaosHandler {
+            return new ChaosHandler($handler, $chaosOption);
         };
     }
 }

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -10,6 +10,7 @@ namespace Microsoft\Kiota\Http\Middleware;
 
 use Microsoft\Kiota\Http\Middleware\Options\CompressionOption;
 use Microsoft\Kiota\Http\Middleware\Options\RetryOption;
+use Microsoft\Kiota\Http\Middleware\Options\TelemetryOption;
 
 /**
  * Class KiotaMiddleware
@@ -48,6 +49,19 @@ class KiotaMiddleware
     {
         return static function (callable $handler) use ($compressionOption): CompressionHandler {
             return new CompressionHandler($handler, $compressionOption);
+        };
+    }
+
+    /**
+     * Middleware that allows configuration of a RequestInterface with telemetry data
+     *
+     * @param TelemetryOption|null $telemetryOption
+     * @return callable
+     */
+    public static function telemetry(?TelemetryOption $telemetryOption = null): callable
+    {
+        return static function (callable $handler) use ($telemetryOption): TelemetryHandler {
+            return new TelemetryHandler($handler, $telemetryOption);
         };
     }
 }

--- a/http/php/guzzle/src/Middleware/KiotaMiddleware.php
+++ b/http/php/guzzle/src/Middleware/KiotaMiddleware.php
@@ -35,7 +35,7 @@ class KiotaMiddleware
     public static function retry(?RetryOption $retryOption = null): callable
     {
         return static function (callable $handler) use ($retryOption) : RetryHandler {
-            return new RetryHandler($retryOption, $handler);
+            return new RetryHandler($handler, $retryOption);
         };
     }
 

--- a/http/php/guzzle/src/Middleware/Options/ChaosOption.php
+++ b/http/php/guzzle/src/Middleware/Options/ChaosOption.php
@@ -28,7 +28,7 @@ class ChaosOption
     /**
      * @var int Threshold below which a random $chaosResponse is returned
      */
-    private int $chaosPercentage = 10;
+    private int $chaosPercentage;
 
     /**
      * @var array set of chaos ResponseInterfaces or callables(RequestInterface, array):ResponseInterface that are returned/executed at random.

--- a/http/php/guzzle/src/Middleware/Options/ChaosOption.php
+++ b/http/php/guzzle/src/Middleware/Options/ChaosOption.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware\Options;
+
+use Microsoft\Kiota\Http\Middleware\ChaosHandler;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class ChaosOption
+ *
+ * Configs for {@link ChaosHandler}
+ *
+ * @package Microsoft\Kiota\Http\Middleware\Options
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class ChaosOption
+{
+    public const MAX_CHAOS_PERCENTAGE = 100;
+
+    /**
+     * @var int Threshold below which a random $chaosResponse is returned
+     */
+    private int $chaosPercentage = 10;
+
+    /**
+     * @var array set of chaos ResponseInterfaces or callables(RequestInterface, array):ResponseInterface that are returned/executed at random.
+     */
+    private array $chaosResponses = [];
+
+    /**
+     * @param int $chaosPercentage
+     * @param array $chaosResponses
+     */
+    public function __construct(array $chaosResponses = [], int $chaosPercentage = 10)
+    {
+        if ($chaosPercentage < 0 || $chaosPercentage > self::MAX_CHAOS_PERCENTAGE) {
+            throw new \InvalidArgumentException("Chaos percentage should be between 0 and ".self::MAX_CHAOS_PERCENTAGE);
+        }
+
+        $this->chaosPercentage = $chaosPercentage;
+        $this->chaosResponses = $chaosResponses;
+    }
+
+    /**
+     * @param int $chaosPercentage
+     */
+    public function setChaosPercentage(int $chaosPercentage): void
+    {
+        if ($chaosPercentage < 0 || $chaosPercentage > self::MAX_CHAOS_PERCENTAGE) {
+            throw new \InvalidArgumentException("Chaos percentage should be between 0 and ".self::MAX_CHAOS_PERCENTAGE);
+        }
+        $this->chaosPercentage = $chaosPercentage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getChaosPercentage(): int
+    {
+        return $this->chaosPercentage;
+    }
+
+    /**
+     * @param array $chaosResponses
+     */
+    public function setChaosResponses(array $chaosResponses): void
+    {
+        $this->chaosResponses = $chaosResponses;
+    }
+
+    /**
+     * @return array
+     */
+    public function getChaosResponses(): array
+    {
+        return $this->chaosResponses;
+    }
+}

--- a/http/php/guzzle/src/Middleware/Options/TelemetryOption.php
+++ b/http/php/guzzle/src/Middleware/Options/TelemetryOption.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware\Options;
+
+use Microsoft\Kiota\Http\Middleware\TelemetryHandler;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class TelemetryOption
+ *
+ * Configs for a {@link TelemetryHandler}
+ *
+ * @package Microsoft\Kiota\Http\Middleware\Options
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class TelemetryOption
+{
+    /**
+     * @var callable(RequestInterface):RequestInterface
+     * Function that adds appropriate telemetry information to a request
+     */
+    private $telemetryConfigurator;
+
+    /**
+     * @param callable(RequestInterface): RequestInterface|null $telemetryConfigurator {@link $telemetryConfigurator}
+     */
+    public function __construct(?callable $telemetryConfigurator = null)
+    {
+        $this->telemetryConfigurator = $telemetryConfigurator;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getTelemetryConfigurator(): ?callable
+    {
+        return $this->telemetryConfigurator;
+    }
+
+    /**
+     * @param callable(RequestInterface):RequestInterface|null $telemetryConfigurator
+     */
+    public function setTelemetryConfigurator(?callable $telemetryConfigurator): void
+    {
+        $this->telemetryConfigurator = $telemetryConfigurator;
+    }
+}

--- a/http/php/guzzle/src/Middleware/RetryHandler.php
+++ b/http/php/guzzle/src/Middleware/RetryHandler.php
@@ -43,7 +43,7 @@ class RetryHandler
      * @param RetryOption|null $retryOption
      * @param callable $nextHandler
      */
-    public function __construct(?RetryOption $retryOption, callable $nextHandler)
+    public function __construct(callable $nextHandler, ?RetryOption $retryOption = null)
     {
         $this->retryOption = ($retryOption) ?: new RetryOption();
         $this->nextHandler = $nextHandler;

--- a/http/php/guzzle/src/Middleware/TelemetryHandler.php
+++ b/http/php/guzzle/src/Middleware/TelemetryHandler.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Microsoft\Kiota\Http\Middleware\Options\TelemetryOption;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class TelemetryHandler
+ *
+ * Middleware that allows configuration of a RequestInterface with telemetry data
+ *
+ * @package Microsoft\Kiota\Http\Middleware
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class TelemetryHandler
+{
+    /**
+     * @var callable(RequestInterface, array):PromiseInterface
+     * Next handler in the handler stack
+     */
+    private $nextHandler;
+
+    /**
+     * @var TelemetryOption|null {@link TelemetryOption}
+     */
+    private ?TelemetryOption $telemetryOption;
+
+    public function __construct(callable $nextHandler, ?TelemetryOption $telemetryOption = null)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->telemetryOption = $telemetryOption;
+    }
+
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        if ($this->telemetryOption && $this->telemetryOption->getTelemetryConfigurator()) {
+            $request = $this->telemetryOption->getTelemetryConfigurator()($request);
+        }
+        $fn = $this->nextHandler;
+        return $fn($request, $options);
+    }
+}

--- a/http/php/guzzle/tests/Middleware/ChaosHandlerTest.php
+++ b/http/php/guzzle/tests/Middleware/ChaosHandlerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Microsoft\Kiota\Http\Test\Middleware;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Middleware\ChaosHandler;
+use Microsoft\Kiota\Http\Middleware\KiotaMiddleware;
+use Microsoft\Kiota\Http\Middleware\Options\ChaosOption;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class ChaosHandlerTest extends TestCase
+{
+    public function testRandomResponseIsSelectedFromChaosOptions()
+    {
+        $chaosOptions = new ChaosOption([
+            new Response(404),
+            function (RequestInterface $request, array $options) {
+                return new Response(500);
+            }
+        ], 100);
+
+        $chaosClient = $this->getChaosClient($chaosOptions);
+        $chaosResponse = $chaosClient->get("/");
+        $this->assertTrue($chaosResponse->getStatusCode() > 200); // mock handler returns 200s only
+    }
+
+    public function testDefaultResponseIsSelectedIfNoChaosResponses()
+    {
+        $chaosOptions = new ChaosOption([], 100);
+        $chaosClient = $this->getChaosClient($chaosOptions);
+        $response = $chaosClient->get("/");
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function testRequestLevelConfigOverridesClientLevelConfig()
+    {
+        $requestChaosOptions = new ChaosOption([
+            new Response(300),
+            function (RequestInterface $request, array $options) {
+                return new Response(300);
+            }
+        ], 100);
+        $requestOption = [
+            ChaosHandler::CHAOS_GUZZLE_CONFIG => $requestChaosOptions
+        ];
+        $chaosClient = $this->getChaosClient(new ChaosOption());
+        $chaosResponse = $chaosClient->get("/", $requestOption);
+        $this->assertTrue($chaosResponse->getStatusCode() == 300);
+    }
+
+    private function getChaosClient(ChaosOption $chaosOption): Client
+    {
+        $mockHandler = new MockHandler([
+            new Response(200),
+            new Response(200),
+            new Response(200),
+            new Response(200),
+            new Response(200)
+        ]);
+        $handlerStack = new HandlerStack($mockHandler);
+        $handlerStack->push(KiotaMiddleware::chaos($chaosOption));
+        return new Client(['handler' => $handlerStack, 'http_errors' => false]);
+    }
+
+
+}

--- a/http/php/guzzle/tests/Middleware/CompressionHandlerTest.php
+++ b/http/php/guzzle/tests/Middleware/CompressionHandlerTest.php
@@ -94,7 +94,7 @@ class CompressionHandlerTest extends TestCase
     {
         $mockHandler = new MockHandler($mockResponses);
         $handlerStack = new HandlerStack($mockHandler);
-        $handlerStack->push(KiotaMiddleware::compress($compressionOption));
+        $handlerStack->push(KiotaMiddleware::compression($compressionOption));
 
         $guzzleClient = new Client(['handler' => $handlerStack, 'http_errors' => false]);
         return $guzzleClient->get("/", $requestOptions);

--- a/http/php/guzzle/tests/Middleware/TelemetryHandlerTest.php
+++ b/http/php/guzzle/tests/Middleware/TelemetryHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Microsoft\Kiota\Http\Test\Middleware;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Middleware\KiotaMiddleware;
+use Microsoft\Kiota\Http\Middleware\Options\TelemetryOption;
+use Microsoft\Kiota\Http\Middleware\TelemetryHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class TelemetryHandlerTest extends TestCase
+{
+    public function testTelemetry()
+    {
+        $telemetryConfigurator = function (RequestInterface $request) {
+            return $request->withHeader('SdkVersion', '1.0');
+        };
+        $telemetryOption = new TelemetryOption($telemetryConfigurator);
+        $mockResponse = [
+            function (RequestInterface $request, array $options) {
+                if ($request->hasHeader('SdkVersion') && $request->getHeaderLine('SdkVersion') === '1.0') {
+                    return new Response(200);
+                }
+                throw new \RuntimeException("Telemetry header not set");
+            }
+        ];
+        $response = $this->executeMockRequest($mockResponse, $telemetryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testTelemetryWithNullCallback()
+    {
+        $telemetryOption = new TelemetryOption(null);
+        $mockResponse = [new Response(200)];
+        $response = $this->executeMockRequest($mockResponse, $telemetryOption);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    private function executeMockRequest(array $mockResponses, ?TelemetryOption $telemetryOption = null, ?array $requestOptions = [])
+    {
+        $mockHandler = new MockHandler($mockResponses);
+        $handlerStack = new HandlerStack($mockHandler);
+        $handlerStack->push(KiotaMiddleware::telemetry($telemetryOption));
+
+        $guzzleClient = new Client(['handler' => $handlerStack, 'http_errors' => false]);
+        return $guzzleClient->get("/", $requestOptions);
+    }
+}


### PR DESCRIPTION
Generic Telemetry & Chaos Handler implementations

Guzzle's built in [MockHandler](https://docs.guzzlephp.org/en/stable/testing.html#mock-handler) handles "Manual mode" scenarios defined by [Chaos Handler design spec](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/ChaosHandler.md). The PHP Chaos Handler will only handle "random mode" scenarios.

part of #364 