### PR TITLE
TS- Bugfix in json parseNode checking for type string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed errors in python serialization due to to responses as json instead of json strings #1290
 - Added python version 3.10 to testing matrix #1290 
 - Fixed bug with inconsistent Java namespace and directory name casing #1267
+- Fixed typeOf string check in JsonParseNode Typescript.
 
 ## [0.0.16] - 2022-02-23
 

--- a/serialization/typescript/json/src/jsonParseNode.ts
+++ b/serialization/typescript/json/src/jsonParseNode.ts
@@ -29,7 +29,7 @@ export class JsonParseNode implements ParseNode {
       const currentParseNode = new JsonParseNode(x);
       if (x instanceof Boolean) {
         return currentParseNode.getBooleanValue() as unknown as T;
-      } else if (x instanceof String) {
+      } else if (x instanceof String || typeof x === "string") {
         return currentParseNode.getStringValue() as unknown as T;
       } else if (x instanceof Number) {
         return currentParseNode.getNumberValue() as unknown as T;


### PR DESCRIPTION
Introducing fix for error:

`encountered an unknown type during deserialization string`