### PR TITLE
Use property names of definition without modifying first character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where CSharp serialization/deserialization names for properties would always be lowercased. [#1830](https://github.com/microsoft/kiota/issues/1830)
+
 ## [0.5.1] - 2022-09-09
 
 ### Added

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -309,7 +309,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"{{\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type, codeElement)}; }} }},");
+            writer.WriteLine($"{{\"{otherProp.SerializationName ?? otherProp.Name}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type, codeElement)}; }} }},");
         }
         writer.CloseBlock("};");
     }
@@ -445,7 +445,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                                         .Where(static x => !x.ExistsInBaseType && !x.ReadOnly)
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}(\"{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
+            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}(\"{otherProp.SerializationName ?? otherProp.Name}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
         }
     }
     private void WriteSerializerBodyForUnionModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer)

--- a/tests/Kiota.Builder.IntegrationTests/ToDoApi.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/ToDoApi.yaml
@@ -65,3 +65,5 @@ components:
           type: string
         subject:
           type: string
+        Notes:
+          type: string

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -75,6 +75,12 @@ public class CodeMethodWriterTests : IDisposable {
         dummyProp.Type = new CodeType {
             Name = "string"
         };
+        var dummyUCaseProp = parentClass.AddProperty(new CodeProperty {
+            Name = "DummyUCaseProp",
+        }).First();
+        dummyUCaseProp.Type = new CodeType {
+            Name = "string"
+        };
         var dummyCollectionProp = parentClass.AddProperty(new CodeProperty {
             Name = "dummyColl",
         }).First();
@@ -758,6 +764,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("GetCollectionOfObjectValues", result);
         Assert.Contains("GetEnumValue", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("{\"DummyUCaseProp", result);
+        Assert.Contains("{\"dummyProp", result);
     }
     [Fact]
     public void WritesInheritedSerializerBody() {
@@ -842,6 +850,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("WriteCollectionOfObjectValues", result);
         Assert.Contains("WriteEnumValue", result);
         Assert.Contains("WriteAdditionalData(additionalData);", result);
+        Assert.Contains("WriteStringValue(\"dummyProp\"", result);
+        Assert.Contains("WriteStringValue(\"DummyUCaseProp\"", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
     }


### PR DESCRIPTION
Do not lowercase first letter of property name for serialization and deserialization.

Reference issue [#1830](https://github.com/microsoft/kiota/issues/1830)