### PR TITLE
PHP - Fix failing Auth with multiple scopes

### DIFF
--- a/authentication/php/phpleague/src/PhpLeagueAccessTokenProvider.php
+++ b/authentication/php/phpleague/src/PhpLeagueAccessTokenProvider.php
@@ -78,7 +78,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
             return new FulfilledPromise(null);
         }
         try {
-            $params = array_merge($this->tokenRequestContext->getParams(), ['scope' => implode(',', $this->scopes)]);
+            $params = array_merge($this->tokenRequestContext->getParams(), ['scope' => implode(' ', $this->scopes)]);
             if ($this->cachedToken) {
                 if ($this->cachedToken->getExpires() && $this->cachedToken->hasExpired()) {
                     if ($this->cachedToken->getRefreshToken()) {


### PR DESCRIPTION
Passing multiple scopes would fail due to wrong concatenation of scopes with a `,` instead of `[space]`

closes https://github.com/microsoftgraph/msgraph-sdk-php-core/issues/61