### PR TITLE
Generate CLI options for headers defined in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added generation of command options for headers defined in the OpenAPI metadata source file. (Shell)
 
 ### Changed
 

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -67,23 +67,23 @@ public class CodeMethod : CodeTerminalWithKind<CodeMethodKind>, ICloneable, IDoc
     public string Description {get; set;}
     
     /// <summary>
-    /// The combination of the path and query parameters for the current URL.
+    /// The combination of the path, query and header parameters for the current URL.
     /// Only use this property if the language you are generating for doesn't support fluent API style (e.g. Shell/CLI)
     /// </summary>
-    public IEnumerable<CodeParameter> PathAndQueryParameters
+    public IEnumerable<CodeParameter> PathQueryAndHeaderParameters
     {
         get; private set;
     }
-    public void AddPathOrQueryParameter(params CodeParameter[] parameters)
+    public void AddPathQueryOrHeaderParameter(params CodeParameter[] parameters)
     {
         if (parameters == null || !parameters.Any()) return;
         foreach (var parameter in parameters)
         {
             EnsureElementsAreChildren(parameter);
         }
-        if (PathAndQueryParameters == null)
-            PathAndQueryParameters = new List<CodeParameter>(parameters);
-        else if (PathAndQueryParameters is List<CodeParameter> cast)
+        if (PathQueryAndHeaderParameters == null)
+            PathQueryAndHeaderParameters = new List<CodeParameter>(parameters);
+        else if (PathQueryAndHeaderParameters is List<CodeParameter> cast)
             cast.AddRange(parameters);
     }
     /// <summary>

--- a/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
@@ -105,11 +105,11 @@ public class ShellCodeMethodWriterTests : IDisposable
         });
     }
 
