### PR TITLE
Fix for Java directory and namespace casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified python test matrix to include python 3.10  #1289
 - Added return statement to AnonymousAuthenticationProvider in python abstractions  #1289
 - Fixed bug in enabling backing store for parse node factory by passing ParseNodeFactoryRegistry to method call  #1289
+- Fixed bug with inconsistent Java namespace and directory name casing #1267
 
 ## [0.0.16] - 2022-02-23
 
@@ -73,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug in Go where empty collections would not be serialized.
 - Fixes a bug where generation would fail because of empty usings.
 - Fixes a bug where Java and Go escaped model properties would not serialize properly.
-- Fixes a bug where null values would not be added to additionalData if there was no matching property in dotnet. 
+- Fixes a bug where null values would not be added to additionalData if there was no matching property in dotnet.
 - Fixes a bug where deserialzation of enums would throw an ArgumentExcpetion if the member didn't exist in dotnet.
 
 ## [0.0.14] - 2021-11-08

--- a/src/Kiota.Builder/PathSegmenters/JavaPathSegementer.cs
+++ b/src/Kiota.Builder/PathSegmenters/JavaPathSegementer.cs
@@ -8,6 +8,6 @@ namespace Kiota.Builder {
         public JavaPathSegmenter(string rootPath, string clientNamespaceName) : base(rootPath, clientNamespaceName) { }
         public override string FileSuffix => ".java";
         public override string NormalizeFileName(CodeElement currentElement) => GetLastFileNameSegment(currentElement).ToFirstCharacterUpperCase();
-        public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToFirstCharacterLowerCase();
+        public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToLower();
     }
 }

--- a/src/Kiota.Builder/PathSegmenters/JavaPathSegementer.cs
+++ b/src/Kiota.Builder/PathSegmenters/JavaPathSegementer.cs
@@ -8,6 +8,6 @@ namespace Kiota.Builder {
         public JavaPathSegmenter(string rootPath, string clientNamespaceName) : base(rootPath, clientNamespaceName) { }
         public override string FileSuffix => ".java";
         public override string NormalizeFileName(CodeElement currentElement) => GetLastFileNameSegment(currentElement).ToFirstCharacterUpperCase();
-        public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToLower();
+        public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToLowerInvariant();
     }
 }

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -234,12 +234,9 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         if (currentElement is CodeNamespace codeNamespace)
         {
             if (!string.IsNullOrEmpty(codeNamespace.Name))
-                codeNamespace.Name = codeNamespace.Name.ToLower();
+                codeNamespace.Name = codeNamespace.Name.ToLowerInvariant();
 
-            foreach(var codeElement in codeNamespace.GetChildElements())
-            {
-                LowerCaseNamespaceNames(codeElement);
-            }
+            CrawlTree(currentElement, LowerCaseNamespaceNames);
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -9,6 +9,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
     public JavaRefiner(GenerationConfiguration configuration) : base(configuration) {}
     public override void Refine(CodeNamespace generatedCode)
     {
+        LowerCaseNamespaceNames(generatedCode);
         AddInnerClasses(generatedCode, false);
         InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
         ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
@@ -45,10 +46,10 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
     }
     private static void SetSetterParametersToNullable(CodeElement currentElement, params Tuple<CodeMethodKind, CodePropertyKind>[] accessorPairs) {
         if(currentElement is CodeMethod method &&
-            accessorPairs.Any(x => method.IsOfKind(x.Item1) && (method.AccessedProperty?.IsOfKind(x.Item2) ?? false))) 
+            accessorPairs.Any(x => method.IsOfKind(x.Item1) && (method.AccessedProperty?.IsOfKind(x.Item2) ?? false)))
             foreach(var param in method.Parameters)
                 param.Type.IsNullable = true;
-        CrawlTree(currentElement, element => SetSetterParametersToNullable(element, accessorPairs));   
+        CrawlTree(currentElement, element => SetSetterParametersToNullable(element, accessorPairs));
     }
     private static void AddEnumSetImport(CodeElement currentElement) {
         if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) &&
@@ -63,7 +64,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         CrawlTree(currentElement, AddEnumSetImport);
     }
     private static readonly JavaConventionService conventionService = new();
-    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] { 
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = new AdditionalUsingEvaluator[] {
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
             "com.microsoft.kiota", "RequestAdapter"),
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.PathParameters),
@@ -82,7 +83,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             "com.microsoft.kiota.serialization", "Parsable"),
         new (x => x is CodeMethod method && method.Parameters.Any(x => !x.Optional),
                 "java.util", "Objects"),
-        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) && 
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) &&
                     method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) &&
                                         x.Type.Name.Equals(conventionService.StreamTypeName, StringComparison.OrdinalIgnoreCase)),
             "java.io", "InputStream"),
@@ -148,7 +149,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 .ToList()
                 .ForEach(x => x.Type.IsNullable = true);
             var urlTplParams = currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters));
-            if(urlTplParams != null) 
+            if(urlTplParams != null)
                 urlTplParams.Type.Name = "HashMap<String, Object>";
         }
         CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
@@ -214,7 +215,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                                             .ToArray());
             }
         }
-        
+
         CrawlTree(currentElement, InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors);
     }
     private static CodeMethod GetMethodClone(CodeMethod currentMethod, params CodeParameterKind[] parameterTypesToExclude) {
@@ -225,5 +226,20 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             return cloneMethod;
         }
         else return null;
+    }
+
+    // Namespaces in Java by convention are all lower case, like:
+    // com.microsoft.kiota.serialization
+    private static void LowerCaseNamespaceNames(CodeElement currentElement) {
+        if (currentElement is CodeNamespace codeNamespace)
+        {
+            if (!string.IsNullOrEmpty(codeNamespace.Name))
+                codeNamespace.Name = codeNamespace.Name.ToLower();
+
+            foreach(var codeElement in codeNamespace.GetChildElements())
+            {
+                LowerCaseNamespaceNames(codeElement);
+            }
+        }
     }
 }


### PR DESCRIPTION
By convention, Java namespaces are lower-cased. Also, directory structure follows the namespace, and is case-sensitive. This fixes enforces lower case for namespaces and directory names.

Fixes #1267