### PR TITLE
Generation fixes in Dotnet and Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed NullReferenceException in Go generator
+- Fixed incorrect mapping when the response type is `text/plain` #1356
+- Fixed a bug in Dotnet.Typescript where properties could have invalid characters #1354
 - Improved error display #1269
 - Fixed a bug where union wrapper models would lack the discriminator methods
 - Fixed bug working with async azure credentials in Python

--- a/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -61,20 +62,21 @@ public abstract class ProprietableBlock<T, U> : CodeBlock<U, BlockEnd>, IDocumen
 
 public class ProprietableBlockDeclaration : BlockDeclaration
 {
-    private readonly List<CodeType> implements = new ();
+    private readonly ConcurrentDictionary<string, CodeType> implements = new ();
     public void AddImplements(params CodeType[] types) {
         if(types == null || types.Any(x => x == null))
             throw new ArgumentNullException(nameof(types));
         EnsureElementsAreChildren(types);
-        implements.AddRange(types);
+        foreach(var type in types)
+            implements.TryAdd(type.Name,type);
     }
     public void RemoveImplements(params CodeType[] types) {
         if(types == null || types.Any(x => x == null))
             throw new ArgumentNullException(nameof(types));
         foreach(var type in types)
-            implements.Remove(type);
+            implements.Remove(type.Name, out var _);
     }
-    public IEnumerable<CodeType> Implements => implements;
+    public IEnumerable<CodeType> Implements => implements.Values;
 }
 
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1066,7 +1066,7 @@ public class KiotaBuilder
                     Type = new CodeType
                     {
                         IsExternal = true,
-                        Name = parameter.Schema.Items?.Type ?? parameter.Schema.Type,
+                        Name = parameter.Schema?.Items?.Type ?? parameter.Schema?.Type ?? "string", // since its a query parameter default to string if there is no schema
                         CollectionKind = parameter.Schema.IsArray() ? CodeType.CodeTypeCollectionKind.Array : default,
                     },
                 };

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -515,7 +515,7 @@ public class KiotaBuilder
         propertyName = propertyName.ToCamelCase(); //ensure the name is camel cased to strip out any potential '-' characters
         var prop = new CodeProperty
         {
-            Name = propertyName.ToCamelCase(),//ensure the name is camel cased to strip out any potential '-' characters
+            Name = propertyName,
             DefaultValue = defaultValue,
             Kind = kind,
             Description = typeSchema?.Description,

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -514,7 +514,7 @@ public class KiotaBuilder
         config.PropertiesPrefixToStrip.ForEach(x => propertyName = propertyName.Replace(x, string.Empty));
         var prop = new CodeProperty
         {
-            Name = propertyName,
+            Name = propertyName.ToCamelCase(),//ensure the name is camel cased to strip out any potential '-' characters
             DefaultValue = defaultValue,
             Kind = kind,
             Description = typeSchema?.Description,
@@ -570,6 +570,7 @@ public class KiotaBuilder
         };
     }
     private const string RequestBodyBinaryContentType = "application/octet-stream";
+    private const string RequestBodyPlainTextContentType = "text/plain";
     private static readonly HashSet<string> noContentStatusCodes = new() { "201", "202", "204" };
     private static readonly HashSet<string> errorStatusCodes = new(Enumerable.Range(400, 599).Select(x => x.ToString())
                                                                                  .Concat(new[] { "4XX", "5XX" }), StringComparer.OrdinalIgnoreCase);
@@ -613,6 +614,8 @@ public class KiotaBuilder
             var returnType = voidType;
             if(operation.Responses.Any(x => x.Value.Content.ContainsKey(RequestBodyBinaryContentType)))
                 returnType = "binary";
