### PR TITLE
Bump version of com.microsoft.kiota.serialization:kiota-serialization-text

### DIFF
--- a/serialization/java/text/lib/build.gradle
+++ b/serialization/java/text/lib/build.gradle
@@ -52,7 +52,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-serialization-text'
-            version '1.0.10'
+            version '1.0.11'
             from(components.java)
         }
     }


### PR DESCRIPTION
Version 1.0.10 didn't build the package correctly, so Gradle can't load it from the private package feed. Per Vincent, bumping version so a new build can be generated.