### PR TITLE
Remove unused Console parameter

### DIFF
--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons/IO/IOutputFormatter.cs
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons/IO/IOutputFormatter.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Kiota.Cli.Commons.IO;
 
 public interface IOutputFormatter
 {
-    void WriteOutput(string content, IConsole console);
+    void WriteOutput(string content);
 
-    void WriteOutput(Stream content, IConsole console);
+    void WriteOutput(Stream content);
 }

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons/Microsoft.Kiota.Cli.Commons.csproj
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons/Microsoft.Kiota.Cli.Commons.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>0.1.0-preview.1</Version>
+    <Version>0.1.1-preview.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     


### PR DESCRIPTION
In the CLI, there's a limit of 16 options or arguments in the SetHandler action. Adding any additional options requires custom types and binders. To simplify the generation, the console argument that's added to each handler action can be removed for now.

See https://github.com/dotnet/command-line-api/issues/1537