### PR TITLE
[Dotnet] adds support for date-only, time-only and duration in Kiota

### DIFF
--- a/abstractions/dotnet/src/Date.cs
+++ b/abstractions/dotnet/src/Date.cs
@@ -1,0 +1,81 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    /// Model to represent only the date component of a DateTime
+    /// </summary>
+    public struct Date
+    {
+        /// <summary>
+        /// Create a new Date object from a <see cref="DateTime"/> object
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> object to use</param>
+        public Date(DateTime dateTime)
+        {
+            this.DateTime = dateTime;
+        }
+
+        /// <summary>
+        /// Create a new Date object from a year, month, and day.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <param name="month">The month.</param>
+        /// <param name="day">The day of the month.</param>
+        public Date(int year, int month, int day)
+            : this(new DateTime(year, month, day))
+        {
+        }
+
+        /// <summary>
+        /// The DateTime object.
+        /// </summary>
+        public DateTime DateTime { get; }
+
+        /// <summary>
+        /// The date's year.
+        /// </summary>
+        public int Year
+        {
+            get
+            {
+                return this.DateTime.Year;
+            }
+        }
+
+        /// <summary>
+        /// The date's month.
+        /// </summary>
+        public int Month
+        {
+            get
+            {
+                return this.DateTime.Month;
+            }
+        }
+
+        /// <summary>
+        /// The date's day.
+        /// </summary>
+        public int Day
+        {
+            get
+            {
+                return this.DateTime.Day;
+            }
+        }
+
+        /// <summary>
+        /// Convert the date to a string.
+        /// </summary>
+        /// <returns>The string value of the date in the format "yyyy-MM-dd".</returns>
+        public override string ToString()
+        {
+            return this.DateTime.ToString("yyyy-MM-dd");
+        }
+    }
+}

--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.26</Version>
+    <Version>1.0.27</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/abstractions/dotnet/src/Time.cs
+++ b/abstractions/dotnet/src/Time.cs
@@ -1,0 +1,81 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    /// Model to represent only the date component of a DateTime
+    /// </summary>
+    public struct Time
+    {
+        /// <summary>
+        /// Create a new Time from hours, minutes, and seconds.
+        /// </summary>
+        /// <param name="hour">The hour.</param>
+        /// <param name="minute">The minute.</param>
+        /// <param name="second">The second.</param>
+        public Time(int hour, int minute, int second)
+            : this(new DateTime(1, 1, 1, hour, minute, second))
+        {
+        }
+
+        /// <summary>
+        /// Create a new Time from a <see cref="DateTime"/> object
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> object to create the object from.</param>
+        public Time(DateTime dateTime)
+        {
+            this.DateTime = dateTime;
+        }
+
+        /// <summary>
+        /// The <see cref="DateTime"/> representation of the class
+        /// </summary>
+        public DateTime DateTime { get; }
+
+        /// <summary>
+        /// The hour.
+        /// </summary>
+        public int Hour
+        {
+            get
+            {
+                return this.DateTime.Hour;
+            }
+        }
+
+        /// <summary>
+        /// The minute.
+        /// </summary>
+        public int Minute
+        {
+            get
+            {
+                return this.DateTime.Minute;
+            }
+        }
+
+        /// <summary>
+        /// The second.
+        /// </summary>
+        public int Second
+        {
+            get
+            {
+                return this.DateTime.Second;
+            }
+        }
+
+        /// <summary>
+        /// The time of day, formatted as "HH:mm:ss".
+        /// </summary>
+        /// <returns>The string time of day.</returns>
+        public override string ToString()
+        {
+            return this.DateTime.ToString("HH:mm:ss");
+        }
+    }
+}

--- a/abstractions/dotnet/src/serialization/IParseNode.cs
+++ b/abstractions/dotnet/src/serialization/IParseNode.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -58,6 +58,21 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// </summary>
         /// <returns>The DateTimeOffset value of the node.</returns>
         DateTimeOffset? GetDateTimeOffsetValue();
+        /// <summary>
+        /// Gets the TimeSpan value of the node.
+        /// </summary>
+        /// <returns>The TimeSpan value of the node.</returns>
+        TimeSpan? GetTimeSpanValue();
+        /// <summary>
+        /// Gets the Date value of the node.
+        /// </summary>
+        /// <returns>The Date value of the node.</returns>
+        Date? GetDateValue();
+        /// <summary>
+        /// Gets the Time value of the node.
+        /// </summary>
+        /// <returns>The Time value of the node.</returns>
+        Time? GetTimeValue();
         /// <summary>
         /// Gets the collection of primitive values of the node.
         /// </summary>

--- a/abstractions/dotnet/src/serialization/ISerializationWriter.cs
+++ b/abstractions/dotnet/src/serialization/ISerializationWriter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -61,6 +61,24 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The DateTimeOffset value to be written.</param>
         void WriteDateTimeOffsetValue(string key, DateTimeOffset? value);
