### PR TITLE
- fixes an issue where typescript headers would return compile errors

### DIFF
--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -228,7 +228,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
                             $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "''")};",
                             $"{RequestInfoVarName}.httpMethod = HttpMethod.{codeElement.HttpMethod.ToString().ToUpperInvariant()};");
         if(requestParams.headers != null)
-            writer.WriteLine($"{RequestInfoVarName}.headers = h;");
+            writer.WriteLine($"if(h) {RequestInfoVarName}.headers = h;");
         if(requestParams.queryString != null)
             writer.WriteLines($"{requestParams.queryString.Name} && {RequestInfoVarName}.setQueryStringParametersFromRawObject(q);");
         if(requestParams.requestBody != null) {


### PR DESCRIPTION
the type of headers in request information is `Record<string, string>` but it's `Record<string, string> | undefined` for the fluent api parameter which caused the transpiler to complain, this adds a undefined check before assigning.