### PR TITLE
parsable interface split

### DIFF
--- a/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
+++ b/abstractions/dotnet/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.31</Version>
+    <Version>1.0.32</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/abstractions/dotnet/src/serialization/IAdditionalDataHolder.cs
+++ b/abstractions/dotnet/src/serialization/IAdditionalDataHolder.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Kiota.Abstractions.Serialization
+{
+    /// <summary>
+    /// Defines a contract for models that can hold additional data besides the described properties.
+    /// </summary>
+    public interface IAdditionalDataHolder
+    {
+        /// <summary>
+        ///  Stores the additional data for this object that did not belong to the properties.
+        /// </summary>
+        IDictionary<string, object> AdditionalData { get; set; }
+    }
+}

--- a/abstractions/dotnet/src/serialization/IParsable.cs
+++ b/abstractions/dotnet/src/serialization/IParsable.cs
@@ -22,9 +22,5 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// </summary>
         /// <param name="writer">The <see cref="ISerializationWriter">writer</see> to write to.</param>
         void Serialize(ISerializationWriter writer);
-        /// <summary>
-        ///  Stores the additional data for this object that did not belong to the properties.
-        /// </summary>
-        IDictionary<string, object> AdditionalData { get; set; }
     }
 }

--- a/abstractions/go/serialization/additional_data_holder.go
+++ b/abstractions/go/serialization/additional_data_holder.go
@@ -1,0 +1,7 @@
+package serialization
+
+// AdditionalDataHolder defines a contract for models that can hold additional data besides the described properties.
+type AdditionalDataHolder interface {
+	// GetAdditionalData returns additional data of the object that doesn't belong to a field.
+	GetAdditionalData() map[string]interface{}
+}

--- a/abstractions/go/serialization/additional_data_holder.go
+++ b/abstractions/go/serialization/additional_data_holder.go
@@ -4,4 +4,6 @@ package serialization
 type AdditionalDataHolder interface {
 	// GetAdditionalData returns additional data of the object that doesn't belong to a field.
 	GetAdditionalData() map[string]interface{}
+	// SetAdditionalData sets additional data of the object that doesn't belong to a field.
+	SetAdditionalData(value map[string]interface{})
 }

--- a/abstractions/go/serialization/parsable.go
+++ b/abstractions/go/serialization/parsable.go
@@ -8,8 +8,6 @@ type Parsable interface {
 	GetFieldDeserializers() map[string]func(interface{}, ParseNode) error
 	// SetAdditionalData sets additional data of the object that doesn't belong to a field.
 	SetAdditionalData(value map[string]interface{})
-	// GetAdditionalData returns additional data of the object that doesn't belong to a field.
-	GetAdditionalData() map[string]interface{}
 	// IsNil returns whether the current object is nil or not.
 	IsNil() bool
 }

--- a/abstractions/go/serialization/parsable.go
+++ b/abstractions/go/serialization/parsable.go
@@ -6,8 +6,6 @@ type Parsable interface {
 	Serialize(writer SerializationWriter) error
 	// GetFieldDeserializers returns the deserialization information for this object.
 	GetFieldDeserializers() map[string]func(interface{}, ParseNode) error
-	// SetAdditionalData sets additional data of the object that doesn't belong to a field.
-	SetAdditionalData(value map[string]interface{})
 	// IsNil returns whether the current object is nil or not.
 	IsNil() bool
 }

--- a/abstractions/java/lib/build.gradle
+++ b/abstractions/java/lib/build.gradle
@@ -48,7 +48,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-abstractions'
-            version '1.0.27'
+            version '1.0.28'
             from(components.java)
         }
     }

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/AdditionalDataHolder.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/AdditionalDataHolder.java
@@ -1,0 +1,15 @@
+package com.microsoft.kiota.serialization;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/** Defines a contract for models that can hold additional data besides the described properties. */
+public interface AdditionalDataHolder {
+    /**
+     * Gets the additional data for this object that did not belong to the properties.
+     * @return The additional data for this object.
+     */
+    @Nonnull
+    Map<String, Object> getAdditionalData();    
+}

--- a/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
+++ b/abstractions/java/lib/src/main/java/com/microsoft/kiota/serialization/Parsable.java
@@ -19,10 +19,4 @@ public interface Parsable {
      * @param writer The writer to write to.
      */
     void serialize(@Nonnull final SerializationWriter writer);
-    /**
-     * Gets the additional data for this object that did not belong to the properties.
-     * @return The additional data for this object.
-     */
-    @Nonnull
-    Map<String, Object> getAdditionalData();
 }

