### PR TITLE
Update command handler to allow handling more than 16 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Azure Identity Authentication Provider for Python. #1108
 - Adds JSON Serialization library for Python. #1186
 - Adds PHP League Authentication Provider for PHP #1201
+- Added Shell language support #738
 
 ### Changed
 

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Binding/CollectionBindingTests.cs
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Binding/CollectionBindingTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Kiota.Cli.Commons.Binding;
+
+public class CollectionBindingTests {
+    [Fact]
+    public void Should_Resolve_Option_Value_On_Get_Bound_Value() {
+        var option = new Option<string>("--name");
+        var binding = new CollectionBinding(option);
+        var cmd = new RootCommand();
+        cmd.AddOption(option);
+        var builder = new CommandLineBuilder(cmd);
+        object? result = null;
+        cmd.SetHandler<object[]>(parameters => result = parameters[0], binding);
+
+        builder.Build().Invoke("--name Test");
+
+        Assert.NotNull(result);
+        Assert.Equal("Test", result);
+    }
+}

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Binding/TypeBindingTests.cs
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Binding/TypeBindingTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Kiota.Cli.Commons.Binding;
+
+public class TypeBindingTests {
+    [Fact]
+    public void Should_Resolve_Service_On_Get_Bound_Value() {
+        var binding = new TypeBinding(typeof(string));
+        var cmd = new RootCommand();
+        var builder = new CommandLineBuilder(cmd);
+        builder.AddMiddleware(invocation => {
+            invocation.BindingContext.AddService<string>(_ => "Test");
+        });
+        string? result = null;
+        cmd.SetHandler<string>(strType => result = strType, binding);
+
+        builder.Build().Invoke("");
+
+        Assert.NotNull(result);
+        Assert.Equal("Test", result);
+    }
+
+    [Fact]
+    public void Should_Throw_Exception_On_Service_Not_Found() {
+        var binding = new TypeBinding(typeof(string));
+        var cmd = new RootCommand();
+        var builder = new CommandLineBuilder(cmd);
+        string? result = null;
+        cmd.SetHandler<string>(strType => result = strType, binding);
+
+        Assert.Throws<ArgumentException>(() => builder.Build().Invoke(""));
+    }
+}

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Microsoft.Kiota.Cli.Commons.Tests.csproj
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons.Tests/Microsoft.Kiota.Cli.Commons.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,6 +19,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Kiota.Cli.Commons\Microsoft.Kiota.Cli.Commons.csproj" />
   </ItemGroup>
 
 </Project>

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons/Binding/CollectionBinding.cs
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons/Binding/CollectionBinding.cs
@@ -1,0 +1,72 @@
+﻿using System.CommandLine;
+using System.CommandLine.Binding;
+
+namespace Microsoft.Kiota.Cli.Commons.Binding;
+
+/// <summary>
+/// Binds a collection of <see cref="IValueDescriptor"/> types and passes the bound values into the handler action as an array.
+/// </summary>
+public class CollectionBinding : BinderBase<object[]>
+{
+    private readonly IValueDescriptor[] _symbols;
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="symbols">The symbols to resolve. Can be <see cref="Option"/>, <see cref="Argument"/> or any other <see cref="BinderBase{T}"/></param>
+    public CollectionBinding(params IValueDescriptor[] symbols)
+    {
+        this._symbols = symbols;
+    }
+
+    /// <inheritdoc/>
+    protected override object[] GetBoundValue(BindingContext bindingContext)
+    {
+        var result = new object[_symbols.Length];
+        for (int i = 0; i < _symbols.Length; i++)
+        {
+            object? value = GetValueForHandlerParameter(_symbols, i, bindingContext);
+            if (value != null)
+            {
+                result[i] = value;
+            }
+        }
+        return result;
+    }
+
+    private static object? GetValueForHandlerParameter(
+        IValueDescriptor[] symbols,
+        int index,
+        BindingContext context)
+    {
+        if (symbols.Length <= index) {
+            throw new ArgumentOutOfRangeException(nameof(index), index, "The index is out of range.");
+        }
+
+        if (symbols[index] is IValueDescriptor symbol)
+        {
+            if (symbol is IValueSource valueSource &&
+                valueSource.TryGetValue(symbol, context, out var boundValue))
+            {
+                return boundValue;
+            }
+            else
+            {
+                if (symbol is Argument argument)
+                {
+                    return context.ParseResult.GetValueForArgument(argument);
+                }
+                else if (symbol is Option option)
+                {
+                    return context.ParseResult.GetValueForOption(option);
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException($"The symbol at index {index} does not correspond to an option or argument.", null as Exception);
+                }
+            }
+        }
+
+        throw new ArgumentException($"The symbol at index {index} is not of type {typeof(IValueDescriptor)}");
+    }
+}

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons/Binding/TypeBinding.cs
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons/Binding/TypeBinding.cs
@@ -1,0 +1,24 @@
+using System.CommandLine.Binding;
+
+namespace Microsoft.Kiota.Cli.Commons.Binding;
+
+/// <summary>
+/// Binding used to resolve a value based on the <see cref="System.Type"/>
+/// </summary>
+public class TypeBinding : BinderBase<object>
+{
+    private readonly Type _valueType;
+    
+    /// <summary></summary>
+    /// <param name="valueType">The type information of the value</param>
+    public TypeBinding(Type valueType)
+    {
+        this._valueType = valueType;
+    }
+
+    /// <inheritdoc/>
+    protected override object GetBoundValue(BindingContext bindingContext)
+    {
+        return bindingContext.GetService(_valueType) ?? throw new ArgumentException($"Service not found for type {_valueType}.");
+    }
+}

