### PR TITLE
Fixes incorrect schema selection when calling `GetDiscriminatorMappings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where CSharp serialization/deserialization names for properties would always be lowercased. [#1830](https://github.com/microsoft/kiota/issues/1830)
+- Fixed a regression where the incorrect schema would be selected in an AllOf collection to generate incorrect type inheritance
 
 ## [0.5.1] - 2022-09-09
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1071,7 +1071,8 @@ public class KiotaBuilder
                 return schema.OneOf.SelectMany(x => GetDiscriminatorMappings(currentNode, x, currentNamespace, baseClass));
             else if (schema.AnyOf.Any())
                 return schema.AnyOf.SelectMany(x => GetDiscriminatorMappings(currentNode, x, currentNamespace, baseClass));
-            else if (schema.AllOf.Any(allOfEvaluatorForMappings))
+            else if (schema.AllOf.Any(allOfEvaluatorForMappings) && schema.AllOf.Last().Equals(schema.AllOf.Last(allOfEvaluatorForMappings)))
+                // ensure the matched AllOf entry is the last in the list
                 return GetDiscriminatorMappings(currentNode, schema.AllOf.Last(allOfEvaluatorForMappings), currentNamespace, baseClass);
             else if (!string.IsNullOrEmpty(schema.Reference?.Id)) {
                 var result = GetAllInheritanceSchemaReferences(schema.Reference?.Id)


### PR DESCRIPTION
This PR fixes a regression at https://github.com/microsoft/kiota/blob/31c07999b03055071664d38f75aca60b81a6e068/src/Kiota.Builder/KiotaBuilder.cs#L1074

In the event an`AllOf` collection has 2 items where the first item matches the `allOfEvaluatorForMappings` criteria but the second/last does not, the first item is the schema passed to the recursive call leading to potential corruption of the codeDom(as the derived class/schema is ignored/left out).

This PR therefore adds a check to verify the last item is indeed the one being matched so that the other branches maybe used to correctly evaluate the scenario described above.
This is because it would be appropriate to either use the Schema Reference of the parent schema containing the `AllOf` collection if present or simply return an empty collection for the discriminator mapping as the last Item in the `AllOf` does not have any discriminator mapping.

A test covering this scenario has been added to validate this and successful run for the generation pipeline can be found at 
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=85782&view=logs&j=09be00da-8404-5a6e-d496-3b97eba1ba4f&t=8df1ae88-b8fc-5f10-3e45-77a7724c8a3f