### PR TITLE
- adds a more explicit message for invalid schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a more explicit error message for invalid schemas. [#1718](https://github.com/microsoft/kiota/issues/1718)
 - Added a parameter to specify why mime types to evaluate for models. [#134](https://github.com/microsoft/kiota/issues/134)
 - Added an explicit error message for external references in the schema. [#1580](https://github.com/microsoft/kiota/issues/1580)
 - Added accept header for all schematized requests. [#1607](https://github.com/microsoft/kiota/issues/1607)

--- a/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
+++ b/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
@@ -3,9 +3,12 @@ using System;
 
 namespace Kiota.Builder.Exceptions;
 
+[Serializable]
 public class InvalidSchemaException : InvalidOperationException
 {
-    public InvalidSchemaException(string message) : base(message)
-    {
-    }
+    public InvalidSchemaException():base(){}
+    public InvalidSchemaException(string message) : base(message){}
+    #nullable enable
+    public InvalidSchemaException(string? message, Exception? innerException):base(message, innerException){}
+    #nullable disable
 }

--- a/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
+++ b/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
@@ -1,0 +1,11 @@
+
+using System;
+
+namespace Kiota.Builder.Exceptions;
+
+public class InvalidSchemaException : InvalidOperationException
+{
+    public InvalidSchemaException(string message) : base(message)
+    {
+    }
+}

--- a/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
+++ b/src/Kiota.Builder/Exceptions/InvalidSchemaException.cs
@@ -3,8 +3,7 @@ using System;
 
 namespace Kiota.Builder.Exceptions;
 
-[Serializable]
-public class InvalidSchemaException : InvalidOperationException
+internal class InvalidSchemaException : InvalidOperationException
 {
     public InvalidSchemaException():base(){}
     public InvalidSchemaException(string message) : base(message){}

--- a/tests/Kiota.Builder.Tests/Exceptions/InvalidSchemaExceptionTests.cs
+++ b/tests/Kiota.Builder.Tests/Exceptions/InvalidSchemaExceptionTests.cs
@@ -1,0 +1,14 @@
+
+using System;
+using Xunit;
+
+namespace Kiota.Builder.Exceptions.Tests;
+
+public class InvalidSchemaExceptionTests {
+    [Fact]
+    public void Instantiates() {
+        Assert.NotNull(new InvalidSchemaException());
+        Assert.NotNull(new InvalidSchemaException("message"));
+        Assert.NotNull(new InvalidSchemaException("message", new InvalidOperationException()));
+    }
+}


### PR DESCRIPTION
fixes #1718

The generator (in release builds) will now return the following error

> crit: Kiota.Builder.KiotaBuilder[0] error generating the SDK: One or more errors occurred. (Error creating property ProviderIds for model BaseItemDto in API path \GameGenres, the schema is invalid.)

which is much more actionable than the previous error message
> crit: Kiota.Builder.KiotaBuilder[0] error generating the SDK: One or more errors occurred. (un handled case, might be object type or array type)