### PR TITLE
Fix ambiguous types in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue with ambiguous type names causing build errors and stack overflows. (Shell) #1052
 - Fixed a bug where symbols (properties, methods, classes) could contain invalid characters #1436
 - Renamed parameters for requests: o => options, q => queryParameters, h => headers. [#1380](https://github.com/microsoft/kiota/issues/1380)
+- Fixed a bug where names would clash with reserved type [#1437](https://github.com/microsoft/kiota/issues/1437)
+- Fixed unnecessary use of fully qualified type names in Dotnet 
 
 ## [0.0.20] - 2022-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unnecessary use of fully qualified type names in Dotnet 
 
 
-
 ## [0.0.20] - 2022-03-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with ambiguous type names causing build errors and stack overflows. (Shell) #1052
 - Fixed a bug where symbols (properties, methods, classes) could contain invalid characters #1436
 - Renamed parameters for requests: o => options, q => queryParameters, h => headers. [#1380](https://github.com/microsoft/kiota/issues/1380)
-
 - Fixed a bug where names would clash with reserved type [#1437](https://github.com/microsoft/kiota/issues/1437)
 - Fixed unnecessary use of fully qualified type names in Dotnet 
 

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -118,16 +119,7 @@ namespace Kiota.Builder.Extensions {
         /// </summary>
         /// <param name="original">The original string</param>
         /// <returns></returns>
-        public static string CleanupXMLString(this string original)
-        {
-            if (string.IsNullOrEmpty(original))
-                return original;
-
-            return original.Replace("&", "&amp;")
-                           .Replace("<", "&lt;")
-                           .Replace(">", "&gt;")
-                           .Replace("&#34;", "&quot;")
-                           .Replace("'", "&apos;");
-        }
+        public static string CleanupXMLString(this string original) 
+            => SecurityElement.Escape(original);
     }
 }

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -112,5 +112,22 @@ namespace Kiota.Builder.Extensions {
 
             return original;
         }
+
+        /// <summary>
+        /// Cleanup the XML string
+        /// </summary>
+        /// <param name="original">The original string</param>
+        /// <returns></returns>
+        public static string CleanupXMLString(this string original)
+        {
+            if (string.IsNullOrEmpty(original))
+                return original;
+
+            return original.Replace("&", "&amp;")
+                           .Replace("<", "&lt;")
+                           .Replace(">", "&gt;")
+                           .Replace("&#34;", "&quot;")
+                           .Replace("'", "&apos;");
+        }
     }
 }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -527,7 +527,7 @@ public class KiotaBuilder
             Name = propertyName,
             DefaultValue = defaultValue,
             Kind = kind,
-            Description = typeSchema?.Description,
+            Description = typeSchema?.Description ?? $"The {propertyName} property",
         };
         if(propertyName != childIdentifier)
             prop.SerializationName = childIdentifier;

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -28,8 +28,10 @@ namespace Kiota.Builder.Refiners {
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type>{ typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod) }
-            ); 
+                new HashSet<Type>{ typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum) }
+            );
+            // Replace the reserved types
+            ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);
@@ -122,6 +124,7 @@ namespace Kiota.Builder.Refiners {
                                                     .Union(new CodeTypeBase[] { currentMethod.ReturnType })
                                                     .ToArray());
         }