--- a/cli/commons/src/Microsoft.Kiota.Cli.Commons/Microsoft.Kiota.Cli.Commons.csproj
+++ b/cli/commons/src/Microsoft.Kiota.Cli.Commons/Microsoft.Kiota.Cli.Commons.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>0.1.1-preview.1</Version>
+    <Version>0.1.2-preview.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     

--- a/src/Kiota.Builder/Refiners/ShellRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ShellRefiner.cs
@@ -152,6 +152,8 @@ namespace Kiota.Builder.Refiners
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
                 "System.CommandLine",  "Command", "RootCommand", "IConsole"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+                "Microsoft.Kiota.Cli.Commons.Binding", "CollectionBinding", "TypeBinding"),
+            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
                 "Microsoft.Kiota.Cli.Commons.IO", "IOutputFormatter", "IOutputFormatterFactory", "FormatterType"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
                 "System.Text",  "Encoding"),

--- a/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
@@ -129,17 +129,6 @@ namespace Kiota.Builder.Writers.Shell
             availableOptions.Add($"new TypeBinding(typeof({cancellationTokenParamType}))");
 
             var zipped = paramTypes.Zip(paramNames).ToArray();
-            if (paramNames.Count > 15)
-            {
-                Console.WriteLine($"Large list of parameters found");
-                Console.WriteLine($"Parameters:\t{paramNames.Count}");
-                Console.WriteLine($"Class:\t{codeElement.Parent.Name}");
-                Console.WriteLine($"Method:\t{codeElement.Name}");
-                var urlTemplateProp = (codeElement.Parent as CodeClass).GetPropertyOfKind(CodePropertyKind.UrlTemplate);
-                if (urlTemplateProp != null) {
-                    Console.WriteLine($"Endpoint:\t{urlTemplateProp.DefaultValue}");
-                }
-            }
             writer.WriteLine($"command.SetHandler(async (object[] parameters) => {{");
             writer.IncreaseIndent();
             for (int i = 0; i < availableOptions.Count; i++)

--- a/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
@@ -253,8 +253,11 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("qOption.IsRequired = false;", result);
         Assert.Contains("command.AddOption(qOption);", result);
         Assert.Contains("command.AddOption(outputOption);", result);
+        Assert.Contains("command.SetHandler(async (object[] parameters) => {", result);
+        Assert.Contains("var q = (string) parameters[0];", result);
         Assert.Contains("var requestInfo = CreateGetRequestInformation", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
+        Assert.Contains("}, new CollectionBinding(qOption,", result);
         Assert.Contains("return command;", result);
     }
 
@@ -346,8 +349,11 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("command.AddOption(outputOption);", result);
         Assert.Contains("var fileOption = new Option<FileInfo>(\"--file\");", result);
         Assert.Contains("command.AddOption(fileOption);", result);
+        Assert.Contains("command.SetHandler(async (object[] parameters) => {", result);
+        Assert.Contains("var q = (string) parameters[0];", result);
         Assert.Contains("var requestInfo = CreateGetRequestInformation", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
+        Assert.Contains("}, new CollectionBinding(qOption,", result);
         Assert.Contains("return command;", result);
     }
 


### PR DESCRIPTION
New generated code will look like:

```csharp
command.SetHandler(async (object[] parameters) => {
    var userId = (string) parameters[0];
    var top = (int?) parameters[1];
    var skip = (int?) parameters[2];
    ...
    var cancellationToken = (CancellationToken) parameters[10];
    ...
}, new CollectionBinding(userIdOption, topOption, skipOption...new TypeBinding(typeof(CancellationToken))));
```