### PR TITLE
splits authentication and access token interfaces for go, java, dotnet and docs

### DIFF
--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
@@ -5,52 +5,50 @@ using Microsoft.Kiota.Abstractions.Authentication;
 using Moq;
 using Xunit;
 
-namespace Microsoft.Kiota.Abstractions.Tests
+namespace Microsoft.Kiota.Abstractions.Tests;
+public class AuthenticationTests
 {
-    public class AuthenticationTests
+    [Fact]
+    public async Task AnonymousAuthenticationProviderReturnsSameRequestAsync()
     {
-        [Fact]
-        public async Task AnonymousAuthenticationProviderReturnsSameRequestAsync()
+        // Arrange
+        var anonymousAuthenticationProvider = new AnonymousAuthenticationProvider();
+        var testRequest = new RequestInformation()
         {
-            // Arrange
-            var anonymousAuthenticationProvider = new AnonymousAuthenticationProvider();
-            var testRequest = new RequestInformation()
-            {
-                HttpMethod = Method.GET,
-                URI = new Uri("http://localhost")
-            };
-            Assert.Empty(testRequest.Headers); // header collection is empty
+            HttpMethod = Method.GET,
+            URI = new Uri("http://localhost")
+        };
+        Assert.Empty(testRequest.Headers); // header collection is empty
 
-            // Act
-            await anonymousAuthenticationProvider.AuthenticateRequestAsync(testRequest);
+        // Act
+        await anonymousAuthenticationProvider.AuthenticateRequestAsync(testRequest);
 
-            // Assert
-            Assert.Empty(testRequest.Headers); // header collection is still empty
+        // Assert
+        Assert.Empty(testRequest.Headers); // header collection is still empty
 
-        }
+    }
 
-        [Fact]
-        public async Task BaseBearerTokenAuthenticationProviderSetsBearerHeader()
+    [Fact]
+    public async Task BaseBearerTokenAuthenticationProviderSetsBearerHeader()
+    {
+        // Arrange
+        var expectedToken = "token";
+        var mockAccessTokenProvider = new Mock<IAccessTokenProvider>();
+        mockAccessTokenProvider.Setup(authProvider => authProvider.GetAuthorizationTokenAsync(It.IsAny<Uri>())).Returns(Task.FromResult(expectedToken));
+        var testAuthProvider = new BaseBearerTokenAuthenticationProvider(mockAccessTokenProvider.Object);
+        var testRequest = new RequestInformation()
         {
-            // Arrange
-            var expectedToken = "token";
-            var mockBaseBearerTokenAuthenticationProvider = new Mock<BaseBearerTokenAuthenticationProvider>();
-            mockBaseBearerTokenAuthenticationProvider.Setup(authProvider => authProvider.GetAuthorizationTokenAsync(It.IsAny<RequestInformation>())).Returns(Task.FromResult(expectedToken));
-            var testAuthProvider = mockBaseBearerTokenAuthenticationProvider.Object;
-            var testRequest = new RequestInformation()
-            {
-                HttpMethod = Method.GET,
-                URI = new Uri("http://localhost")
-            };
-            Assert.Empty(testRequest.Headers); // header collection is empty
+            HttpMethod = Method.GET,
+            URI = new Uri("http://localhost")
+        };
+        Assert.Empty(testRequest.Headers); // header collection is empty
 
-            // Act
-            await testAuthProvider.AuthenticateRequestAsync(testRequest);
+        // Act
+        await testAuthProvider.AuthenticateRequestAsync(testRequest);
 
-            // Assert
-            Assert.NotEmpty(testRequest.Headers); // header collection is longer empty
-            Assert.Equal("Authorization", testRequest.Headers.First().Key); // First element is Auth header
-            Assert.Equal($"Bearer {expectedToken}", testRequest.Headers.First().Value); // First element is Auth header
-        }
+        // Assert
+        Assert.NotEmpty(testRequest.Headers); // header collection is longer empty
+        Assert.Equal("Authorization", testRequest.Headers.First().Key); // First element is Auth header
+        Assert.Equal($"Bearer {expectedToken}", testRequest.Headers.First().Value); // First element is Auth header
     }
 }

--- a/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
+++ b/abstractions/dotnet/Microsoft.Kiota.Abstractions.Tests/Authentication/AuthenticationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Moq;
@@ -34,7 +35,7 @@ public class AuthenticationTests
         // Arrange
         var expectedToken = "token";
         var mockAccessTokenProvider = new Mock<IAccessTokenProvider>();
