### PR TITLE
Adds context to go code writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update namespace qualification algorithm (helps in resolving when a type name appears in multiple namespaces) to use case insensitive string comparison (CSharp).
 - Fix an issue where namespace reserved name replacement would not include replacing import names in the declared areas in CSharp. [#1799](https://github.com/microsoft/kiota/issues/1799)
 - Removed Python abstractions, http, authentication and serialization packages
-- Fixed an issue with generating the incorrect serialized type name and require statement for get/post methods (Ruby). 
-- Fixed an issue with the require statements generated for entity superclass in Ruby.  
+- Fixed an issue with generating the incorrect serialized type name and require statement for get/post methods (Ruby).
+- Remove all overloads for GO request executors
+- Adds a context object in all GO requests
+- Remove all overloads for GO request executors and Adds a context object in all GO requests [GO#176](https://github.com/microsoftgraph/msgraph-sdk-go/issues/176)
+
 
 ## [0.4.0] - 2022-08-18
 

--- a/src/Kiota.Builder/CodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/CodeParameterOrderComparer.cs
@@ -4,7 +4,7 @@ namespace Kiota.Builder;
 public class CodeParameterOrderComparer : IComparer<CodeParameter>
 {
 
-    private List<string> parameterTypeOrders = new ();
+    private readonly List<string> parameterTypeOrders;
 
     public CodeParameterOrderComparer(List<string> defaultParamOrder)
     {
@@ -12,6 +12,7 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
     }
     public CodeParameterOrderComparer()
     {
+        parameterTypeOrders = new List<string>();
     }
 
     public int Compare(CodeParameter x, CodeParameter y)

--- a/src/Kiota.Builder/CodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/CodeParameterOrderComparer.cs
@@ -3,37 +3,20 @@ using System.Collections.Generic;
 namespace Kiota.Builder;
 public class CodeParameterOrderComparer : IComparer<CodeParameter>
 {
-
-    private readonly List<string> parameterTypeOrders;
-
-    public CodeParameterOrderComparer(List<string> defaultParamOrder)
-    {
-        parameterTypeOrders = defaultParamOrder;
-    }
-    public CodeParameterOrderComparer()
-    {
-        parameterTypeOrders = new List<string>();
-    }
-
     public int Compare(CodeParameter x, CodeParameter y)
     {
         return (x, y) switch {
             (null, null) => 0,
             (null, _) => -1,
             (_, null) => 1,
-            _ => getDefaultOrder(y.Type).CompareTo(getDefaultOrder(x.Type)) * defaultParamOrderWeight +
-                 x.Optional.CompareTo(y.Optional) * optionalWeight +
+            _ => x.Optional.CompareTo(y.Optional) * optionalWeight +
                  getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight +
                  x.Name.CompareTo(y.Name) * nameWeight,
         };
     }
-    
-    private int getDefaultOrder(CodeTypeBase codeType)
-    {
-        return parameterTypeOrders.IndexOf(codeType.Name);
-    }
     private static int getKindOrderHint(CodeParameterKind kind) {
         return kind switch {
+            CodeParameterKind.Cancellation => 0,
             CodeParameterKind.PathParameters => 1,
             CodeParameterKind.RawUrl => 2,
             CodeParameterKind.RequestAdapter => 3,
@@ -49,7 +32,6 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
             _ => 13,
         };
     }
-    private static readonly int defaultParamOrderWeight = 100000;
     private static readonly int optionalWeight = 10000;
     private static readonly int kindWeight = 100;
     private static readonly int nameWeight = 10;

--- a/src/Kiota.Builder/CodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/CodeParameterOrderComparer.cs
@@ -3,16 +3,33 @@ using System.Collections.Generic;
 namespace Kiota.Builder;
 public class CodeParameterOrderComparer : IComparer<CodeParameter>
 {
+
+    private List<string> parameterTypeOrders = new ();
+
+    public CodeParameterOrderComparer(List<string> defaultParamOrder)
+    {
+        parameterTypeOrders = defaultParamOrder;
+    }
+    public CodeParameterOrderComparer()
+    {
+    }
+
     public int Compare(CodeParameter x, CodeParameter y)
     {
         return (x, y) switch {
             (null, null) => 0,
             (null, _) => -1,
             (_, null) => 1,
-            _ => x.Optional.CompareTo(y.Optional) * optionalWeight +
-                getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight +
-                x.Name.CompareTo(y.Name) * nameWeight,
+            _ => getDefaultOrder(y.Type).CompareTo(getDefaultOrder(x.Type)) * defaultParamOrderWeight +
+                 x.Optional.CompareTo(y.Optional) * optionalWeight +
+                 getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight +
+                 x.Name.CompareTo(y.Name) * nameWeight,
         };
+    }
+    
+    private int getDefaultOrder(CodeTypeBase codeType)
+    {
+        return parameterTypeOrders.IndexOf(codeType.Name);
     }
     private static int getKindOrderHint(CodeParameterKind kind) {
         return kind switch {
@@ -31,6 +48,7 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
             _ => 13,
         };
     }
+    private static readonly int defaultParamOrderWeight = 100000;
     private static readonly int optionalWeight = 10000;
     private static readonly int kindWeight = 100;
     private static readonly int nameWeight = 10;

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -117,19 +117,14 @@ public class GoRefiner : CommonLanguageRefiner
     }
     
     protected static void RenameCancellationParameter(CodeElement currentElement){
-        if (currentElement is CodeMethod currentMethod && currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
+        if (currentElement is CodeMethod currentMethod && currentMethod.IsOfKind(CodeMethodKind.RequestExecutor) && currentMethod.Parameters.OfKind(CodeParameterKind.Cancellation) is CodeParameter parameter)
         {
-            var parameter = currentMethod.Parameters.Where(x => x.Kind == CodeParameterKind.Cancellation).FirstOrDefault();
-
-            if (parameter != null)
-            {
-                parameter.Name = "ctx";
-                parameter.Description = "Pass a context parameter to the request";
-                parameter.Kind = CodeParameterKind.Custom;
-                parameter.Optional = false;
-                parameter.Type.Name = conventions.ContextVarTypeName;
-                parameter.Type.IsNullable = false;
-            }
+            parameter.Name = "ctx";
+            parameter.Description = "Pass a context parameter to the request";
+            parameter.Kind = CodeParameterKind.Custom;
+            parameter.Optional = false;
+            parameter.Type.Name = conventions.ContextVarTypeName;
+            parameter.Type.IsNullable = false;
         }
         CrawlTree(currentElement, RenameCancellationParameter);
     }

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Kiota.Builder.Writers.Go;
 
 namespace Kiota.Builder.Refiners;
 public class GoRefiner : CommonLanguageRefiner
 {
-    public GoRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public GoRefiner(GenerationConfiguration configuration) : base(configuration) { }
     public override void Refine(CodeNamespace generatedCode)
     {
         _configuration.NamespaceNameSeparator = "/";
@@ -55,7 +56,7 @@ public class GoRefiner : CommonLanguageRefiner
             CorrectMethodType,
             CorrectPropertyType,
             CorrectImplements);
-        InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
+        InsertOverrideMethodForBuildersAndConstructors(generatedCode);
         DisableActionOf(generatedCode, 
             CodeParameterKind.RequestConfiguration);
         AddGetterAndSetterMethods(
@@ -112,31 +113,63 @@ public class GoRefiner : CommonLanguageRefiner
             generatedCode,
             x => $"{x.Name}able"
         );
+        MoveResponseHandlerToStructs(generatedCode);
     }
-    private void InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(CodeElement currentElement) {
-        if(currentElement is CodeClass currentClass) {
-            var codeMethods = currentClass.Methods;
-            if(codeMethods.Any(x => x.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator))) {
-                var originalExecutorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestExecutor)).ToList();
-                var executorMethodsToAdd = originalExecutorMethods
-                                    .Select(x => GetMethodClone(x, CodeParameterKind.RequestConfiguration, CodeParameterKind.ResponseHandler))
-                                    .Where(x => x != null)
-                                    .ToArray();//otherwise the name change also affects the clones
-                var originalGeneratorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestGenerator)).ToList();
-                var generatorMethodsToAdd = originalGeneratorMethods
-                                    .Select(x => GetMethodClone(x, CodeParameterKind.RequestConfiguration))
-                                    .Where(x => x != null)
-                                    .ToArray();
-                originalExecutorMethods.ForEach(x => x.Name = $"{x.Name}With{nameof(CodeParameterKind.RequestConfiguration)}And{nameof(CodeParameterKind.ResponseHandler)}");
-                originalGeneratorMethods.ForEach(x => x.Name = $"{x.Name}With{nameof(CodeParameterKind.RequestConfiguration)}");
-                if(executorMethodsToAdd.Any() || generatorMethodsToAdd.Any())
-                    currentClass.AddMethod(executorMethodsToAdd
-                                            .Union(generatorMethodsToAdd)
-                                            .ToArray());
+
+    private void MoveResponseHandlerToStructs(CodeElement currentElement)
+    {
+        if (currentElement is CodeClass currentClass)
+        {
+            // remove all response handlers from request builder param
+            if (currentClass.IsOfKind(CodeClassKind.RequestBuilder))
+            {
+                var codeMethods = currentClass.Methods.Where(x => x.Kind == CodeMethodKind.RequestExecutor);
+                foreach (var codeMethod in codeMethods)
+                {
+                    codeMethod.RemoveParametersByKind(CodeParameterKind.ResponseHandler);
+                }
+            }
+            // add response handler to struct
+            if (currentClass.IsOfKind(CodeClassKind.RequestConfiguration))
+            {
+                currentClass.AddProperty(new CodeProperty
+                {
+                    Access = AccessModifier.Public,
+                    Description ="Response handler to use in place of the default response handling provided by the core service",
+                    Kind = CodePropertyKind.ResponseHandler,
+                    Name = "responseHandler",
+                    ReadOnly = false,
+                    Parent = currentClass.Parent,
+                    Type = new CodeType {
+                        IsNullable = false,
+                        Name = ((currentElement.Parent as CodeClass)?.StartBlock)?
+                            .Usings
+                            .Select(x => x.Name)
+                            .FirstOrDefault(x => "ResponseHandler".Equals(x,StringComparison.OrdinalIgnoreCase)),
+                    }
+                });
             }
         }
 
-        CrawlTree(currentElement, InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors);
+        CrawlTree(currentElement, MoveResponseHandlerToStructs);
+    }
+
+    private void InsertOverrideMethodForBuildersAndConstructors(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass) {
+            var codeMethods = currentClass.Methods;
+            if(codeMethods.Any(x => x.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator))) {
+                var originalGeneratorMethods = codeMethods.Where(x => x.IsOfKind(CodeMethodKind.RequestGenerator)).ToList();
+                var generatorMethodsToAdd = originalGeneratorMethods
+                    .Select(x => GetMethodClone(x, CodeParameterKind.RequestConfiguration))
+                    .Where(x => x != null)
+                    .ToArray();
+                originalGeneratorMethods.ForEach(x => x.Name = $"{x.Name}With{nameof(CodeParameterKind.RequestConfiguration)}");
+                if(generatorMethodsToAdd.Any())
+                    currentClass.AddMethod(generatorMethodsToAdd.ToArray());
+            }
+        }
+
+        CrawlTree(currentElement, InsertOverrideMethodForBuildersAndConstructors);
     }
     private static void RemoveModelPropertiesThatDependOnSubNamespaces(CodeElement currentElement) {
         if(currentElement is CodeClass currentClass && 
@@ -242,6 +275,7 @@ public class GoRefiner : CommonLanguageRefiner
                                             (@class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)) ||
                                             @class.StartBlock.Implements.Any(x => KiotaBuilder.AdditionalHolderInterface.Equals(x.Name, StringComparison.OrdinalIgnoreCase))),
             "github.com/microsoft/kiota-abstractions-go/serialization", "AdditionalDataHolder"),
