### PR TITLE
fixes a bug where host and scheme validation would fail because of sequence of calls

### DIFF
--- a/abstractions/go/authentication/allowed_hosts_validator.go
+++ b/abstractions/go/authentication/allowed_hosts_validator.go
@@ -41,7 +41,7 @@ func (v *AllowedHostsValidator) IsUrlHostValid(uri *u.URL) bool {
 	if uri == nil {
 		return false
 	}
-	host := uri.Host
+	host := uri.Hostname()
 	if host == "" {
 		return false
 	}

--- a/abstractions/go/authentication/allowed_hosts_validator_test.go
+++ b/abstractions/go/authentication/allowed_hosts_validator_test.go
@@ -1,0 +1,14 @@
+package authentication
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	u "net/url"
+	"testing"
+)
+
+func TestItValidatesHosts(t *testing.T) {
+	validator := NewAllowedHostsValidator([]string{"graph.microsoft.com"})
+	url, err := u.Parse("https://graph.microsoft.com/v1.0/me")
+	assert.Nil(t, err)
+	assert.True(t, validator.IsUrlHostValid(url))
+}

--- a/authentication/go/azure/azure_identity_access_token_provider_test.go
+++ b/authentication/go/azure/azure_identity_access_token_provider_test.go
@@ -29,6 +29,19 @@ func TestAddsTokenOnValidHost(t *testing.T) {
 	assert.Equal(t, "token", token)
 }
 
+func TestAddsTokenOnValidHostFromParse(t *testing.T) {
+	provider, err := NewAzureIdentityAccessTokenProvider(&MockTokenCredential{TokenValue: "token"})
+	assert.Nil(t, err)
+	assert.NotNil(t, provider)
+
+	url, err := u.Parse("https://graph.microsoft.com")
+	assert.Nil(t, err)
+
+	token, err := provider.GetAuthorizationToken(url)
+	assert.Nil(t, err)
+	assert.Equal(t, "token", token)
+}
+
 func TestDoesntAddTokenOnDifferentHost(t *testing.T) {
 	provider, err := NewAzureIdentityAccessTokenProvider(&MockTokenCredential{TokenValue: "token"})
 	assert.Nil(t, err)

--- a/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
+++ b/http/dotnet/httpclient/src/HttpClientRequestAdapter.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(requestInfo == null)
                 throw new ArgumentNullException(nameof(requestInfo));
 
+            SetBaseUrlForRequestInformation(requestInfo);
             await authProvider.AuthenticateRequestAsync(requestInfo, cancellationToken);
 
             using var message = GetRequestMessageFromRequestInformation(requestInfo);
@@ -207,6 +208,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 throw new InvalidOperationException("Could not get a response after calling the service");
             return response;
         }
+        private void SetBaseUrlForRequestInformation(RequestInformation requestInfo)
+        {
+            requestInfo.PathParameters.Add("baseurl", BaseUrl);
+        }
         /// <summary>
         /// Creates a <see cref="HttpRequestMessage"/> instance from a <see cref="RequestInformation"/> instance.
         /// </summary>
