### PR TITLE
better error display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved error display #1269
 - Fixed a bug where union wrapper models would lack the discriminator methods
 - Fixed bug working with async azure credentials in Python
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -14,6 +14,7 @@ using Microsoft.OpenApi.Any;
 using Kiota.Builder.Refiners;
 using System.Security;
 using Microsoft.OpenApi.Services;
+using System.Threading;
 
 namespace Kiota.Builder;
 
@@ -29,7 +30,7 @@ public class KiotaBuilder
         this.config = config;
     }
 
-    public async Task GenerateSDK()
+    public async Task GenerateSDK(CancellationToken cancellationToken)
     {
         var sw = new Stopwatch();
         // Step 1 - Read input stream
@@ -39,12 +40,16 @@ public class KiotaBuilder
             // doing this verification at the begining to give immediate feedback to the user
             Directory.CreateDirectory(config.OutputPath);
         } catch (Exception ex) {
-            logger.LogError($"Could not open/create output directory {config.OutputPath}, reason: {ex.Message}");
+#if DEBUG
+            logger.LogCritical(ex, "Could not open/create output directory {configOutputPath}, reason: {exMessage}", config.OutputPath, ex.Message);
+#else
+            logger.LogCritical("Could not open/create output directory {configOutputPath}, reason: {exMessage}", config.OutputPath, ex.Message);
+#endif
             return;
         }
         
         sw.Start();
-        using var input = await LoadStream(inputPath);
+        using var input = await LoadStream(inputPath, cancellationToken);
         if(input == null)
             return;
         StopLogAndReset(sw, "step 1 - reading the stream - took");
@@ -73,7 +78,7 @@ public class KiotaBuilder
 
         // Step 6 - Write language source 
         sw.Start();
-        await CreateLanguageSourceFilesAsync(config.Language, generatedCode);
+        await CreateLanguageSourceFilesAsync(config.Language, generatedCode, cancellationToken);
         StopLogAndReset(sw, "step 6 - writing files - took");
     }
     private void SetApiRootUrl() {
@@ -83,12 +88,12 @@ public class KiotaBuilder
     }
     private void StopLogAndReset(Stopwatch sw, string prefix) {
         sw.Stop();
-        logger.LogDebug($"{prefix} {sw.Elapsed}");
+        logger.LogDebug("{prefix} {swElapsed}", prefix, sw.Elapsed);
         sw.Reset();
     }
 
 
-    private async Task<Stream> LoadStream(string inputPath)
+    private async Task<Stream> LoadStream(string inputPath, CancellationToken cancellationToken)
     {
         var stopwatch = new Stopwatch();
         stopwatch.Start();
@@ -97,9 +102,13 @@ public class KiotaBuilder
         if (inputPath.StartsWith("http"))
             try {
                 using var httpClient = new HttpClient();
-                input = await httpClient.GetStreamAsync(inputPath);
+                input = await httpClient.GetStreamAsync(inputPath, cancellationToken);
             } catch (HttpRequestException ex) {
-                logger.LogError($"Could not download the file at {inputPath}, reason: {ex.Message}");
+#if DEBUG
+                logger.LogCritical(ex, "Could not download the file at {inputPath}, reason: {exMessage}", inputPath, ex.Message);
+#else
+                logger.LogCritical("Could not download the file at {inputPath}, reason: {exMessage}", inputPath, ex.Message);
+#endif
                 return null;
             }
         else
@@ -112,7 +121,11 @@ public class KiotaBuilder
                 ex is UnauthorizedAccessException ||
                 ex is SecurityException ||
                 ex is NotSupportedException) {
-                logger.LogError($"Could not open the file at {inputPath}, reason: {ex.Message}");
+#if DEBUG
+                logger.LogCritical(ex, "Could not open the file at {inputPath}, reason: {exMessage}", inputPath, ex.Message);
+#else
+                logger.LogCritical("Could not open the file at {inputPath}, reason: {exMessage}", inputPath, ex.Message);
+#endif
                 return null;
             }
         stopwatch.Stop();
