### PR TITLE
Docs: Fix Using link on Get started page

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -66,6 +66,6 @@ https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/open
 
 ## Next steps
 
-For details on running Kiota, see [Using the Kiota tool](..\using.md)
+For details on running Kiota, see [Using the Kiota tool](/docs/using.md)
 
 The following topics provide details on using Kiota to generate SDKs for specific languages.


### PR DESCRIPTION
Fix the `Using the Kiota tool` link on the `Get started` page.