### PR TITLE
- udpates issues automation to target new projects

### DIFF
--- a/.github/workflows/issue-labels-projects.yml
+++ b/.github/workflows/issue-labels-projects.yml
@@ -7,55 +7,105 @@ on:
     types: [opened, labeled, reopened]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN : ${{ secrets.GITHUB_PROJECT_TOKEN }}
+  triage: Needs Triage 🔍
 
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
     name: Assign to One Project
     steps:
-    - name: Assign Java issues to Java project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+    - name: Set Java project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Java')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/7'
-    - name: Assign Go issues to Go project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '25'
+        org: 'microsoftgraph'
+    - name: Set Go project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Go')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/8'
-    - name: Assign Ruby issues to Ruby project
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: contains(github.event.issue.labels.*.name, 'Ruby')
-      with:
-        project: 'https://github.com/microsoft/kiota/projects/6'
-    - name: Assign PHP issues to PHP project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '26'
+        org: 'microsoftgraph'
+    # - name: Set Ruby project info
+    #   run: |
+    #     echo '$PROJECT_NUMBER='$PROJECT_NB
+    #     echo '$ORGANIZATION='$ORG
+    #   if: contains(github.event.issue.labels.*.name, 'Ruby')
+    #   with:
+    #     project_nb: '6'
+    #     org: 'microsoftgraph'
+    - name: Set PHP project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'PHP')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/4'
-    - name: Assign Python issues to Python project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '33'
+        org: 'microsoftgraph'
+    - name: Set Python project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Python')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/3'
-    - name: Assign TypeScript issues to TypeScript project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '34'
+        org: 'microsoftgraph'
+    - name: Set TypeScript project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'TypeScript')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/2'
-    - name: Assign CSharp issues to CSharp project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '21'
+        org: 'microsoftgraph'
+    - name: Set CSharp project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'CSharp')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/5'
-    - name: Assign Generator issues to Generator project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '28'
+        org: 'microsoftgraph'
+    - name: Set Generator project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'generator')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/9'
-    - name: Assign Generator issues to Generator project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+        project_nb: '220'
+        org: 'microsoft'
+    - name: Set Generator project info
+      run: |
+        echo '$PROJECT_NUMBER='$PROJECT_NB
+        echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'CLI')
       with:
-        project: 'https://github.com/microsoft/kiota/projects/10'
+        project_nb: '23'
+        org: 'microsoftgraph'
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1.5.2
+      with:
+        app_id: ${{ secrets.GRAPHBOT_APP_ID }}
+        private_key: ${{ secrets.GRAPHBOT_APP_PEM }}
+    - name: Set token for assignment tasks
+      run: echo '$MY_GITHUB_TOKEN=${{ steps.generate_token.outputs.token }}'
+    - name: Assign issue to project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: "${{ env.ORGANIZATION != '' }}"
+      with:
+        project: https://github.com/orgs/${{ env.ORGANIZATION }}/projects/${{ env.PROJECT_NUMBER }}
+    - name: Set Triage
+      uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+      if: "${{ env.ORGANIZATION != '' }}"
+      with:
+        gh_token: ${{ env.MY_GITHUB_TOKEN }}
+        organization: ${{ env.ORGANIZATION }}
+        project_id: ${{ env.PROJECT_NUMBER }}
+        resource_node_id: ${{ github.event.issue.node_id }}
+        status_value: ${{ env.triage }}

--- a/.github/workflows/issue-labels-projects.yml
+++ b/.github/workflows/issue-labels-projects.yml
@@ -20,7 +20,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Java')
-      with:
+      env:
         project_nb: '25'
         org: 'microsoftgraph'
     - name: Set Go project info
@@ -28,7 +28,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Go')
-      with:
+      env:
         project_nb: '26'
         org: 'microsoftgraph'
     # - name: Set Ruby project info
@@ -36,7 +36,7 @@ jobs:
     #     echo '$PROJECT_NUMBER='$PROJECT_NB
     #     echo '$ORGANIZATION='$ORG
     #   if: contains(github.event.issue.labels.*.name, 'Ruby')
-    #   with:
+    #   env:
     #     project_nb: '6'
     #     org: 'microsoftgraph'
     - name: Set PHP project info
@@ -44,7 +44,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'PHP')
-      with:
+      env:
         project_nb: '33'
         org: 'microsoftgraph'
     - name: Set Python project info
@@ -52,7 +52,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'Python')
-      with:
+      env:
         project_nb: '34'
         org: 'microsoftgraph'
     - name: Set TypeScript project info
@@ -60,7 +60,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'TypeScript')
-      with:
+      env:
         project_nb: '21'
         org: 'microsoftgraph'
     - name: Set CSharp project info
@@ -68,7 +68,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'CSharp')
-      with:
+      env:
         project_nb: '28'
         org: 'microsoftgraph'
     - name: Set Generator project info
@@ -76,7 +76,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'generator')
-      with:
+      env:
         project_nb: '220'
         org: 'microsoft'
     - name: Set Generator project info
@@ -84,7 +84,7 @@ jobs:
         echo '$PROJECT_NUMBER='$PROJECT_NB
         echo '$ORGANIZATION='$ORG
       if: contains(github.event.issue.labels.*.name, 'CLI')
-      with:
+      env:
         project_nb: '23'
         org: 'microsoftgraph'
     - name: Generate token

