### PR TITLE
Generate go de-serializers with generic helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a regression where the incorrect schema would be selected in an AllOf collection to generate incorrect type inheritance.
 - Fixed a bug where discriminator information could contain non-derived types. [#1833](https://github.com/microsoft/kiota/issues/1833)
 - Fixes a bug where mapping value would be missing from factories. [#1833](https://github.com/microsoft/kiota/issues/1833)
+- Update go serializers and deserializers to use abstractions utils
 
 ## [0.5.1] - 2022-09-09
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -266,7 +266,7 @@ public class GoRefiner : CommonLanguageRefiner
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer),
-            "github.com/microsoftgraph/msgraph-sdk-go-core", "*core"),
+            "github.com/microsoft/kiota-abstractions-go", ""),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&
                         method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) && 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -267,7 +267,7 @@ public class GoRefiner : CommonLanguageRefiner
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer)
-            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType).Any(),
+            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Any(static x => !x.ExistsInBaseType),
             "github.com/microsoft/kiota-abstractions-go", ""),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
+using Kiota.Builder.Writers;
 using Kiota.Builder.Writers.Go;
 
 namespace Kiota.Builder.Refiners;
@@ -265,8 +266,9 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota-abstractions-go/serialization", "ParseNode", "Parsable"),
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
-        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer),
-            "github.com/microsoft/kiota-abstractions-go", ""),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer)
+            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType).Any(),
+            "github.com/microsoft/kiota-abstractions-go", "*utils"),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&
                         method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) && 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -268,7 +268,7 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer)
             && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType).Any(),