--- a/abstractions/typescript/package-lock.json
+++ b/abstractions/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/kiota-abstractions",
-    "version": "1.0.30",
+    "version": "1.0.31",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/kiota-abstractions",
-            "version": "1.0.30",
+            "version": "1.0.31",
             "license": "MIT",
             "dependencies": {
                 "tinyduration": "^3.2.2",

--- a/abstractions/typescript/package.json
+++ b/abstractions/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-abstractions",
-    "version": "1.0.30",
+    "version": "1.0.31",
     "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/abstractions/typescript/src/serialization/additionalDataHolder.ts
+++ b/abstractions/typescript/src/serialization/additionalDataHolder.ts
@@ -1,0 +1,8 @@
+/** Defines a contract for models that can hold additional data besides the described properties. */
+export interface AdditionalDataHolder {
+  /**
+   * Gets the additional data for this object that did not belong to the properties.
+   * @return The additional data for this object.
+   */
+  additionalData: Map<string, unknown>;
+}

--- a/abstractions/typescript/src/serialization/index.ts
+++ b/abstractions/typescript/src/serialization/index.ts
@@ -1,3 +1,4 @@
+export * from "./additionalDataHolder";
 export * from "./parsable";
 export * from "./parsableFactory";
 export * from "./parseNode";

--- a/abstractions/typescript/src/serialization/parsable.ts
+++ b/abstractions/typescript/src/serialization/parsable.ts
@@ -15,9 +15,4 @@ export interface Parsable {
    * @param writer The writer to write to.
    */
   serialize(writer: SerializationWriter): void;
-  /**
-   * Gets the additional data for this object that did not belong to the properties.
-   * @return The additional data for this object.
-   */
-  additionalData: Map<string, unknown>;
 }

--- a/docs/extending/kiotaabstractions.md
+++ b/docs/extending/kiotaabstractions.md
@@ -25,23 +25,23 @@ public interface IRequestAdapter
         RequestInformation requestInfo,
         ParsableFactory<ModelType> factory,
         IResponseHandler responseHandler = default,
-        Dictionary<string, Func<IParsable>> errorMappings = default) where ModelType : IParsable;
+        Dictionary<string, ParsableFactory<IParsable>> errorMappings = default) where ModelType : IParsable;
 
     Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(
         RequestInformation requestInfo,
         ParsableFactory<ModelType> factory,
         IResponseHandler responseHandler = default,
-        Dictionary<string, Func<IParsable>> errorMappings = default) where ModelType : IParsable;
+        Dictionary<string, ParsableFactory<IParsable>> errorMappings = default) where ModelType : IParsable;
 
     Task<ModelType> SendPrimitiveAsync<ModelType>(
         RequestInformation requestInfo,
         IResponseHandler responseHandler = default,
-        Dictionary<string, Func<IParsable>> errorMappings = default);
+        Dictionary<string, ParsableFactory<IParsable>> errorMappings = default);
 
     Task SendNoContentAsync(
         RequestInformation requestInfo,
         IResponseHandler responseHandler = default,
-        Dictionary<string, Func<IParsable>> errorMappings = default);
+        Dictionary<string, ParsableFactory<IParsable>> errorMappings = default);
 }
 ```
 

--- a/docs/extending/serialization.md
+++ b/docs/extending/serialization.md
@@ -9,6 +9,18 @@ APIs rely on some serialization format (JSON, YAML, XML...) to be able to receiv
 - Models rely on a set of abstractions described below, available in the abstractions package and implemented in a separate package for each format.
 - Models self-describe their serialization/deserialization logic, more information in [the models](./models.md) documentation page.
 
+## Additional Data Holder
+
+The additional data holder interface defines members implemented by models when they support additional properties that are not described in the OpenAPI description of the API but could be part of the response.
+
+```csharp
+public interface IAdditionalDataHolder
+{
+    IDictionary<string, object> AdditionalData { get; set; }
+}
+
+```
+
 ## Parsable
 
 The parsable interface defines members that are required to be implemented by a model in order to be able to self serialize/deserialize itself. You can find a detailed description of those members in the [models](./models.md) documentation page.

--- a/http/java/okhttp/lib/.classpath
+++ b/http/java/okhttp/lib/.classpath
@@ -13,7 +13,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-16/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
+++ b/serialization/dotnet/json/Microsoft.Kiota.Serialization.Json.Tests/Mocks/TestEntity.cs
@@ -5,7 +5,7 @@ using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Microsoft.Kiota.Serialization.Json.Tests.Mocks
 {
-    public class TestEntity : IParsable
+    public class TestEntity : IParsable, IAdditionalDataHolder
     {
         /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
         public IDictionary<string, object> AdditionalData { get; set; }

--- a/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/serialization/dotnet/json/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.31" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.32" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 </Project>

--- a/serialization/go/json/json_parse_node.go
+++ b/serialization/go/json/json_parse_node.go
@@ -168,6 +168,10 @@ func (n *JsonParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Pars
 		var itemAdditionalData map[string]interface{}
 		if isHolder {
 			itemAdditionalData = itemAsHolder.GetAdditionalData()
+			if itemAdditionalData == nil {
+				itemAdditionalData = make(map[string]interface{})
+				itemAsHolder.SetAdditionalData(itemAdditionalData)
+			}
 		}
 
 		for key, value := range properties {

--- a/serialization/go/json/json_parse_node.go
+++ b/serialization/go/json/json_parse_node.go
@@ -164,11 +164,17 @@ func (n *JsonParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Pars
 	}
 	fields := result.GetFieldDeserializers()
 	if len(properties) != 0 {
+		itemAsHolder, isHolder := result.(absser.AdditionalDataHolder)
+		var itemAdditionalData map[string]interface{}
+		if isHolder {
+			itemAdditionalData = itemAsHolder.GetAdditionalData()
+		}
+
 		for key, value := range properties {
 			field := fields[key]
 			if field == nil {
-				if value != nil {
-					result.GetAdditionalData()[key] = value.value
+				if value != nil && isHolder {
+					itemAdditionalData[key] = value.value
 				}
 			} else {
 				err := field(result, value)

--- a/serialization/java/json/lib/build.gradle
+++ b/serialization/java/json/lib/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:31.1-jre'
     api 'com.google.code.gson:gson:2.9.0'
-    api 'com.microsoft.kiota:kiota-abstractions:1.0.27'
+    api 'com.microsoft.kiota:kiota-abstractions:1.0.28'
 }
 
 publishing {
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-serialization-json'
-            version '1.0.7'
+            version '1.0.8'
             from(components.java)
         }
     }

--- a/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/serialization/java/json/lib/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 
 import com.microsoft.kiota.serialization.ParseNode;
 import com.microsoft.kiota.serialization.Parsable;
+import com.microsoft.kiota.serialization.AdditionalDataHolder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -239,6 +240,10 @@ public class JsonParseNode implements ParseNode {
             if(this.onBeforeAssignFieldValues != null) {
                 this.onBeforeAssignFieldValues.accept(item);
             }
+            Map<String, Object> itemAdditionalData = null;
+            if(item instanceof AdditionalDataHolder) {
+                itemAdditionalData = ((AdditionalDataHolder)item).getAdditionalData();
+            }
             for (final Map.Entry<String, JsonElement> fieldEntry : currentNode.getAsJsonObject().entrySet()) {
                 final String fieldKey = fieldEntry.getKey();
                 final BiConsumer<? super T, ParseNode> fieldDeserializer = fieldDeserializers.get(fieldKey);
@@ -253,8 +258,8 @@ public class JsonParseNode implements ParseNode {
                         this.setOnAfterAssignFieldValues(onAfter);
                     }});
                 }
-                else
-                    item.getAdditionalData().put(fieldKey, this.tryGetAnything(fieldValue));
+                else if (itemAdditionalData != null)
+                    itemAdditionalData.put(fieldKey, this.tryGetAnything(fieldValue));
             }
             if(this.onAfterAssignFieldValues != null) {
                 this.onAfterAssignFieldValues.accept(item);

--- a/serialization/typescript/json/package-lock.json
+++ b/serialization/typescript/json/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/kiota-serialization-json",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/kiota-serialization-json",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/kiota-abstractions": "^1.0.30",

--- a/serialization/typescript/json/package.json
+++ b/serialization/typescript/json/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-serialization-json",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Implementation of Kiota Serialization interfaces for JSON",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",
@@ -47,6 +47,6 @@
     },
     "dependencies": {
         "tslib": "^2.3.1",
-        "@microsoft/kiota-abstractions": "^1.0.30"
+        "@microsoft/kiota-abstractions": "^1.0.31"
     }
 }

--- a/serialization/typescript/json/src/jsonParseNode.ts
+++ b/serialization/typescript/json/src/jsonParseNode.ts
@@ -1,4 +1,5 @@
 import {
+  AdditionalDataHolder,
   DateOnly,
   Duration,
   Parsable,
@@ -59,9 +60,13 @@ export class JsonParseNode implements ParseNode {
   };
   public getObjectValue = <T extends Parsable>(type: ParsableFactory<T>): T => {
     const result = type(this);
-    this.onBeforeAssignFieldValues && this.onBeforeAssignFieldValues(result);
+    if (this.onBeforeAssignFieldValues) {
+      this.onBeforeAssignFieldValues(result);
+    }
     this.assignFieldValues(result);
-    this.onAfterAssignFieldValues && this.onAfterAssignFieldValues(result);
+    if (this.onAfterAssignFieldValues) {
+      this.onAfterAssignFieldValues(result);
+    }
     return result;
   };
   public getEnumValues = <T>(type: any): T[] => {
@@ -81,12 +86,17 @@ export class JsonParseNode implements ParseNode {
   };
   private assignFieldValues = <T extends Parsable>(item: T): void => {
     const fields = item.getFieldDeserializers();
+    let itemAdditionalData: Map<string, unknown> | undefined;
+    const holder = item as unknown as AdditionalDataHolder;
+    if (holder && holder.additionalData) {
+      itemAdditionalData = holder.additionalData;
+    }
     Object.entries(this._jsonNode as any).forEach(([k, v]) => {
       const deserializer = fields.get(k);
       if (deserializer) {
         deserializer(item, new JsonParseNode(v));
-      } else {
-        item.additionalData.set(k, v);
+      } else if (itemAdditionalData) {
+        itemAdditionalData.set(k, v);
       }
     });
   };

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -38,9 +38,7 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         return AddRange(codeClasses);
     }
     public CodeClass GetParentClass() {
-        if(StartBlock is ClassDeclaration declaration)
-            return declaration.Inherits?.TypeDefinition as CodeClass;
-        else return null;
+        return StartBlock.Inherits?.TypeDefinition as CodeClass;
     }
     
     public CodeClass GetGreatestGrandparent(CodeClass startClassToSkip = null) {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -941,6 +941,7 @@ public class KiotaBuilder
     private const string BackingStoreInterface = "IBackingStore";
     private const string BackedModelInterface = "IBackedModel";
     private const string ParseNodeInterface = "IParseNode";
+    private const string AdditionalHolderInterface = "IAdditionalDataHolder";
     internal static void AddSerializationMembers(CodeClass model, bool includeAdditionalProperties, bool usesBackingStore) {
         var serializationPropsType = $"IDictionary<string, Action<T, {ParseNodeInterface}>>";
         if(!model.ContainsMember(FieldDeserializersMethodName)) {
@@ -993,6 +994,10 @@ public class KiotaBuilder
                 },
             };
             model.AddProperty(additionalDataProp);
+            model.StartBlock.AddImplements(new CodeType {
+                Name = AdditionalHolderInterface,
+                IsExternal = true,
+            });
         }
         if(!model.ContainsMember(BackingStorePropertyName) &&
             usesBackingStore &&

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -79,6 +79,8 @@ namespace Kiota.Builder.Refiners {
                 "Microsoft.Kiota.Abstractions.Serialization", "IParseNode"),
             new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
                 "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
+            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+                "Microsoft.Kiota.Abstractions.Serialization", "IAdditionalDataHolder"),
             new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
                 "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
             new (x => x is CodeClass || x is CodeEnum,

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -734,28 +734,24 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     Kind = CodeInterfaceKind.Model,
         }).First();
         var usingsToRemove = new List<string>();
-        if(modelClass.StartBlock is ClassDeclaration classDeclaration) {
-            if(classDeclaration.Inherits != null) {
-                if (classDeclaration.Inherits.TypeDefinition is CodeClass baseClass) {
-                        var parentInterface = CopyClassAsInterface(baseClass, config, interfaceNamingCallback);
-                        inter.StartBlock.AddImplements(new CodeType {
-                            Name = parentInterface.Name,
-                            TypeDefinition = parentInterface,
-                        });
-                }
-            } 
-            if (classDeclaration.Implements.Any()) {
-                var originalImplements = classDeclaration.Implements.ToArray();
-                inter.StartBlock.AddImplements(originalImplements
-                                                            .Select(x => x.Clone() as CodeType)
-                                                            .ToArray());
-                classDeclaration.RemoveImplements(originalImplements);
-            }
-            classDeclaration.AddImplements(new CodeType {
-                Name = interfaceName,
-                TypeDefinition = inter,
+        if(modelClass.StartBlock.Inherits?.TypeDefinition is CodeClass baseClass) {
+            var parentInterface = CopyClassAsInterface(baseClass, config, interfaceNamingCallback);
+            inter.StartBlock.AddImplements(new CodeType {
+                Name = parentInterface.Name,
+                TypeDefinition = parentInterface,
             });
         }
+        if (modelClass.StartBlock.Implements.Any()) {
+            var originalImplements = modelClass.StartBlock.Implements.ToArray();
+            inter.StartBlock.AddImplements(originalImplements
+                                                        .Select(x => x.Clone() as CodeType)
+                                                        .ToArray());
+            modelClass.StartBlock.RemoveImplements(originalImplements);
+        }
+        modelClass.StartBlock.AddImplements(new CodeType {
+            Name = interfaceName,
+            TypeDefinition = inter,
+        });
         var classModelChildItems = modelClass.GetChildElements(true);
         foreach(var method in classModelChildItems.OfType<CodeMethod>()
                                                     .Where(x => x.IsOfKind(CodeMethodKind.Getter, 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -146,10 +146,11 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         }
         CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional, getterPrefix, setterPrefix));
     }
-    protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited) {
+    protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited, bool forceAdd = false) {
         if(current is CodeClass currentClass &&
             !currentClass.IsOfKind(CodeClassKind.RequestBuilder, CodeClassKind.QueryParameters) &&
-            (currentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)) ||
+            (forceAdd ||
+            currentClass.Properties.Any(x => !string.IsNullOrEmpty(x.DefaultValue)) ||
             addIfInherited && DoesAnyParentHaveAPropertyWithDefaultValue(currentClass)) &&
             !currentClass.Methods.Any(x => x.IsOfKind(CodeMethodKind.ClientConstructor)))
             currentClass.AddMethod(new CodeMethod {
@@ -161,7 +162,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 IsAsync = false,
                 Description = $"Instantiates a new {current.Name} and sets the default values."
             });
-        CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited));
+        CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited, forceAdd));
     }
     protected static void ReplaceReservedNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement, HashSet<Type> codeElementExceptions = null, Func<CodeElement, bool> shouldReplaceCallback = null) {
         var shouldReplace = shouldReplaceCallback?.Invoke(current) ?? true;

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -742,7 +742,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                             TypeDefinition = parentInterface,
                         });
                 }
-            } else if (classDeclaration.Implements.Any()) {
+            } 
+            if (classDeclaration.Implements.Any()) {
                 var originalImplements = classDeclaration.Implements.ToArray();
                 inter.StartBlock.AddImplements(originalImplements
                                                             .Select(x => x.Clone() as CodeType)

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -487,7 +487,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         foreach(var childElement in currentElement.GetChildElements())
             function.Invoke(childElement);
     }
-    protected static void CorrectCoreType(CodeElement currentElement, Action<CodeMethod> correctMethodType, Action<CodeProperty> correctPropertyType) {
+    protected static void CorrectCoreType(CodeElement currentElement, Action<CodeMethod> correctMethodType, Action<CodeProperty> correctPropertyType, Action<ProprietableBlockDeclaration> correctImplements = default) {
         switch(currentElement) {
             case CodeProperty property:
                 correctPropertyType?.Invoke(property);
@@ -495,8 +495,11 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             case CodeMethod method:
                 correctMethodType?.Invoke(method);
                 break;
+            case ProprietableBlockDeclaration block:
+                correctImplements?.Invoke(block);
+                break;
         }
-        CrawlTree(currentElement, x => CorrectCoreType(x, correctMethodType, correctPropertyType));
+        CrawlTree(currentElement, x => CorrectCoreType(x, correctMethodType, correctPropertyType, correctImplements));
     }
     protected static void MakeModelPropertiesNullable(CodeElement currentElement) {
         if(currentElement is CodeClass currentClass &&

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -74,7 +74,8 @@ public class GoRefiner : CommonLanguageRefiner
             "Set");
         AddConstructorsForDefaultValues(
             generatedCode,
-            true);
+            true,
+            true); //forcing add as constructors are required for by factories
         MakeModelPropertiesNullable(
             generatedCode);
         AddErrorImportForEnums(

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -57,7 +57,8 @@ public class GoRefiner : CommonLanguageRefiner
         CorrectCoreType(
             generatedCode,
             CorrectMethodType,
-            CorrectPropertyType);
+            CorrectPropertyType,
+            CorrectImplements);
         PatchHeaderParametersType(
             generatedCode,
             "map[string]string");
@@ -278,8 +279,13 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota/abstractions/go/serialization", "ParseNode", "Parsable"),
         new (x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota/abstractions/go/serialization", "Parsable"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            "github.com/microsoft/kiota/abstractions/go/serialization", "AdditionalDataHolder"),
         new (x => x is CodeEnum num, "ToUpper", "strings"),
     };//TODO add backing store types once we have them defined
+    private static void CorrectImplements(ProprietableBlockDeclaration block) {
+        block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = x.Name[1..]); // skipping the I
+    }
     private static void CorrectMethodType(CodeMethod currentMethod) {
         var parentClass = currentMethod.Parent as CodeClass;
         if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator) &&

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -16,7 +16,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         RemoveCancellationParameter(generatedCode);
         ConvertUnionTypesToWrapper(generatedCode, _configuration.UsesBackingStore);
         AddRawUrlConstructorOverload(generatedCode);
-        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
+        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
         ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
         AddGetterAndSetterMethods(generatedCode,
             new() {
@@ -92,6 +92,8 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             "com.microsoft.kiota", "QueryParametersBase"),
         new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
             "com.microsoft.kiota.serialization", "Parsable"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            "com.microsoft.kiota.serialization", "AdditionalDataHolder"),
         new (x => x is CodeMethod method && method.Parameters.Any(x => !x.Optional),
                 "java.util", "Objects"),
         new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor) &&
@@ -133,6 +135,9 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 currentProperty.DefaultValue = "new HashMap<>()";
         } else
             CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+    }
+    private static void CorrectImplements(ProprietableBlockDeclaration block) {
+        block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = x.Name[1..]); // skipping the I
     }
     private static void CorrectMethodType(CodeMethod currentMethod) {
         if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator)) {

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -66,8 +66,8 @@ namespace Kiota.Builder.Refiners {
         };
         protected static void AddInheritedAndMethodTypesImports(CodeElement currentElement) {
             if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) 
-                && currentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null) {
-                currentClass.AddUsing(new CodeUsing { Name = declaration.Inherits.Name, Declaration = declaration.Inherits});
+                && currentClass.StartBlock.Inherits != null) {
+                currentClass.AddUsing(new CodeUsing { Name = currentClass.StartBlock.Inherits.Name, Declaration = currentClass.StartBlock.Inherits});
             }
             CrawlTree(currentElement, (x) => AddInheritedAndMethodTypesImports(x));
         }
@@ -76,9 +76,9 @@ namespace Kiota.Builder.Refiners {
 
             var nameSpaceName = string.IsNullOrEmpty(prefix) ? FetchEntityNamespace(currentElement).NormalizeNameSpaceName("::") : prefix; 
             if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) 
-                && currentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null 
-                && "entity".Equals(declaration.Inherits.Name, StringComparison.OrdinalIgnoreCase)) {
-                declaration.Inherits.Name = prefix + declaration.Inherits.Name.ToFirstCharacterUpperCase();
+                && currentClass.StartBlock.Inherits != null 
+                && "entity".Equals(currentClass.StartBlock.Inherits.Name, StringComparison.OrdinalIgnoreCase)) {
+                currentClass.StartBlock.Inherits.Name = prefix + currentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase();
             }
             CrawlTree(currentElement, (c) => FixInheritedEntityType(c, nameSpaceName));
         }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -12,7 +12,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
         AddDefaultImports(generatedCode, defaultUsingEvaluators);
         ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
         RemoveCancellationParameter(generatedCode);
-        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
+        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
         CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
         AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
         AliasUsingsWithSameSymbol(generatedCode);
@@ -116,12 +116,17 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             AbstractionsPackageName, "Parsable", "ParsableFactory"),
         new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
             AbstractionsPackageName, "Parsable"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            AbstractionsPackageName, "AdditionalDataHolder"),
         new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
                     method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
             AbstractionsPackageName, "BackingStoreFactory", "BackingStoreFactorySingleton"),
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
             AbstractionsPackageName, "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
     };
+    private static void CorrectImplements(ProprietableBlockDeclaration block) {
+        block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = x.Name[1..]); // skipping the I
+    }
     private static void CorrectPropertyType(CodeProperty currentProperty) {
         if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter))
             currentProperty.Type.Name = "RequestAdapter";

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -16,7 +16,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
 
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
         var parentClass = codeElement.Parent as CodeClass;
-        var inherits = parentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null && !parentClass.IsErrorDefinition;
+        var inherits = parentClass.StartBlock.Inherits != null && !parentClass.IsErrorDefinition;
         var isVoid = conventions.VoidTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
         WriteMethodDocumentation(codeElement, writer);
         WriteMethodPrototype(codeElement, writer, returnType, inherits, isVoid);

--- a/src/Kiota.Builder/Writers/Go/CodeInterfaceDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeInterfaceDeclarationWriter.cs
@@ -13,8 +13,8 @@ public class CodeInterfaceDeclarationWriter : CodeProprietableBlockDeclarationWr
         conventions.WriteShortDescription($"{interName} {inter.Description.ToFirstCharacterLowerCase()}", writer);
         writer.WriteLine($"type {interName} interface {{");
         writer.IncreaseIndent();
-        if(codeElement.Implements.Any()) {
-            var parentTypeName = conventions.GetTypeString(codeElement.Implements.First(), inter, true, false);
+        foreach (var implement in codeElement.Implements) {
+            var parentTypeName = conventions.GetTypeString(implement, inter, true, false);
             writer.WriteLine($"{parentTypeName}");
         }
     }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -20,7 +20,7 @@ namespace Kiota.Builder.Writers.Go {
             WriteMethodPrototype(codeElement, writer, returnType, writePrototypeOnly);
             if(writePrototypeOnly) return;
             var parentClass = codeElement.Parent as CodeClass;
-            var inherits = parentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null && !parentClass.IsErrorDefinition;
+            var inherits = parentClass.StartBlock.Inherits != null && !parentClass.IsErrorDefinition;
             writer.IncreaseIndent();
             var requestOptionsParam = codeElement.Parameters.OfKind(CodeParameterKind.ParameterSet);
             var requestParamSetDefinition = requestOptionsParam != null && requestOptionsParam.Type is CodeType rpsType &&
@@ -139,9 +139,8 @@ namespace Kiota.Builder.Writers.Go {
         private void WriteSerializerBody(CodeClass parentClass, LanguageWriter writer, bool inherits) {
             var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
             var shouldDeclareErrorVar = !inherits;
-            if(parentClass.StartBlock is ClassDeclaration declaration &&
-                inherits) {
-                writer.WriteLine($"err := m.{declaration.Inherits.Name.ToFirstCharacterUpperCase()}.Serialize(writer)");
+            if(inherits) {
+                writer.WriteLine($"err := m.{parentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase()}.Serialize(writer)");
                 WriteReturnError(writer);
             }
             foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)) {
@@ -244,11 +243,10 @@ namespace Kiota.Builder.Writers.Go {
         }
         private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
             writer.WriteLine($"m := &{parentClass.Name.ToFirstCharacterUpperCase()}{{");
-            if(parentClass.StartBlock is ClassDeclaration declaration &&
-                (inherits || parentClass.IsErrorDefinition)) {
+            if(inherits || parentClass.IsErrorDefinition) {
                 writer.IncreaseIndent();
-                var parentClassName = declaration.Inherits.Name.ToFirstCharacterUpperCase();
-                writer.WriteLine($"{parentClassName}: *{conventions.GetImportedStaticMethodName(declaration.Inherits, parentClass)}(),");
+                var parentClassName = parentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase();
+                writer.WriteLine($"{parentClassName}: *{conventions.GetImportedStaticMethodName(parentClass.StartBlock.Inherits, parentClass)}(),");
                 writer.DecreaseIndent();
             }
             writer.CloseBlock(decreaseIndent: false);
@@ -309,9 +307,8 @@ namespace Kiota.Builder.Writers.Go {
         }
         private void WriteDeserializerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, bool inherits) {
             var fieldToSerialize = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom);
-            if(parentClass.StartBlock is ClassDeclaration declaration &&
-                inherits)
-                writer.WriteLine($"res := m.{declaration.Inherits.Name.ToFirstCharacterUpperCase()}.{codeElement.Name.ToFirstCharacterUpperCase()}()");
+            if(inherits)
+                writer.WriteLine($"res := m.{parentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase()}.{codeElement.Name.ToFirstCharacterUpperCase()}()");
             else
                 writer.WriteLine($"res := make({codeElement.ReturnType.Name})");
             if(fieldToSerialize.Any()) {

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -26,7 +26,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         WriteMethodPrototype(codeElement, writer, returnType);
         writer.IncreaseIndent();
         var parentClass = codeElement.Parent as CodeClass;
-        var inherits = parentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null && !parentClass.IsErrorDefinition;
+        var inherits = parentClass.StartBlock.Inherits != null && !parentClass.IsErrorDefinition;
         var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
         var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
         var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -24,7 +24,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
         WriteMethodPrototype(codeElement, writer, returnType, isVoid);
         writer.IncreaseIndent();
         var parentClass = codeElement.Parent as CodeClass;
-        var inherits = parentClass.StartBlock is ClassDeclaration declaration && declaration.Inherits != null && !parentClass.IsErrorDefinition;
+        var inherits = parentClass.StartBlock.Inherits != null && !parentClass.IsErrorDefinition;
         var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
         var queryStringParam = codeElement.Parameters.OfKind(CodeParameterKind.QueryParameter);
         var headersParam = codeElement.Parameters.OfKind(CodeParameterKind.Headers);
@@ -114,8 +114,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
     private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
         if(inherits || parentClass.IsErrorDefinition)
             writer.WriteLine("super();");
-        if(parentClass.IsErrorDefinition && parentClass.StartBlock is ClassDeclaration declaration)
-            writer.WriteLine($"Object.setPrototypeOf(this, {declaration.Inherits.Name.ToFirstCharacterUpperCase()}.prototype);");
+        if(parentClass.IsErrorDefinition)
+            writer.WriteLine($"Object.setPrototypeOf(this, {parentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase()}.prototype);");
         var propertiesWithDefaultValues = new List<CodePropertyKind> {
             CodePropertyKind.AdditionalData,
             CodePropertyKind.BackingStore,

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -722,6 +722,81 @@ public class KiotaBuilderTests
         Assert.Null(codeModel.FindChildByName<CodeClass>("tasks4XXError", true));
         Assert.Null(codeModel.FindChildByName<CodeClass>("tasks5XXError", true));
     }
+    [Fact]
+    public void DoesntAddPropertyHolderOnNonAdditionalModels(){
+        var weatherForecastSchema = new OpenApiSchema {
+            Type = "object",
+            AdditionalPropertiesAllowed = false,
+            Properties = new Dictionary<string, OpenApiSchema> {
+                {
+                    "date", new OpenApiSchema {
+                        Type = "string",
+                        Format = "date-time"
+                    }
+                },
+                {
+                    "temperature", new OpenApiSchema {
+                        Type = "integer",
+                        Format = "int32"
+                    }
+                }
+            },
+            Reference = new OpenApiReference {
+                Id = "weatherForecast",
+                Type = ReferenceType.Schema
+            },
+            UnresolvedReference = false
+        };
+        var forecastResponse = new OpenApiResponse()
+        {
+            Content =
+            {
+                ["application/json"] = new OpenApiMediaType()
+                {
+                    Schema = weatherForecastSchema
+                }
+            },
+            Reference = new OpenApiReference {
+                Id = "weatherForecast",
+                Type = ReferenceType.Response
+            },
+            UnresolvedReference = false
+        };
+        var document = new OpenApiDocument() {
+            Paths = new OpenApiPaths() {
+                ["weatherforecast"] = new OpenApiPathItem() {
+                    Operations = {
+                        [OperationType.Get] = new OpenApiOperation() { 
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = forecastResponse
+                            }
+                        }
+                    } 
+                }
+            },
+            Components = new OpenApiComponents() {
+                Schemas = new Dictionary<string, OpenApiSchema> {
+                    {
+                        "weatherForecast", weatherForecastSchema
+                    }
+                },
+                Responses = new Dictionary<string, OpenApiResponse> {
+                    {
+                        "weatherForecast", forecastResponse
+                    }
+                }
+            },
+        };
+        var node = OpenApiUrlTreeNode.Create(document, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var weatherType = codeModel.FindChildByName<CodeClass>("WeatherForecast", true);
+        Assert.NotNull(weatherType);
+        Assert.Empty(weatherType.StartBlock.Implements.Where(x => x.Name.Equals("IAdditionalDataHolder", StringComparison.OrdinalIgnoreCase)));
+        Assert.Empty(weatherType.Properties.Where(x => x.IsOfKind(CodePropertyKind.AdditionalData)));
+    }
 
     [Fact]
     public void AddsDiscriminatorMappings(){

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -341,6 +341,11 @@ public class JavaLanguageRefinerTests {
         });
         const string handlerDefaultName = "IResponseHandler";
         const string headersDefaultName = "IDictionary<string, string>";
+        const string additionalDataHolderDefaultName = "IAdditionalDataHolder";
+        model.StartBlock.AddImplements(new CodeType {
+            Name = additionalDataHolderDefaultName,
+            IsExternal = true,
+        });
         var executorMethod = model.AddMethod(new CodeMethod {
             Name = "executor",
             Kind = CodeMethodKind.RequestExecutor,
@@ -391,6 +396,8 @@ public class JavaLanguageRefinerTests {
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => handlerDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
+        Assert.Empty(model.StartBlock.Implements.Where(x => additionalDataHolderDefaultName.Equals(x.Name, StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(additionalDataHolderDefaultName[1..], model.StartBlock.Implements.First().Name);
     }
     [Fact]
     public void AddsMethodsOverloads() {


### PR DESCRIPTION
fixes #737

## Generation diff

https://github.com/microsoft/kiota-samples/pull/544

## TODO

### CSharp

- [x] test with additional properties disabled
- [x] bump abstractions and serialization

### Go

- [x] add new interface and update parsable
- [x] update refiner for new types
- [x] update parse node implementation
- [x] check the interface extraction code
- [x] test with additional properties disabled

### Java

- [x] add new interface and update parsable
- [x] udpate refienr for new types
- [x] update parse node implementation
- [x] bump abstractions and serialization
- [x] test with additional properties disabled

### TypeScript

- [x] add new interface and update parsable
- [x] update refiner for new types
- [x] update parse node implementation
- [x] bump abstractions and serialization
- [x] test with additional properties disabled

### Global

- [x] add unit tests for usings/interfaces
- [x] update documentation
- [x] ping php and python teams
- [x] update ruby checklist