+        new(x => x is CodeMethod method && (method.IsOfKind(CodeMethodKind.RequestExecutor) || method.IsOfKind(CodeMethodKind.RequestGenerator)), "context","*context"),
     };//TODO add backing store types once we have them defined
     private static void CorrectImplements(ProprietableBlockDeclaration block) {
         block.ReplaceImplementByName(KiotaBuilder.AdditionalHolderInterface, "AdditionalDataHolder");

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -121,7 +121,7 @@ public class GoRefiner : CommonLanguageRefiner
         {
             parameter.Name = "ctx";
             parameter.Description = "Pass a context parameter to the request";
-            parameter.Kind = CodeParameterKind.Custom;
+            parameter.Kind = CodeParameterKind.Cancellation;
             parameter.Optional = false;
             parameter.Type.Name = conventions.ContextVarTypeName;
             parameter.Type.IsNullable = false;

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -131,16 +131,12 @@ public class GoRefiner : CommonLanguageRefiner
     
     private void RemoveHandlerFromRequestBuilder(CodeElement currentElement)
     {
-        if (currentElement is CodeClass currentClass)
+        if (currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.RequestBuilder))
         {
-            // remove all response handlers from request builder param
-            if (currentClass.IsOfKind(CodeClassKind.RequestBuilder))
+            var codeMethods = currentClass.Methods.Where(x => x.Kind == CodeMethodKind.RequestExecutor);
+            foreach (var codeMethod in codeMethods)
             {
-                var codeMethods = currentClass.Methods.Where(x => x.Kind == CodeMethodKind.RequestExecutor);
-                foreach (var codeMethod in codeMethods)
-                {
-                    codeMethod.RemoveParametersByKind(CodeParameterKind.ResponseHandler);
-                }
+                codeMethod.RemoveParametersByKind(CodeParameterKind.ResponseHandler);
             }
         }
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -20,7 +20,7 @@ public class GoRefiner : CommonLanguageRefiner
             generatedCode,
             false,
             "ById");
-        RemoveCancellationParameter(generatedCode);
+        RenameCancellationParameter(generatedCode);
         RemoveDiscriminatorMappingsTargetingSubNamespaces(generatedCode);
         ReplaceRequestBuilderPropertiesByMethods(
             generatedCode
@@ -115,7 +115,25 @@ public class GoRefiner : CommonLanguageRefiner
         );
         RemoveHandlerFromRequestBuilder(generatedCode);
     }
