### PR TITLE
- fixes a bug where implements generation would not be deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed indeterministic parameters ordering #1358
+- Fixed indeterministic error mappings ordering #1358
+- Fixed indeterministic discriminator mapping ordering #1358
+- Fixed race condition when removing child items leading to erratic code generation results #1358
+- Replaced models namespaces flattening by circular properties trimming in Go #1358
+- Fixed a bug where inherited interfaces would be missing imports in Go #1358
+- Fixed a bug where inherited interfaces would be missing imports for the parent #1358
 - Fixed bugs across request adapter and serialization in PHP #1353
 - Fixed NullReferenceException in Go generator
 - Fixed incorrect mapping when the response type is `text/plain` #1356

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -111,6 +111,13 @@ public class BlockDeclaration : CodeTerminal
         EnsureElementsAreChildren(codeUsings);
         usings.AddRange(codeUsings);
     }
+    public void RemoveUsings(params CodeUsing[] codeUsings)
+    {
+        if(codeUsings == null || codeUsings.Any(x => x == null))
+            throw new ArgumentNullException(nameof(codeUsings));
+        foreach(var codeUsing in codeUsings)
+            usings.Remove(codeUsing);
+    }
     public void RemoveUsingsByDeclarationName(params string[] names) {
         if(names == null || names.Any(x => string.IsNullOrEmpty(x)))
             throw new ArgumentNullException(nameof(names));

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -11,7 +11,7 @@ namespace Kiota.Builder;
 public class CodeBlock<V, U> : CodeElement, IBlock where V : BlockDeclaration, new() where U : BlockEnd, new()
 {
     public V StartBlock {get; set;}
-    protected IDictionary<string, CodeElement> InnerChildElements {get; private set;} = new ConcurrentDictionary<string, CodeElement>(StringComparer.OrdinalIgnoreCase);
+    protected ConcurrentDictionary<string, CodeElement> InnerChildElements {get; private set;} = new (StringComparer.OrdinalIgnoreCase);
     public U EndBlock {get; set;}
     public CodeBlock():base()
     {
@@ -29,7 +29,7 @@ public class CodeBlock<V, U> : CodeElement, IBlock where V : BlockDeclaration, n
         if(elements == null) return;
 
         foreach(var element in elements) {
-            InnerChildElements.Remove(element.Name);
+            InnerChildElements.TryRemove(element.Name, out _);
         }
     }
     public void RemoveUsingsByDeclarationName(params string[] names) => StartBlock.RemoveUsingsByDeclarationName(names);
@@ -38,36 +38,35 @@ public class CodeBlock<V, U> : CodeElement, IBlock where V : BlockDeclaration, n
     protected IEnumerable<T> AddRange<T>(params T[] elements) where T : CodeElement {
         if(elements == null) return Enumerable.Empty<T>();
         EnsureElementsAreChildren(elements);
-        var innerChildElements = InnerChildElements as ConcurrentDictionary<string, CodeElement>; // to avoid calling the non thread-safe extension method
         var result = new T[elements.Length]; // not using yield return as they'll only get called if the result is assigned
 
         for(var i = 0; i < elements.Length; i++) {
             var element = elements[i];
-            var returnedValue = innerChildElements.GetOrAdd(element.Name, element);
-            result[i] = (T)HandleDuplicatedExceptions(innerChildElements, element, returnedValue);
+            var returnedValue = InnerChildElements.GetOrAdd(element.Name, element);
+            result[i] = HandleDuplicatedExceptions(element, returnedValue);
         }
         return result;
     }
-    private static CodeElement HandleDuplicatedExceptions(ConcurrentDictionary<string, CodeElement> innerChildElements, CodeElement element, CodeElement returnedValue) {
+    private T HandleDuplicatedExceptions<T>(T element, CodeElement returnedValue) where T: CodeElement {
         var added = returnedValue == element;
         if(!added && element is CodeMethod currentMethod)
             if(currentMethod.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility) &&
                 returnedValue is CodeProperty cProp &&
                 cProp.IsOfKind(CodePropertyKind.RequestBuilder)) {
                 // indexer retrofitted to method in the parent request builder on the path and conflicting with the collection request builder property
-                returnedValue = innerChildElements.GetOrAdd($"{element.Name}-indexerbackcompat", element);
+                returnedValue = InnerChildElements.GetOrAdd($"{element.Name}-indexerbackcompat", element);
                 added = true;
             } else if(currentMethod.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {
                 // allows for methods overload
                 var methodOverloadNameSuffix = currentMethod.Parameters.Any() ? currentMethod.Parameters.Select(x => x.Name).OrderBy(x => x).Aggregate((x, y) => x + y) : "1";
-                returnedValue = innerChildElements.GetOrAdd($"{element.Name}-{methodOverloadNameSuffix}", element);
+                returnedValue = InnerChildElements.GetOrAdd($"{element.Name}-{methodOverloadNameSuffix}", element);
                 added = true;
             }
 
         if(!added && returnedValue.GetType() != element.GetType())
             throw new InvalidOperationException($"the current dom node already contains a child with name {returnedValue.Name} and of type {returnedValue.GetType().Name}");
 
-        return returnedValue;
+        return returnedValue as T;
     }
     public IEnumerable<T> FindChildrenByName<T>(string childName) where T: ICodeElement {
         if(string.IsNullOrEmpty(childName))

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -37,6 +37,14 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
             throw new ArgumentOutOfRangeException(nameof(codeClasses));
         return AddRange(codeClasses);
     }
+    public IEnumerable<CodeInterface> AddInnerInterface(params CodeInterface[] codeInterfaces)
+    {
+        if(codeInterfaces == null || codeInterfaces.Any(x => x == null))
+            throw new ArgumentNullException(nameof(codeInterfaces));
+        if(!codeInterfaces.Any())
+            throw new ArgumentOutOfRangeException(nameof(codeInterfaces));
+        return AddRange(codeInterfaces);
+    }
     public CodeClass GetParentClass() {
         return StartBlock.Inherits?.TypeDefinition as CodeClass;
     }

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -23,7 +23,13 @@ namespace Kiota.Builder
                 StartBlock.Name = name;
             }
         }
-
+        public bool IsParentOf(CodeNamespace childNamespace) {
+            if(childNamespace == null)
+                throw new ArgumentNullException(nameof(childNamespace));
+            if(this == childNamespace)
+                return false;
+            return childNamespace.Name.StartsWith(Name + ".", StringComparison.OrdinalIgnoreCase);
+        }
         public IEnumerable<CodeClass> AddClass(params CodeClass[] codeClasses)
         {
             if(codeClasses == null || codeClasses.Any( x=> x == null))

--- a/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
@@ -76,7 +76,7 @@ public class ProprietableBlockDeclaration : BlockDeclaration
         foreach(var type in types)
             implements.Remove(type.Name, out var _);
     }
-    public IEnumerable<CodeType> Implements => implements.Values;
+    public IEnumerable<CodeType> Implements => implements.Values.OrderBy(x => x.Name);
 }
 
 

