### PR TITLE
Fix for null reference exception and incorrect send methods for enums in dotnet 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug with enums detection for generation. (interpreted as string)
 - Fixes a bug where classes names cleanup could end-up in a collision.
 - Fixes a bug where null reference exception would be thrown when trying to lookup type inheritance on discriminators
-- Updated the lookup of model namespaces to only look in the target namespace to avoid reference collissions
+- Fixes the lookup of model namespaces to only look in the target namespace to avoid reference collissions
+- Fixes a bug for the generated send method for paths returning Enums in dotnet.
 
 ## [0.1.3] - 2022-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where arrays without items definition would derail generation.
 - Fixed a bug with enums detection for generation. (interpreted as string)
 - Fixes a bug where classes names cleanup could end-up in a collision.
+- Fixes a bug where null reference exception would be thrown when trying to lookup type inheritance on discriminators
+- Updated the lookup of model namespaces to only look in the target namespace to avoid reference collissions
 
 ## [0.1.3] - 2022-05-06
 


### PR DESCRIPTION
Closes #1576 

This would block generation of SDKs using the latest openApi document from metadata repository for Microsoft graph.

Changes include:
 
- Fixes a bug where null reference exception would be thrown when trying to lookup type inheritance on discriminators.
- Fixes incorrectly generated send method if the path return type is an Enum
- Eliminates the searching of models across all namespaces. This should hopefully result in better performance of the generator when generating CodeDom and eliminates the possibility of incorrect lookup of models in the incorrect namespace. Since we generate model namespaces in a consistent fashion, we can correctly obtain the type since we will know beforehand where the type would be.

Generation run can viewed here
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=75025&view=logs&j=0c914960-8b50-5299-c9aa-dd3c9595168e&t=3b0ef9b7-0b0d-5874-6c1c-de7c5a8ae365