+    
+    protected static void RenameCancellationParameter(CodeElement currentElement){
+        if (currentElement is CodeMethod currentMethod && currentMethod.IsOfKind(CodeMethodKind.RequestExecutor))
+        {
+            var parameter = currentMethod.Parameters.Where(x => x.Kind == CodeParameterKind.Cancellation).FirstOrDefault();
 
+            if (parameter != null)
+            {
+                parameter.Name = "ctx";
+                parameter.Description = "Pass a context parameter to the request";
+                parameter.Kind = CodeParameterKind.Custom;
+                parameter.Optional = false;
+                parameter.Type.Name = conventions.ContextVarTypeName;
+                parameter.Type.IsNullable = false;
+            }
+        }
+        CrawlTree(currentElement, RenameCancellationParameter);
+    }
+    
     private void RemoveHandlerFromRequestBuilder(CodeElement currentElement)
     {
         if (currentElement is CodeClass currentClass)

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -113,10 +113,10 @@ public class GoRefiner : CommonLanguageRefiner
             generatedCode,
             x => $"{x.Name}able"
         );
-        MoveResponseHandlerToStructs(generatedCode);
+        RemoveHandlerFromRequestBuilder(generatedCode);
     }
 
-    private void MoveResponseHandlerToStructs(CodeElement currentElement)
+    private void RemoveHandlerFromRequestBuilder(CodeElement currentElement)
     {
         if (currentElement is CodeClass currentClass)
         {
@@ -129,29 +129,9 @@ public class GoRefiner : CommonLanguageRefiner
                     codeMethod.RemoveParametersByKind(CodeParameterKind.ResponseHandler);
                 }
             }
