### PR TITLE
[Dotnet] Fix for imports/usings reserved names replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed/fixed passing in the current instance to fields deserializers in Ruby. [#1663](https://github.com/microsoft/kiota/issues/1663)
 - Fix issue with duplicate variable declaration in command handlers (Shell)
 - Update namespace qualification algorithm (helps in resolving when a type name appears in multiple namespaces) to use case insensitive string comparison (CSharp).
+- Fix an issue where namespace reserved name replacement would not include replacing import names in the declared areas in CSharp. [#1799](https://github.com/microsoft/kiota/issues/1799)
 
 ## [0.4.0] - 2022-08-18
 

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -30,8 +30,9 @@ namespace Kiota.Builder.Refiners {
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
                 new HashSet<Type>{ typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum) }
             );
-            // Replace the reserved types
+            // Replace the reserved types and namespace segments
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
+            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Namespace");
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -32,7 +32,7 @@ namespace Kiota.Builder.Refiners {
             );
             // Replace the reserved types and namespace segments
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
-            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Namespace");
+            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), static x => $"{x}Namespace");
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -259,13 +259,13 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     {
         // replace the using namespace segment names that are internally defined by the generator
         currentDeclaration.Usings
-            .Where(codeUsing => codeUsing is { IsExternal: false })
-            .Select(codeUsing => new Tuple<CodeUsing, string[]>(codeUsing, codeUsing.Name.Split('.')))
+            .Where(static codeUsing => codeUsing is { IsExternal: false })
+            .Select(static codeUsing => new Tuple<CodeUsing, string[]>(codeUsing, codeUsing.Name.Split('.')))
             .Where(tuple => tuple.Item2.Any(x => provider.ReservedNames.Contains(x)))
             .ToList()
             .ForEach(tuple => {
                 tuple.Item1.Name = tuple.Item2.Select(x => provider.ReservedNames.Contains(x) ? replacement.Invoke(x) : x)
-                                              .Aggregate((x, y) => $"{x}.{y}");
+                                              .Aggregate(static (x, y) => $"{x}.{y}");
             });
     }
             

--- a/src/Kiota.Builder/Refiners/ShellRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ShellRefiner.cs
@@ -34,6 +34,7 @@ namespace Kiota.Builder.Refiners
             );
             // Replace the reserved types
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
+            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Namespace");
             AddParentClassToErrorClasses(
                 generatedCode,
                 "ApiException",

--- a/src/Kiota.Builder/Refiners/ShellRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ShellRefiner.cs
@@ -34,7 +34,7 @@ namespace Kiota.Builder.Refiners
             );
             // Replace the reserved types
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
-            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Namespace");
+            ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), static x => $"{x}Namespace");
             AddParentClassToErrorClasses(
                 generatedCode,
                 "ApiException",

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.Extensions;
@@ -101,10 +101,10 @@ namespace Kiota.Builder.Writers.CSharp {
                     var duplicateMappingTypes = discriminatorMethod.DiscriminatorMappings.Select(x => x.Value).OfType<CodeType>()
                         .Where(x => !DoesTypeExistsInSameNamesSpaceAsTarget(x, targetElement))
                         .Select(x => x.Name)
-                        .GroupBy(x => x)
+                        .GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
                         .Where(group => group.Count() > 1)
                         .Select(x => x.Key);
-                    
+
                     parentElements.AddRange(duplicateMappingTypes);
                 }
             }

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -101,7 +101,7 @@ namespace Kiota.Builder.Writers.CSharp {
                     var duplicateMappingTypes = discriminatorMethod.DiscriminatorMappings.Select(x => x.Value).OfType<CodeType>()
                         .Where(x => !DoesTypeExistsInSameNamesSpaceAsTarget(x, targetElement))
                         .Select(x => x.Name)
-                        .GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
+                        .GroupBy(static x => x, StringComparer.OrdinalIgnoreCase)
                         .Where(group => group.Count() > 1)
                         .Select(x => x.Key);
 


### PR DESCRIPTION
This PR closes #1799

It resolves compile issues after the introduction of the `Microsoft.Graph.IdentityGovernance` namespace to the beta metadata.
As the namespace introduces a `task` navigation property, it results to conflict between the generated namespace name and generated Types. 

Changes include: -
- Fixes an issue where if namespaces are renamed, the corresponding using statements referencing the namespaces were not renamed
- Adds the `ReplaceReservedNamespaceTypeNames` function to allow for namespaces to replaced with a different format than models as a namespace `Microsoft.Graph.IdentitityGovernance.TaskObject` conflict with trying to reference a type called `TaskObject` as the compiler would not know whether to reference the type or the Namespace. 

Generation run - https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=84434&view=results
V1 changes - https://github.com/microsoftgraph/msgraph-sdk-dotnet/commit/e317ddab1e37960892ca922e937e556e93cdc7d2
Beta changes - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/commit/0cdc5cb608844f7fe2889631f06ecf6467e10cba