### PR TITLE
Update PHPDoc types in request config classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed abstractions, authentication, http and serialization packages for PHP. [#1637](https://github.com/microsoft/kiota/pull/1637)
 - Fixed a bug where generated discriminator methods would reference types in other namespaces without proper resolution. [#1670](https://github.com/microsoft/kiota/issues/1670)
 - Fixed a bug where additional data and backing store properties would be duplicated. [#1671](https://github.com/microsoft/kiota/issues/1671)
+- Corrected PHPDoc types for headers and request options properties in request configuration classes. []()
 
 ## [0.2.1] - 2022-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed abstractions, authentication, http and serialization packages for PHP. [#1637](https://github.com/microsoft/kiota/pull/1637)
 - Fixed a bug where generated discriminator methods would reference types in other namespaces without proper resolution. [#1670](https://github.com/microsoft/kiota/issues/1670)
 - Fixed a bug where additional data and backing store properties would be duplicated. [#1671](https://github.com/microsoft/kiota/issues/1671)
-- Corrected PHPDoc types for headers and request options properties in request configuration classes. []()
+- Corrected PHPDoc types for headers and request options properties in request configuration classes. [#1711](https://github.com/microsoft/kiota/pull/1711)
 
 ## [0.2.1] - 2022-05-30
 

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -141,7 +141,8 @@ namespace Kiota.Builder.Refiners
             new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTime", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
             new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
             new(x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor), "Microsoft\\Kiota\\Abstractions", "ApiClientBuilder"),
-            new(x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), "Microsoft\\Kiota\\Abstractions", "QueryParameter")
+            new(x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), "Microsoft\\Kiota\\Abstractions", "QueryParameter"),
+            new(x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration), "Microsoft\\Kiota\\Abstractions", "RequestOption")
         };
         private static void CorrectPropertyType(CodeProperty currentProperty) {
             if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter)) {
@@ -171,6 +172,7 @@ namespace Kiota.Builder.Refiners
                 currentProperty.Type.Name = "DateTime";
             } else if (currentProperty.IsOfKind(CodePropertyKind.Options, CodePropertyKind.Headers))
             {
+                currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
                 currentProperty.Type.Name = "array";
             }
             CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);

--- a/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
@@ -46,7 +46,14 @@ namespace Kiota.Builder.Writers.Php
 
         private string GetCollectionDocString(CodeProperty codeProperty)
         {
-            return codeProperty.IsOfKind(CodePropertyKind.AdditionalData, CodePropertyKind.PathParameters) ? "array<string, mixed>" : $"array<{conventions.TranslateType(codeProperty.Type)}>";
+            return codeProperty.Kind switch
+            {
+                CodePropertyKind.AdditionalData => "array<string, mixed>",
+                CodePropertyKind.PathParameters => "array<string, mixed>",
+                CodePropertyKind.Headers => "array<string, string>",
+                CodePropertyKind.Options => "array<string, RequestOption>",
+                _ => $"array<{conventions.TranslateType(codeProperty.Type)}>"
+            };
         }
 
         private void WriteRequestBuilderBody(CodeProperty codeElement, LanguageWriter writer, string returnType, string propertyAccess, string propertyName)


### PR DESCRIPTION
Static analysis in Graph service libraries fails due to PHPDoc types in Request Config classes not being explicit enough.

Sample diff:
https://github.com/microsoft/kiota-samples/pull/807/files#diff-adb5363858815f105dbf0ff26b1e2443afa69693a28c2c4602cda1685083d676R10