### PR TITLE
Fix for parameter orders in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where Java would skip duplicated imports instead of deduplicating them.
 - Fixed a bug where Java would not convert date types for query parameters.
 - Fixed a bug where Java doc comments could contain invalid characters.
-
+- Fixed a bug where function parameters would be reodered incorrectly in dotnet[#1822](https://github.com/microsoft/kiota/issues/1822)
 
 ## [0.4.0] - 2022-08-18
 

--- a/src/Kiota.Builder/BaseCodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/BaseCodeParameterOrderComparer.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections.Generic;
 
 namespace Kiota.Builder;
-public class CodeParameterOrderComparer : IComparer<CodeParameter>
+public class BaseCodeParameterOrderComparer : IComparer<CodeParameter>
 {
     public int Compare(CodeParameter x, CodeParameter y)
     {
@@ -10,13 +11,12 @@ public class CodeParameterOrderComparer : IComparer<CodeParameter>
             (null, _) => -1,
             (_, null) => 1,
             _ => x.Optional.CompareTo(y.Optional) * optionalWeight +
-                 getKindOrderHint(x.Kind).CompareTo(getKindOrderHint(y.Kind)) * kindWeight +
+                 GetKindOrderHint(x.Kind).CompareTo(GetKindOrderHint(y.Kind)) * kindWeight +
                  x.Name.CompareTo(y.Name) * nameWeight,
         };
     }
-    private static int getKindOrderHint(CodeParameterKind kind) {
+    protected virtual int GetKindOrderHint(CodeParameterKind kind) {
         return kind switch {
-            CodeParameterKind.Cancellation => 0,
             CodeParameterKind.PathParameters => 1,
             CodeParameterKind.RawUrl => 2,
             CodeParameterKind.RequestAdapter => 3,

--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -137,7 +137,7 @@ public class CodeMethod : CodeTerminalWithKind<CodeMethodKind>, ICloneable, IDoc
     {
         parameters.Clear();
     }
-    private readonly CodeParameterOrderComparer parameterOrderComparer = new ();
+    private readonly BaseCodeParameterOrderComparer parameterOrderComparer = new ();
     public IEnumerable<CodeParameter> Parameters { get => parameters.Values.OrderBy(static x => x, parameterOrderComparer); }
     public bool IsStatic {get;set;} = false;
     public bool IsAsync {get;set;} = true;

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -534,7 +534,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             writer.WriteLine($"{conventions.DocCommentPrefix}</summary>");
         }
     }
-    private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+    private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
     private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool inherits, bool isVoid)
     {
         var staticModifier = code.IsStatic ? "static " : string.Empty;

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -333,7 +333,7 @@ namespace Kiota.Builder.Writers.Go {
             }
         }
         private static string errorVarDeclaration(bool shouldDeclareErrorVar) => shouldDeclareErrorVar ? ":" : string.Empty;
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+        private static readonly GoCodeParameterOrderComparer ParameterOrderComparer = new();
         
         private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool writePrototypeOnly) {
             var parentBlock = code.Parent;
@@ -350,7 +350,7 @@ namespace Kiota.Builder.Writers.Go {
             };
             if(!writePrototypeOnly)
                 WriteMethodDocumentation(code, methodName, writer);
-            var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p => conventions.GetParameterSignature(p, parentBlock)).ToList());
+            var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, ParameterOrderComparer).Select(p => conventions.GetParameterSignature(p, parentBlock)).ToList());
             var classType = conventions.GetTypeString(new CodeType { Name = parentBlock.Name, TypeDefinition = parentBlock }, parentBlock);
             var associatedTypePrefix = isConstructor ||code.IsStatic || writePrototypeOnly ? string.Empty : $"(m {classType}) ";
             var finalReturnType = isConstructor ? classType : $"{returnType}{returnTypeAsyncSuffix}";