--- a/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
@@ -90,7 +90,7 @@ public class ProprietableBlockDeclaration : BlockDeclaration
         if(types == null || types.Any(x => x == null))
             throw new ArgumentNullException(nameof(types));
         foreach(var type in types)
-            implements.Remove(type.Name, out var _);
+            implements.TryRemove(type.Name, out var _);
     }
     public IEnumerable<CodeType> Implements => implements.Values.OrderBy(x => x.Name);
 }

--- a/src/Kiota.Builder/CodeElementOrderComparerWithExternalMethods.cs
+++ b/src/Kiota.Builder/CodeElementOrderComparerWithExternalMethods.cs
@@ -9,8 +9,9 @@ namespace Kiota.Builder {
                 CodeMethod when element.Parent is CodeInterface => 5, //methods are declared inside of interfaces
                 BlockEnd => 6,
                 CodeClass => 7,
-                CodeIndexer => 8,
-                CodeMethod => 9,
+                CodeInterface => 8,
+                CodeIndexer => 9,
+                CodeMethod => 10,
                 _ => 0,
             };
         }

--- a/src/Kiota.Builder/CodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/CodeParameterOrderComparer.cs
@@ -10,7 +10,8 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
             (null, _) => -1,
             (_, null) => 1,
             _ => x.Optional.CompareTo(y.Optional) * optionalWeight +
-                getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight,
+                getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight +
+                x.Name.CompareTo(y.Name) * nameWeight,
         };
     }
     private static int getKindOrderHint(CodeParameterKind kind) {
@@ -33,5 +34,6 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
         };
     }
     private static readonly int optionalWeight = 1000;
-    private static readonly int kindWeight = 10;
+    private static readonly int kindWeight = 100;
+    private static readonly int nameWeight = 10;
 }

--- a/src/Kiota.Builder/CodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/CodeParameterOrderComparer.cs
@@ -33,7 +33,7 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
             _ => 15,
         };
     }