-        mockAccessTokenProvider.Setup(authProvider => authProvider.GetAuthorizationTokenAsync(It.IsAny<Uri>())).Returns(Task.FromResult(expectedToken));
+        mockAccessTokenProvider.Setup(authProvider => authProvider.GetAuthorizationTokenAsync(It.IsAny<Uri>(),It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedToken));
         var testAuthProvider = new BaseBearerTokenAuthenticationProvider(mockAccessTokenProvider.Object);
         var testRequest = new RequestInformation()
         {

--- a/abstractions/dotnet/src/authentication/AnonymousAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/AnonymousAuthenticationProvider.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions.Authentication
@@ -15,8 +16,9 @@ namespace Microsoft.Kiota.Abstractions.Authentication
         /// Authenticates the <see cref="RequestInformation"/> instance
         /// </summary>
         /// <param name="request">The request to authenticate</param>
+        /// <param name="cancellationToken">The cancellation token for the task</param>
         /// <returns></returns>
-        public Task AuthenticateRequestAsync(RequestInformation request)
+        public Task AuthenticateRequestAsync(RequestInformation request, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions.Authentication;
@@ -29,13 +30,14 @@ public class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider
     /// Authenticates the <see cref="RequestInformation"/> instance
     /// </summary>
     /// <param name="request">The request to authenticate</param>
+    /// <param name="cancellationToken">The cancellation token for the task</param>
     /// <returns></returns>
-    public async Task AuthenticateRequestAsync(RequestInformation request)
+    public async Task AuthenticateRequestAsync(RequestInformation request, CancellationToken cancellationToken = default)
     {
         if(request == null) throw new ArgumentNullException(nameof(request));
         if(!request.Headers.ContainsKey(AuthorizationHeaderKey))
         {
-            var token = await AccessTokenProvider.GetAuthorizationTokenAsync(request.URI);
+            var token = await AccessTokenProvider.GetAuthorizationTokenAsync(request.URI, cancellationToken);
             if(string.IsNullOrEmpty(token))
                 throw new InvalidOperationException("Could not get an authorization token");
             request.Headers.Add(AuthorizationHeaderKey, $"Bearer {token}");

--- a/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/BaseBearerTokenAuthenticationProvider.cs
@@ -5,36 +5,40 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Microsoft.Kiota.Abstractions.Authentication
+namespace Microsoft.Kiota.Abstractions.Authentication;
+/// <summary>
+///     Provides a base class for implementing <see cref="IAuthenticationProvider" /> for Bearer token scheme.
+/// </summary>
+public class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider
 {
     /// <summary>
-    ///     Provides a base class for implementing <see cref="IAuthenticationProvider" /> for Bearer token scheme.
+    /// Creates a new instance of <see cref="BaseBearerTokenAuthenticationProvider"/>.
     /// </summary>
-    public abstract class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider
+    /// <param name="accessTokenProvider">The <see cref="IAccessTokenProvider"/> to use for getting the access token.</param>
+    public BaseBearerTokenAuthenticationProvider(IAccessTokenProvider accessTokenProvider)
     {
-        private const string AuthorizationHeaderKey = "Authorization";
+        AccessTokenProvider = accessTokenProvider ?? throw new ArgumentNullException(nameof(accessTokenProvider));
+    }
+    /// <summary>
+    ///     Gets the <see cref="IAccessTokenProvider" /> to use for getting the access token.
+    /// </summary>
+    public IAccessTokenProvider AccessTokenProvider {get; private set;}
+    private const string AuthorizationHeaderKey = "Authorization";
 
-        /// <summary>
-        /// Authenticates the <see cref="RequestInformation"/> instance
-        /// </summary>
-        /// <param name="request">The request to authenticate</param>
-        /// <returns></returns>
-        public async Task AuthenticateRequestAsync(RequestInformation request)
+    /// <summary>
+    /// Authenticates the <see cref="RequestInformation"/> instance
+    /// </summary>
+    /// <param name="request">The request to authenticate</param>
+    /// <returns></returns>
+    public async Task AuthenticateRequestAsync(RequestInformation request)
+    {
+        if(request == null) throw new ArgumentNullException(nameof(request));
+        if(!request.Headers.ContainsKey(AuthorizationHeaderKey))
         {
-            if(request == null) throw new ArgumentNullException(nameof(request));
-            if(!request.Headers.ContainsKey(AuthorizationHeaderKey))
-            {
-                var token = await GetAuthorizationTokenAsync(request);
-                if(string.IsNullOrEmpty(token))
-                    throw new InvalidOperationException("Could not get an authorization token");
-                request.Headers.Add(AuthorizationHeaderKey, $"Bearer {token}");
-            }
+            var token = await AccessTokenProvider.GetAuthorizationTokenAsync(request.URI);
+            if(string.IsNullOrEmpty(token))
+                throw new InvalidOperationException("Could not get an authorization token");
+            request.Headers.Add(AuthorizationHeaderKey, $"Bearer {token}");
         }
-        /// <summary>
-        ///     This method is called by the <see cref="BaseBearerTokenAuthenticationProvider" /> class to authenticate the request via the returned access token.
-        /// </summary>
-        /// <param name="request">The request to authenticate.</param>
-        /// <returns>A Task that holds the access token to use for the request.</returns>
-        public abstract Task<string> GetAuthorizationTokenAsync(RequestInformation request);
     }
 }

--- a/abstractions/dotnet/src/authentication/IAccessTokenProvider.cs
+++ b/abstractions/dotnet/src/authentication/IAccessTokenProvider.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions.Authentication;
@@ -15,6 +16,7 @@ public interface IAccessTokenProvider
     ///     This method is called by the <see cref="BaseBearerTokenAuthenticationProvider" /> class to get the access token.
     /// </summary>
     /// <param name="uri">The target URI to get an access token for.</param>
+    /// <param name="cancellationToken">The cancellation token for the task</param>
     /// <returns>A Task that holds the access token to use for the request.</returns>
-    Task<string> GetAuthorizationTokenAsync(Uri uri);
+    Task<string> GetAuthorizationTokenAsync(Uri uri, CancellationToken cancellationToken = default);
 }

--- a/abstractions/dotnet/src/authentication/IAccessTokenProvider.cs
+++ b/abstractions/dotnet/src/authentication/IAccessTokenProvider.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kiota.Abstractions.Authentication;
+
+/// <summary>
+/// Defines a contract for obtaining access tokens for a given url.
+/// </summary>
+public interface IAccessTokenProvider
+{
+    /// <summary>
+    ///     This method is called by the <see cref="BaseBearerTokenAuthenticationProvider" /> class to get the access token.
+    /// </summary>
+    /// <param name="uri">The target URI to get an access token for.</param>
+    /// <returns>A Task that holds the access token to use for the request.</returns>
+    Task<string> GetAuthorizationTokenAsync(Uri uri);
+}

--- a/abstractions/dotnet/src/authentication/IAuthenticationProvider.cs
+++ b/abstractions/dotnet/src/authentication/IAuthenticationProvider.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Abstractions.Authentication
@@ -15,7 +16,8 @@ namespace Microsoft.Kiota.Abstractions.Authentication
         /// Authenticates the application request.
         /// </summary>
         /// <param name="request">The request to authenticate.</param>
+        /// <param name="cancellationToken">The cancellation token for the task</param>
         /// <returns>A task to await for the authentication to be completed.</returns>
-        Task AuthenticateRequestAsync(RequestInformation request);
+        Task AuthenticateRequestAsync(RequestInformation request, CancellationToken cancellationToken = default);
     }
 }

--- a/abstractions/go/authentication/access_token_provider.go
+++ b/abstractions/go/authentication/access_token_provider.go
@@ -1,0 +1,11 @@
+package authentication
+
+import (
+	u "net/url"
+)
+
+//AccessTokenProvider returns access tokens.
+type AccessTokenProvider interface {
+	// GetAuthorizationToken returns the access token for the provided url.
+	GetAuthorizationToken(url *u.URL) (string, error)
+}

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/authentication/AccessTokenProvider.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/authentication/AccessTokenProvider.java
@@ -1,0 +1,17 @@
+package com.microsoft.kiota.authentication;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nonnull;
+
+/** Returns access tokens */
+public interface AccessTokenProvider {
+    /**
+     * This method returns the access token for the provided url.
+     * @param uri The target URI to get an access token for.
+     * @return A CompletableFuture that holds the access token.
+     */
+    @Nonnull
+    CompletableFuture<String> getAuthorizationToken(@Nonnull final URI uri);
+}

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/authentication/BaseBearerTokenAuthenticationProvider.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/authentication/BaseBearerTokenAuthenticationProvider.java
@@ -3,18 +3,30 @@ package com.microsoft.kiota.authentication;
 import com.microsoft.kiota.RequestInformation;
 
 import java.lang.UnsupportedOperationException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.CompletableFuture;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
 /** Provides a base class for implementing AuthenticationProvider for Bearer token scheme. */
-public abstract class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
+public class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
+    public BaseBearerTokenAuthenticationProvider(@Nonnull final AccessTokenProvider accessTokenProvider) {
+        this.accessTokenProvider = Objects.requireNonNull(accessTokenProvider);
+    }
+    private final AccessTokenProvider accessTokenProvider;
     private final static String authorizationHeaderKey = "Authorization";
     public CompletableFuture<Void> authenticateRequest(final RequestInformation request) {
         Objects.requireNonNull(request);
         if(!request.headers.keySet().contains(authorizationHeaderKey)) {
-            return this.getAuthorizationToken(request)
+            final URI targetUri;
+            try {
+                targetUri = request.getUri();
+            } catch (URISyntaxException e) {
+                return CompletableFuture.failedFuture(e);
+            }
+            return this.accessTokenProvider.getAuthorizationToken(targetUri)
                 .thenApply(token -> {
                     if(token == null || token.isEmpty()) {
                         throw new UnsupportedOperationException("Could not get an authorization token", null);
@@ -26,11 +38,4 @@ public abstract class BaseBearerTokenAuthenticationProvider implements Authentic
             return CompletableFuture.completedFuture(null);
         }
     }
-    /**
-     * This method is called by the BaseBearerTokenAuthenticationProvider class to authenticate the request via the returned access token.
-     * @param request The request to authenticate.
-     * @return A CompletableFuture that holds the access token to use for the request.
-     */
-    @Nonnull
-    public abstract CompletableFuture<String> getAuthorizationToken(@Nonnull final RequestInformation request);
 }

--- a/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
+++ b/authentication/dotnet/azure/Microsoft.Kiota.Authentication.Azure.Tests/AzureIdentityAuthenticationProviderTests.cs
@@ -7,63 +7,56 @@ using Xunit;
 using Azure.Core;
 using Microsoft.Kiota.Abstractions;
 
-namespace Microsoft.Kiota.Authentication.Azure.Tests
+namespace Microsoft.Kiota.Authentication.Azure.Tests;
+public class AzureIdentityAuthenticationProviderTests
 {
-    public class AzureIdentityAuthenticationProviderTests
+    [Fact]
+    public void ConstructorThrowsArgumentNullExceptionOnNullTokenCredential()
     {
-        [Fact]
-        public void ConstructorThrowsArgumentNullExceptionOnNullTokenCredential()
+        // Arrange
+        var exception = Assert.Throws<ArgumentNullException>(() => new AzureIdentityAccessTokenProvider(null, null));
+
+        // Assert
+        Assert.Equal("credential", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationTokenAsyncGetsToken()
+    {
+        // Arrange
+        var expectedToken = "token";
+        var mockTokenCredential = new Mock<TokenCredential>();
+        mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
+        var azureIdentityAuthenticationProvider = new AzureIdentityAccessTokenProvider(mockTokenCredential.Object, null);
+
+        // Act
+        var token = await azureIdentityAuthenticationProvider.GetAuthorizationTokenAsync(new Uri("http://localhost"));
+
+        // Assert
+        Assert.Equal(expectedToken, token);
+    }
+
+    [Fact]
+    public async Task AuthenticateRequestAsyncSetsBearerHeader()
+    {
+        // Arrange
+        var expectedToken = "token";
+        var mockTokenCredential = new Mock<TokenCredential>();
+        mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
+        var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object,"User.Read");
+        var testRequest = new RequestInformation()
         {
-            // Arrange
-            var exception = Assert.Throws<ArgumentNullException>(() => new AzureIdentityAuthenticationProvider(null, null));
+            HttpMethod = Method.GET,
+            URI = new Uri("http://localhost")
+        };
+        Assert.Empty(testRequest.Headers); // header collection is empty
 
-            // Assert
-            Assert.Equal("credentials", exception.ParamName);
-        }
+        // Act
+        await azureIdentityAuthenticationProvider.AuthenticateRequestAsync(testRequest);
 
-        [Fact]
-        public async Task GetAuthorizationTokenAsyncGetsToken()
-        {
-            // Arrange
-            var expectedToken = "token";
-            var mockTokenCredential = new Mock<TokenCredential>();
-            mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
-            var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object, null);
-            var testRequest = new RequestInformation()
-            {
-                HttpMethod = Method.GET,
-                URI = new Uri("http://localhost")
-            };
-
-            // Act
-            var token = await azureIdentityAuthenticationProvider.GetAuthorizationTokenAsync(testRequest);
-
-            // Assert
-            Assert.Equal(expectedToken, token);
-        }
-
-        [Fact]
-        public async Task AuthenticateRequestAsyncSetsBearerHeader()
-        {
-            // Arrange
-            var expectedToken = "token";
-            var mockTokenCredential = new Mock<TokenCredential>();
-            mockTokenCredential.Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>())).Returns(ValueTask.FromResult(new AccessToken(expectedToken, DateTimeOffset.Now)));
-            var azureIdentityAuthenticationProvider = new AzureIdentityAuthenticationProvider(mockTokenCredential.Object,"User.Read");
-            var testRequest = new RequestInformation()
-            {
-                HttpMethod = Method.GET,
-                URI = new Uri("http://localhost")
-            };
-            Assert.Empty(testRequest.Headers); // header collection is empty
-
-            // Act
-            await azureIdentityAuthenticationProvider.AuthenticateRequestAsync(testRequest);
-
-            // Assert
-            Assert.NotEmpty(testRequest.Headers); // header collection is longer empty
-            Assert.Equal("Authorization", testRequest.Headers.First().Key); // First element is Auth header
-            Assert.Equal($"Bearer {expectedToken}", testRequest.Headers.First().Value); // First element is Auth header
-        }
+        // Assert
+        Assert.NotEmpty(testRequest.Headers); // header collection is longer empty
+        Assert.Equal("Authorization", testRequest.Headers.First().Key); // First element is Auth header
+        Assert.Equal($"Bearer {expectedToken}", testRequest.Headers.First().Value); // First element is Auth header
     }
 }