@@ -214,7 +219,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// <returns>A <see cref="HttpRequestMessage"/> instance</returns>
         public HttpRequestMessage GetRequestMessageFromRequestInformation(RequestInformation requestInfo)
         {
-            requestInfo.PathParameters.Add("baseurl", BaseUrl);
             var message = new HttpRequestMessage
             {
                 Method = new HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),

--- a/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/http/dotnet/httpclient/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.18</Version>
+    <Version>1.0.19</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->

--- a/http/go/nethttp/nethttp_request_adapter.go
+++ b/http/go/nethttp/nethttp_request_adapter.go
@@ -88,6 +88,7 @@ func (a *NetHttpRequestAdapter) GetBaseUrl() string {
 	return a.baseUrl
 }
 func (a *NetHttpRequestAdapter) getHttpResponseMessage(requestInfo abs.RequestInformation) (*nethttp.Response, error) {
+	a.setBaseUrlForRequestInformation(requestInfo)
 	err := a.authenticationProvider.AuthenticateRequest(requestInfo)
 	if err != nil {
 		return nil, err
@@ -106,8 +107,10 @@ func (a *NetHttpRequestAdapter) getResponsePrimaryContentType(response *nethttp.
 	splat := strings.Split(rawType, ";")
 	return strings.ToLower(splat[0])
 }
-func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(requestInfo abs.RequestInformation) (*nethttp.Request, error) {
+func (a *NetHttpRequestAdapter) setBaseUrlForRequestInformation(requestInfo abs.RequestInformation) {
 	requestInfo.PathParameters["baseurl"] = a.GetBaseUrl()
+}
+func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(requestInfo abs.RequestInformation) (*nethttp.Request, error) {
 	uri, err := requestInfo.GetUri()
 	if err != nil {
 		return nil, err

--- a/http/java/okhttp/lib/build.gradle
+++ b/http/java/okhttp/lib/build.gradle
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-http-okhttplibrary'
-            version '1.0.12'
+            version '1.0.13'
             from(components.java)
         }
     }

--- a/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/http/java/okhttp/lib/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -208,6 +208,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
     }
     private CompletableFuture<Response> getHttpResponseMessage(@Nonnull final RequestInformation requestInfo) {
         Objects.requireNonNull(requestInfo, "parameter requestInfo cannot be null");
+        this.setBaseUrlForRequestInformation(requestInfo);
         return this.authProvider.authenticateRequest(requestInfo).thenCompose(x -> {
             try {
                 final OkHttpCallbackFutureWrapper wrapper = new OkHttpCallbackFutureWrapper();
@@ -221,8 +222,11 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
         });
         
     }
-    private Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo) throws URISyntaxException, MalformedURLException {
+    private void setBaseUrlForRequestInformation(@Nonnull final RequestInformation requestInfo) {
+        Objects.requireNonNull(requestInfo);
         requestInfo.pathParameters.put("baseurl", getBaseUrl());
+    }
+    private Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo) throws URISyntaxException, MalformedURLException {
         final RequestBody body = requestInfo.content == null ? null :
                                 new RequestBody() {
                                     @Override

--- a/http/typescript/fetch/package-lock.json
+++ b/http/typescript/fetch/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/kiota-http-fetchlibrary",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/kiota-http-fetchlibrary",
-            "version": "1.0.14",
+            "version": "1.0.15",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/kiota-abstractions": "^1.0.27",

--- a/http/typescript/fetch/package.json
+++ b/http/typescript/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-http-fetchlibrary",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "Kiota request adapter implementation with fetch",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/http/typescript/fetch/src/fetchRequestAdapter.ts
+++ b/http/typescript/fetch/src/fetchRequestAdapter.ts
@@ -161,13 +161,16 @@ export class FetchRequestAdapter implements RequestAdapter {
         if (!requestInfo) {
             throw new Error('requestInfo cannot be null');
         }
+        this.setBaseUrlForRequestInformation(requestInfo);
         await this.authenticationProvider.authenticateRequest(requestInfo);
 
         const request = this.getRequestFromRequestInformation(requestInfo);
         return await this.httpClient.fetch(requestInfo.URL, request);
     }
+    private setBaseUrlForRequestInformation = (requestInfo: RequestInformation): void => {
+        requestInfo.pathParameters["baseurl"] = this.baseUrl;
+    }
     private getRequestFromRequestInformation = (requestInfo: RequestInformation): RequestInit => {
-        requestInfo.pathParameters["baseurl"]= this.baseUrl;
         const request = {
             method: requestInfo.httpMethod?.toString(),
             headers: requestInfo.headers,


### PR DESCRIPTION
- fixes a bug where go host validator would not be using the right method for hostname
- fixes a bug where request adapters would attempt to auth the request before setting the base url
- bumps versions for http libraries

no generation diff
no changelog entry since we just merged #1051

CC @Ndiritu for PHP implementation of http provider which might be impacted by this.