--- a/src/Kiota.Builder/Writers/Go/GoCodeParameterOrderComparer.cs
+++ b/src/Kiota.Builder/Writers/Go/GoCodeParameterOrderComparer.cs
@@ -1,12 +1,14 @@
-namespace Kiota.Builder.Writers.Python;
-public class PythonCodeParameterOrderComparer : BaseCodeParameterOrderComparer
+﻿namespace Kiota.Builder.Writers.Go;
+
+public class GoCodeParameterOrderComparer : BaseCodeParameterOrderComparer
 {
-    // Non-default parameters must come before parameters with defaults in python.
+    // Cancellation/context parameters must come before other parameters with defaults in Golang.
     protected override int GetKindOrderHint(CodeParameterKind kind) {
         return kind switch {
-            CodeParameterKind.RequestAdapter => 1,
+            CodeParameterKind.Cancellation => 0,
+            CodeParameterKind.PathParameters => 1,
             CodeParameterKind.RawUrl => 2,
-            CodeParameterKind.PathParameters => 3,
+            CodeParameterKind.RequestAdapter => 3,
             CodeParameterKind.Path => 4,
             CodeParameterKind.RequestConfiguration => 5,
             CodeParameterKind.RequestBody => 6,

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -576,7 +576,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             dataToSerialize = $"this.{otherProp.Getter?.Name?.ToFirstCharacterLowerCase() ?? "get" + otherProp.Name.ToFirstCharacterUpperCase()}()";
         writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}({serializationKey}, {dataToSerialize});");
     }
-    private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+    private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
     private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType) {
         var accessModifier = conventions.GetAccessModifier(code.Access);
         var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -174,7 +174,7 @@ namespace Kiota.Builder.Writers.Php
             };
         }
         
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+        private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
         private void WriteMethodsAndParameters(CodeMethod codeMethod, LanguageWriter writer, IReadOnlyList<string> orNullReturn, bool isConstructor = false)
         {
             var methodParameters = string.Join(", ", codeMethod.Parameters

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -220,7 +220,7 @@ namespace Kiota.Builder.Writers.Ruby {
             if(additionalDataProperty != null)
                 writer.WriteLine($"writer.write_additional_data(@{additionalDataProperty.Name.ToSnakeCase()})");
         }
-        private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+        private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
         private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer) {
             var methodName = (code.Kind switch {
                 CodeMethodKind.Constructor or CodeMethodKind.ClientConstructor => $"initialize",

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -357,7 +357,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
             writer.WriteLine(localConventions.DocCommentEnd);
         }
     }
-    private static readonly CodeParameterOrderComparer parameterOrderComparer = new();
+    private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
     private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType, bool isVoid) {
         WriteMethodPrototypeInternal(code, writer, returnType, isVoid, localConventions, false);
     }

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeParameterOrderComparerTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeParameterOrderComparerTests.cs
@@ -71,13 +71,19 @@ namespace Kiota.Builder.Tests {
             Assert.Equal(-110, comparer.Compare(param1, param2));
             Assert.Equal(0, comparer.Compare(param2, param2));
         }
-        [Fact]
-        public void CancellationParameterIsBeforeRequestConfigurationForGolang() {
+        [Theory]
+        [InlineData(CodeParameterKind.Path)]
+        [InlineData(CodeParameterKind.RequestConfiguration)]
+        [InlineData(CodeParameterKind.Serializer)]
+        [InlineData(CodeParameterKind.SetterValue)]
+        [InlineData(CodeParameterKind.ParseNode)]
+        [InlineData(CodeParameterKind.Custom)]
+        public void CancellationParameterIsBeforeOthersForGolang(CodeParameterKind testKind) {
             var comparer = new GoCodeParameterOrderComparer();
             Assert.NotNull(comparer);
             var param1 =  new CodeParameter {
                 Name = "param1",
-                Kind = CodeParameterKind.RequestConfiguration,
+                Kind = testKind,
             };
             var param2 =  new CodeParameter {
                 Name = "param2",
@@ -85,8 +91,6 @@ namespace Kiota.Builder.Tests {
             };
             var parameters = new List<CodeParameter> { param1, param2 };
             Assert.Equal("param2",parameters.OrderBy(x => x, comparer).First().Name);
-            Assert.Equal(-90, comparer.Compare(param2, param1));
-            Assert.Equal(90, comparer.Compare(param1, param2));
             Assert.Equal(0, comparer.Compare(param2, param2));
         }
     }

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeParameterOrderComparerTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeParameterOrderComparerTests.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using Kiota.Builder.Writers.Go;
+using Kiota.Builder.Writers.Python;
 using Xunit;
 using Moq;
 
@@ -5,7 +9,7 @@ namespace Kiota.Builder.Tests {
     public class CodeParameterOrderComparerTests {
         [Fact]
         public void DefensiveProgramming() {
-            var comparer = new CodeParameterOrderComparer();
+            var comparer = new BaseCodeParameterOrderComparer();
             Assert.NotNull(comparer);
             var root = CodeNamespace.InitRootNamespace();
             var mockParameter = new Mock<CodeParameter>().Object;
@@ -27,6 +31,62 @@ namespace Kiota.Builder.Tests {
             };
             Assert.Equal(110, comparer.Compare(param2, param1));
             Assert.Equal(-110, comparer.Compare(param1, param2));
+            Assert.Equal(0, comparer.Compare(param2, param2));
+        }
+        [Fact]
+        public void CancellationParameterIsAfterRequestConfigurationByDefault() {
+            var comparer = new BaseCodeParameterOrderComparer();
+            Assert.NotNull(comparer);
+            var param1 =  new CodeParameter {
+                Name = "param1",
+                Kind = CodeParameterKind.RequestConfiguration,
+            };
+            var param2 =  new CodeParameter {
+                Name = "param2",
+                Kind = CodeParameterKind.Cancellation,
+            };
+            var parameters = new List<CodeParameter> { param1, param2 };
+            Assert.Equal("param1",parameters.OrderBy(x => x, comparer).First().Name);
+            Assert.Equal(110, comparer.Compare(param2, param1));
+            Assert.Equal(-110, comparer.Compare(param1, param2));
+            Assert.Equal(0, comparer.Compare(param2, param2));
+        }
+        [Fact]
+        public void CancellationParameterIsAfterRequestConfigurationByDefaultIfBothOptional() {
+            var comparer = new BaseCodeParameterOrderComparer();
+            Assert.NotNull(comparer);
+            var param1 =  new CodeParameter {
+                Name = "param1",
+                Kind = CodeParameterKind.RequestConfiguration,
+                Optional = true
+            };
+            var param2 =  new CodeParameter {
+                Name = "param2",
+                Kind = CodeParameterKind.Cancellation,
+                Optional = true
+            };
+            var parameters = new List<CodeParameter> { param1, param2 };
+            Assert.Equal("param1",parameters.OrderBy(x => x, comparer).First().Name);
+            Assert.Equal(110, comparer.Compare(param2, param1));
+            Assert.Equal(-110, comparer.Compare(param1, param2));
+            Assert.Equal(0, comparer.Compare(param2, param2));
+        }
+        [Fact]
+        public void CancellationParameterIsBeforeRequestConfigurationForGolang() {
+            var comparer = new GoCodeParameterOrderComparer();
+            Assert.NotNull(comparer);
+            var param1 =  new CodeParameter {
+                Name = "param1",
+                Kind = CodeParameterKind.RequestConfiguration,
+            };
+            var param2 =  new CodeParameter {
+                Name = "param2",
+                Kind = CodeParameterKind.Cancellation,
+            };
+            var parameters = new List<CodeParameter> { param1, param2 };
+            Assert.Equal("param2",parameters.OrderBy(x => x, comparer).First().Name);
+            Assert.Equal(-90, comparer.Compare(param2, param1));
+            Assert.Equal(90, comparer.Compare(param1, param2));
             Assert.Equal(0, comparer.Compare(param2, param2));
         }
     }


### PR DESCRIPTION
This PR closes #1822 

It fixes a bug where the parameter orders was changed placing the CancellationToken before the RequestConfiguration.

In summary, changes include:
- Renames `CodeParameterOrderComparer` to `BaseCodeParameterOrderComparer` to create a derived `GoCodeParameterOrderComparer` to allow Go to have custom order.
- Cleans up the `PythonCodeParameterOrderComparer` to also derived from the new `BaseCodeParameterOrderComparer`
- Adds test to validate the refactoring. 