### PR TITLE
Revise command-line interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -124,7 +124,7 @@
                  "${workspaceFolder}/samples/msgraph-mail/Swiftconsoleapp/Sources/Swiftconsoleapp",
                  "-n",
                  "Swiftconsoleapp",
-                 "-co" ],
+                 "--co" ],
             "cwd": "${workspaceFolder}/src/kiota",
             "console": "internalConsole",
             "stopAtEntry": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.1.2] - 2022-05-06
+
+### Changed
+
+- Minor changes in the parameters (-co => --co, -ll => --ll, -d is required, -l is required).
+
 ## [0.1.1] - 2022-05-06
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ COPY --from=build-env /app/kiota/src/kiota/bin/Release/net6.0 ./
 
 VOLUME /app/output
 VOLUME /app/openapi.yml
-ENTRYPOINT ["dotnet", "kiota.dll", "--openapi", "openapi.yml"]
+ENV KIOTA_CONTAINER=true
+ENTRYPOINT ["dotnet", "kiota.dll"]
 LABEL description="# Welcome to Kiota Generator \
 To start generating SDKs checkout [the getting started documentation](https://microsoft.github.io/kiota/get-started/#run-in-docker)  \
 [Source dockerfile](https://github.com/microsoft/kiota/blob/main/Dockerfile)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=build-env /app/kiota/src/kiota/bin/Release/net6.0 ./
 
 VOLUME /app/output
 VOLUME /app/openapi.yml
-ENTRYPOINT ["dotnet", "kiota.dll"]
+ENTRYPOINT ["dotnet", "kiota.dll", "--openapi", "openapi.yml"]
 LABEL description="# Welcome to Kiota Generator \
 To start generating SDKs checkout [the getting started documentation](https://microsoft.github.io/kiota/get-started/#run-in-docker)  \
 [Source dockerfile](https://github.com/microsoft/kiota/blob/main/Dockerfile)"

--- a/docs/using.md
+++ b/docs/using.md
@@ -14,14 +14,36 @@ Kiota accepts the following parameters during the generation.
 ```shell
 kiota [--backing-store | -b]
       [--class-name | -c]
-      [--clean-output | -co]
-      [--deserializer | -ds]
+      [--clean-output | --co]
+      [--deserializer | --ds]
       [--language | -l]
-      [--loglevel | -ll]
+      [--loglevel | --ll]
       [--namespace-name | -n]
       [--openapi | -d]
       [--output | -o]
       [--serializer | -s]
+```
+
+## Mandatory parameters
+
+### `--language (-l)`
+
+The target language for the generated code files.
+
+#### Accepted values
+
+- `csharp`
+- `go`
+- `java`
+- `php`
+- `python`
+- `ruby`
+- `shell`
+- `swift`
+- `typescript`
+
+```shell
+kiota --language java
 ```
 
 ## Optional parameters
@@ -38,14 +60,6 @@ kiota --backing-store
 
 The class name to use for the core client class. Defaults to `ApiClient`.
 
-### `--clean-output (-co)`
-
-Delete the output directory before generating the client. Defaults to false.
-
-```shell
-kiota --clean-output
-```
-
 #### Accepted values
 
 The provided name MUST be a valid class name for the target language.
@@ -54,7 +68,15 @@ The provided name MUST be a valid class name for the target language.
 kiota --class-name MyApiClient
 ```
 
-### `--deserializer (-ds)`
+### `--clean-output (--co)`
+
+Delete the output directory before generating the client. Defaults to false.
+
+```shell
+kiota --clean-output
+```
+
+### `--deserializer (--ds)`
 
 The fully qualified class names for deserializers. Defaults to the following values.
 
@@ -74,25 +96,7 @@ One or more module names that implements `IParseNodeFactory`.
 kiota --deserializer Contoso.Json.CustomDeserializer
 ```
 