-            // add response handler to struct
-            if (currentClass.IsOfKind(CodeClassKind.RequestConfiguration))
-            {
-                currentClass.AddProperty(new CodeProperty
-                {
-                    Access = AccessModifier.Public,
-                    Description ="Response handler to use in place of the default response handling provided by the core service",
-                    Kind = CodePropertyKind.ResponseHandler,
-                    Name = "responseHandler",
-                    ReadOnly = false,
-                    Parent = currentClass.Parent,
-                    Type = new CodeType {
-                        IsNullable = false,
-                        Name = ((currentElement.Parent as CodeClass)?.StartBlock)?
-                            .Usings
-                            .Select(x => x.Name)
-                            .FirstOrDefault(x => "ResponseHandler".Equals(x,StringComparison.OrdinalIgnoreCase)),
-                    }
-                });
-            }
         }
 
-        CrawlTree(currentElement, MoveResponseHandlerToStructs);
+        CrawlTree(currentElement, RemoveHandlerFromRequestBuilder);
     }
 
     private void InsertOverrideMethodForBuildersAndConstructors(CodeElement currentElement) {

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -44,9 +44,6 @@ namespace Kiota.Builder.Writers.Go {
                 case CodeMethodKind.RequestExecutor when !codeElement.IsOverload:
                     WriteRequestExecutorBody(codeElement, requestParams, returnType, parentClass, writer);
                 break;
-                case CodeMethodKind.RequestExecutor when codeElement.IsOverload:
-                    WriteExecutorMethodCall(codeElement, requestParams, writer);
-                break;
                 case CodeMethodKind.Getter:
                     WriteGetterBody(codeElement, writer, parentClass);
                     break;
@@ -431,13 +428,7 @@ namespace Kiota.Builder.Writers.Go {
 
             writer.WriteLine(template(generatorMethodName, paramsCall));
         }
-        private static void WriteExecutorMethodCall(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer)
-        {
-            WriteMethodCall(codeElement, requestParams, writer, CodeMethodKind.RequestExecutor, (name, paramsCall) => 
-                $"return m.{name}({paramsCall});",
-                1
-            );
-        }
+
         private static void WriteGeneratorMethodCall(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer, string prefix) {
             WriteMethodCall(codeElement, requestParams, writer, CodeMethodKind.RequestGenerator, (name, paramsCall) => 
                 $"{prefix}m.{name}({paramsCall});"

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -396,7 +396,7 @@ namespace Kiota.Builder.Writers.Go {
             }
             
             writer.WriteLine($"var {ResponseHandlerVarName} {conventions.AbstractionsHash}.ResponseHandler = nil");
-            writer.WriteLine("if requestConfiguration != nil && requestConfiguration.ResponseHandler != nil {{");
+            writer.WriteLine("if requestConfiguration != nil && requestConfiguration.ResponseHandler != nil {");
             writer.IncreaseIndent();
             writer.WriteLine($"{ResponseHandlerVarName} = requestConfiguration.ResponseHandler");
             writer.CloseBlock();

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -395,16 +395,10 @@ namespace Kiota.Builder.Writers.Go {
                 writer.CloseBlock();
             }
             
-            writer.WriteLine($"var {ResponseHandlerVarName} {conventions.AbstractionsHash}.ResponseHandler = nil");
-            writer.WriteLine("if requestConfiguration != nil && requestConfiguration.ResponseHandler != nil {");
-            writer.IncreaseIndent();
-            writer.WriteLine($"{ResponseHandlerVarName} = requestConfiguration.ResponseHandler");
-            writer.CloseBlock();
-            
             var assignmentPrefix = isVoid ?
                         "err =" :
                         "res, err :=";
-            writer.WriteLine($"{assignmentPrefix} m.requestAdapter.{sendMethodName}({ContextVarName}, {RequestInfoVarName}, {constructorFunction}{ResponseHandlerVarName}, {errorMappingVarName})");
+            writer.WriteLine($"{assignmentPrefix} m.requestAdapter.{sendMethodName}({ContextVarName}, {RequestInfoVarName}, {constructorFunction}{errorMappingVarName})");
             WriteReturnError(writer, returnType);
             var valueVarName = string.Empty;
             if(codeElement.ReturnType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None) {
@@ -464,7 +458,6 @@ namespace Kiota.Builder.Writers.Go {
         private const string RequestInfoVarName = "requestInfo";
         private const string ContextVarName = "ctx";
         private const string ContextVarTypeName = "context.Context";
-        private const string ResponseHandlerVarName = "responseHandler";
         private void WriteRequestGeneratorBody(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer, CodeClass parentClass) {
             if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
             

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -150,7 +150,7 @@ namespace Kiota.Builder.Writers.Go {
             writer.WriteLine("return nil");
         }
         private static string errorVarDeclaration(bool shouldDeclareErrorVar) => shouldDeclareErrorVar ? ":" : string.Empty;
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new(new List<string> { "context.Context" });
+        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
         
         private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool writePrototypeOnly) {
             var parentBlock = code.Parent;

--- a/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeProprietableBlockDeclarationWriter.cs
@@ -33,7 +33,7 @@ public abstract class CodeProprietableBlockDeclarationWriter<T> : BaseElementWri
             {
                 writer.WriteLines(string.Empty, "import (");
                 writer.IncreaseIndent();
-                importSegments.ForEach(x => writer.WriteLine($"{x.Item1} \"{x.Item2}\""));
+                importSegments.ForEach(x => writer.WriteLine(x.Item1.Equals(x.Item2) ? $"\"{x.Item2}\"" : $"{x.Item1} \"{x.Item2}\""));
                 writer.DecreaseIndent();
                 writer.WriteLines(")", string.Empty);
             }

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -15,6 +15,9 @@ public class GoConventionService : CommonLanguageConventionService
     #pragma warning disable CA1822 // Method should be static
     public string AbstractionsHash => "i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f";
     public string SerializationHash => "i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91";
+    
+    public string ContextVarTypeName => "context.Context";
+    
     #pragma warning restore CA1822 // Method should be static
     public override string GetAccessModifier(AccessModifier access)
     {
@@ -87,6 +90,7 @@ public class GoConventionService : CommonLanguageConventionService
             "binary" => "[]byte",
             "string" or "float32" or "float64" or "int32" or "int64" => type.Name,
             "String" or "Int64" or "Int32" or "Float32" or "Float64" => type.Name.ToFirstCharacterLowerCase(), //casing hack
+            "context.Context" => "context.Context",
             _ => type.Name.ToFirstCharacterUpperCase() ?? "Object",
         };
     }

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -640,12 +640,12 @@ public class GoLanguageRefinerTests {
         generator.AddParameter(executor.Parameters.Where(x => !x.IsOfKind(CodeParameterKind.ResponseHandler)).ToArray());
         ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
         var childMethods = builder.Methods;
-        Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 1);//body only
+        Assert.DoesNotContain(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor)); // no executor overloads
         Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 1);//body only
         Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 3);// body + query + response handler
         Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 2);// body + query config
-        Assert.Equal(4, childMethods.Count());
-        Assert.Equal(2, childMethods.Count(x => x.IsOverload));
+        Assert.Equal(3, childMethods.Count());
+        Assert.Equal(1, childMethods.Count(x => x.IsOverload));
     }
     #endregion
 }

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -265,7 +265,7 @@ public class GoLanguageRefinerTests {
         Assert.Equal(factoryMethod, requestBuilderClass.StartBlock.Usings.First(x => x.Declaration.Name.Equals("factory", StringComparison.OrdinalIgnoreCase)).Declaration.TypeDefinition);
     }
     [Fact]
