### PR TITLE
Bump version of kiota-serialization-json

### DIFF
--- a/serialization/java/json/lib/build.gradle
+++ b/serialization/java/json/lib/build.gradle
@@ -53,7 +53,7 @@ publishing {
     publications {
         gpr(MavenPublication) {
             artifactId 'kiota-serialization-json'
-            version '1.0.11'
+            version '1.0.17'
             from(components.java)
         }
     }


### PR DESCRIPTION
Version 1.0.11 didn't build the package correctly, so Gradle can't load it from the private package feed. Per Vincent, bumping version so a new build can be generated. Bumping to 1.0.17 because the metadata in the private feed has 1.0.16 as the latest version.