### PR TITLE
☄ New command line arg: additional-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for no-content responses in python abstractions and http packages. [#1630](https://github.com/microsoft/kiota/issues/1459)
 - Added support for vendor-specific content types in python. [#1631](https://github.com/microsoft/kiota/issues/1463)
 - Simplified field deserializers for json in Python. [#1632](https://github.com/microsoft/kiota/issues/1492)
+- Adds a `--additional-data` argument to generate the AdditionalData properties #1772
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for no-content responses in python abstractions and http packages. [#1630](https://github.com/microsoft/kiota/issues/1459)
 - Added support for vendor-specific content types in python. [#1631](https://github.com/microsoft/kiota/issues/1463)
 - Simplified field deserializers for json in Python. [#1632](https://github.com/microsoft/kiota/issues/1492)
-- Added a `--additional-data` argument to generate the AdditionalData properties #1772
+- Added a `--additional-data` argument to generate the AdditionalData properties [#1772](https://github.com/microsoft/kiota/issues/1772)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for no-content responses in python abstractions and http packages. [#1630](https://github.com/microsoft/kiota/issues/1459)
 - Added support for vendor-specific content types in python. [#1631](https://github.com/microsoft/kiota/issues/1463)
 - Simplified field deserializers for json in Python. [#1632](https://github.com/microsoft/kiota/issues/1492)
-- Adds a `--additional-data` argument to generate the AdditionalData properties #1772
+- Added a `--additional-data` argument to generate the AdditionalData properties #1772
 
 ### Changed
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -19,6 +19,7 @@ kiota (--openapi | -d) <path>
       [(--namespace-name | -n) <name>]
       [(--log-level | --ll) <level>]
       [--backing-store | -b]
+      [--additional-data | -ad]
       [(--serializer | -s) <classes>]
       [(--deserializer | --ds) <classes>]
       [--clean-output | --co]
@@ -59,6 +60,14 @@ Enables backing store for models. Defaults to `false`.
 
 ```shell
 kiota --backing-store
+```
+
+### `--additional-data (-ad)`
+
+Will include the 'AdditionalData' property for generated models. Defaults to 'true'.
+
+```shell
+kiota --additional-data false
 ```
 
 ### `--class-name (-c)`

--- a/docs/using.md
+++ b/docs/using.md
@@ -19,7 +19,7 @@ kiota (--openapi | -d) <path>
       [(--namespace-name | -n) <name>]
       [(--log-level | --ll) <level>]
       [--backing-store | -b]
-      [--additional-data | -ad]
+      [--additional-data | --ad]
       [(--serializer | -s) <classes>]
       [(--deserializer | --ds) <classes>]
       [--clean-output | --co]

--- a/docs/using.md
+++ b/docs/using.md
@@ -62,7 +62,7 @@ Enables backing store for models. Defaults to `false`.
 kiota --backing-store
 ```
 
-### `--additional-data (-ad)`
+### `--additional-data (--ad)`
 
 Will include the 'AdditionalData' property for generated models. Defaults to 'true'.
 

--- a/src/Kiota.Builder/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/GenerationConfiguration.cs
@@ -12,6 +12,7 @@ namespace Kiota.Builder {
         public GenerationLanguage Language { get; set; } = GenerationLanguage.CSharp;
         public string ApiRootUrl { get; set; }
         public bool UsesBackingStore { get; set; }
+        public bool IncludeAdditionalData { get; set; } = true;
         public HashSet<string> Serializers { get; set; } = new(StringComparer.OrdinalIgnoreCase){
             "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
             "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory"

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1073,7 +1073,11 @@ public class KiotaBuilder
         };
     }
     private void CreatePropertiesForModelClass(OpenApiUrlTreeNode currentNode, OpenApiSchema schema, CodeNamespace ns, CodeClass model) {
-        AddSerializationMembers(model, schema?.AdditionalPropertiesAllowed ?? false, config.UsesBackingStore);
+
+        var includeAdditionalDataProperties = config.IncludeAdditionalData &&
+            (schema?.AdditionalPropertiesAllowed ?? false);
+
+        AddSerializationMembers(model, includeAdditionalDataProperties, config.UsesBackingStore);
         if(schema?.Properties?.Any() ?? false)
         {
             model.AddProperty(schema

--- a/src/kiota/KiotaCommandHandler.cs
+++ b/src/kiota/KiotaCommandHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
@@ -23,6 +23,7 @@ internal class KiotaCommandHandler : ICommandHandler
     public Option<string> NamespaceOption { get;set; }
     public Option<LogLevel> LogLevelOption { get;set; }
     public Option<bool> BackingStoreOption { get;set; }
+    public Option<bool> AdditionalDataOption { get;set; }
     public Option<List<string>> SerializerOption { get;set; }
     public Option<List<string>> DeserializerOption { get;set; }
     public Option<bool> CleanOutputOption { get;set; }
@@ -37,6 +38,7 @@ internal class KiotaCommandHandler : ICommandHandler
         GenerationLanguage language = context.ParseResult.GetValueForOption(LanguageOption);
         string openapi = context.ParseResult.GetValueForOption(DescriptionOption);
         bool backingStore = context.ParseResult.GetValueForOption(BackingStoreOption);
+        bool includeAdditionalData = context.ParseResult.GetValueForOption(AdditionalDataOption);
         string className = context.ParseResult.GetValueForOption(ClassOption);
         LogLevel logLevel = context.ParseResult.GetValueForOption(LogLevelOption);
         string namespaceName = context.ParseResult.GetValueForOption(NamespaceOption);
@@ -50,6 +52,7 @@ internal class KiotaCommandHandler : ICommandHandler
         AssignIfNotNullOrEmpty(className, (c, s) => c.ClientClassName = s);
         AssignIfNotNullOrEmpty(namespaceName, (c, s) => c.ClientNamespaceName = s);
         Configuration.UsesBackingStore = backingStore;
+        Configuration.IncludeAdditionalData = includeAdditionalData;
         Configuration.Language = language;
         if(serializer?.Any() ?? false)
             Configuration.Serializers = serializer.Select(x => x.TrimQuotes()).ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
@@ -47,6 +47,9 @@ public class KiotaHost {
         var backingStoreOption = new Option<bool>("--backing-store", () => defaultConfiguration.UsesBackingStore, "Enables backing store for models.");
         backingStoreOption.AddAlias("-b");
 
+        var additionalDataOption = new Option<bool>("--additional-data", () => defaultConfiguration.IncludeAdditionalData, "Will include the 'AdditionalData' property for models.");
+        additionalDataOption.AddAlias("-ad");
+
         var serializerOption = new Option<List<string>>(
             "--serializer", 
             () => defaultConfiguration.Serializers.ToList(),
@@ -78,6 +81,7 @@ public class KiotaHost {
             namespaceOption,
             logLevelOption,
             backingStoreOption,
+            additionalDataOption,
             serializerOption,
             deserializerOption,
             cleanOutputOption,
@@ -92,6 +96,7 @@ public class KiotaHost {
             NamespaceOption = namespaceOption,
             LogLevelOption = logLevelOption,
             BackingStoreOption = backingStoreOption,
+            AdditionalDataOption = additionalDataOption,
             SerializerOption = serializerOption,
             DeserializerOption = deserializerOption,
             CleanOutputOption = cleanOutputOption,

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -48,7 +48,7 @@ public class KiotaHost {
         backingStoreOption.AddAlias("-b");
 
         var additionalDataOption = new Option<bool>("--additional-data", () => defaultConfiguration.IncludeAdditionalData, "Will include the 'AdditionalData' property for models.");
-        additionalDataOption.AddAlias("-ad");
+        additionalDataOption.AddAlias("--ad");
 
         var serializerOption = new Option<List<string>>(
             "--serializer", 


### PR DESCRIPTION
Resolves #1573

- new command line arg: `--additional-data [true|false]`  (or `-ad [true|false]`). Default is `true` (which is the current status quo).

Here's an example which does NOT add the additional data to any generated models:

```
--openapi https://petstore.swagger.io/v2/swagger.json --additional-data false --language csharp -o PetshopClient -c ApiClient --log-level information --clean-output true
```

![](https://media.giphy.com/media/1zKdUbpLNEJXEwlm6P/giphy.gif)