### PR TITLE
uncompress response body

### DIFF
--- a/http/go/nethttp/compression_handler.go
+++ b/http/go/nethttp/compression_handler.go
@@ -3,6 +3,7 @@ package nethttplibrary
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -67,6 +68,9 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	}
 
 	unCompressedBody, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		fmt.Println("Sending uncompressed")
+	}
 	unCompressedContentLength := req.ContentLength
 	if err != nil {
 		return nil, err
@@ -78,7 +82,6 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	}
 
 	req.Header.Set("Content-Encoding", "gzip")
-	req.Header.Set("Accept-Encoding", "gzip")
 	req.Body = compressedBody
 	req.ContentLength = int64(contentLength)
 

--- a/http/go/nethttp/compression_handler_test.go
+++ b/http/go/nethttp/compression_handler_test.go
@@ -82,6 +82,29 @@ func TestCompressionHandlerRetriesRequest(t *testing.T) {
 	assert.Equal(t, reqCount, 2)
 }
 
+func TestTransportDecompressesResponse(t *testing.T) {
+	postBody, _ := json.Marshal(map[string]string{"name": "Test", "email": "Test@Test.com"})
+	var compressedBody []byte
+
+	testServer := httptest.NewServer(nethttp.HandlerFunc(func(res nethttp.ResponseWriter, req *nethttp.Request) {
+		compressedBody, _ = io.ReadAll(req.Body)
+		fmt.Println(compressedBody)
+
+		res.Header().Set("Content-Type", "application/json")
+		res.Header().Set("Content-Encoding", "gzip")
+		fmt.Fprint(res, string(compressedBody))
+	}))
+	defer testServer.Close()
+
+	client := getDefaultClientWithoutMiddleware()
+	client.Transport = NewCustomTransport(NewCompressionHandler())
+
+	fmt.Print(testServer.URL)
+	resp, _ := client.Post(testServer.URL, "application/json", bytes.NewBuffer(postBody))
+
+	assert.True(t, resp.Uncompressed)
+}
+
 func TestResetTransport(t *testing.T) {
 	client := getDefaultClientWithoutMiddleware()
 	client.Transport = &nethttp.Transport{}

--- a/http/go/nethttp/pipeline.go
+++ b/http/go/nethttp/pipeline.go
@@ -1,6 +1,8 @@
 package nethttplibrary
 
-import nethttp "net/http"
+import (
+	nethttp "net/http"
+)
 
 // Pipeline contract for middleware infrastructure
 type Pipeline interface {
@@ -48,6 +50,7 @@ func (transport *customTransport) RoundTrip(req *nethttp.Request) (*nethttp.Resp
 func GetDefaultTransport() nethttp.RoundTripper {
 	defaultTransport := nethttp.DefaultTransport.(*nethttp.Transport).Clone()
 	defaultTransport.ForceAttemptHTTP2 = true
+	defaultTransport.DisableCompression = false
 	return defaultTransport
 }
 


### PR DESCRIPTION
Enable automatic decompression by transport.

Closes [#44](https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/44)