### PR TITLE
Switch AddUsings condition to True for Java Generation

### DIFF
--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -65,7 +65,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         AddDiscriminatorMappingsUsingsToParentClasses(
             generatedCode,
             "ParseNode",
-            addUsings: false
+            addUsings: true
         );
     }
     private static void SetSetterParametersToNullable(CodeElement currentElement, params Tuple<CodeMethodKind, CodePropertyKind>[] accessorPairs) {


### PR DESCRIPTION
AddDiscriminatorMappingsUsingsToParentClasses has a parameter, 'AddUsings', which was previously set to false. This caused issues when mapping large quantities of entities in the Entity model class of the V1 and Beta SDK's, more specifically those within the sub-namespaces in the models package. By changing this condition we have added the appropriate import statements so that our generated SDK's will compile. 