-### `--language (-l)`
-
-The target language for the generated code files. Defaults to `csharp`.
-
-#### Accepted values
-
-- `csharp`
-- `go`
-- `java`
-- `php`
-- `python`
-- `ruby`
-- `typescript`
-
-```shell
-kiota --language java
-```
-
-### `--loglevel (-ll)`
+### `--loglevel (--ll)`
 
 The log level to use when logging events to the main output. Defaults to `warning`.
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -12,19 +12,23 @@ nav_order: 2
 Kiota accepts the following parameters during the generation.
 
 ```shell
-kiota [--backing-store | -b]
-      [--class-name | -c]
+kiota (--openapi | -d) <path>
+      (--language | -l) <language>
+      [(--output | -o) <path>]
+      [(--class-name | -c) <name>]
+      [(--namespace-name | -n) <name>]
+      [(--loglevel | --ll) <level>]
+      [--backing-store | -b]
+      [(--serializer | -s) <classes>]
+      [(--deserializer | --ds) <classes>]
       [--clean-output | --co]
-      [--deserializer | --ds]
-      [--language | -l]
-      [--loglevel | --ll]
-      [--namespace-name | -n]
-      [--openapi | -d]
-      [--output | -o]
-      [--serializer | -s]
 ```
 
 ## Mandatory parameters
+
+### `--openapi (-d)`
+
+The location of the OpenAPI description in JSON or YAML format to use to generate the SDK.
 
 ### `--language (-l)`
 
@@ -125,10 +129,6 @@ The provided name MUST be a valid module or namespace name for the target langua
 ```shell
 kiota --namespace-name MyAppNamespace.Clients
 ```