-            "github.com/microsoft/kiota-abstractions-go", "*utils"),
+            "github.com/microsoft/kiota-abstractions-go", ""),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&
                         method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) && 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -265,6 +265,8 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota-abstractions-go/serialization", "ParseNode", "Parsable"),
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer),
+            "github.com/microsoftgraph/msgraph-sdk-go-core", "*core"),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&
                         method.Parameters.Any(x => x.IsOfKind(CodeParameterKind.RequestBody) && 

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -572,7 +572,7 @@ namespace Kiota.Builder.Writers.Go {
             };
 
             var methodFactory = string.IsNullOrEmpty(sourceArgument) ? string.Empty : $"{sourceArgument} , ";
-            writer.WriteLine($"res[\"{property.SerializationName ?? property.Name.ToFirstCharacterLowerCase()}\"] = utils.{utilitySetter}({methodFactory}m.{property.Setter.Name.ToFirstCharacterUpperCase()})");
+            writer.WriteLine($"res[\"{property.SerializationName ?? property.Name.ToFirstCharacterLowerCase()}\"] = {conventions.AbstractionsHash}.{utilitySetter}({methodFactory}m.{property.Setter.Name.ToFirstCharacterUpperCase()})");
         }
 
         private string getSerializerTypeName(CodeProperty property) {
@@ -585,9 +585,9 @@ namespace Kiota.Builder.Writers.Go {
         
         private static string GetTypeAssertion(string originalReference, string typeImportName, string assignVarName = default, string statusVarName = default) =>
             $"{assignVarName}{(!string.IsNullOrEmpty(statusVarName) && !string.IsNullOrEmpty(assignVarName) ? ", ": string.Empty)}{statusVarName}{(string.IsNullOrEmpty(statusVarName) && string.IsNullOrEmpty(assignVarName) ? string.Empty : " := ")}{originalReference}.({typeImportName})";
-        private static void WriteCollectionCast(string propertyTypeImportName, string sourceVarName, string targetVarName, LanguageWriter writer, string pointerSymbol = "*", bool dereference = true) {
+        private void WriteCollectionCast(string propertyTypeImportName, string sourceVarName, string targetVarName, LanguageWriter writer, string pointerSymbol = "*", bool dereference = true) {
             var castFunc = dereference ? "CollectionValueCast" : "CollectionCast";
-            writer.WriteLine($"{targetVarName} := utils.{castFunc}[{propertyTypeImportName}]({sourceVarName})");
+            writer.WriteLine($"{targetVarName} := {conventions.AbstractionsHash}.{castFunc}[{propertyTypeImportName}]({sourceVarName})");
         }
         private static string getSendMethodName(string returnType, CodeMethod codeElement, bool isPrimitive, bool isBinary, bool isEnum) {
             return returnType switch {
@@ -826,7 +826,7 @@ namespace Kiota.Builder.Writers.Go {
                 var parsableSymbol = GetConversionHelperMethodImport(parentBlock, "Parsable");
 
                 var collectionUtilityFunc = isInterface ? "CollectionCast" : "CollectionStructCast";
-                writer.WriteLines($"cast := utils.{collectionUtilityFunc}[{parsableSymbol}]({valueGet})");
+                writer.WriteLines($"cast := {conventions.AbstractionsHash}.{collectionUtilityFunc}[{parsableSymbol}]({valueGet})");
             }
             var collectionPrefix = propType.IsCollection ? "CollectionOf" : string.Empty;
             var collectionSuffix = propType.IsCollection ? "s" : string.Empty;

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -574,7 +574,7 @@ namespace Kiota.Builder.Writers.Go {
             };
 
             var methodFactory = sourceArgument == String.Empty ? "" : $", {sourceArgument} ";
-            writer.WriteLine($"return core.{utilitySetter}(n.{sourceName} {methodFactory}, m.{property.Setter.Name.ToFirstCharacterUpperCase()})");
+            writer.WriteLine($"return {conventions.AbstractionsHash}.{utilitySetter}(n.{sourceName} {methodFactory}, m.{property.Setter.Name.ToFirstCharacterUpperCase()})");
             writer.CloseBlock();
         }
         

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -42,7 +42,7 @@ public class GoConventionService : CommonLanguageConventionService
     }
     public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true, LanguageWriter writer = null) =>
         GetTypeString(code, targetElement, includeCollectionInformation, true);
-    public string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation, bool addPointerSymbol)
+    public string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation, bool addPointerSymbol, bool includeImportSymbol = true)
     {
         if(code is CodeComposedTypeBase) 
             throw new InvalidOperationException($"Go does not support union types, the union type {code.Name} should have been filtered out by the refiner");
@@ -50,7 +50,7 @@ public class GoConventionService : CommonLanguageConventionService
             var importSymbol = GetImportSymbol(code, targetElement);
             if(!string.IsNullOrEmpty(importSymbol))
                 importSymbol += ".";
-            var typeName = TranslateType(currentType, true);
+            var typeName = TranslateType(currentType, includeImportSymbol);
             var nullableSymbol = addPointerSymbol && 
                                  currentType.IsNullable &&
                                  currentType.TypeDefinition is not CodeInterface &&

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -932,10 +932,10 @@ public class CodeMethodWriterTests : IDisposable {
         AddSerializationProperties();
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains("GetStringValue", result);
-        Assert.Contains("GetCollectionOfPrimitiveValues", result);
-        Assert.Contains("GetCollectionOfObjectValues", result);
-        Assert.Contains("GetEnumValue", result);
+        Assert.Contains("SetCollectionOfPrimitiveValues(\"string\" , m.SetDummyColl)", result);
+        Assert.Contains("SetCollectionOfObjectValues(CreateComplexFromDiscriminatorValue , m.SetDummyComplexColl)", result);
+        Assert.Contains("SetEnumValue(ParseSomeEnum , m.SetDummyEnumCollection)", result);
+        Assert.Contains("SetStringValue(m.SetDummyProp)", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
     }

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -563,7 +563,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("m.requestAdapter.SendEnumCollectionAsync", result);
         Assert.Contains("ParseSomeEnum", result);
         Assert.DoesNotContain("val[i] = *(v.(*SomeEnum))", result);
-        Assert.Contains("val := utils.CollectionCast[SomeEnum](res)", result);
+        Assert.Contains("val := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.CollectionCast[SomeEnum](res)", result);
         Assert.Contains("return nil, err", result);
         Assert.DoesNotContain("if res == nil", result);
         Assert.DoesNotContain("return nil, nil", result);
@@ -612,7 +612,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("if val, err := parseNode.GetStringValue(); val != nil {", result);
         Assert.Contains("result.SetStringValue(val)", result);
         Assert.Contains("else if val, err := parseNode.GetCollectionOfObjectValues(CreateComplexType2FromDiscriminatorValue); val != nil {", result);
-        Assert.Contains("cast := utils.CollectionValueCast[ComplexType2](val)", result);
+        Assert.Contains("cast := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.CollectionValueCast[ComplexType2](val)", result);
         Assert.DoesNotContain("for i, v := range val", result);
         Assert.Contains("result.SetComplexType2Value(cast)", result);
         Assert.Contains("return result, nil", result);
@@ -657,7 +657,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("if val, err := parseNode.GetStringValue(); val != nil {", result);
         Assert.Contains("result.SetStringValue(val)", result);
         Assert.Contains("else if val, err := parseNode.GetCollectionOfObjectValues(CreateComplexType2FromDiscriminatorValue); val != nil {", result);
-        Assert.Contains("cast := utils.CollectionValueCast[ComplexType2](val)", result);
+        Assert.Contains("cast := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.CollectionValueCast[ComplexType2](val)", result);
         Assert.DoesNotContain("for i, v := range val", result);
         Assert.Contains("result.SetComplexType2Value(cast)", result);
         Assert.Contains("return result, nil", result);

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -563,7 +563,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("m.requestAdapter.SendEnumCollectionAsync", result);
         Assert.Contains("ParseSomeEnum", result);
         Assert.DoesNotContain("val[i] = *(v.(*SomeEnum))", result);
-        Assert.Contains("val[i] = v.(SomeEnum)", result);
+        Assert.Contains("val := utils.CollectionCast[SomeEnum](res)", result);
         Assert.Contains("return nil, err", result);
         Assert.DoesNotContain("if res == nil", result);
         Assert.DoesNotContain("return nil, nil", result);
@@ -612,9 +612,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("if val, err := parseNode.GetStringValue(); val != nil {", result);
         Assert.Contains("result.SetStringValue(val)", result);
         Assert.Contains("else if val, err := parseNode.GetCollectionOfObjectValues(CreateComplexType2FromDiscriminatorValue); val != nil {", result);
-        Assert.Contains("cast := make([]ComplexType2, len(val))", result);
-        Assert.Contains("for i, v := range val", result);
-        Assert.Contains("cast[i] = *(v.(*ComplexType2))", result);
+        Assert.Contains("cast := utils.CollectionValueCast[ComplexType2](val)", result);
+        Assert.DoesNotContain("for i, v := range val", result);
         Assert.Contains("result.SetComplexType2Value(cast)", result);
         Assert.Contains("return result, nil", result);
         Assert.DoesNotContain("return NewUnionTypeWrapper(), nil", result);
@@ -658,9 +657,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("if val, err := parseNode.GetStringValue(); val != nil {", result);
         Assert.Contains("result.SetStringValue(val)", result);
         Assert.Contains("else if val, err := parseNode.GetCollectionOfObjectValues(CreateComplexType2FromDiscriminatorValue); val != nil {", result);
-        Assert.Contains("cast := make([]ComplexType2, len(val))", result);
-        Assert.Contains("for i, v := range val", result);
-        Assert.Contains("cast[i] = *(v.(*ComplexType2))", result);
+        Assert.Contains("cast := utils.CollectionValueCast[ComplexType2](val)", result);
+        Assert.DoesNotContain("for i, v := range val", result);
         Assert.Contains("result.SetComplexType2Value(cast)", result);
         Assert.Contains("return result, nil", result);
         Assert.DoesNotContain("return NewIntersectionTypeWrapper(), nil", result);


### PR DESCRIPTION
Utilizes generic helper methods introduced in https://github.com/microsoftgraph/msgraph-sdk-go-core/pull/126

Reduces code generated for methods that can use utility  generic methods 

Sample PR with the generated code https://github.com/microsoft/kiota-samples/pull/1045