-    private static readonly int optionalWeight = 1000;
+    private static readonly int optionalWeight = 10000;
     private static readonly int kindWeight = 100;
     private static readonly int nameWeight = 10;
 }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -590,7 +590,7 @@ public class KiotaBuilder
             {
                 codeClass.IsErrorDefinition = true;
             }
-            executorMethod.ErrorMappings.TryAdd(errorCode, errorType);
+            executorMethod.AddErrorMapping(errorCode, errorType);
         }
     }
     private void CreateOperationMethods(OpenApiUrlTreeNode currentNode, OperationType operationType, OpenApiOperation operation, CodeClass parentClass)
@@ -917,7 +917,7 @@ public class KiotaBuilder
                     .Select(x => (x.Key, GetCodeTypeForMapping(currentNode, x.Value, currentNamespace, newClass, schema)))
                     .Where(x => x.Item2 != null)
                     .ToList()
-                    .ForEach(x => factoryMethod.DiscriminatorMappings.TryAdd(x.Key, x.Item2));
+                    .ForEach(x => factoryMethod.AddDiscriminatorMapping(x.Key, x.Item2));
         CreatePropertiesForModelClass(currentNode, schema, currentNamespace, newClass);
         return newClass;
     }
@@ -967,7 +967,7 @@ public class KiotaBuilder
     private const string BackingStoreInterface = "IBackingStore";
     private const string BackedModelInterface = "IBackedModel";
     private const string ParseNodeInterface = "IParseNode";
