### PR TITLE
Use ISO 8601 date formats for dateTime in Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed duplicate properties defined in base types from model serialization and deserialization methods and initialise property defaults in constructor. [#1737](https://github.com/microsoft/kiota/pull/1737)
 - Fixed a bug where the generated code had incorrect casing within a method (Ruby). [#1672](https://github.com/microsoft/kiota/issues/1672)
 - Fixed an issue where duplicate 'require' statements are generated for inner classes in the middle of the file (Ruby). [#1649](https://github.com/microsoft/kiota/issues/1649)
+- Changed format of datetimes in Go to be converted to ISO 8601 by default when place in path parameters(Go)
 
 ## [0.3.0] - 2022-07-08
 

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -170,6 +170,7 @@ public class GoConventionService : CommonLanguageConventionService
     }
     #pragma warning restore CA1822 // Method should be static
     private const string StrConvHash = "i53ac87e8cb3cc9276228f74d38694a208cacb99bb8ceb705eeae99fb88d4d274";
+    private const string TimeFormatHash = "i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e";
     private static string GetValueStringConversion(string typeName, string reference) {
         return typeName switch {
             "boolean" => $"{StrConvHash}.FormatBool({reference})",
@@ -177,7 +178,8 @@ public class GoConventionService : CommonLanguageConventionService
             "integer" or "int32" => $"{StrConvHash}.FormatInt(int64({reference}), 10)",
             "long" => $"{StrConvHash}.FormatInt({reference}, 10)",
             "float" or "double" or "decimal" or "float64" or "float32" => $"{StrConvHash}.FormatFloat({reference}, 'E', -1, 64)",
-            "DateTimeOffset" or "Time" or "ISODuration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
+            "DateTimeOffset" or "Time" => $"({reference}).Format({TimeFormatHash}.RFC3339)", // default to using ISO 8601
+            "ISODuration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
             _ => reference,
         };
     }


### PR DESCRIPTION
This PR fixes the dateTime formats used in the pathParameters in Go to default to ISO 8601. As the dateTimes are converted to strings before being placed in the pathParameters collection as seen in https://github.com/microsoft/kiota-abstractions-go/pull/24, the changes are made to the generator.

Generation changes can be previewed on this commit https://github.com/microsoftgraph/msgraph-sdk-go/commit/1f844053bbc1afe7008f2bd4ff23323b3253e042