-
-### `--openapi (-d)`
-
-The location of the OpenAPI description in JSON or YAML format to use to generate the SDK. Defaults to `./openapi.yml`.
 
 #### Accepted values
 

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -25,8 +25,9 @@ namespace Kiota {
             outputOption.AddAlias("-o");
             outputOption.ArgumentHelpName = "path";
             
-            var languageOption = new Option<GenerationLanguage>("--language", () => GenerationLanguage.CSharp, "The target language for the generated code files.");
+            var languageOption = new Option<GenerationLanguage>("--language", "The target language for the generated code files.");
             languageOption.AddAlias("-l");
+            languageOption.IsRequired = true;
             AddEnumValidator(languageOption, "language");
 
             var classOption = new Option<string>("--class-name", () => "ApiClient", "The class name to use for the core client class.");

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -105,8 +105,8 @@ namespace Kiota {
             loglevel = loglevel > LogLevel.Debug ? LogLevel.Debug : loglevel;
 #endif
 
-            Configuration.OpenAPIFilePath = Path.GetFullPath(Configuration.OpenAPIFilePath);
-            Configuration.OutputPath = Path.GetFullPath(Configuration.OutputPath);
+            Configuration.OpenAPIFilePath = GetAbsolutePath(Configuration.OpenAPIFilePath);
+            Configuration.OutputPath = GetAbsolutePath(Configuration.OutputPath);
             Configuration.CleanOutput = cleanOutput;
 
             var logger = LoggerFactory.Create((builder) => {
@@ -161,6 +161,7 @@ namespace Kiota {
             configuration.Bind(configObject);
             return configObject;
         });
+        private static string GetAbsolutePath(string source) => Path.IsPathRooted(source) || source.StartsWith("http") ? source : Path.Combine(Directory.GetCurrentDirectory(), source);
     }
     
 }

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -16,10 +16,14 @@ namespace Kiota {
     public class KiotaHost {
         public RootCommand GetRootCommand()
         {
+            var kiotaInContainerRaw = Environment.GetEnvironmentVariable("KIOTA_CONTAINER");
+            var runsInContainer = !string.IsNullOrEmpty(kiotaInContainerRaw) && bool.TryParse(kiotaInContainerRaw, out var kiotaInContainer) && kiotaInContainer;
             var descriptionOption = new Option<string>("--openapi", "The path to the OpenAPI description file used to generate the code files.");
+            if(runsInContainer)
+                descriptionOption.SetDefaultValue("openapi.yaml");
             descriptionOption.AddAlias("-d");
             descriptionOption.ArgumentHelpName = "path";
-            descriptionOption.IsRequired = true;
+            descriptionOption.IsRequired = !runsInContainer;
 
             var outputOption = new Option<string>("--output", () => "./output", "The output directory path for the generated code files.");
             outputOption.AddAlias("-o");

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -21,9 +21,10 @@ namespace Kiota {
             var descriptionOption = new Option<string>("--openapi", "The path to the OpenAPI description file used to generate the code files.");
             if(runsInContainer)
                 descriptionOption.SetDefaultValue("openapi.yaml");
+            else
+                descriptionOption.IsRequired = true;
             descriptionOption.AddAlias("-d");
             descriptionOption.ArgumentHelpName = "path";
-            descriptionOption.IsRequired = !runsInContainer;
 
             var outputOption = new Option<string>("--output", () => "./output", "The output directory path for the generated code files.");
             outputOption.AddAlias("-o");

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -16,25 +16,32 @@ namespace Kiota {
     public class KiotaHost {
         public RootCommand GetRootCommand()
         {
+            var descriptionOption = new Option<string>("--openapi", "The path to the OpenAPI description file used to generate the code files.");
+            descriptionOption.AddAlias("-d");
+            descriptionOption.ArgumentHelpName = "path";
+            descriptionOption.IsRequired = true;
+
             var outputOption = new Option<string>("--output", () => "./output", "The output directory path for the generated code files.");
             outputOption.AddAlias("-o");
+            outputOption.ArgumentHelpName = "path";
             
             var languageOption = new Option<GenerationLanguage>("--language", () => GenerationLanguage.CSharp, "The target language for the generated code files.");
             languageOption.AddAlias("-l");
             AddEnumValidator(languageOption, "language");
+
             var classOption = new Option<string>("--class-name", () => "ApiClient", "The class name to use for the core client class.");
             classOption.AddAlias("-c");
+            classOption.ArgumentHelpName = "name";
             AddStringRegexValidator(classOption, @"^[a-zA-Z_][\w_-]+", "class name");
 
             var namespaceOption = new Option<string>("--namespace-name", () => "ApiSdk", "The namespace to use for the core client class specified with the --class-name option.");
             namespaceOption.AddAlias("-n");
+            namespaceOption.ArgumentHelpName = "name";
             AddStringRegexValidator(namespaceOption, @"^[\w][\w\._-]+", "namespace name");
 
             var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Warning, "The log level to use when logging messages to the main output.");
             logLevelOption.AddAlias("--ll");
             AddEnumValidator(logLevelOption, "log level");
-            var descriptionOption = new Option<string>("--openapi", () => "openapi.yml", "The path to the OpenAPI description file used to generate the code files.");
-            descriptionOption.AddAlias("-d");
 
             var backingStoreOption = new Option<bool>("--backing-store", () => false, "Enables backing store for models.");
             backingStoreOption.AddAlias("-b");
@@ -47,6 +54,7 @@ namespace Kiota {
                 },
                 "The fully qualified class names for serializers. Accepts multiple values.");
             serializerOption.AddAlias("-s");
+            serializerOption.ArgumentHelpName = "classes";
 
             var deserializerOption = new Option<List<string>>(
                 "--deserializer",
@@ -56,22 +64,24 @@ namespace Kiota {
                 },
                 "The fully qualified class names for deserializers. Accepts multiple values.");
             deserializerOption.AddAlias("--ds");
+            deserializerOption.ArgumentHelpName = "classes";
 
             var cleanOutputOption = new Option<bool>("--clean-output", () => false, "Removes all files from the output directory before generating the code files.");
-            cleanOutputOption.AddAlias("-co");
+            cleanOutputOption.AddAlias("--co");
 
             var command = new RootCommand {
+                descriptionOption,
                 outputOption,
                 languageOption,
-                descriptionOption,
-                backingStoreOption,
                 classOption,
-                logLevelOption,
                 namespaceOption,
+                logLevelOption,
+                backingStoreOption,
                 serializerOption,
                 deserializerOption,
                 cleanOutputOption,
             };
+            command.Description = "OpenAPI-based HTTP Client SDK code generator";
             command.SetHandler<string, GenerationLanguage, string, bool, string, LogLevel, string, List<string>, List<string>, bool, CancellationToken>(HandleCommandCall, outputOption, languageOption, descriptionOption, backingStoreOption, classOption, logLevelOption, namespaceOption, serializerOption, deserializerOption, cleanOutputOption);
             return command;
         }
@@ -91,12 +101,12 @@ namespace Kiota {
             if(deserializer?.Any() ?? false)
                 Configuration.Deserializers.AddRange(deserializer.Select(x => x.TrimQuotes()));
 
-            #if DEBUG
+#if DEBUG
             loglevel = loglevel > LogLevel.Debug ? LogLevel.Debug : loglevel;
-            #endif
+#endif
 
-            Configuration.OpenAPIFilePath = GetAbsolutePath(Configuration.OpenAPIFilePath);
-            Configuration.OutputPath = GetAbsolutePath(Configuration.OutputPath);
+            Configuration.OpenAPIFilePath = Path.GetFullPath(Configuration.OpenAPIFilePath);
+            Configuration.OutputPath = Path.GetFullPath(Configuration.OutputPath);
             Configuration.CleanOutput = cleanOutput;
 
             var logger = LoggerFactory.Create((builder) => {
@@ -151,7 +161,6 @@ namespace Kiota {
             configuration.Bind(configObject);
             return configObject;
         });
-        private static string GetAbsolutePath(string source) => Path.IsPathRooted(source) || source.StartsWith("http") ? source : Path.Combine(Directory.GetCurrentDirectory(), source);
     }
     
 }

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -16,7 +16,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Version>0.1.1-preview</Version>
     <PackageReleaseNotes>
-      - Initial public release
+      https://github.com/microsoft/kiota/releases
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota</RepositoryUrl>

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -14,7 +14,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>0.1.1-preview</Version>
+    <Version>0.1.2-preview</Version>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases
     </PackageReleaseNotes>


### PR DESCRIPTION
This bundles a couple of tweaks and improvements to the CLI:

- Changed the order of the parameters as they are listed in the CLI help. In particular, `--openapi` is the first parameter.
- Removed the default value of `--openapi` and made it a required parameter instead. It's very unlikely that a file named `openapi.yml` exists. By making it a required parameter, users will get a better error message when they don't pass `--openapi` and the file does not exist.
- Added more descriptive argument help names. E.g. instead of `--output <output>`, `--output <path>` is shown in the CLI help.
- Changed parameter alias `-co` to `--co` in order to be consistent with the other aliases `--ll` and `--ds`.
- Added a program description `OpenAPI-based HTTP Client SDK code generator` which is shown in the CLI help. Before, it just printed `Description:` without any text.

This is how the output of `--help` now looks like:
```
Description:
  OpenAPI-based HTTP Client SDK code generator

Usage:
  kiota [options]

Options:
  -d, --openapi <path> (REQUIRED)                                         The path to the OpenAPI description file used to generate the code files.
  -o, --output <path>                                                     The output directory path for the generated code files. [default: ./output]
  -l, --language <CSharp|Go|Java|PHP|Python|Ruby|Shell|Swift|TypeScript>  The target language for the generated code files. [default: CSharp]
  -c, --class-name <name>                                                 The class name to use for the core client class. [default: ApiClient]
  -n, --namespace-name <name>                                             The namespace to use for the core client class specified with the --class-name option. [default: ApiSdk]
  --ll, --loglevel <Critical|Debug|Error|Information|None|Trace|Warning>  The log level to use when logging messages to the main output. [default: Warning]
  -b, --backing-store                                                     Enables backing store for models. [default: False]
  -s, --serializer <classes>                                              The fully qualified class names for serializers. Accepts multiple values. [default: 
                                                                          Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory|Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory]
  --deserializer, --ds <classes>                                          The fully qualified class names for deserializers. Accepts multiple values. [default: Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory|Microsoft.Kiota.Serialization.Text.TextParseNodeFactory]
  --clean-output, --co                                                    Removes all files from the output directory before generating the code files. [default: False]
  --version                                                               Show version information
  -?, -h, --help                                                          Show help and usage information
```