+            else if (operation.Responses.Any(x => x.Value.Content.ContainsKey(RequestBodyPlainTextContentType)))
+                returnType = "string";
             else if(!operation.Responses.Any(x => noContentStatusCodes.Contains(x.Key)))
                 logger.LogWarning("could not find operation return type {operationType} {currentNodePath}", operationType, currentNode.Path);
             executorMethod.ReturnType = new CodeType { Name = returnType, IsExternal = true, };
@@ -838,8 +841,13 @@ public class KiotaBuilder
         else throw new InvalidOperationException("un handled case, might be object type or array type");
     }
     private CodeElement GetExistingDeclaration(bool checkInAllNamespaces, CodeNamespace currentNamespace, OpenApiUrlTreeNode currentNode, string declarationName) {
-        var searchNameSpace = GetSearchNamespace(checkInAllNamespaces, currentNode, currentNamespace);
-        return searchNameSpace.FindChildByName<ITypeDefinition>(declarationName, checkInAllNamespaces) as CodeElement;
+        var localNameSpace = GetSearchNamespace(false, currentNode, currentNamespace);
+        var localItemSearchItem = localNameSpace.FindChildByName<ITypeDefinition>(declarationName, checkInAllNamespaces) as CodeElement;
+        if (!checkInAllNamespaces || localItemSearchItem != null)
+            return localItemSearchItem; // if we can find an item in the target namespace lets default to that.
+
+        var globalSearchNameSpace = GetSearchNamespace(checkInAllNamespaces, currentNode, currentNamespace);
+        return globalSearchNameSpace.FindChildByName<ITypeDefinition>(declarationName, checkInAllNamespaces) as CodeElement;
     }
     private CodeNamespace GetSearchNamespace(bool checkInAllNamespaces, OpenApiUrlTreeNode currentNode, CodeNamespace currentNamespace) {
         if(checkInAllNamespaces) return rootNamespace;

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -512,6 +512,7 @@ public class KiotaBuilder
     {
         var propertyName = childIdentifier;
         config.PropertiesPrefixToStrip.ForEach(x => propertyName = propertyName.Replace(x, string.Empty));
+        propertyName = propertyName.ToCamelCase(); //ensure the name is camel cased to strip out any potential '-' characters
         var prop = new CodeProperty
         {
             Name = propertyName.ToCamelCase(),//ensure the name is camel cased to strip out any potential '-' characters

--- a/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Kiota.Builder.Extensions;
 
@@ -17,7 +17,7 @@ public abstract class CodeProprietableBlockDeclarationWriter<T> : BaseElementWri
             writer.WriteLine($"package {ns.Name.GetLastNamespaceSegment().Replace("-", string.Empty)}");
         var importSegments = codeElement
                             .Usings
-                            .Where(x => !x.Declaration.IsExternal && !x.Name.Equals(ns.Name, StringComparison.OrdinalIgnoreCase))
+                            .Where(x => !x.Declaration.IsExternal && !x.Name.Equals(ns?.Name ?? string.Empty, StringComparison.OrdinalIgnoreCase))
                             .Select(x => x.GetInternalNamespaceImport())
                             .Select(x => new Tuple<string, string>(x.GetNamespaceImportSymbol(), x))
                             .Distinct()

--- a/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
@@ -12,29 +12,31 @@ public abstract class CodeProprietableBlockDeclarationWriter<T> : BaseElementWri
     {
         if(codeElement == null) throw new ArgumentNullException(nameof(codeElement));
         if(writer == null) throw new ArgumentNullException(nameof(writer));
-        var ns = codeElement.Parent?.Parent as CodeNamespace;
-        if (ns != null)
+        if (codeElement.Parent?.Parent is CodeNamespace ns)
+        {
             writer.WriteLine($"package {ns.Name.GetLastNamespaceSegment().Replace("-", string.Empty)}");
-        var importSegments = codeElement
-                            .Usings
-                            .Where(x => !x.Declaration.IsExternal && !x.Name.Equals(ns?.Name ?? string.Empty, StringComparison.OrdinalIgnoreCase))
-                            .Select(x => x.GetInternalNamespaceImport())
-                            .Select(x => new Tuple<string, string>(x.GetNamespaceImportSymbol(), x))
-                            .Distinct()
-                            .Union(codeElement
+            var importSegments = codeElement
                                 .Usings
-                                .Where(x => x.Declaration.IsExternal)
-                                .Select(x => new Tuple<string, string>(x.Name.StartsWith("*") ? x.Name[1..] : x.Declaration.Name.GetNamespaceImportSymbol(), x.Declaration.Name))
-                                .Distinct())
-                            .OrderBy(x => x.Item2.Count(y => y == '/'))
-                            .ThenBy(x => x)
-                            .ToList();
-        if(importSegments.Any()) {
-            writer.WriteLines(string.Empty, "import (");
-            writer.IncreaseIndent();
-            importSegments.ForEach(x => writer.WriteLine($"{x.Item1} \"{x.Item2}\""));
-            writer.DecreaseIndent();
-            writer.WriteLines(")", string.Empty);
+                                .Where(x => !x.Declaration.IsExternal && !x.Name.Equals(ns.Name, StringComparison.OrdinalIgnoreCase))
+                                .Select(x => x.GetInternalNamespaceImport())
+                                .Select(x => new Tuple<string, string>(x.GetNamespaceImportSymbol(), x))
+                                .Distinct()
+                                .Union(codeElement
+                                    .Usings
+                                    .Where(x => x.Declaration.IsExternal)
+                                    .Select(x => new Tuple<string, string>(x.Name.StartsWith("*") ? x.Name[1..] : x.Declaration.Name.GetNamespaceImportSymbol(), x.Declaration.Name))
+                                    .Distinct())
+                                .OrderBy(x => x.Item2.Count(y => y == '/'))
+                                .ThenBy(x => x)
+                                .ToList();
+            if (importSegments.Any())
+            {
+                writer.WriteLines(string.Empty, "import (");
+                writer.IncreaseIndent();
+                importSegments.ForEach(x => writer.WriteLine($"{x.Item1} \"{x.Item2}\""));
+                writer.DecreaseIndent();
+                writer.WriteLines(")", string.Empty);
+            }
         }
         WriteTypeDeclaration(codeElement, writer);
     }

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -397,7 +397,7 @@ public class JavaLanguageRefinerTests {
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => headersDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Methods.SelectMany(x => x.Parameters).Where(x => serializerDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.StartBlock.Implements.Where(x => additionalDataHolderDefaultName.Equals(x.Name, StringComparison.OrdinalIgnoreCase)));
-        Assert.Equal(additionalDataHolderDefaultName[1..], model.StartBlock.Implements.First().Name);
+        Assert.Contains( additionalDataHolderDefaultName[1..], model.StartBlock.Implements.Select(x => x.Name).ToList());
     }
     [Fact]
     public void AddsMethodsOverloads() {


### PR DESCRIPTION
This PR closes #1354 and closes #1356

In summary, changes include :- 
- Ensure property names are Camel Cased when added to the code DOM to eliminate the possibility of `-` characters to cause compile time issues.
- Add a default response return type of type `string` for content type `text/plain`
- Fix for `NullReferenceException` [CodeProprietableBlockDeclarationWriter.cs](https://github.com/microsoft/kiota/pull/1355/files#diff-23fe0448659d8a316d18d89ca908098bed5b2ec82c9139c35b2ad6cca4ad23e5) when the namespace is null in Go
- Refactored the `GetExistingDeclaration` method to first search for the declaration in the target namespace before searching the root model namespace to avoid incorrect type resolution.
- `ProprietableBlockDeclaration` to use a `ConcurrentDictionary` for holding the `implements` collection as race conditions were observed during testing


Generation pipeline run can viewed at the link below
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=69641&view=logs&j=fbf82ed0-029a-5388-186b-43225c9ecb54