--- a/authentication/dotnet/azure/src/AzureIdentityAccessTokenProvider.cs
+++ b/authentication/dotnet/azure/src/AzureIdentityAccessTokenProvider.cs
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Authentication;
+
+namespace Microsoft.Kiota.Authentication.Azure;
+/// <summary>
+/// Provides an implementation of <see cref="IAuthenticationProvider"/> for Azure.Identity.
+/// </summary>
+public class AzureIdentityAccessTokenProvider : IAccessTokenProvider
+{
+    private readonly TokenCredential _credential;
+    private readonly List<string> _scopes;
+
+    /// <summary>
+    /// The <see cref="AzureIdentityAccessTokenProvider"/> constructor
+    /// </summary>
+    /// <param name="credential">The credential implementation to use to obtain the access token.</param>
+    /// <param name="scopes">The scopes to request the access token for.</param>
+    public AzureIdentityAccessTokenProvider(TokenCredential credential, params string[] scopes)
+    {
+        _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+        if(scopes == null)
+            _scopes = new();
+        else
+            _scopes = scopes.ToList();
+
+        if(!_scopes.Any())
+            _scopes.Add("https://graph.microsoft.com/.default"); //TODO: init from the request hostname instead so it doesn't block national clouds?
+    }
+
+    /// <summary>
+    /// Gets the authorization token for the given target URI.
+    /// </summary>
+    /// <param name="uri">The target <see cref="Uri"/> to get token for</param>
+    /// <returns>An authorization token string.</returns>
+    public async Task<string> GetAuthorizationTokenAsync(Uri uri)
+    {
+        var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray()), default); //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
+        return result.Token;
+    }
+
+}