@@ -131,7 +144,11 @@ public class KiotaBuilder
         stopwatch.Stop();
         if (diag.Errors.Count > 0)
         {
-            logger.LogError($"{stopwatch.ElapsedMilliseconds}ms: OpenApi Parsing errors {string.Join(Environment.NewLine, diag.Errors.Select(e => e.Message))}");
+            logger.LogTrace("{timestamp}ms: Parsed OpenAPI with errors. {count} paths found.", stopwatch.ElapsedMilliseconds, doc.Paths.Count);
+            foreach(var parsingError in diag.Errors)
+            {
+                logger.LogError("OpenApi Parsing error: {message}", parsingError.ToString());
+            }
         }
         else
         {
@@ -207,12 +224,12 @@ public class KiotaBuilder
     /// <param name="root">Root node of URI space from the OpenAPI described API</param>
     /// <returns>A CodeNamespace object that contains request builder classes for the Uri Space</returns>
 
-    public async Task CreateLanguageSourceFilesAsync(GenerationLanguage language, CodeNamespace generatedCode)
+    public async Task CreateLanguageSourceFilesAsync(GenerationLanguage language, CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        var languageWriter = LanguageWriter.GetLanguageWriter(language, this.config.OutputPath, this.config.ClientNamespaceName);
+        var languageWriter = LanguageWriter.GetLanguageWriter(language, config.OutputPath, config.ClientNamespaceName);
         var stopwatch = new Stopwatch();
         stopwatch.Start();
-        await new CodeRenderer(config).RenderCodeNamespaceToFilePerClassAsync(languageWriter, generatedCode);
+        await new CodeRenderer(config).RenderCodeNamespaceToFilePerClassAsync(languageWriter, generatedCode, cancellationToken);
         stopwatch.Stop();
         logger.LogTrace("{timestamp}ms: Files written to {path}", stopwatch.ElapsedMilliseconds, config.OutputPath);
     }
@@ -420,7 +437,7 @@ public class KiotaBuilder
         var unmappedTypesWithNoName = unmappedTypes.Where(x => string.IsNullOrEmpty(x.Name)).ToList();
         
         unmappedTypesWithNoName.ForEach(x => {
-            logger.LogWarning($"Type with empty name and parent {x.Parent.Name}");
+            logger.LogWarning("Type with empty name and parent {ParentName}", x.Parent.Name);
         });
 
         var unmappedTypesWithName = unmappedTypes.Except(unmappedTypesWithNoName);
@@ -456,7 +473,7 @@ public class KiotaBuilder
                 foreach (var type in x)
                 {
                     type.TypeDefinition = definition;
-                    logger.LogWarning($"Mapped type {type.Name} for {type.Parent.Name} using the fallback approach.");
+                    logger.LogWarning("Mapped type {typeName} for {ParentName} using the fallback approach.", type.Name, type.Parent.Name);
                 }
         });
     }
@@ -597,7 +614,7 @@ public class KiotaBuilder
             if(operation.Responses.Any(x => x.Value.Content.ContainsKey(RequestBodyBinaryContentType)))
                 returnType = "binary";
             else if(!operation.Responses.Any(x => noContentStatusCodes.Contains(x.Key)))
-                logger.LogWarning($"could not find operation return type {operationType} {currentNode.Path}");
+                logger.LogWarning("could not find operation return type {operationType} {currentNodePath}", operationType, currentNode.Path);
             executorMethod.ReturnType = new CodeType { Name = returnType, IsExternal = true, };
         }
 
