### PR TITLE
Small Update to the Auth Package Hyperlink

### DIFF
--- a/docs/get-started/ruby.md
+++ b/docs/get-started/ruby.md
@@ -10,7 +10,7 @@ parent: Get started
 
 ## Intializing target project
 
-Before you can compile and run the target project, you will need to initialize it. After initializing the test project, you will need to add references to the [abstraction](https://github.com/microsoft/kiota/tree/main/abstractions/ruby/microsoft_kiota_abstractions), [authentication](https://github.com/microsoft/kiota/tree/main/authentication/ruby/azure), [http](https://github.com/microsoft/kiota/tree/main/http/ruby/nethttp/microsoft_kiota_nethttplibrary), and [serialization](https://github.com/microsoft/kiota/tree/main/serialization/ruby/json/microsoft_kiota_serialization) packages from the GitHub feed.
+Before you can compile and run the target project, you will need to initialize it. After initializing the test project, you will need to add references to the [abstraction](https://github.com/microsoft/kiota/tree/main/abstractions/ruby/microsoft_kiota_abstractions), [authentication](https://github.com/microsoft/kiota/tree/main/authentication/ruby/oauth/microsoft_kiota_authentication_oauth), [http](https://github.com/microsoft/kiota/tree/main/http/ruby/nethttp/microsoft_kiota_nethttplibrary), and [serialization](https://github.com/microsoft/kiota/tree/main/serialization/ruby/json/microsoft_kiota_serialization) packages from the GitHub feed.
 
 ### Getting access to the packages
 > **Note:** This is a temporary requirement while Kiota is in preview.


### PR DESCRIPTION
The auth package hyperlink is outdated, as it led to the previous auth folder. 
Also, the formatting on one of the blocks looked fine on GitHub, but weird on the website, so I tried to change the formatting a little, so it looks more normal on the website. 