+
         private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
         {
             {

--- a/src/Kiota.Builder/Refiners/CSharpReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedNamesProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Kiota.Builder.Refiners {
@@ -90,7 +90,6 @@ namespace Kiota.Builder.Refiners {
             "string",
             "struct",
             "switch",
-            "task",
             "this",
             "throw",
             "true",

--- a/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kiota.Builder.Refiners {
+    public class CSharpReservedTypesProvider : IReservedNamesProvider
+    {
+        private readonly Lazy<HashSet<string>> _reservedNames = new(() => new(StringComparer.OrdinalIgnoreCase)
+        {
+            "task",
+        });
+        public HashSet<string> ReservedNames => _reservedNames.Value;
+    }
+}

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -170,6 +170,10 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             });
         CrawlTree(current, x => AddConstructorsForDefaultValues(x, addIfInherited, forceAdd));
     }
+
+    protected static void ReplaceReservedModelTypes(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement) => 
+        ReplaceReservedNames(current, provider, replacement, shouldReplaceCallback: (codeElement) => codeElement is CodeClass || codeElement is CodeMethod || codeElement is CodeProperty);
+
     protected static void ReplaceReservedNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement, HashSet<Type> codeElementExceptions = null, Func<CodeElement, bool> shouldReplaceCallback = null) {
         var shouldReplace = shouldReplaceCallback?.Invoke(current) ?? true;
         var isNotInExceptions = !codeElementExceptions?.Contains(current.GetType()) ?? true;
@@ -205,6 +209,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 provider.ReservedNames.Contains(currentProperty.Type.Name))
             propertyType.Name = replacement.Invoke(propertyType.Name);
         else if (current is CodeEnum currentEnum &&
+                isNotInExceptions &&
                 shouldReplace &&
                 currentEnum.Options.Any(x => provider.ReservedNames.Contains(x)))
             ReplaceReservedEnumNames(currentEnum, provider, replacement);

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -321,9 +321,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         {
             writer.WriteLine($"{conventions.DocCommentPrefix}<summary>");
             if (isDescriptionPresent)
-                writer.WriteLine($"{conventions.DocCommentPrefix}{code.Description}");
+                writer.WriteLine($"{conventions.DocCommentPrefix}{code.Description.CleanupXMLString()}");
             foreach (var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
-                writer.WriteLine($"{conventions.DocCommentPrefix}<param name=\"{paramWithDescription.Name}\">{paramWithDescription.Description}</param>");
+                writer.WriteLine($"{conventions.DocCommentPrefix}<param name=\"{paramWithDescription.Name.ToFirstCharacterLowerCase()}\">{paramWithDescription.Description.CleanupXMLString()}</param>");
             writer.WriteLine($"{conventions.DocCommentPrefix}</summary>");
         }
     }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -85,21 +85,25 @@ public class CodeMethodWriterTests : IDisposable {
         var dummyComplexCollection = parentClass.AddProperty(new CodeProperty {
             Name = "dummyComplexColl"
         }).First();
+        var complexTypeClass = root.AddClass(new CodeClass
+        {
+            Name = "SomeComplexType"
+        }).First();
         dummyComplexCollection.Type = new CodeType {
             Name = "Complex",
             CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
-            TypeDefinition = new CodeClass {
-                Name = "SomeComplexType"
-            }
+            TypeDefinition = complexTypeClass
         };
         var dummyEnumProp = parentClass.AddProperty(new CodeProperty{
             Name = "dummyEnumCollection",
         }).First();
+        var enumDefinition = root.AddEnum(new CodeEnum
+        {
+            Name = "EnumType"
+        }).First();
         dummyEnumProp.Type = new CodeType {
             Name = "SomeEnum",
-            TypeDefinition = new CodeEnum {
-                Name = "EnumType"
-            }
+            TypeDefinition = enumDefinition
         };
     }
     private void AddInheritanceClass() {
@@ -230,9 +234,6 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodeParameterKind.ParseNode,
             Type = new CodeType {
                 Name = "ParseNode",
-                TypeDefinition = new CodeClass {
-                    Name = "ParseNode",
-                },
                 IsExternal = true,
             },
             Optional = false,
@@ -316,9 +317,6 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodeParameterKind.ParseNode,
             Type = new CodeType {
                 Name = "ParseNode",
-                TypeDefinition = new CodeClass {
-                    Name = "ParseNode",
-                },
                 IsExternal = true,
             },
             Optional = false,
@@ -353,9 +351,6 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodeParameterKind.ParseNode,
             Type = new CodeType {
                 Name = "ParseNode",
-                TypeDefinition = new CodeClass {
-                    Name = "ParseNode",
-                },
                 IsExternal = true,
             },
             Optional = false,

--- a/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
@@ -331,14 +331,15 @@ public class ShellCodeMethodWriterTests : IDisposable
         method.Description = "Test description";
         method.SimpleName = "User";
         method.HttpMethod = HttpMethod.Get;
+        var userClass = root.AddClass(new CodeClass
+        {
+            Name = "User",
+            Kind = CodeClassKind.Model
+        }).First();
         var stringType = new CodeType
         {
             Name = "user",
-            TypeDefinition = new CodeClass
-            {
-                Name = "User",
-                Kind = CodeClassKind.Model
-            },
+            TypeDefinition = userClass,
         };
         var generatorMethod = new CodeMethod
         {
@@ -395,14 +396,15 @@ public class ShellCodeMethodWriterTests : IDisposable
         {
             Name = "string",
         };
+        var contentClass = root.AddClass(new CodeClass
+        {
+            Name = "Content",
+            Kind = CodeClassKind.Model
+        }).First();
         var bodyType = new CodeType
         {
             Name = "content",
-            TypeDefinition = new CodeClass
-            {
-                Name = "Content",
-                Kind = CodeClassKind.Model
-            },
+            TypeDefinition = contentClass,
         };
         var generatorMethod = new CodeMethod
         {
@@ -459,14 +461,15 @@ public class ShellCodeMethodWriterTests : IDisposable
         {
             Name = "string",
         };
+        var contentClass = root.AddClass(new CodeClass
+        {
+            Name = "Content",
+            Kind = CodeClassKind.Model
+        }).First();
         var bodyType = new CodeType
         {
             Name = "content",
-            TypeDefinition = new CodeClass
-            {
-                Name = "Content",
-                Kind = CodeClassKind.Model
-            },
+            TypeDefinition = contentClass,
             CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex
         };
         var generatorMethod = new CodeMethod


### PR DESCRIPTION
This PR closes #1437 

Changes include: - 

- Adds support for escaping only types by taking advantage of the existing `ReplaceReservedNames` function
- Adds support for escaping strings used in XML comments to reduce likelihood of warning in generates SDKs
- Fix unnecessary of escaping Enum members in dotnet as they will be capitalized
- Fixed unnecessary use of fully qualified type names in Dotnet as the new  function `DoesTypeExistsInTargetAncestorNamespace` would also match types in the same namespace.
- Fixed CSharp and Shell tests that had set up orphaned instances of `CodeClass` which led to test failures.


Successful generation in dotnet can be verified at the link below
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=71393&view=results