+        /// <summary>
+        /// Writes the specified TimeSpan value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The TimeSpan value to be written.</param>
+        void WriteTimeSpanValue(string key, TimeSpan? value);
+        /// <summary>
+        /// Writes the specified Date value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The Date value to be written.</param>
+        void WriteDateValue(string key, Date? value);
+        /// <summary>
+        /// Writes the specified Time value to the stream with an optional given key.
+        /// </summary>
+        /// <param name="key">The key to be used for the written value. May be null.</param>
+        /// <param name="value">The Time value to be written.</param>
+        void WriteTimeValue(string key, Time? value);
         /// <summary>
         /// Writes the specified collection of primitive values to the stream with an optional given key.
         /// </summary>

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.Json;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -24,7 +26,11 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                             "    \"officeLocation\": null,\r\n" +
                                             "    \"preferredLanguage\": \"en-US\",\r\n" +
                                             "    \"surname\": \"Bowen\",\r\n" +
+                                            "    \"workDuration\": \"PT1H\",\r\n" +
+                                            "    \"startWorkTime\": \"08:00:00.0000000\",\r\n" +
+                                            "    \"endWorkTime\": \"17:00:00.0000000\",\r\n" +
                                             "    \"userPrincipalName\": \"MeganB@M365x214355.onmicrosoft.com\",\r\n" +
+                                            "    \"birthDay\": \"2017-09-04\",\r\n" +
                                             "    \"id\": \"48d31887-5fad-4d73-a9f5-3c356e68a038\"\r\n" +
                                             "}";
 
@@ -47,6 +53,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal("Auditor", testEntity.AdditionalData["jobTitle"]);
             Assert.Equal("48d31887-5fad-4d73-a9f5-3c356e68a038", testEntity.Id);
             Assert.Equal(TestEnum.One | TestEnum.Two, testEntity.Numbers ); // Unknown enum value is not included
+            Assert.Equal(TimeSpan.FromHours(1), testEntity.WorkDuration); // Parses timespan values
+            Assert.Equal(new Time(8,0,0).ToString(),testEntity.StartWorkTime.ToString());// Parses time values
+            Assert.Equal(new Time(17, 0, 0).ToString(), testEntity.EndWorkTime.ToString());// Parses time values
+            Assert.Equal(new Date(2017,9,4).ToString(), testEntity.BirthDay.ToString());// Parses date values
         }
 
         [Fact]

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -16,6 +17,9 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var testEntity = new TestEntity()
             {
                 Id = "48d31887-5fad-4d73-a9f5-3c356e68a038",
+                WorkDuration = TimeSpan.FromHours(1),
+                StartWorkTime = new Time(8, 0, 0),
+                BirthDay = new Date(2017, 9, 4),
                 AdditionalData = new Dictionary<string, object>
                 {
                     {"mobilePhone",null}, // write null value
@@ -37,6 +41,9 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             // Assert
             var expectedString = "{" +
                                  "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
+                                 "\"workDuration\":\"PT1H\","+    // Serializes timespans
+                                 "\"birthDay\":\"2017-09-04\"," + // Serializes dates
+                                 "\"startWorkTime\":\"08:00:00\"," + //Serializes times
                                  "\"mobilePhone\":null," +
                                  "\"accountEnabled\":false," +
                                  "\"jobTitle\":\"Author\"," +

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
@@ -12,6 +13,14 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
         public string Id { get; set; }
         /// <summary>Read-only.</summary>
         public TestEnum? Numbers { get; set; }
+        /// <summary>Read-only.</summary>
+        public TimeSpan? WorkDuration { get; set; }
+        /// <summary>Read-only.</summary>
+        public Date? BirthDay { get; set; }
+        /// <summary>Read-only.</summary>
+        public Time? StartWorkTime { get; set; }
+        /// <summary>Read-only.</summary>
+        public Time? EndWorkTime { get; set; }
         /// <summary>Read-only.</summary>
         public DateTimeOffset? CreatedDateTime { get; set; }
         /// <summary>Read-only.</summary>
@@ -33,6 +42,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
                 {"numbers", (o,n) => { (o as TestEntity).Numbers = n.GetEnumValue<TestEnum>(); } },
                 {"createdDateTime", (o,n) => { (o as TestEntity).CreatedDateTime = n.GetDateTimeOffsetValue(); } },
                 {"officeLocation", (o,n) => { (o as TestEntity).OfficeLocation = n.GetStringValue(); } },
+                {"workDuration", (o,n) => { (o as TestEntity).WorkDuration = n.GetTimeSpanValue(); } },
+                {"birthDay", (o,n) => { (o as TestEntity).BirthDay = n.GetDateValue(); } },
+                {"startWorkTime", (o,n) => { (o as TestEntity).StartWorkTime = n.GetTimeValue(); } },
+                {"endWorkTime", (o,n) => { (o as TestEntity).EndWorkTime = n.GetTimeValue(); } },
             };
         }
         /// <summary>