@@ -898,7 +915,7 @@ public class KiotaBuilder
     private CodeTypeBase GetCodeTypeForMapping(OpenApiUrlTreeNode currentNode, string referenceId, CodeNamespace currentNamespace, CodeClass currentClass, OpenApiSchema currentSchema) {
         var componentKey = referenceId.Replace("#/components/schemas/", string.Empty);
         if(!openApiDocument.Components.Schemas.TryGetValue(componentKey, out var discriminatorSchema)) {
-            logger.LogWarning($"Discriminator {componentKey} not found in the OpenAPI document.");
+            logger.LogWarning("Discriminator {componentKey} not found in the OpenAPI document.", componentKey);
             return null;
         }
         var className = currentNode.GetClassName(schema: discriminatorSchema);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -144,7 +144,7 @@ public class KiotaBuilder
         stopwatch.Stop();
         if (diag.Errors.Count > 0)
         {
-            logger.LogTrace("{timestamp}ms: Parsed OpenAPI with errors. {count} paths found.", stopwatch.ElapsedMilliseconds, doc.Paths.Count);
+            logger.LogTrace("{timestamp}ms: Parsed OpenAPI with errors. {count} paths found.", stopwatch.ElapsedMilliseconds, doc?.Paths?.Count ?? 0);
             foreach(var parsingError in diag.Errors)
             {
                 logger.LogError("OpenApi Parsing error: {message}", parsingError.ToString());
@@ -152,7 +152,7 @@ public class KiotaBuilder
         }
         else
         {
-            logger.LogTrace("{timestamp}ms: Parsed OpenAPI successfully. {count} paths found.", stopwatch.ElapsedMilliseconds, doc.Paths.Count);
+            logger.LogTrace("{timestamp}ms: Parsed OpenAPI successfully. {count} paths found.", stopwatch.ElapsedMilliseconds, doc?.Paths?.Count ?? 0);
         }
 
         return doc;

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Kiota.Builder;
 using Kiota.Builder.Extensions;
@@ -55,14 +56,14 @@ namespace Kiota {
                 serializerOption,
                 deserializerOption,
             };
-            command.SetHandler<string, GenerationLanguage, string, bool, string, LogLevel, string, List<string>, List<string>>(HandleCommandCall, outputOption, languageOption, descriptionOption, backingStoreOption, classOption, logLevelOption, namespaceOption, serializerOption, deserializerOption);
+            command.SetHandler<string, GenerationLanguage, string, bool, string, LogLevel, string, List<string>, List<string>, CancellationToken>(HandleCommandCall, outputOption, languageOption, descriptionOption, backingStoreOption, classOption, logLevelOption, namespaceOption, serializerOption, deserializerOption);
             return command;
         }
         private void AssignIfNotNullOrEmpty(string input, Action<GenerationConfiguration, string> assignment) {
             if (!string.IsNullOrEmpty(input))
                 assignment.Invoke(Configuration, input);
         }
-        private async Task HandleCommandCall(string output, GenerationLanguage language, string openapi, bool backingstore, string classname, LogLevel loglevel, string namespacename, List<string> serializer, List<string> deserializer) {
+        private async Task<int> HandleCommandCall(string output, GenerationLanguage language, string openapi, bool backingstore, string classname, LogLevel loglevel, string namespacename, List<string> serializer, List<string> deserializer, CancellationToken cancellationToken) {
             AssignIfNotNullOrEmpty(output, (c, s) => c.OutputPath = s);
             AssignIfNotNullOrEmpty(openapi, (c, s) => c.OpenAPIFilePath = s);
             AssignIfNotNullOrEmpty(classname, (c, s) => c.ClientClassName = s);
@@ -92,7 +93,18 @@ namespace Kiota {
 
             logger.LogTrace("configuration: {configuration}", JsonSerializer.Serialize(Configuration));
 
-            await new KiotaBuilder(logger, Configuration).GenerateSDK();
+            try {
+                await new KiotaBuilder(logger, Configuration).GenerateSDK(cancellationToken);
+                return 0;
+            } catch (Exception ex) {
+#if DEBUG
+                logger.LogCritical(ex, "error generating the SDK: {exceptionMessage}", ex.Message);
+                throw; // so debug tools go straight to the source of the exception when attached
+#else
+                logger.LogCritical("error generating the SDK: {exceptionMessage}", ex.Message);
+                return 1;
+#endif
+            }
         }
         private static void AddStringRegexValidator(Option<string> option, string pattern, string parameterName) {
             var validator = new Regex(pattern);

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -28,7 +28,7 @@ namespace Kiota.Builder.integrationtests
                 OutputPath = $".\\Generated\\{language}{backingStoreSuffix}",
                 UsesBackingStore = backingStore,
             };
-            await new KiotaBuilder(logger, configuration).GenerateSDK();
+            await new KiotaBuilder(logger, configuration).GenerateSDK(new());
         }
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -19,7 +19,7 @@ public class KiotaBuilderTests
         await File.WriteAllLinesAsync(tempFilePath, new string[] {"openapi: 3.0.0", "info:", "  title: \"Todo API\"", "  version: \"1.0.0\""});
         var mockLogger = new Mock<ILogger<KiotaBuilder>>();
         var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
-        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.GenerateSDK());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.GenerateSDK(new()));
         File.Delete(tempFilePath);
     }
     [Fact]
@@ -28,7 +28,7 @@ public class KiotaBuilderTests
         await File.WriteAllLinesAsync(tempFilePath, new string[] {"swagger: 2.0", "title: \"Todo API\"", "version: \"1.0.0\"", "host: mytodos.doesntexit", "basePath: v2", "schemes:", " - https"," - http"});
         var mockLogger = new Mock<ILogger<KiotaBuilder>>();
         var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration() { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
-        await builder.GenerateSDK();
+        await builder.GenerateSDK(new());
         File.Delete(tempFilePath);
     }
     [Fact]


### PR DESCRIPTION
fixes #1269

- passes the cancellation token all the way from the system.command line host to async APIs to avoid getting task cancelled exceptions when users press ctrl + c
- formats all the logging to use templates instead of doing string interpolation so logging APIs can do sampling and metrics
- adds a global try catch/log to log a proper error message instead of throwing an exception to the user.


![image](https://user-images.githubusercontent.com/7905502/157113770-235075ef-2456-4708-99cc-e64e7d874420.png)


@MaggieKimani1 you might want to replicate this onto hidi.