### PR TITLE
Ensure the `baseUrl` is added to the PathParameters on creating request information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixes a bug where `Create**RequestInformation` methods would fail to add the baseUrl to the path parameters collection in dotnet.
+
 ## [0.1.3] - 2022-05-06
 
 ### Added

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -256,6 +256,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                         $"PathParameters = {GetPropertyCall(urlTemplateParamsProperty, "string.Empty")},");
         writer.DecreaseIndent();
         writer.WriteLine("};");
+        writer.WriteLine($"if(!{RequestInfoVarName}.PathParameters.ContainsKey(\"baseurl\")) {{");
+        writer.IncreaseIndent();
+        writer.WriteLine($"{RequestInfoVarName}.PathParameters.Add(\"baseurl\", {requestAdapterProperty.Name.ToFirstCharacterUpperCase()}.BaseUrl);");
+        writer.CloseBlock();
         if (requestParams.requestBody != null)
         {
             if (requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1346

It ensures that the `Create**RequestInformation` methods would add the baseUrl to the path parameters to ensure possible access of the URI from the `RequestInformation` object.

Changes can be viewed via https://github.com/microsoft/kiota-samples/pull/685