### PR TITLE
Fix for Enum collections types described as string collections 

### DIFF
--- a/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
@@ -70,6 +70,14 @@ namespace Kiota.Builder.Extensions {
         {
             return schema?.OneOf?.Count(IsSemanticallyMeaningful) > 1;
         }
+        public static bool IsEnum(this OpenApiSchema schema)
+        {
+            return schema?.Enum?.Any() ?? false;
+        }
+        public static bool IsComposedEnum(this OpenApiSchema schema)
+        {
+            return ((schema.IsAnyOf() && schema.AnyOf.Any(x => x.IsEnum())) || (schema.IsOneOf() && schema.OneOf.Any(x => x.IsEnum())));
+        }
         private static bool IsSemanticallyMeaningful(this OpenApiSchema schema)
         {
             return schema.Properties.Any() || schema.Items != null || !string.IsNullOrEmpty(schema.Type) || !string.IsNullOrEmpty(schema.Format) || !string.IsNullOrEmpty(schema.Reference?.Id);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -980,7 +980,10 @@ public class KiotaBuilder
     private CodeTypeBase CreateCollectionModelDeclaration(OpenApiUrlTreeNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeNamespace codeNamespace, string typeNameForInlineSchema, bool isRequestBody)
     {
         CodeTypeBase type = GetPrimitiveType(schema?.Items, string.Empty);
-        if (string.IsNullOrEmpty(type?.Name))
+        bool isEnumCollectionType =    (schema?.Items.Enum.Any() ?? false) //the collection could be an enum type so override with strong type instead of string type.
+                                    || ((schema?.Items.IsAnyOf() ?? false) || (schema?.Items.IsOneOf() ?? false)) && string.IsNullOrEmpty(schema?.Items.Format);//the collection could be a composed type with an enum type so override with strong type instead of string type.
+        if (   string.IsNullOrEmpty(type?.Name) 
+               || isEnumCollectionType)
         {
             var targetNamespace = schema?.Items == null ? codeNamespace : GetShortestNamespace(codeNamespace, schema.Items);
             type = CreateModelDeclarations(currentNode, schema?.Items, operation, targetNamespace, default , typeNameForInlineSchema: typeNameForInlineSchema, isRequestBody: isRequestBody);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -602,7 +602,7 @@ public class KiotaBuilder
         var typeName = typeNames.FirstOrDefault(static x => !string.IsNullOrEmpty(x) && !typeNamesToSkip.Contains(x));
         
         var isExternal = false;
-        if (typeSchema?.Items?.Enum?.Any() ?? false)
+        if (typeSchema?.Items?.IsEnum() ?? false)
             typeName = childType;
         else {
             var format = typeSchema?.Format ?? typeSchema?.Items?.Format;
@@ -961,7 +961,7 @@ public class KiotaBuilder
             return CreateComposedModelDeclaration(currentNode, schema, operation, suffix, codeNamespace, isRequestBody);
         }
 
-        if(schema.IsObject() || schema.Properties.Any() || schema.Enum.Any() || !string.IsNullOrEmpty(schema.AdditionalProperties?.Type)) {
+        if(schema.IsObject() || schema.Properties.Any() || schema.IsEnum() || !string.IsNullOrEmpty(schema.AdditionalProperties?.Type)) {
             // no inheritance or union type, often empty definitions with only additional properties are used as property bags.
             return CreateModelDeclarationAndType(currentNode, schema, operation, codeNamespace, suffix, response: responseValue, typeNameForInlineSchema: typeNameForInlineSchema, isRequestBody);
         }
@@ -980,10 +980,10 @@ public class KiotaBuilder
     private CodeTypeBase CreateCollectionModelDeclaration(OpenApiUrlTreeNode currentNode, OpenApiSchema schema, OpenApiOperation operation, CodeNamespace codeNamespace, string typeNameForInlineSchema, bool isRequestBody)
     {
         CodeTypeBase type = GetPrimitiveType(schema?.Items, string.Empty);
-        bool isEnumCollectionType =    (schema?.Items.Enum.Any() ?? false) //the collection could be an enum type so override with strong type instead of string type.
-                                    || ((schema?.Items.IsAnyOf() ?? false) || (schema?.Items.IsOneOf() ?? false)) && string.IsNullOrEmpty(schema?.Items.Format);//the collection could be a composed type with an enum type so override with strong type instead of string type.
+        bool isEnumOrComposedCollectionType =    (schema?.Items.IsEnum() ?? false) //the collection could be an enum type so override with strong type instead of string type.
+                                    || ((schema?.Items.IsComposedEnum() ?? false) && string.IsNullOrEmpty(schema?.Items.Format));//the collection could be a composed type with an enum type so override with strong type instead of string type.
         if (   string.IsNullOrEmpty(type?.Name) 
-               || isEnumCollectionType)
+               || isEnumOrComposedCollectionType)
         {
             var targetNamespace = schema?.Items == null ? codeNamespace : GetShortestNamespace(codeNamespace, schema.Items);
             type = CreateModelDeclarations(currentNode, schema?.Items, operation, targetNamespace, default , typeNameForInlineSchema: typeNameForInlineSchema, isRequestBody: isRequestBody);
@@ -1005,7 +1005,7 @@ public class KiotaBuilder
         var existingDeclaration = GetExistingDeclaration(currentNamespace, currentNode, declarationName);
         if(existingDeclaration == null) // we can find it in the components
         {
-            if(schema.Enum.Any()) {
+            if(schema.IsEnum()) {
                 var newEnum = new CodeEnum { 
                     Name = declarationName,//TODO set the flag property
                     Description = currentNode.GetPathItemDescription(Constants.DefaultOpenApiLabel),

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -324,8 +324,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                 var collectionMethod = propType.IsArray ? "?.ToArray()" : "?.ToList()";
                 if (currentType.TypeDefinition == null)
                     return $"GetCollectionOfPrimitiveValues<{propertyType}>(){collectionMethod}";
-                else if (currentType.TypeDefinition is CodeEnum enumType)
-                    return $"GetCollectionOfEnumValues<{enumType.Name.ToFirstCharacterUpperCase()}>(){collectionMethod}";
+                else if (currentType.TypeDefinition is CodeEnum)
+                    return $"GetCollectionOfEnumValues<{propertyType.TrimEnd('?')}>(){collectionMethod}";
                 else
                     return $"GetCollectionOfObjectValues<{propertyType}>({propertyType}.CreateFromDiscriminatorValue){collectionMethod}";
             } else if (currentType.TypeDefinition is CodeEnum enumType)
@@ -567,8 +567,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             if (isCollection)
                 if (currentType.TypeDefinition == null)
                     return $"WriteCollectionOfPrimitiveValues<{propertyType}>";
-                else if (currentType.TypeDefinition is CodeEnum enumType)
-                    return $"WriteCollectionOfEnumValues<{enumType.Name.ToFirstCharacterUpperCase()}>";
+                else if (currentType.TypeDefinition is CodeEnum)
+                    return $"WriteCollectionOfEnumValues<{propertyType.TrimEnd('?')}>";
                 else
                     return $"WriteCollectionOfObjectValues<{propertyType}>";
             else if (currentType.TypeDefinition is CodeEnum enumType)


### PR DESCRIPTION
This PR closes #1845 

It fixes a bug where a property that is a collection of an Enum would be incorrectly evaluated to the `string` type in the CodeDom. 
This led to some missing models (as the enum would potentially not be referenced) as well as models having the `List<string>` leading to loss of the strongly typed enum.

In summary the changes include: -
- Update the `CreateCollectionModelDeclaration` to check if the schema contains an `Enum` to allow the `CreateModelDeclarations` method to do its job.
- Add tests to validate the scenarios

Generation changes can be viewed at the links below.
- https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/commit/9ef8f0c4de1fb5a932350a0c381472e64a7f9d60
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/commit/a1be18b674111c36d39047d6c9005103f6bab83d