--- a/authentication/dotnet/azure/src/AzureIdentityAccessTokenProvider.cs
+++ b/authentication/dotnet/azure/src/AzureIdentityAccessTokenProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Kiota.Abstractions;
@@ -40,10 +41,11 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider
     /// Gets the authorization token for the given target URI.
     /// </summary>
     /// <param name="uri">The target <see cref="Uri"/> to get token for</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> of the task</param>
     /// <returns>An authorization token string.</returns>
-    public async Task<string> GetAuthorizationTokenAsync(Uri uri)
+    public async Task<string> GetAuthorizationTokenAsync(Uri uri, CancellationToken cancellationToken = default)
     {
-        var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray()), default); //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
+        var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray()), cancellationToken); //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
         return result.Token;
     }
 

--- a/authentication/dotnet/azure/src/AzureIdentityAuthenticationProvider.cs
+++ b/authentication/dotnet/azure/src/AzureIdentityAuthenticationProvider.cs
@@ -10,42 +10,18 @@ using Azure.Core;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 
-namespace Microsoft.Kiota.Authentication.Azure
+namespace Microsoft.Kiota.Authentication.Azure;
+/// <summary>
+/// The <see cref="BaseBearerTokenAuthenticationProvider"/> implementation that supports implementations of <see cref="TokenCredential"/> from Azure.Identity.
+/// </summary>
+public class AzureIdentityAuthenticationProvider : BaseBearerTokenAuthenticationProvider
 {
     /// <summary>
-    /// The <see cref="BaseBearerTokenAuthenticationProvider"/> implementation that supports implementations of <see cref="TokenCredential"/> from Azure.Identity.
+    /// The <see cref="AzureIdentityAuthenticationProvider"/> constructor
     /// </summary>
-    public class AzureIdentityAuthenticationProvider : BaseBearerTokenAuthenticationProvider
+    /// <param name="credential">The credential implementation to use to obtain the access token.</param>
+    /// <param name="scopes">The scopes to request the access token for.</param>
+    public AzureIdentityAuthenticationProvider(TokenCredential credential, params string[] scopes) : base(new AzureIdentityAccessTokenProvider(credential, scopes))
     {
-        private readonly TokenCredential _credential;
-        private readonly List<string> _scopes;
-
-        /// <summary>
-        /// The <see cref="AzureIdentityAuthenticationProvider"/> constructor
-        /// </summary>
-        /// <param name="credentials"></param>
-        /// <param name="scopes"></param>
-        public AzureIdentityAuthenticationProvider(TokenCredential credentials, params string[] scopes)
-        {
-            _credential = credentials ?? throw new ArgumentNullException(nameof(credentials));
-            if(scopes == null)
-                _scopes = new();
-            else
-                _scopes = scopes.ToList();
-
-            if(!_scopes.Any())
-                _scopes.Add("https://graph.microsoft.com/.default"); //TODO: init from the request hostname instead so it doesn't block national clouds?
-        }
-
-        /// <summary>
-        /// Gets the authorization token for the given request.
-        /// </summary>
-        /// <param name="request">The <see cref="RequestInformation"/> instance to get te token for</param>
-        /// <returns> An authorization token string.</returns>
-        public async override Task<string> GetAuthorizationTokenAsync(RequestInformation request)
-        {
-            var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray()), default); //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
-            return result.Token;
-        }
     }
 }

