### PR TITLE
- fixes an error where validate protocol would read window on node

### DIFF
--- a/abstractions/typescript/src/authentication/validateProtocol.ts
+++ b/abstractions/typescript/src/authentication/validateProtocol.ts
@@ -1,11 +1,9 @@
 export function validateProtocol(url: string): void {
-  // @ts-ignore
-  if (
-    !url.toLocaleLowerCase().startsWith("https://") ||
-    (window && (window.location.protocol as string).toLowerCase() !== "https:")
-  ) {
-    throw new Error(
-      "Authentication scheme can only be used with https requests"
-    );
-  }
+    if(!url.toLocaleLowerCase().startsWith('https://') && !windowUrlStartsWithHttps()) {
+        throw new Error('Authentication scheme can only be used with https requests');
+    }
+}
+function windowUrlStartsWithHttps(): boolean {
+    // @ts-ignore
+    return window && window.location && (window.location.protocol as string).toLowerCase() !== 'https:';
 }


### PR DESCRIPTION
because of the way the condition was structured when running on a node environment the runtime tried to access the window object, which doesn't exist/