### PR TITLE
Fix missing discriminator functions union type wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where union wrapper models would lack the discriminator methods
+
 ## [0.0.17] - 2022-03-03
 
 ### Added

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -332,6 +332,22 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             KiotaBuilder.AddSerializationMembers(newClass, true, usesBackingStore);
             newClass.Kind = CodeClassKind.Model;
         }
+        // Add the discrimnator function to the wrapper as it will be referenced. 
+        var factoryMethod = newClass.AddMethod(new CodeMethod
+        {
+            Name = "CreateFromDiscriminatorValue",
+            ReturnType = new CodeType { TypeDefinition = newClass, Name = newClass.Name, IsNullable = false },
+            Kind = CodeMethodKind.Factory,
+            IsStatic = true,
+            IsAsync = false,
+        }).First();
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Optional = false,
+            Type = new CodeType { Name = "IParseNode", IsExternal = true },
+        });
         return new CodeType {
             Name = newClass.Name,
             TypeDefinition = newClass,

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -95,9 +95,9 @@ namespace Kiota.Builder.Writers.CSharp {
             var parentElementsHash = new HashSet<string>(parentElements, StringComparer.OrdinalIgnoreCase);
             var typeName = TranslateType(currentType);
             if(currentType.TypeDefinition != null &&
-                GetNamesInUseByNamespaceSegments(targetElement).Contains(typeName) &&
+                (GetNamesInUseByNamespaceSegments(targetElement).Contains(typeName) &&
                 !DoesTypeExistsInSameNamesSpaceAsTarget(currentType,targetElement) ||
-                parentElementsHash.Contains(typeName))
+                parentElementsHash.Contains(typeName)))
                 return $"{currentType.TypeDefinition.GetImmediateParentOfType<CodeNamespace>().Name}.{typeName}";
             else
                 return typeName;


### PR DESCRIPTION
This PR fixes an edge case where there would be missing discriminator functions for model types created from union type wrappers.

As the union type wrappers are created in the refiner stages, these models would miss out on getting the relevant functions resulting to unresolved references.

Generation for the same has been tested with the full v1/beta description and can be checked here.

https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=69106&view=logs&j=09be00da-8404-5a6e-d496-3b97eba1ba4f

Generation changes can be previewed at 
V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1268
Beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/408