--- a/authentication/go/azure/azure_identity_access_token_provider.go
+++ b/authentication/go/azure/azure_identity_access_token_provider.go
@@ -1,0 +1,54 @@
+package microsoft_kiota_authentication_azure
+
+import (
+	"context"
+	"errors"
+
+	u "net/url"
+
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// AzureIdentityAccessTokenProvider implementation of AccessTokenProvider that supports implementations of TokenCredential from Azure.Identity.
+type AzureIdentityAccessTokenProvider struct {
+	scopes     []string
+	credential azcore.TokenCredential
+}
+
+// NewAzureIdentityAccessTokenProvider creates a new instance of the AzureIdentityAccessTokenProvider using "https://graph.microsoft.com/.default" as the default scope.
+func NewAzureIdentityAccessTokenProvider(credential azcore.TokenCredential) (*AzureIdentityAccessTokenProvider, error) {
+	return NewAzureIdentityAccessTokenProviderWithScopes(credential, nil)
+}
+
+// NewAzureIdentityAccessTokenProviderWithScopes creates a new instance of the AzureIdentityAccessTokenProvider.
+func NewAzureIdentityAccessTokenProviderWithScopes(credential azcore.TokenCredential, scopes []string) (*AzureIdentityAccessTokenProvider, error) {
+	if credential == nil {
+		return nil, errors.New("credential cannot be nil")
+	}
+	scopesLen := len(scopes)
+	finalScopes := make([]string, scopesLen)
+	if scopesLen == 0 {
+		finalScopes = append(finalScopes, "https://graph.microsoft.com/.default")
+	} else {
+		copy(finalScopes, scopes)
+	}
+	result := &AzureIdentityAccessTokenProvider{
+		credential: credential,
+		scopes:     finalScopes,
+	}
+
+	return result, nil
+}
+
+// GetAuthorizationToken returns the access token for the provided url.
+func (p *AzureIdentityAccessTokenProvider) GetAuthorizationToken(url *u.URL) (string, error) {
+	options := azpolicy.TokenRequestOptions{
+		Scopes: p.scopes,
+	}
+	token, err := p.credential.GetToken(context.Background(), options)
+	if err != nil {
+		return "", err
+	}
+	return token.Token, nil
+}

--- a/authentication/go/azure/azure_identity_authentication_provider.go
+++ b/authentication/go/azure/azure_identity_authentication_provider.go
@@ -3,20 +3,13 @@
 package microsoft_kiota_authentication_azure
 
 import (
-	"context"
-	"errors"
-
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	abs "github.com/microsoft/kiota/abstractions/go"
 	auth "github.com/microsoft/kiota/abstractions/go/authentication"
 )
 
 // AzureIdentityAuthenticationProvider implementation of AuthenticationProvider that supports implementations of TokenCredential from Azure.Identity.
 type AzureIdentityAuthenticationProvider struct {
 	auth.BaseBearerTokenAuthenticationProvider
-	scopes     []string
-	credential azcore.TokenCredential
 }
 
 // NewAzureIdentityAuthenticationProvider creates a new instance of the AzureIdentityAuthenticationProvider using "https://graph.microsoft.com/.default" as the default scope.
@@ -26,32 +19,13 @@ func NewAzureIdentityAuthenticationProvider(credential azcore.TokenCredential) (
 
 // NewAzureIdentityAuthenticationProviderWithScopes creates a new instance of the AzureIdentityAuthenticationProvider.
 func NewAzureIdentityAuthenticationProviderWithScopes(credential azcore.TokenCredential, scopes []string) (*AzureIdentityAuthenticationProvider, error) {
-	if credential == nil {
-		return nil, errors.New("credential cannot be nil")
+	accessTokenProvider, err := NewAzureIdentityAccessTokenProviderWithScopes(credential, scopes)
+	if err != nil {
+		return nil, err
 	}
-	scopesLen := len(scopes)
-	finalScopes := make([]string, scopesLen)
-	if scopesLen == 0 {
-		finalScopes = append(finalScopes, "https://graph.microsoft.com/.default")
-	} else {
-		copy(finalScopes, scopes)
-	}
-	baseBearer := auth.NewBaseBearerTokenAuthenticationProvider(
-		func(request abs.RequestInformation) (string, error) {
-			options := azpolicy.TokenRequestOptions{
-				Scopes: finalScopes,
-			}
-			token, err := credential.GetToken(context.Background(), options)
-			if err != nil {
-				return "", err
-			}
-			return token.Token, nil
-		})
+	baseBearer := auth.NewBaseBearerTokenAuthenticationProvider(accessTokenProvider)
 	result := &AzureIdentityAuthenticationProvider{
 		BaseBearerTokenAuthenticationProvider: *baseBearer,
-		credential:                            credential,
-		scopes:                                finalScopes,
 	}
-
 	return result, nil
 }

--- a/authentication/java/azure/lib/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
+++ b/authentication/java/azure/lib/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
@@ -1,0 +1,43 @@
+package com.microsoft.kiota.authentication;
+
+import java.net.URI;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nonnull;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+
+import com.microsoft.kiota.authentication.AccessTokenProvider;
+
+/** Implementation of AccessTokenProvider that supports implementations of TokenCredential from Azure.Identity. */
+public class AzureIdentityAccessTokenProvider implements AccessTokenProvider {
+    private final TokenCredential creds;
+    private final List<String> _scopes;
+    /**
+     * Creates a new instance of AzureIdentityAccessTokenProvider.
+     * @param tokenCredential The Azure.Identity.TokenCredential implementation to use.
+     * @param scopes The scopes to request access tokens for.
+     */
+    public AzureIdentityAccessTokenProvider(@Nonnull final TokenCredential tokenCredential, @Nonnull final String... scopes) {
+        creds = Objects.requireNonNull(tokenCredential, "parameter tokenCredential cannot be null");
+
+        if(scopes == null) {
+            _scopes = new ArrayList<String>();
+        } else if(scopes.length == 0) {
+            _scopes = Arrays.asList(new String[] { "https://graph.microsoft.com/.default" });
+        } else {
+            _scopes = Arrays.asList(scopes);
+        }
+    }
+    @Nonnull
+    public CompletableFuture<String> getAuthorizationToken(@Nonnull final URI uri) {
+        return this.creds.getToken(new TokenRequestContext() {{
+            this.setScopes(_scopes);
+        }}).toFuture().thenApply(r -> r.getToken());
+    }
+}

--- a/authentication/java/azure/lib/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAuthenticationProvider.java
+++ b/authentication/java/azure/lib/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAuthenticationProvider.java
@@ -1,39 +1,20 @@
 package com.microsoft.kiota.authentication;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.kiota.authentication.BaseBearerTokenAuthenticationProvider;
-import com.microsoft.kiota.RequestInformation;
 
+/** Implementation of AuthenticationProvider that supports implementations of TokenCredential from Azure.Identity. */
 public class AzureIdentityAuthenticationProvider extends BaseBearerTokenAuthenticationProvider {
-    private final TokenCredential creds;
-    private final List<String> _scopes;
+    /**
+     * Creates a new instance of AzureIdentityAuthenticationProvider.
+     * @param tokenCredential The Azure.Identity.TokenCredential implementation to use.
+     * @param scopes The scopes to request access tokens for.
+     */
     public AzureIdentityAuthenticationProvider(@Nonnull final TokenCredential tokenCredential, @Nonnull final String... scopes) {
-        creds = Objects.requireNonNull(tokenCredential, "parameter tokenCredential cannot be null");
-
-        if(scopes == null) {
-            _scopes = new ArrayList<String>();
-        } else if(scopes.length == 0) {
-            _scopes = Arrays.asList(new String[] { "https://graph.microsoft.com/.default" });
-        } else {
-            _scopes = Arrays.asList(scopes);
-        }
-    }
-
-    @Nonnull
-    public CompletableFuture<String> getAuthorizationToken(@Nonnull final RequestInformation request) {
-        return this.creds.getToken(new TokenRequestContext() {{
-            this.setScopes(_scopes);
-        }}).toFuture().thenApply(r -> r.getToken());
-    }
+        super(new AzureIdentityAccessTokenProvider(tokenCredential, scopes));
+    }    
 }

--- a/docs/extending/authentication.md
+++ b/docs/extending/authentication.md
@@ -19,16 +19,30 @@ public interface IAuthenticationProvider
 
 Where the request parameter is the abstract request to be executed. And the return value must be a Task that completes whenever the authentication sequence has completed and the request object has been updates with the additional authentication/authorization information.
 
+## Access Token Provider interface
+
+Implementations of this interface can be used in combination with the BaseBearerTokenAuthentication provider class to provide the access token to the request before it's executed. They can also be used to retrieve an access token to build and execute arbitrary requests with a native http client.
+
+```csharp
+public interface IAccessTokenProvider
+{
+    Task<string> GetAuthorizationToken(Uri uri);
+}
+```
+
 ## Base bearer token authentication provider
 
 A common practice in the industry for APIs is to implement authentication and authorization via the `Authorization` request header with a bearer token value.
 
-Should you want to add support for additional authentication providers for that scheme, Kiota abstractions already offer a base class to extend so you only need to implement the access token acquisition sequence and not the header composition/addition.
+Should you want to add support for additional authentication providers for that scheme, Kiota abstractions already offer a class to use in combination with available or your own implementation of Access Token Provider so you only need to implement the access token acquisition sequence and not the header composition/addition.
 
 ```csharp
-public abstract class BaseBearerTokenAuthenticationProvider
+public class BaseBearerTokenAuthenticationProvider
 {
-    public abstract Task<string> GetAuthorizationToken(RequestInformation request);
+    public BaseBearerTokenAuthenticationProvider(IAccessTokenProvider tokenProvider) {
+
+    }
+    public IAccessTokenProvider AccessTokenProvider {get; private set;};
 }
 ```
 

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(requestInfo == null)
                 throw new ArgumentNullException(nameof(requestInfo));
 
-            await authProvider.AuthenticateRequestAsync(requestInfo);
+            await authProvider.AuthenticateRequestAsync(requestInfo, cancellationToken);
 
             using var message = GetRequestMessageFromRequestInformation(requestInfo);
             var response = await this.client.SendAsync(message,cancellationToken);


### PR DESCRIPTION
completion of #1039

CC @Ndiritu @SilasKenneth when you move on to implementing azure authentication provider for PHP, and to update your abstractions as well.