@@ -46,6 +59,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
             writer.WriteEnumValue<TestEnum>("numbers",Numbers);
             writer.WriteDateTimeOffsetValue("createdDateTime", CreatedDateTime);
             writer.WriteStringValue("officeLocation", OfficeLocation);
+            writer.WriteTimeSpanValue("workDuration", WorkDuration);
+            writer.WriteDateValue("birthDay", BirthDay);
+            writer.WriteTimeValue("startWorkTime", StartWorkTime);
+            writer.WriteTimeValue("endWorkTime", EndWorkTime);
             writer.WriteAdditionalData(AdditionalData);
         }
     }

--- a/serialization/dotnet/json/src/JsonParseNode.cs
+++ b/serialization/dotnet/json/src/JsonParseNode.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.Kiota.Abstractions.Serialization;
+using Microsoft.Kiota.Abstractions;
+using System.Xml;
 
 namespace Microsoft.Kiota.Serialization.Json
 {
@@ -84,6 +86,46 @@ namespace Microsoft.Kiota.Serialization.Json
         }
 
         /// <summary>
+        /// Get the <see cref="TimeSpan"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="TimeSpan"/> value</returns>
+        public TimeSpan? GetTimeSpanValue()
+        {
+            var jsonString = _jsonNode.GetString();
+            if(string.IsNullOrEmpty(jsonString))
+                return null;
+
+            // Parse an ISO8601 duration.http://en.wikipedia.org/wiki/ISO_8601#Durations to a TimeSpan
+            return XmlConvert.ToTimeSpan(jsonString);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Date"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="Date"/> value</returns>
+        public Date? GetDateValue()
+        {
+            var dateString = _jsonNode.GetString();
+            if(!DateTime.TryParse(dateString,out var result))
+                return null;
+
+            return new Date(result);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Time"/> value from the json node
+        /// </summary>
+        /// <returns>A <see cref="Time"/> value</returns>
+        public Time? GetTimeValue()
+        {
+            var dateString = _jsonNode.GetString();
+            if(!DateTime.TryParse(dateString,out var result))
+                return null;
+
+            return new Time(result);
+        }
+
+        /// <summary>
         /// Get the enumeration value of type <typeparam name="T"/>from the json node
         /// </summary>
         /// <returns>An enumeration value or null</returns>
@@ -154,6 +196,9 @@ namespace Microsoft.Kiota.Serialization.Json
         private static Type doubleType = typeof(double?);
         private static Type guidType = typeof(Guid?);
         private static Type dateTimeOffsetType = typeof(DateTimeOffset?);
+        private static Type timeSpanType = typeof(TimeSpan?);
+        private static Type dateType = typeof(Date?);
+        private static Type timeType = typeof(Time?);
 
         /// <summary>
         /// Get the collection of primitives of type <typeparam name="T"/>from the json node
@@ -183,6 +228,12 @@ namespace Microsoft.Kiota.Serialization.Json
                     yield return (T)(object)currentParseNode.GetGuidValue();
                 else if(genericType == dateTimeOffsetType)
                     yield return (T)(object)currentParseNode.GetDateTimeOffsetValue();
+                else if(genericType == timeSpanType)
+                    yield return (T)(object)currentParseNode.GetTimeSpanValue();
+                else if(genericType == dateType)
+                    yield return (T)(object)currentParseNode.GetDateValue();
+                else if(genericType == timeType)
+                    yield return (T)(object)currentParseNode.GetTimeValue();
                 else
                     throw new InvalidOperationException($"unknown type for deserialization {genericType.FullName}");
             }

--- a/serialization/dotnet/json/src/JsonSerializationWriter.cs
+++ b/serialization/dotnet/json/src/JsonSerializationWriter.cs
@@ -10,6 +10,8 @@ using Microsoft.Kiota.Abstractions.Serialization;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Kiota.Abstractions.Extensions;
+using Microsoft.Kiota.Abstractions;
+using System.Xml;
 
 namespace Microsoft.Kiota.Serialization.Json
 {
@@ -147,6 +149,39 @@ namespace Microsoft.Kiota.Serialization.Json
         {
             if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
             if(value.HasValue) writer.WriteStringValue(value.Value);
+        }
+
+        /// <summary>
+        /// Write the TimeSpan(An ISO8601 duration.For example, PT1M is "period time of 1 minute") value.
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The TimeSpan value</param>
+        public void WriteTimeSpanValue(string key, TimeSpan? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(XmlConvert.ToString(value.Value));
+        }
+
+        /// <summary>
+        /// Write the Date value
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The Date value</param>
+        public void WriteDateValue(string key, Date? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
+        }
+
+        /// <summary>
+        /// Write the Time value
+        /// </summary>
+        /// <param name="key">The key of the json node</param>
+        /// <param name="value">The Time value</param>
+        public void WriteTimeValue(string key, Time? value)
+        {
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
         }
 
         /// <summary>
@@ -310,11 +345,20 @@ namespace Microsoft.Kiota.Serialization.Json
                 case DateTimeOffset dto:
                     WriteDateTimeOffsetValue(key, dto);
                     break;
+                case TimeSpan timeSpan:
+                    WriteTimeSpanValue(key, timeSpan);
+                    break;
                 case IEnumerable<object> coll:
                     WriteCollectionOfPrimitiveValues(key, coll);
                     break;
                 case IParsable parseable:
                     WriteObjectValue(key, parseable);
+                    break;
+                case Date date:
+                    WriteDateValue(key, date);
+                    break;
+                case Time time:
+                    WriteTimeValue(key, time);
                     break;
                 case object o:
                     WriteNonParsableObjectValue(key, o);

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.27" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -10,6 +10,7 @@ namespace Kiota.Builder.Refiners {
         public override void Refine(CodeNamespace generatedCode)
         {
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
             AddRawUrlConstructorOverload(generatedCode);
@@ -98,5 +99,41 @@ namespace Kiota.Builder.Refiners {
                 currentMethod.Name += "Async";
             CrawlTree(currentElement, AddAsyncSuffix);
         }
+        private static void CorrectPropertyType(CodeProperty currentProperty)
+        {
+            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+        }
+        private static void CorrectMethodType(CodeMethod currentMethod)
+        {
+            CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                                    .Select(x => x.Type)
+                                                    .Union(new CodeTypeBase[] { currentMethod.ReturnType })
+                                                    .ToArray());
+        }
+        private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
+        {
+            {
+                "DateOnly",("Date", new CodeUsing
+                    {
+                        Name = "Date",
+                        Declaration = new CodeType
+                        {
+                            Name = "Microsoft.Kiota.Abstractions",
+                            IsExternal = true,
+                        },
+                    })
+            },
+            {
+                "TimeOnly",("Time", new CodeUsing
+                    {
+                        Name = "Time",
+                        Declaration = new CodeType
+                        {
+                            Name = "Microsoft.Kiota.Abstractions",
+                            IsExternal = true,
+                        },
+                    })
+            },
+        };
     }
 }

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -9,7 +9,7 @@ namespace Kiota.Builder.Writers.CSharp {
         public override string StreamTypeName => "stream";
         public override string VoidTypeName => "void";
         public override string DocCommentPrefix => "/// ";
-        private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "bool", "float", "double", "decimal", "long", "Guid", "DateTimeOffset" };
+        private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "bool", "float", "double", "decimal", "long", "Guid", "DateTimeOffset", "TimeSpan", "Date","Time" };
         public static readonly char NullableMarker = '?';
         public static string NullableMarkerAsString => "?";
         public override string ParseNodeInterfaceName => "IParseNode";

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -145,6 +145,46 @@ namespace Kiota.Builder.Refiners.Tests {
             ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
             Assert.Equal(serializationName, propToAdd.SerializationName);
         }