-    public void DoesNotKeepCancellationParametersInRequestExecutors()
+    public void RenamesCancellationParametersInRequestExecutors()
     {
         var model = root.AddClass(new CodeClass
         {
@@ -291,8 +291,9 @@ public class GoLanguageRefinerTests {
         };
         method.AddParameter(cancellationParam);
         ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root); //using CSharp so the cancelletionToken doesn't get removed
-        Assert.False(method.Parameters.Any());
-        Assert.DoesNotContain(cancellationParam, method.Parameters);
+        Assert.True(method.Parameters.Any());
+        Assert.Contains(cancellationParam, method.Parameters);
+        Assert.Equal("ctx", cancellationParam.Name);
     }
     [Fact]
     public void ReplacesDateTimeOffsetByNativeType() {

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -642,7 +642,7 @@ public class GoLanguageRefinerTests {
         var childMethods = builder.Methods;
         Assert.DoesNotContain(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor)); // no executor overloads
         Assert.Contains(childMethods, x => x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 1);//body only
-        Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 3);// body + query + response handler
+        Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestExecutor) && x.Parameters.Count() == 2);// body + query
         Assert.Contains(childMethods, x => !x.IsOverload && x.IsOfKind(CodeMethodKind.RequestGenerator) && x.Parameters.Count() == 2);// body + query config
         Assert.Equal(3, childMethods.Count());
         Assert.Equal(1, childMethods.Count(x => x.IsOverload));

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -260,6 +260,19 @@ public class CodeMethodWriterTests : IDisposable {
         method.AddErrorMapping("5XX", new CodeType {Name = "Error5XX", TypeDefinition = error5XX});
         method.AddErrorMapping("403", new CodeType {Name = "Error403", TypeDefinition = error401});
         AddRequestBodyParameters();
+        method.AddParameter(new CodeParameter {
+            Name = "ctx",
+            Kind = CodeParameterKind.Cancellation,
+            Type = new CodeType {
+                Name = "context.Context",
+                TypeDefinition = new CodeClass {
+                    Name = "CancellationToken",
+                },
+                IsExternal = false,
+                IsNullable = false,
+            },
+            Optional = false,
+        });
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("requestInfo, err :=", result);

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -268,6 +268,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains($"\"5XX\": CreateError5XXFromDiscriminatorValue", result);
         Assert.Contains($"\"403\": CreateError403FromDiscriminatorValue", result);
         Assert.Contains("m.requestAdapter.SendAsync", result);
+        Assert.Contains("ctx context.Context,", result);
+        Assert.Contains("m.requestAdapter.SendAsync(ctx,", result);
         Assert.Contains("return res.(", result);
         Assert.Contains("err != nil", result);
         Assert.Contains("return nil, err", result);


### PR DESCRIPTION
Refactor to Pass a Context object to all executor methods in GO. Resolves : https://github.com/microsoftgraph/msgraph-sdk-go/issues/176
- This PR also removes method overloads for in GO sdk generation and only retains the primary HTTP executor method in the builder.

Example in Kiota-Sample OutPut  https://github.com/microsoft/kiota-samples/pull/950/

Output

```go
func (m *ServiceHealthIssueItemRequestBuilder) Delete(ctx context.Context, requestConfiguration *ServiceHealthIssueItemRequestBuilderDeleteRequestConfiguration)(error) {
    requestInfo, err := m.CreateDeleteRequestInformationWithRequestConfiguration(requestConfiguration);
    if err != nil {
        return err
    }
    errorMapping := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.ErrorMappings {
        "4XX": ia572726a95efa92ddd544552cd950653dc691023836923576b2f4bf716cf204a.CreateODataErrorFromDiscriminatorValue,
        "5XX": ia572726a95efa92ddd544552cd950653dc691023836923576b2f4bf716cf204a.CreateODataErrorFromDiscriminatorValue,
    }
    err = m.requestAdapter.SendNoContentAsync(ctx, requestInfo, errorMapping)
    if err != nil {
        return err
    }
    return nil
}
```