--- a/.github/workflows/issue-labels-projects.yml
+++ b/.github/workflows/issue-labels-projects.yml
@@ -7,7 +7,6 @@ on:
     types: [opened, labeled, reopened]
 
 env:
-  MY_GITHUB_TOKEN : ${{ secrets.GITHUB_PROJECT_TOKEN }}
   triage: Needs Triage 🔍
 
 jobs:

--- a/.github/workflows/issue-labels-projects.yml
+++ b/.github/workflows/issue-labels-projects.yml
@@ -7,104 +7,64 @@ on:
     types: [opened, labeled, reopened]
 
 env:
-  triage: Needs Triage 🔍
+  GITHUB_TOKEN: ${{ secrets.ISSUES_TOKEN }}
 
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
     name: Assign to One Project
     steps:
-    - name: Set Java project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'Java')
-      env:
-        project_nb: '25'
-        org: 'microsoftgraph'
-    - name: Set Go project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'Go')
-      env:
-        project_nb: '26'
-        org: 'microsoftgraph'
-    # - name: Set Ruby project info
-    #   run: |
-    #     echo '$PROJECT_NUMBER='$PROJECT_NB
-    #     echo '$ORGANIZATION='$ORG
-    #   if: contains(github.event.issue.labels.*.name, 'Ruby')
-    #   env:
-    #     project_nb: '6'
-    #     org: 'microsoftgraph'
-    - name: Set PHP project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'PHP')
-      env:
-        project_nb: '33'
-        org: 'microsoftgraph'
-    - name: Set Python project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'Python')
-      env:
-        project_nb: '34'
-        org: 'microsoftgraph'
-    - name: Set TypeScript project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'TypeScript')
-      env:
-        project_nb: '21'
-        org: 'microsoftgraph'
-    - name: Set CSharp project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'CSharp')
-      env:
-        project_nb: '28'
-        org: 'microsoftgraph'
-    - name: Set Generator project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'generator')
-      env:
-        project_nb: '220'
-        org: 'microsoft'
-    - name: Set Generator project info
-      run: |
-        echo '$PROJECT_NUMBER='$PROJECT_NB
-        echo '$ORGANIZATION='$ORG
-      if: contains(github.event.issue.labels.*.name, 'CLI')
-      env:
-        project_nb: '23'
-        org: 'microsoftgraph'
-    - name: Generate token
-      id: generate_token
-      uses: tibdex/github-app-token@v1.5.2
-      with:
-        app_id: ${{ secrets.GRAPHBOT_APP_ID }}
-        private_key: ${{ secrets.GRAPHBOT_APP_PEM }}
-    - name: Set token for assignment tasks
-      run: echo '$MY_GITHUB_TOKEN=${{ steps.generate_token.outputs.token }}'
-    - name: Assign issue to project
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: "${{ env.ORGANIZATION != '' }}"
-      with:
-        project: https://github.com/orgs/${{ env.ORGANIZATION }}/projects/${{ env.PROJECT_NUMBER }}
-    - name: Set Triage
-      uses: leonsteinhaeuser/project-beta-automations@v1.2.1
-      if: "${{ env.ORGANIZATION != '' }}"
-      with:
-        gh_token: ${{ env.MY_GITHUB_TOKEN }}
-        organization: ${{ env.ORGANIZATION }}
-        project_id: ${{ env.PROJECT_NUMBER }}
-        resource_node_id: ${{ github.event.issue.node_id }}
-        status_value: ${{ env.triage }}
+      - name: Set Java project info
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'Java')
+        env:
+          project_nb: "25"
+          org: "microsoftgraph"
+      - name: Set Go project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'Go')
+        env:
+          project_nb: "26"
+          org: "microsoftgraph"
+      - name: Set Ruby project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'Ruby')
+        env:
+          project_nb: "38"
+          org: "microsoftgraph"
+      - name: Set PHP project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'PHP')
+        env:
+          project_nb: "33"
+          org: "microsoftgraph"
+      - name: Set Python project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'Python')
+        env:
+          project_nb: "34"
+          org: "microsoftgraph"
+      - name: Set TypeScript project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'TypeScript')
+        env:
+          project_nb: "21"
+          org: "microsoftgraph"
+      - name: Set CSharp project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'CSharp')
+        env:
+          project_nb: "28"
+          org: "microsoftgraph"
+      - name: Set Generator project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'generator')
+        env:
+          project_nb: "220"
+          org: "microsoft"
+      - name: Set CLI project
+        run: gh project item-add $PROJECT_NB --owner $ORG --url ${{ github.event.issue.html_url}}
+        if: contains(github.event.issue.labels.*.name, 'CLI')
+        env:
+          project_nb: "23"
+          org: "microsoftgraph"


### PR DESCRIPTION
fixes #1395

@ddyett auth is going to be challenging on this one:
- microsoft graph requires additional secrets, I could have created my own app, but I don't have permissions on the org to install it, so I figured we could reuse the app you've already created. Could you [create a new pair of secrets](https://github.com/microsoft/kiota/settings/secrets/actions/new) for GRAPHBOT_APP_PEM and GRAPHBOT_APP_ID with the values you're already using please?
- microsoft would require a similar setup, but we won't have the permission to install the app, I suggest we move the generator project under the microsoft graph org as only our team is contributing internally so far. Thoughts?

I looked into [using workflow permissions](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) but they only give you access to the repo for obvious reasons. And PATs would also not work due to a lack of permissions.