+        [Fact]
+        public void ReplacesDateOnlyByNativeType()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "method",
+                ReturnType = new CodeType
+                {
+                    Name = "DateOnly"
+                },
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+            Assert.NotEmpty(model.StartBlock.Usings);
+            Assert.Equal("Date", method.ReturnType.Name);
+        }
+        [Fact]
+        public void ReplacesTimeOnlyByNativeType()
+        {
+            var model = root.AddClass(new CodeClass
+            {
+                Name = "model",
+                ClassKind = CodeClassKind.Model
+            }).First();
+            var method = model.AddMethod(new CodeMethod
+            {
+                Name = "method",
+                ReturnType = new CodeType
+                {
+                    Name = "TimeOnly"
+                },
+            }).First();
+            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+            Assert.NotEmpty(model.StartBlock.Usings);
+            Assert.Equal("Time", method.ReturnType.Name);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
This PR is part of #1004 

It covers dotnet changes needed to add support for date-only, time-only and duration in Kiota.

Changes involve 

- Adding the `Date` and `Time` types as the types from system are only available in dotnet 6. 
- Duration instances are represented with the `TimeSpan` type.
- Adding relevant serialization methods to the abstractions and serialization packages.
- Tests updated/added to cover the scenarios.

Sample generation of this using the full v1 description can be previewed [here](https://github.com/andrueastman/KiotaSdk/commit/476d19c2ee582be1cdb4797c1ecf9825c7667afa).