-    private const string AdditionalHolderInterface = "IAdditionalDataHolder";
+    internal const string AdditionalHolderInterface = "IAdditionalDataHolder";
     internal static void AddSerializationMembers(CodeClass model, bool includeAdditionalProperties, bool usesBackingStore) {
         var serializationPropsType = $"IDictionary<string, Action<T, {ParseNodeInterface}>>";
         if(!model.ContainsMember(FieldDeserializersMethodName)) {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -762,7 +762,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             });
         }
         if (modelClass.StartBlock.Implements.Any()) {
-            var originalImplements = modelClass.StartBlock.Implements.ToArray();
+            var originalImplements = modelClass.StartBlock.Implements.Where(x => x.TypeDefinition != inter).ToArray();
             inter.StartBlock.AddImplements(originalImplements
                                                         .Select(x => x.Clone() as CodeType)
                                                         .ToArray());

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -198,7 +198,7 @@ public class GoRefiner : CommonLanguageRefiner
                 currentClass.RemoveChildElement(propertiesToRemove);
                 var propertiesToRemoveHashSet = propertiesToRemove.ToHashSet();
                 var methodsToRemove = currentClass.Methods
-                                                    .Where(x => x.IsOfKind(CodeMethodKind.Getter, CodeMethodKind.Setter) &&
+                                                    .Where(x => x.IsAccessor &&
                                                             propertiesToRemoveHashSet.Contains(x.AccessedProperty))
                                                     .ToArray();
                 currentClass.RemoveChildElement(methodsToRemove);

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -246,7 +246,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var errorMappingVarName = "null";
         if(codeElement.ErrorMappings.Any()) {
             errorMappingVarName = "errorMapping";
-            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<>({codeElement.ErrorMappings.Count}) {{{{");
+            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<>({codeElement.ErrorMappings.Count()}) {{{{");
             writer.IncreaseIndent();
             foreach(var errorMapping in codeElement.ErrorMappings) {
                 writer.WriteLine($"put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeBlockTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeBlockTests.cs
@@ -78,6 +78,31 @@ namespace Kiota.Builder.Tests {
             Assert.Single(child.StartBlock.Usings);
         }
         [Fact]
+        public void RemoveUsing() {
+            var root = CodeNamespace.InitRootNamespace();
+            var child = root.AddNamespace(CodeNamespaceTests.ChildName);
+            var usng = new CodeUsing {
+                Name = "someNS"
+            };
+            child.AddUsing(usng);
+            child.StartBlock.RemoveUsings(usng);
+            Assert.Empty(child.StartBlock.Usings);
+        }
+        [Fact]
+        public void RemoveUsingByDeclarationName() {
+            var root = CodeNamespace.InitRootNamespace();
+            var child = root.AddNamespace(CodeNamespaceTests.ChildName);
+            var usng = new CodeUsing {
+                Name = "someNS",
+                Declaration = new CodeType {
+                    Name = "someClass"
+                }
+            };
+            child.AddUsing(usng);
+            child.StartBlock.RemoveUsingsByDeclarationName("someClass");
+            Assert.Empty(child.StartBlock.Usings);
+        }
+        [Fact]
         public void ThrowsWhenInsertingDuplicatedElements() {
             var root = CodeNamespace.InitRootNamespace();
             var child = root.AddNamespace(CodeNamespaceTests.ChildName);
@@ -161,6 +186,22 @@ namespace Kiota.Builder.Tests {
                 Name = className
             });
             Assert.Equal(2, root.FindChildrenByName<CodeClass>(className).Count());
+        }
+        [Fact]
+        public void ReplacesImplementsByName() {
+            var root = CodeNamespace.InitRootNamespace();
+            var child = root.AddNamespace(CodeNamespaceTests.ChildName);
+            var className = "class1";
+            var model = child.AddClass(new CodeClass {
+                Name = className
+            }).First();
+            model.StartBlock.AddImplements(new CodeType {
+                Name = "IParsable",
+                IsExternal = true
+            });
+            model.StartBlock.ReplaceImplementByName("IParsable", "Parsable");
+            Assert.Empty(model.StartBlock.Implements.Where(x => x.Name == "IParsable"));
+            Assert.Single(model.StartBlock.Implements.Where(x => x.Name == "Parsable"));
         }
     }
 }

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeClassTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeClassTests.cs
@@ -104,6 +104,18 @@ namespace Kiota.Builder.Tests {
             Assert.Equal(3, codeClass.GetChildElements(true).Count());
         }
         [Fact]
+        public void AddsInnerInterface() {
+            var root = CodeNamespace.InitRootNamespace();
+            var child = root.AddNamespace(CodeNamespaceTests.ChildName);
+            var codeClass = child.AddClass(new CodeClass {
+                Name = "class1"
+            }).First();
+            codeClass.AddInnerInterface(new CodeInterface {
+                Name = "subinterface"
+            });
+            Assert.Single(codeClass.GetChildElements(true).OfType<CodeInterface>());
+        }
+        [Fact]
         public void GetsParentAndGrandParent() {
             var root = CodeNamespace.InitRootNamespace();
             var child = root.AddNamespace(CodeNamespaceTests.ChildName);

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeClassTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeClassTests.cs
@@ -114,6 +114,15 @@ namespace Kiota.Builder.Tests {
                 Name = "subinterface"
             });
             Assert.Single(codeClass.GetChildElements(true).OfType<CodeInterface>());
+            Assert.Throws<ArgumentNullException>(() => {
+                codeClass.AddInnerInterface(null);
+            });
+            Assert.Throws<ArgumentNullException>(() => {
+                codeClass.AddInnerInterface(new CodeInterface[] {null});
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                codeClass.AddInnerInterface(new CodeInterface[] {});
+            });
         }
         [Fact]
         public void GetsParentAndGrandParent() {

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeMethodTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeMethodTests.cs
@@ -11,6 +11,14 @@ namespace Kiota.Builder.Tests {
             };
             Assert.False(method.IsOfKind((CodeMethodKind[])null));
             Assert.False(method.IsOfKind(Array.Empty<CodeMethodKind>()));
+            Assert.Throws<ArgumentNullException>(() => method.AddDiscriminatorMapping(null, new CodeType{Name = "class"}));
+            Assert.Throws<ArgumentNullException>(() => method.AddDiscriminatorMapping("oin", null));
+            Assert.Throws<ArgumentNullException>(() => method.GetDiscriminatorMappingValue(null));
+            Assert.Null(method.GetDiscriminatorMappingValue("oin"));
+            Assert.Throws<ArgumentNullException>(() => method.AddErrorMapping(null, new CodeType{Name = "class"}));
+            Assert.Throws<ArgumentNullException>(() => method.AddErrorMapping("oin", null));
+            Assert.Throws<ArgumentNullException>(() => method.GetErrorMappingValue(null));
+            Assert.Null(method.GetErrorMappingValue("oin"));
         }
         [Fact]
         public void IsOfKind() {

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeNamespaceTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeNamespaceTests.cs
@@ -107,5 +107,13 @@ namespace Kiota.Builder.Tests
                 child.AddInterface(new CodeInterface[] {null});
             });
         }
+        [Fact]
+        public void IsParentOf() {
+            var root = CodeNamespace.InitRootNamespace();
+            var child = root.AddNamespace(ChildName);
+            var grandchild = child.AddNamespace(ChildName + ".four");
+            Assert.True(child.IsParentOf(grandchild));
+            Assert.False(grandchild.IsParentOf(child));
+        }
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -606,9 +606,10 @@ public class KiotaBuilderTests
         var executorMethod = codeModel.FindChildByName<CodeMethod>("get", true);
         Assert.NotNull(executorMethod);
         Assert.NotEmpty(executorMethod.ErrorMappings);
-        Assert.Contains("4XX", executorMethod.ErrorMappings.Keys);
-        Assert.Contains("401", executorMethod.ErrorMappings.Keys);
-        Assert.Contains("5XX", executorMethod.ErrorMappings.Keys);
+        var keys = executorMethod.ErrorMappings.Select(x => x.Key).ToHashSet();
+        Assert.Contains("4XX", keys);
+        Assert.Contains("401", keys);
+        Assert.Contains("5XX", keys);
         var errorType401 = codeModel.FindChildByName<CodeClass>("tasks401Error", true);
         Assert.NotNull(errorType401);
         Assert.True(errorType401.IsErrorDefinition);
@@ -710,9 +711,10 @@ public class KiotaBuilderTests
         var executorMethod = codeModel.FindChildByName<CodeMethod>("get", true);
         Assert.NotNull(executorMethod);
         Assert.NotEmpty(executorMethod.ErrorMappings);
-        Assert.Contains("4XX", executorMethod.ErrorMappings.Keys);
-        Assert.Contains("401", executorMethod.ErrorMappings.Keys);
-        Assert.Contains("5XX", executorMethod.ErrorMappings.Keys);
+        var keys = executorMethod.ErrorMappings.Select(x => x.Key).ToHashSet();
+        Assert.Contains("4XX", keys);
+        Assert.Contains("401", keys);
+        Assert.Contains("5XX", keys);
         var errorType = codeModel.FindChildByName<CodeClass>("Error", true);
         Assert.NotNull(errorType);
         Assert.True(errorType.IsErrorDefinition);
@@ -904,9 +906,8 @@ public class KiotaBuilderTests
         var doFactoryMethod = directoryObjectClass.GetChildElements(true).OfType<CodeMethod>().FirstOrDefault(x => x.IsOfKind(CodeMethodKind.Factory));
         Assert.NotNull(doFactoryMethod);
         Assert.Empty(doFactoryMethod.DiscriminatorMappings);
-        Assert.True(factoryMethod.DiscriminatorMappings.TryGetValue("#microsoft.graph.directoryObject", out var directoryObjectMappingType));
-        var castType = directoryObjectMappingType as CodeType;
-        Assert.NotNull(castType);
+        if(factoryMethod.GetDiscriminatorMappingValue("#microsoft.graph.directoryObject") is not CodeType castType)
+            throw new InvalidOperationException("Discriminator mapping value is not a CodeType");
         Assert.NotNull(castType.TypeDefinition);
         Assert.Equal(directoryObjectClass, castType.TypeDefinition);
     }

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -52,7 +52,7 @@ public class CSharpLanguageRefinerTests {
                 Name = "string"
             },
         }).First();
-        requestExecutor.ErrorMappings.TryAdd("4XX", new CodeType {
+        requestExecutor.AddErrorMapping("4XX", new CodeType {
                         Name = "Error4XX",
                         TypeDefinition = errorClass,
                     });

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -108,7 +108,7 @@ public class GoLanguageRefinerTests {
                 Name = "string"
             },
         }).First();
-        requestExecutor.ErrorMappings.TryAdd("4XX", new CodeType {
+        requestExecutor.AddErrorMapping("4XX", new CodeType {
                         Name = "Error4XX",
                         TypeDefinition = errorClass,
                     });
@@ -138,7 +138,7 @@ public class GoLanguageRefinerTests {
                 TypeDefinition = parentModel,
             },
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -170,7 +170,7 @@ public class GoLanguageRefinerTests {
                 TypeDefinition = parentModel,
             },
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -52,7 +52,7 @@ public class JavaLanguageRefinerTests {
                 Name = "string"
             },
         }).First();
-        requestExecutor.ErrorMappings.TryAdd("4XX", new CodeType {
+        requestExecutor.AddErrorMapping("4XX", new CodeType {
                         Name = "Error4XX",
                         TypeDefinition = errorClass,
                     });

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -118,7 +118,7 @@ public class TypeScriptLanguageRefinerTests {
                 Name = "string"
             },
         }).First();
-        requestExecutor.ErrorMappings.TryAdd("4XX", new CodeType {
+        requestExecutor.AddErrorMapping("4XX", new CodeType {
                         Name = "Error4XX",
                         TypeDefinition = errorClass,
                     });
@@ -151,7 +151,7 @@ public class TypeScriptLanguageRefinerTests {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -168,9 +168,9 @@ public class CodeMethodWriterTests : IDisposable {
         var error401 = root.AddClass(new CodeClass{
             Name = "Error401",
         }).First();
-        method.ErrorMappings.TryAdd("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
-        method.ErrorMappings.TryAdd("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
-        method.ErrorMappings.TryAdd("403", new CodeType {Name = "Error403", TypeDefinition = error401});
+        method.AddErrorMapping("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
+        method.AddErrorMapping("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
+        method.AddErrorMapping("403", new CodeType {Name = "Error403", TypeDefinition = error401});
         AddRequestBodyParameters();
         writer.Write(method);
         var result = tw.ToString();
@@ -220,7 +220,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -269,7 +269,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -306,7 +306,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -182,9 +182,9 @@ public class CodeMethodWriterTests : IDisposable {
         var error401 = root.AddClass(new CodeClass{
             Name = "Error401",
         }).First();
-        method.ErrorMappings.TryAdd("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
-        method.ErrorMappings.TryAdd("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
-        method.ErrorMappings.TryAdd("403", new CodeType {Name = "Error403", TypeDefinition = error401});
+        method.AddErrorMapping("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
+        method.AddErrorMapping("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
+        method.AddErrorMapping("403", new CodeType {Name = "Error403", TypeDefinition = error401});
         AddRequestBodyParameters();
         writer.Write(method);
         var result = tw.ToString();
@@ -232,7 +232,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -285,7 +285,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -326,7 +326,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -173,9 +173,9 @@ public class CodeMethodWriterTests : IDisposable {
         var error401 = root.AddClass(new CodeClass{
             Name = "Error401",
         }).First();
-        method.ErrorMappings.TryAdd("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
-        method.ErrorMappings.TryAdd("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
-        method.ErrorMappings.TryAdd("403", new CodeType {Name = "Error403", TypeDefinition = error401});
+        method.AddErrorMapping("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
+        method.AddErrorMapping("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
+        method.AddErrorMapping("403", new CodeType {Name = "Error403", TypeDefinition = error401});
         AddRequestBodyParameters();
         writer.Write(method);
         var result = tw.ToString();
@@ -222,7 +222,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -272,7 +272,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -310,7 +310,7 @@ public class CodeMethodWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -62,7 +62,7 @@ public class CodeFunctionWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -115,7 +115,7 @@ public class CodeFunctionWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });
@@ -156,7 +156,7 @@ public class CodeFunctionWriterTests : IDisposable {
             },
             IsStatic = true,
         }).First();
-        factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+        factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                         Name = "childModel",
                         TypeDefinition = childModel,
                     });

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeMethodWriterTests.cs
@@ -159,9 +159,9 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
             var error401 = root.AddClass(new CodeClass{
                 Name = "Error401",
             }).First();
-            method.ErrorMappings.TryAdd("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
-            method.ErrorMappings.TryAdd("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
-            method.ErrorMappings.TryAdd("403", new CodeType {Name = "Error403", TypeDefinition = error401});
+            method.AddErrorMapping("4XX", new CodeType {Name = "Error4XX", TypeDefinition = error4XX});
+            method.AddErrorMapping("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
+            method.AddErrorMapping("403", new CodeType {Name = "Error403", TypeDefinition = error401});
             AddRequestBodyParameters();
             writer.Write(method);
             var result = tw.ToString();
@@ -196,7 +196,7 @@ namespace Kiota.Builder.Writers.TypeScript.Tests {
                     TypeDefinition = parentModel,
                 },
             }).First();
-            factoryMethod.DiscriminatorMappings.TryAdd("ns.childmodel", new CodeType {
+            factoryMethod.AddDiscriminatorMapping("ns.childmodel", new CodeType {
                             Name = "childModel",
                             TypeDefinition = childModel,
                         });


### PR DESCRIPTION
- Fixed indeterministic parameters ordering
- Fixed indeterministic error mappings ordering
- Fixed indeterministic discriminator mapping ordering
- Fixed race condition when removing child items leading to erratic code generation results
- Replaced models namespaces flattening by circular properties trimming in Go
- Fixed a bug where inherited interfaces would be missing imports in Go
- Fixed a bug where inherited interfaces would be missing imports for the parent

no generation diff for samples