-    private static void AddPathAndQueryParameters(CodeMethod method) {
+    private static void AddPathQueryAndHeaderParameters(CodeMethod method) {
         var stringType = new CodeType {
             Name = "string",
         };
-        method.AddPathOrQueryParameter(new CodeParameter{
+        method.AddPathQueryOrHeaderParameter(new CodeParameter{
             Name = "q",
             Kind = CodeParameterKind.QueryParameter,
             Type = stringType,
@@ -117,10 +117,16 @@ public class ShellCodeMethodWriterTests : IDisposable
             Description = "The q option",
             Optional = true
         });
-        method.AddPathOrQueryParameter(new CodeParameter {
+        method.AddPathQueryOrHeaderParameter(new CodeParameter {
             Name = "p",
             Kind = CodeParameterKind.Path,
             Type = stringType
+        });
+        method.AddPathQueryOrHeaderParameter(new CodeParameter {
+            Name = "Test-Header",
+            Kind = CodeParameterKind.Headers,
+            Type = stringType,
+            Description = "The test header",
         });
     }
 
@@ -300,7 +306,7 @@ public class ShellCodeMethodWriterTests : IDisposable
 
         AddRequestProperties();
         AddRequestBodyParameters(method.OriginalMethod);
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -310,16 +316,20 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var qOption = new Option<string>(\"-q\", getDefaultValue: ()=> \"test\", description: \"The q option\")", result);
         Assert.Contains("qOption.IsRequired = false;", result);
         Assert.Contains("command.AddOption(qOption);", result);
+        Assert.Contains("var testHeaderOption = new Option<string>(\"--test-header\", description: \"The test header\")", result);
+        Assert.Contains("testHeaderOption.IsRequired = true;", result);
+        Assert.Contains("command.AddOption(testHeaderOption);", result);
         Assert.Contains("command.SetHandler(async (object[] parameters) => {", result);
         Assert.Contains("var q = (string) parameters[0];", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
+        Assert.Contains("var testHeader = (string) parameters[2];", result);
         Assert.Contains("var requestInfo = CreateGetRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
+        Assert.Contains("requestInfo.Headers[\"Test-Header\"] = testHeader;", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
-        Assert.Contains("var outputFormatterFactory = (IOutputFormatterFactory) parameters[3];", result);
+        Assert.Contains("var outputFormatterFactory = (IOutputFormatterFactory) parameters[4];", result);
         Assert.Contains("var formatter = outputFormatterFactory.GetFormatter(FormatterType.TEXT);", result);
         Assert.Contains("await formatter.WriteOutputAsync(response, null, cancellationToken);", result);
-        Assert.Contains("}, new CollectionBinding(qOption,", result);
+        Assert.Contains("}, new CollectionBinding(qOption, pOption, testHeaderOption", result);
         Assert.Contains("return command;", result);
     }
 
@@ -359,7 +369,7 @@ public class ShellCodeMethodWriterTests : IDisposable
 
         AddRequestProperties();
         AddRequestBodyParameters(method.OriginalMethod);
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -374,9 +384,8 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("command.AddOption(outputOption);", result);
         Assert.Contains("command.SetHandler(async (object[] parameters) => {", result);
         Assert.Contains("var q = (string) parameters[0];", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var requestInfo = CreateGetRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("var formatterOptions = output.GetOutputFormatterOptions(new FormatterOptionsModel(!jsonNoIndent));", result);
         Assert.Contains("response = await outputFilter?.FilterOutputAsync(response, query, cancellationToken)", result);
@@ -429,7 +438,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         codeClass.AddMethod(generatorMethod);
 
         AddRequestProperties();
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -441,11 +450,10 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var bodyOption = new Option<string>(\"--body\")", result);
         Assert.Contains("bodyOption.IsRequired = true;", result);
         Assert.Contains("command.AddOption(bodyOption);", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));", result);
         Assert.Contains("var model = parseNode.GetObjectValue<Content>(Content.CreateFromDiscriminatorValue);", result);
         Assert.Contains("var requestInfo = CreatePostRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("return command;", result);
     }
@@ -495,7 +503,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         codeClass.AddMethod(generatorMethod);
 
         AddRequestProperties();
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -507,11 +515,10 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var bodyOption = new Option<string>(\"--body\")", result);
         Assert.Contains("bodyOption.IsRequired = true;", result);
         Assert.Contains("command.AddOption(bodyOption);", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));", result);
         Assert.Contains("var model = parseNode.GetCollectionOfObjectValues<Content>(Content.CreateFromDiscriminatorValue);", result);
         Assert.Contains("var requestInfo = CreatePostRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("return command;", result);
     }
@@ -554,7 +561,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         codeClass.AddMethod(generatorMethod);
 
         AddRequestProperties();
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -566,10 +573,9 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var bodyOption = new Option<Stream>(\"--file\")", result);
         Assert.Contains("bodyOption.IsRequired = true;", result);
         Assert.Contains("command.AddOption(bodyOption);", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("using var stream = file.OpenRead();", result);
         Assert.Contains("var requestInfo = CreatePostRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("return command;", result);
     }
@@ -598,7 +604,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         codeClass.AddMethod(generatorMethod);
 
         AddRequestProperties();
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -607,9 +613,8 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var qOption = new Option<string>(\"-q\", getDefaultValue: ()=> \"test\", description: \"The q option\")", result);
         Assert.Contains("qOption.IsRequired = false;", result);
         Assert.Contains("command.AddOption(qOption);", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var requestInfo = CreateDeleteRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("await RequestAdapter.SendNoContentAsync(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("Console.WriteLine(\"Success\");", result);
         Assert.Contains("return command;", result);
@@ -646,7 +651,7 @@ public class ShellCodeMethodWriterTests : IDisposable
 
         AddRequestProperties();
         AddRequestBodyParameters(method.OriginalMethod);
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -659,9 +664,8 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("command.AddOption(fileOption);", result);
         Assert.Contains("command.SetHandler(async (object[] parameters) => {", result);
         Assert.Contains("var q = (string) parameters[0];", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var requestInfo = CreateGetRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var response = await RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("}, new CollectionBinding(qOption,", result);
         Assert.Contains("return command;", result);
@@ -699,7 +703,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         codeClass.AddMethod(generatorMethod);
 
         AddRequestProperties();
-        AddPathAndQueryParameters(generatorMethod);
+        AddPathQueryAndHeaderParameters(generatorMethod);
 
         writer.Write(method);
         var result = tw.ToString();
@@ -711,9 +715,8 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("var bodyOption = new Option<string>(\"--body\")", result);
         Assert.Contains("bodyOption.IsRequired = true;", result);
         Assert.Contains("command.AddOption(bodyOption);", result);
-        Assert.Contains("PathParameters.Clear();", result);
-        Assert.Contains("PathParameters.Add(\"p\", p);", result);
         Assert.Contains("var requestInfo = CreatePostRequestInformation", result);
+        Assert.Contains("requestInfo.PathParameters.Add(\"p\", p);", result);
         Assert.Contains("await RequestAdapter.SendNoContentAsync(requestInfo, errorMapping: default, cancellationToken: cancellationToken);", result);
         Assert.Contains("Console.WriteLine(\"Success\");", result);
         Assert.Contains("return command;", result);


### PR DESCRIPTION
Known issues:

- Headers with `-` in their name are replaced with `_` when applying the headers to the request info object. For example, `If-Match` becomes `If_Match`.
See https://github.com/microsoft/kiota/issues/1445
- Some OpenAPI endpoints don't have required headers defined in the metadata file. One example is the `users/$count` endpoint that requires the `ConsistencyLevel` header set to `eventual`