### PR TITLE
bugfix/generation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the ability to cancel the refinement process.
 - Added Java 8 generation support.
 
 ### Changed
 
+- Fixed a bug where OData primitive types would result in composed types.
+- Fixed a concurrency issue with imports management.
 - Fixed a bug where Java request options type could conflict with generated types.
 - Fixed a bug where CSharp serialization/deserialization names for properties would always be lowercased. [#1830](https://github.com/microsoft/kiota/issues/1830)
 - Fixed a regression where the incorrect schema would be selected in an AllOf collection to generate incorrect type inheritance.

--- a/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
@@ -70,13 +70,31 @@ namespace Kiota.Builder.Extensions {
         {
             return schema?.OneOf?.Count(IsSemanticallyMeaningful) > 1;
         }
+        private static readonly HashSet<string> oDataTypes = new() {
+            "number",
+            "integer",
+        };
+        public static bool IsODataPrimitiveType(this OpenApiSchema schema)
+        {
+            return schema.IsOneOf() &&
+                    schema.OneOf.Count == 3 &&
+                    schema.OneOf.Count(static x => x.Enum?.Any() ?? false) == 1 &&
+                    schema.OneOf.Count(static x => oDataTypes.Contains(x.Type)) == 1 &&
+                    schema.OneOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase)) == 1
+                    ||
+                schema.IsAnyOf() &&
+                    schema.AnyOf.Count == 3 &&
+                    schema.AnyOf.Count(static x => x.Enum?.Any() ?? false) == 1 &&
+                    schema.AnyOf.Count(static x => oDataTypes.Contains(x.Type)) == 1 &&
+                    schema.AnyOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase)) == 1;
+        }
         public static bool IsEnum(this OpenApiSchema schema)
         {
             return schema?.Enum?.Any() ?? false;
         }
         public static bool IsComposedEnum(this OpenApiSchema schema)
         {
-            return ((schema.IsAnyOf() && schema.AnyOf.Any(x => x.IsEnum())) || (schema.IsOneOf() && schema.OneOf.Any(x => x.IsEnum())));
+            return (schema.IsAnyOf() && schema.AnyOf.Any(x => x.IsEnum())) || (schema.IsOneOf() && schema.OneOf.Any(x => x.IsEnum()));
         }
         private static bool IsSemanticallyMeaningful(this OpenApiSchema schema)
         {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -89,7 +89,7 @@ public class KiotaBuilder
 
         // Step 5 - RefineByLanguage
         sw.Start();
-        ApplyLanguageRefinement(config, generatedCode);
+        await ApplyLanguageRefinement(config, generatedCode, cancellationToken);
         StopLogAndReset(sw, "step 5 - refine by language - took");
 
         // Step 6 - Write language source 
@@ -254,12 +254,13 @@ public class KiotaBuilder
     /// </summary>
     /// <param name="config"></param>
     /// <param name="generatedCode"></param>
-    public void ApplyLanguageRefinement(GenerationConfiguration config, CodeNamespace generatedCode)
+    /// <param name="token"></param>
+    public async Task ApplyLanguageRefinement(GenerationConfiguration config, CodeNamespace generatedCode, CancellationToken token)
     {
         var stopwatch = new Stopwatch();
         stopwatch.Start();
 
-        ILanguageRefiner.Refine(config, generatedCode);
+        await ILanguageRefiner.Refine(config, generatedCode, token);
 
         stopwatch.Stop();
         logger.LogDebug("{timestamp}ms: Language refinement applied", stopwatch.ElapsedMilliseconds);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -958,7 +958,8 @@ public class KiotaBuilder
             return CreateInheritedModelDeclaration(currentNode, schema, operation, suffix, codeNamespace, isRequestBody);
         }
 
-        if((schema.IsAnyOf() || schema.IsOneOf()) && string.IsNullOrEmpty(schema.Format)) {
+        if((schema.IsAnyOf() || schema.IsOneOf()) && string.IsNullOrEmpty(schema.Format) 
+            && !schema.IsODataPrimitiveType()) { // OData types are oneOf string, type + format, enum
             return CreateComposedModelDeclaration(currentNode, schema, operation, suffix, codeNamespace, isRequestBody);
         }
 

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -1,44 +1,51 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
-namespace Kiota.Builder.Refiners {
-    public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
+namespace Kiota.Builder.Refiners;
+public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
+{
+    public CSharpRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        public CSharpRefiner(GenerationConfiguration configuration) : base(configuration) {}
-        public override void Refine(CodeNamespace generatedCode)
-        {
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore
             );
+            cancellationToken.ThrowIfCancellationRequested();
             AddRawUrlConstructorOverload(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
             AddAsyncSuffix(generatedCode);
             AddInnerClasses(generatedCode, false, string.Empty);
+            cancellationToken.ThrowIfCancellationRequested();
             AddParsableImplementsForModelClasses(generatedCode, "IParsable");
             CapitalizeNamespacesFirstLetters(generatedCode);
             ReplaceBinaryByNativeType(generatedCode, "Stream", "System.IO");
             MakeEnumPropertiesNullable(generatedCode);
             /* Exclude the following as their names will be capitalized making the change unnecessary in this case sensitive language
-             * code classes, class declarations, property names, using declarations, namespace names
-             * Exclude CodeMethod as the return type will also be capitalized (excluding the CodeType is not enough since this is evaluated at the code method level)
+                * code classes, class declarations, property names, using declarations, namespace names
+                * Exclude CodeMethod as the return type will also be capitalized (excluding the CodeType is not enough since this is evaluated at the code method level)
             */
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
                 new HashSet<Type>{ typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum) }
             );
+            cancellationToken.ThrowIfCancellationRequested();
             // Replace the reserved types and namespace segments
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
             ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), static x => $"{x}Namespace");
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
+            cancellationToken.ThrowIfCancellationRequested();
             AddSerializationModulesImport(generatedCode);
             AddParentClassToErrorClasses(
                 generatedCode,
@@ -49,118 +56,118 @@ namespace Kiota.Builder.Refiners {
                 generatedCode,
                 "IParseNode"
             );
-        }
-        protected static void DisambiguatePropertiesWithClassNames(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass) {
-                var sameNameProperty = currentClass.Properties
-                                                .FirstOrDefault(x => x.Name.Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase));
-                if(sameNameProperty != null) {
-                    currentClass.RemoveChildElement(sameNameProperty);
-                    sameNameProperty.SerializationName ??= sameNameProperty.Name;
-                    sameNameProperty.Name = $"{sameNameProperty.Name}_prop";
-                    currentClass.AddProperty(sameNameProperty);
-                }
-            }
-            CrawlTree(currentElement, DisambiguatePropertiesWithClassNames);
-        }
-        protected static void MakeEnumPropertiesNullable(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model))
-                currentClass.Properties
-                            .Where(x => x.Type is CodeType propType && propType.TypeDefinition is CodeEnum)
-                            .ToList()
-                            .ForEach(x => x.Type.IsNullable = true);
-            CrawlTree(currentElement, MakeEnumPropertiesNullable);
-        }
-        
-        protected static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
-            new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "Microsoft.Kiota.Abstractions", "IRequestAdapter"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "Microsoft.Kiota.Abstractions", "Method", "RequestInformation", "IRequestOption"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "Microsoft.Kiota.Abstractions", "IResponseHandler"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "Microsoft.Kiota.Abstractions.Serialization", "ISerializationWriter"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "Microsoft.Kiota.Abstractions.Serialization", "IParseNode"),
-            new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
-                "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
-            new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
-                "Microsoft.Kiota.Abstractions.Serialization", "IAdditionalDataHolder"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
-            new (static x => x is CodeClass || x is CodeEnum,
-                "System", "String"),
-            new (static x => x is CodeClass,
-                "System.Collections.Generic", "List", "Dictionary"),
-            new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
-                "System.IO", "Stream"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "System.Threading", "CancellationToken"),
-            new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "System.Threading.Tasks", "Task"),
-            new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
-                "System.Linq", "Enumerable"),
-            new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                        method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
-                "Microsoft.Kiota.Abstractions.Store",  "IBackingStoreFactory", "IBackingStoreFactorySingleton"),
-            new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
-                "Microsoft.Kiota.Abstractions.Store",  "IBackingStore", "IBackedModel", "BackingStoreFactorySingleton" ),
-            new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(prop.SerializationName),
-                "Microsoft.Kiota.Abstractions", "QueryParameterAttribute"),
-            new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal) && intersectionType.DiscriminatorInformation.HasBasicDiscriminatorInformation,
-                "Microsoft.Kiota.Abstractions.Serialization", "ParseNodeHelper"),
-        };
-        protected static void CapitalizeNamespacesFirstLetters(CodeElement current) {
-            if(current is CodeNamespace currentNamespace)
-                currentNamespace.Name = currentNamespace.Name?.Split('.')?.Select(x => x.ToFirstCharacterUpperCase())?.Aggregate((x, y) => $"{x}.{y}");
-            CrawlTree(current, CapitalizeNamespacesFirstLetters);
-        }
-        protected static void AddAsyncSuffix(CodeElement currentElement) {
-            if(currentElement is CodeMethod currentMethod && currentMethod.IsAsync)
-                currentMethod.Name += "Async";
-            CrawlTree(currentElement, AddAsyncSuffix);
-        }
-        protected static void CorrectPropertyType(CodeProperty currentProperty)
-        {
-            if(currentProperty.IsOfKind(CodePropertyKind.Options))
-                currentProperty.DefaultValue = "new List<IRequestOption>()";
-            else if(currentProperty.IsOfKind(CodePropertyKind.Headers))
-                currentProperty.DefaultValue = "new Dictionary<string, string>()";
-            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
-        }
-        protected static void CorrectMethodType(CodeMethod currentMethod)
-        {
-            CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
-                                                    .Select(x => x.Type)
-                                                    .Union(new[] { currentMethod.ReturnType })
-                                                    .ToArray());
-        }
-
-        private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
-        {
-            {
-                "DateOnly",("Date", new CodeUsing
-                    {
-                        Name = "Date",
-                        Declaration = new CodeType
-                        {
-                            Name = "Microsoft.Kiota.Abstractions",
-                            IsExternal = true,
-                        },
-                    })
-            },
-            {
-                "TimeOnly",("Time", new CodeUsing
-                    {
-                        Name = "Time",
-                        Declaration = new CodeType
-                        {
-                            Name = "Microsoft.Kiota.Abstractions",
-                            IsExternal = true,
-                        },
-                    })
-            },
-        };
+        }, cancellationToken);
     }
+    protected static void DisambiguatePropertiesWithClassNames(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass) {
+            var sameNameProperty = currentClass.Properties
+                                            .FirstOrDefault(x => x.Name.Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase));
+            if(sameNameProperty != null) {
+                currentClass.RemoveChildElement(sameNameProperty);
+                sameNameProperty.SerializationName ??= sameNameProperty.Name;
+                sameNameProperty.Name = $"{sameNameProperty.Name}_prop";
+                currentClass.AddProperty(sameNameProperty);
+            }
+        }
+        CrawlTree(currentElement, DisambiguatePropertiesWithClassNames);
+    }
+    protected static void MakeEnumPropertiesNullable(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model))
+            currentClass.Properties
+                        .Where(x => x.Type is CodeType propType && propType.TypeDefinition is CodeEnum)
+                        .ToList()
+                        .ForEach(x => x.Type.IsNullable = true);
+        CrawlTree(currentElement, MakeEnumPropertiesNullable);
+    }
+    
+    protected static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
+        new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            "Microsoft.Kiota.Abstractions", "IRequestAdapter"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "Microsoft.Kiota.Abstractions", "Method", "RequestInformation", "IRequestOption"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "Microsoft.Kiota.Abstractions", "IResponseHandler"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            "Microsoft.Kiota.Abstractions.Serialization", "ISerializationWriter"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "Microsoft.Kiota.Abstractions.Serialization", "IParseNode"),
+        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
+            "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
+        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            "Microsoft.Kiota.Abstractions.Serialization", "IAdditionalDataHolder"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "Microsoft.Kiota.Abstractions.Serialization", "IParsable"),
+        new (static x => x is CodeClass || x is CodeEnum,
+            "System", "String"),
+        new (static x => x is CodeClass,
+            "System.Collections.Generic", "List", "Dictionary"),
+        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
+            "System.IO", "Stream"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "System.Threading", "CancellationToken"),
+        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "System.Threading.Tasks", "Task"),
+        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model, CodeClassKind.RequestBuilder),
+            "System.Linq", "Enumerable"),
+        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
+                    method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
+            "Microsoft.Kiota.Abstractions.Store",  "IBackingStoreFactory", "IBackingStoreFactorySingleton"),
+        new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
+            "Microsoft.Kiota.Abstractions.Store",  "IBackingStore", "IBackedModel", "BackingStoreFactorySingleton" ),
+        new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(prop.SerializationName),
+            "Microsoft.Kiota.Abstractions", "QueryParameterAttribute"),
+        new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal) && intersectionType.DiscriminatorInformation.HasBasicDiscriminatorInformation,
+            "Microsoft.Kiota.Abstractions.Serialization", "ParseNodeHelper"),
+    };
+    protected static void CapitalizeNamespacesFirstLetters(CodeElement current) {
+        if(current is CodeNamespace currentNamespace)
+            currentNamespace.Name = currentNamespace.Name?.Split('.')?.Select(x => x.ToFirstCharacterUpperCase())?.Aggregate((x, y) => $"{x}.{y}");
+        CrawlTree(current, CapitalizeNamespacesFirstLetters);
+    }
+    protected static void AddAsyncSuffix(CodeElement currentElement) {
+        if(currentElement is CodeMethod currentMethod && currentMethod.IsAsync)
+            currentMethod.Name += "Async";
+        CrawlTree(currentElement, AddAsyncSuffix);
+    }
+    protected static void CorrectPropertyType(CodeProperty currentProperty)
+    {
+        if(currentProperty.IsOfKind(CodePropertyKind.Options))
+            currentProperty.DefaultValue = "new List<IRequestOption>()";
+        else if(currentProperty.IsOfKind(CodePropertyKind.Headers))
+            currentProperty.DefaultValue = "new Dictionary<string, string>()";
+        CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+    }
+    protected static void CorrectMethodType(CodeMethod currentMethod)
+    {
+        CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                                .Select(x => x.Type)
+                                                .Union(new[] { currentMethod.ReturnType })
+                                                .ToArray());
+    }
+
+    private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        {
+            "DateOnly",("Date", new CodeUsing
+                {
+                    Name = "Date",
+                    Declaration = new CodeType
+                    {
+                        Name = "Microsoft.Kiota.Abstractions",
+                        IsExternal = true,
+                    },
+                })
+        },
+        {
+            "TimeOnly",("Time", new CodeUsing
+                {
+                    Name = "Time",
+                    Declaration = new CodeType
+                    {
+                        Name = "Microsoft.Kiota.Abstractions",
+                        IsExternal = true,
+                    },
+                })
+        },
+    };
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -121,31 +121,29 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 AccessedProperty = currentProperty,
             }).First();
             currentProperty.Getter.Name = $"{getterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
-            if(!currentProperty.ReadOnly) {
-                var setter = parentClass.AddMethod(new CodeMethod {
-                    Name = $"set-{accessorName}",
-                    Access = AccessModifier.Public,
-                    IsAsync = false,
-                    Kind = CodeMethodKind.Setter,
-                    Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
-                    AccessedProperty = currentProperty,
-                    ReturnType = new CodeType {
-                        Name = "void",
-                        IsNullable = false,
-                        IsExternal = true,
-                    },
-                }).First();
-                setter.Name = $"{setterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
-                currentProperty.Setter = setter;
-                
-                setter.AddParameter(new CodeParameter {
-                    Name = "value",
-                    Kind = CodeParameterKind.SetterValue,
-                    Description = $"Value to set for the {current.Name} property.",
-                    Optional = parameterAsOptional,
-                    Type = currentProperty.Type.Clone() as CodeTypeBase,
-                });
-            }
+            var setter = parentClass.AddMethod(new CodeMethod {
+                Name = $"set-{accessorName}",
+                Access = AccessModifier.Public,
+                IsAsync = false,
+                Kind = CodeMethodKind.Setter,
+                Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
+                AccessedProperty = currentProperty,
+                ReturnType = new CodeType {
+                    Name = "void",
+                    IsNullable = false,
+                    IsExternal = true,
+                },
+            }).First();
+            setter.Name = $"{setterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
+            currentProperty.Setter = setter;
+            
+            setter.AddParameter(new CodeParameter {
+                Name = "value",
+                Kind = CodeParameterKind.SetterValue,
+                Description = $"Value to set for the {current.Name} property.",
+                Optional = parameterAsOptional,
+                Type = currentProperty.Type.Clone() as CodeTypeBase,
+            });
         }
         CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional, getterPrefix, setterPrefix));
     }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
@@ -11,7 +12,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     protected CommonLanguageRefiner(GenerationConfiguration configuration) {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
     }
-    public abstract void Refine(CodeNamespace generatedCode);
+    public abstract Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken);
     /// <summary>
     ///     This method adds the imports for the default serializers and deserializers to the api client class.
     ///     It also updates the module names to replace the fully qualified class name by the class name without the namespace.

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers;
@@ -11,115 +12,125 @@ namespace Kiota.Builder.Refiners;
 public class GoRefiner : CommonLanguageRefiner
 {
     public GoRefiner(GenerationConfiguration configuration) : base(configuration) { }
-    public override void Refine(CodeNamespace generatedCode)
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
         _configuration.NamespaceNameSeparator = "/";
-        AddInnerClasses(
-            generatedCode,
-            true,
-            null);
-        ReplaceIndexersByMethodsWithParameter(
-            generatedCode,
-            generatedCode,
-            false,
-            "ById");
-        RenameCancellationParameter(generatedCode);
-        RemoveDiscriminatorMappingsTargetingSubNamespaces(generatedCode);
-        ReplaceRequestBuilderPropertiesByMethods(
-            generatedCode
-        );
-        ConvertUnionTypesToWrapper(
-            generatedCode,
-            _configuration.UsesBackingStore
-        );
-        AddRawUrlConstructorOverload(
-            generatedCode
-        );
-        RemoveModelPropertiesThatDependOnSubNamespaces(
-            generatedCode
-        );
-        ReplaceReservedNames(
-            generatedCode,
-            new GoReservedNamesProvider(),
-            x => $"{x}_escaped",
-            shouldReplaceCallback: x => x is not CodeProperty currentProp || 
-                                        !(currentProp.Parent is CodeClass parentClass &&
-                                        parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&
-                                        currentProp.Access == AccessModifier.Public)); // Go reserved keywords are all lowercase and public properties are uppercased when we don't provide accessors (models)
-        AddPropertiesAndMethodTypesImports(
-            generatedCode,
-            true,
-            false,
-            true);
-        AddDefaultImports(
-            generatedCode,
-            defaultUsingEvaluators);
-        CorrectCoreType(
-            generatedCode,
-            CorrectMethodType,
-            CorrectPropertyType,
-            CorrectImplements);
-        InsertOverrideMethodForBuildersAndConstructors(generatedCode);
-        DisableActionOf(generatedCode, 
-            CodeParameterKind.RequestConfiguration);
-        AddGetterAndSetterMethods(
-            generatedCode, 
-            new () { 
-                CodePropertyKind.AdditionalData,
-                CodePropertyKind.Custom,
-                CodePropertyKind.BackingStore }, 
-            _configuration.UsesBackingStore,
-            false,
-            "Get",
-            "Set");
-        AddConstructorsForDefaultValues(
-            generatedCode,
-            true,
-            true,  //forcing add as constructors are required for by factories 
-            new[] { CodeClassKind.RequestConfiguration });
-        MakeModelPropertiesNullable(
-            generatedCode);
-        AddErrorImportForEnums(
-            generatedCode);
-        var defaultConfiguration = new GenerationConfiguration();
-        ReplaceDefaultSerializationModules(
-            generatedCode,
-            defaultConfiguration.Serializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "github.com/microsoft/kiota-serialization-json-go.JsonSerializationWriterFactory",
-                "github.com/microsoft/kiota-serialization-text-go.TextSerializationWriterFactory"});
-        ReplaceDefaultDeserializationModules(
-            generatedCode,
-            defaultConfiguration.Deserializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "github.com/microsoft/kiota-serialization-json-go.JsonParseNodeFactory",
-                "github.com/microsoft/kiota-serialization-text-go.TextParseNodeFactory"});
-        AddSerializationModulesImport(
-            generatedCode,
-            new[] {"github.com/microsoft/kiota-abstractions-go/serialization.SerializationWriterFactory", "github.com/microsoft/kiota-abstractions-go.RegisterDefaultSerializer"},
-            new[] {"github.com/microsoft/kiota-abstractions-go/serialization.ParseNodeFactory", "github.com/microsoft/kiota-abstractions-go.RegisterDefaultDeserializer"});
-        AddParentClassToErrorClasses(
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
+            AddInnerClasses(
                 generatedCode,
-                "ApiError",
-                "github.com/microsoft/kiota-abstractions-go"
-        );
-        AddDiscriminatorMappingsUsingsToParentClasses(
-            generatedCode,
-            "ParseNode",
-            true
-        );
-        AddParsableImplementsForModelClasses(
-            generatedCode,
-            "Parsable"
-        );
-        RenameInnerModelsToAppended(
-            generatedCode
-        );
-        CopyModelClassesAsInterfaces(
-            generatedCode,
-            x => $"{x.Name}able"
-        );
-        RemoveHandlerFromRequestBuilder(generatedCode);
+                true,
+                null);
+            ReplaceIndexersByMethodsWithParameter(
+                generatedCode,
+                generatedCode,
+                false,
+                "ById");
+            RenameCancellationParameter(generatedCode);
+            RemoveDiscriminatorMappingsTargetingSubNamespaces(generatedCode);
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceRequestBuilderPropertiesByMethods(
+                generatedCode
+            );
+            ConvertUnionTypesToWrapper(
+                generatedCode,
+                _configuration.UsesBackingStore
+            );
+            AddRawUrlConstructorOverload(
+                generatedCode
+            );
+            cancellationToken.ThrowIfCancellationRequested();
+            RemoveModelPropertiesThatDependOnSubNamespaces(
+                generatedCode
+            );
+            ReplaceReservedNames(
+                generatedCode,
+                new GoReservedNamesProvider(),
+                x => $"{x}_escaped",
+                shouldReplaceCallback: x => x is not CodeProperty currentProp || 
+                                            !(currentProp.Parent is CodeClass parentClass &&
+                                            parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&
+                                            currentProp.Access == AccessModifier.Public)); // Go reserved keywords are all lowercase and public properties are uppercased when we don't provide accessors (models)
+            cancellationToken.ThrowIfCancellationRequested();
+            AddPropertiesAndMethodTypesImports(
+                generatedCode,
+                true,
+                false,
+                true);
+            AddDefaultImports(
+                generatedCode,
+                defaultUsingEvaluators);
+            CorrectCoreType(
+                generatedCode,
+                CorrectMethodType,
+                CorrectPropertyType,
+                CorrectImplements);
+            cancellationToken.ThrowIfCancellationRequested();
+            InsertOverrideMethodForBuildersAndConstructors(generatedCode);
+            DisableActionOf(generatedCode, 
+                CodeParameterKind.RequestConfiguration);
+            AddGetterAndSetterMethods(
+                generatedCode, 
+                new () { 
+                    CodePropertyKind.AdditionalData,
+                    CodePropertyKind.Custom,
+                    CodePropertyKind.BackingStore }, 
+                _configuration.UsesBackingStore,
+                false,
+                "Get",
+                "Set");
+            AddConstructorsForDefaultValues(
+                generatedCode,
+                true,
+                true,  //forcing add as constructors are required for by factories 
+                new[] { CodeClassKind.RequestConfiguration });
+            cancellationToken.ThrowIfCancellationRequested();
+            MakeModelPropertiesNullable(
+                generatedCode);
+            AddErrorImportForEnums(
+                generatedCode);
+            var defaultConfiguration = new GenerationConfiguration();
+            ReplaceDefaultSerializationModules(
+                generatedCode,
+                defaultConfiguration.Serializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "github.com/microsoft/kiota-serialization-json-go.JsonSerializationWriterFactory",
+                    "github.com/microsoft/kiota-serialization-text-go.TextSerializationWriterFactory"});
+            ReplaceDefaultDeserializationModules(
+                generatedCode,
+                defaultConfiguration.Deserializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "github.com/microsoft/kiota-serialization-json-go.JsonParseNodeFactory",
+                    "github.com/microsoft/kiota-serialization-text-go.TextParseNodeFactory"});
+            AddSerializationModulesImport(
+                generatedCode,
+                new[] {"github.com/microsoft/kiota-abstractions-go/serialization.SerializationWriterFactory", "github.com/microsoft/kiota-abstractions-go.RegisterDefaultSerializer"},
+                new[] {"github.com/microsoft/kiota-abstractions-go/serialization.ParseNodeFactory", "github.com/microsoft/kiota-abstractions-go.RegisterDefaultDeserializer"});
+            cancellationToken.ThrowIfCancellationRequested();
+            AddParentClassToErrorClasses(
+                    generatedCode,
+                    "ApiError",
+                    "github.com/microsoft/kiota-abstractions-go"
+            );
+            AddDiscriminatorMappingsUsingsToParentClasses(
+                generatedCode,
+                "ParseNode",
+                true
+            );
+            AddParsableImplementsForModelClasses(
+                generatedCode,
+                "Parsable"
+            );
+            RenameInnerModelsToAppended(
+                generatedCode
+            );
+            cancellationToken.ThrowIfCancellationRequested();
+            CopyModelClassesAsInterfaces(
+                generatedCode,
+                x => $"{x.Name}able"
+            );
+            RemoveHandlerFromRequestBuilder(generatedCode);
+        }, cancellationToken);
     }
     
     protected static void RenameCancellationParameter(CodeElement currentElement){

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -278,7 +278,7 @@ public class GoRefiner : CommonLanguageRefiner
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer)
-            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Any(static x => !x.ExistsInBaseType),
+            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Any(static x => !x.ExistsInBaseType && x.Setter != null),
             "github.com/microsoft/kiota-abstractions-go", ""),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -278,7 +278,7 @@ public class GoRefiner : CommonLanguageRefiner
         new (static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.Model),
             "github.com/microsoft/kiota-abstractions-go/serialization", "Parsable"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer, CodeMethodKind.Deserializer)
-            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Any(static x => !x.ExistsInBaseType && x.Setter != null),
+            && method.Parent is CodeClass codeClass && codeClass.GetPropertiesOfKind(CodePropertyKind.Custom).Any(static x => !x.ExistsInBaseType),
             "github.com/microsoft/kiota-abstractions-go", ""),
         new (static x => x is CodeMethod method && 
                         method.IsOfKind(CodeMethodKind.RequestGenerator) &&

--- a/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
@@ -1,41 +1,41 @@
-﻿using Kiota.Builder.CodeDOM;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Kiota.Builder.CodeDOM;
 
-namespace Kiota.Builder.Refiners
+namespace Kiota.Builder.Refiners;
+public interface ILanguageRefiner
 {
-    public interface ILanguageRefiner
-    {
-        void Refine(CodeNamespace generatedCode);
-        public static void Refine(GenerationConfiguration config, CodeNamespace generatedCode) {
-            switch (config.Language)
-            {
-                case GenerationLanguage.CSharp:
-                    new CSharpRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.TypeScript:
-                    new TypeScriptRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Java:
-                    new JavaRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Ruby:
-                    new RubyRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.PHP:
-                    new PhpRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Go:
-                    new GoRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Shell:
-                    new ShellRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Swift:
-                    new SwiftRefiner(config).Refine(generatedCode);
-                    break;
-                case GenerationLanguage.Python:
-                    new PythonRefiner(config).Refine(generatedCode);
-                    break;
-            }
+    Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken);
+    public static async Task Refine(GenerationConfiguration config, CodeNamespace generatedCode, CancellationToken cancellationToken = default) {
+        switch (config.Language)
+        {
+            case GenerationLanguage.CSharp:
+                await new CSharpRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.TypeScript:
+                await new TypeScriptRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Java:
+                await new JavaRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Ruby:
+                await new RubyRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.PHP:
+                await new PhpRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Go:
+                await new GoRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Shell:
+                await new ShellRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Swift:
+                await new SwiftRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
+            case GenerationLanguage.Python:
+                await new PythonRefiner(config).Refine(generatedCode, cancellationToken);
+                break;
         }
     }
 }

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Java;
@@ -10,67 +11,76 @@ namespace Kiota.Builder.Refiners;
 public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
 {
     public JavaRefiner(GenerationConfiguration configuration) : base(configuration) {}
-    public override void Refine(CodeNamespace generatedCode)
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        LowerCaseNamespaceNames(generatedCode);
-        AddInnerClasses(generatedCode, false, string.Empty);
-        InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
-        ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
-        RemoveCancellationParameter(generatedCode);
-        ConvertUnionTypesToWrapper(generatedCode, 
-            _configuration.UsesBackingStore
-        );
-        AddRawUrlConstructorOverload(generatedCode);
-        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
-        ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
-        AddGetterAndSetterMethods(generatedCode,
-            new() {
-                CodePropertyKind.Custom,
-                CodePropertyKind.AdditionalData,
-                CodePropertyKind.BackingStore,
-            },
-            _configuration.UsesBackingStore,
-            true,
-            "get",
-            "set"
-        );
-        ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");
-        AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
-        AddDefaultImports(generatedCode, defaultUsingEvaluators);
-        AddParsableImplementsForModelClasses(generatedCode, "Parsable");
-        AddEnumSetImport(generatedCode);
-        SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
-        AddConstructorsForDefaultValues(generatedCode, true);
-        CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
-        var defaultConfiguration = new GenerationConfiguration();
-        ReplaceDefaultSerializationModules(
-            generatedCode,
-            defaultConfiguration.Serializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "com.microsoft.kiota.serialization.JsonSerializationWriterFactory",
-                "com.microsoft.kiota.serialization.TextSerializationWriterFactory"}
-        );
-        ReplaceDefaultDeserializationModules(
-            generatedCode,
-            defaultConfiguration.Deserializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "com.microsoft.kiota.serialization.JsonParseNodeFactory",
-                "com.microsoft.kiota.serialization.TextParseNodeFactory"}
-        );
-        AddSerializationModulesImport(generatedCode,
-                                    new [] { "com.microsoft.kiota.ApiClientBuilder",
-                                            "com.microsoft.kiota.serialization.SerializationWriterFactoryRegistry" },
-                                    new [] { "com.microsoft.kiota.serialization.ParseNodeFactoryRegistry" });
-        AddParentClassToErrorClasses(
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
+            LowerCaseNamespaceNames(generatedCode);
+            AddInnerClasses(generatedCode, false, string.Empty);
+            InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
+            ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, true);
+            cancellationToken.ThrowIfCancellationRequested();
+            RemoveCancellationParameter(generatedCode);
+            ConvertUnionTypesToWrapper(generatedCode, 
+                _configuration.UsesBackingStore
+            );
+            AddRawUrlConstructorOverload(generatedCode);
+            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceBinaryByNativeType(generatedCode, "InputStream", "java.io", true);
+            AddGetterAndSetterMethods(generatedCode,
+                new() {
+                    CodePropertyKind.Custom,
+                    CodePropertyKind.AdditionalData,
+                    CodePropertyKind.BackingStore,
+                },
+                _configuration.UsesBackingStore,
+                true,
+                "get",
+                "set"
+            );
+            ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");
+            AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
+            cancellationToken.ThrowIfCancellationRequested();
+            AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            AddParsableImplementsForModelClasses(generatedCode, "Parsable");
+            AddEnumSetImport(generatedCode);
+            cancellationToken.ThrowIfCancellationRequested();
+            SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
+            AddConstructorsForDefaultValues(generatedCode, true);
+            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
+            var defaultConfiguration = new GenerationConfiguration();
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceDefaultSerializationModules(
                 generatedCode,
-                "ApiException",
-                "com.microsoft.kiota"
-        );
-        AddDiscriminatorMappingsUsingsToParentClasses(
-            generatedCode,
-            "ParseNode",
-            addUsings: true
-        );
+                defaultConfiguration.Serializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "com.microsoft.kiota.serialization.JsonSerializationWriterFactory",
+                    "com.microsoft.kiota.serialization.TextSerializationWriterFactory"}
+            );
+            ReplaceDefaultDeserializationModules(
+                generatedCode,
+                defaultConfiguration.Deserializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "com.microsoft.kiota.serialization.JsonParseNodeFactory",
+                    "com.microsoft.kiota.serialization.TextParseNodeFactory"}
+            );
+            AddSerializationModulesImport(generatedCode,
+                                        new [] { "com.microsoft.kiota.ApiClientBuilder",
+                                                "com.microsoft.kiota.serialization.SerializationWriterFactoryRegistry" },
+                                        new [] { "com.microsoft.kiota.serialization.ParseNodeFactoryRegistry" });
+            cancellationToken.ThrowIfCancellationRequested();
+            AddParentClassToErrorClasses(
+                    generatedCode,
+                    "ApiException",
+                    "com.microsoft.kiota"
+            );
+            AddDiscriminatorMappingsUsingsToParentClasses(
+                generatedCode,
+                "ParseNode",
+                addUsings: true
+            );
+        }, cancellationToken);
     }
     private static void SetSetterParametersToNullable(CodeElement currentElement, params Tuple<CodeMethodKind, CodePropertyKind>[] accessorPairs) {
         if(currentElement is CodeMethod method &&

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -1,20 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
-namespace Kiota.Builder.Refiners
+namespace Kiota.Builder.Refiners;
+public class PhpRefiner: CommonLanguageRefiner
 {
-    public class PhpRefiner: CommonLanguageRefiner
+    private static readonly CodeUsingDeclarationNameComparer usingComparer = new();
+    public PhpRefiner(GenerationConfiguration configuration) : base(configuration) { }
+    
+    
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        private static readonly CodeUsingDeclarationNameComparer usingComparer = new();
-        public PhpRefiner(GenerationConfiguration configuration) : base(configuration) { }
-        
-        
-        public override void Refine(CodeNamespace generatedCode)
-        {
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
             ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}");
             AddParentClassToErrorClasses(
                 generatedCode,
@@ -22,6 +24,7 @@ namespace Kiota.Builder.Refiners
                 "Microsoft\\Kiota\\Abstractions"
             );
             AddConstructorsForDefaultValues(generatedCode, true);
+            cancellationToken.ThrowIfCancellationRequested();
             RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, 
                 _configuration.UsesBackingStore,
@@ -31,9 +34,11 @@ namespace Kiota.Builder.Refiners
                 "ParseNode",
                 addUsings: false
             );
+            cancellationToken.ThrowIfCancellationRequested();
             CorrectParameterType(generatedCode);
             MakeModelPropertiesNullable(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
+            cancellationToken.ThrowIfCancellationRequested();
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
             var defaultConfiguration = new GenerationConfiguration();
             ReplaceDefaultSerializationModules(generatedCode,
@@ -48,9 +53,11 @@ namespace Kiota.Builder.Refiners
                     "Microsoft\\Kiota\\Serialization\\Json\\JsonParseNodeFactory",
                     "Microsoft\\Kiota\\Serialization\\Text\\TextParseNodeFactory"}
             );
+            cancellationToken.ThrowIfCancellationRequested();
             AliasUsingWithSameSymbol(generatedCode);
             AddSerializationModulesImport(generatedCode, new []{"Microsoft\\Kiota\\Abstractions\\ApiClientBuilder"}, null, '\\');
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
+            cancellationToken.ThrowIfCancellationRequested();
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -63,176 +70,178 @@ namespace Kiota.Builder.Refiners
                 "set");
             AddParsableImplementsForModelClasses(generatedCode, "Parsable");
             ReplaceBinaryByNativeType(generatedCode, "StreamInterface", "Psr\\Http\\Message", true);
+            cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             AddInnerClasses(generatedCode, 
                 true, 
                 string.Empty,
                 true);
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
-        }
-        private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
+        }, cancellationToken);
+    }
+    private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
+    {
         {
+            "DateOnly",("Date", new CodeUsing
             {
-                "DateOnly",("Date", new CodeUsing
+                Name = "Date",
+                Declaration = new CodeType
                 {
-                    Name = "Date",
-                    Declaration = new CodeType
-                    {
-                        Name = "Microsoft\\Kiota\\Abstractions\\Types",
-                        IsExternal = true,
-                    },
-                })
-            },
-            {
-                "TimeOnly",("Time", new CodeUsing
-                {
-                    Name = "Time",
-                    Declaration = new CodeType
-                    {
-                        Name = "Microsoft\\Kiota\\Abstractions\\Types",
-                        IsExternal = true,
-                    },
-                })
-            },
-            {
-                "TimeSpan", ("DateInterval", new CodeUsing
-                {
-                    Name = "DateInterval",
-                    Declaration = new CodeType
-                    {
-                        Name = "",
-                        IsExternal = true
-                    }
-                })
-            },
-            {
-                "DateTimeOffset", ("DateTime", new CodeUsing
-                {
-                    Name = "DateTime",
-                    Declaration = new CodeType
-                    {
-                        Name = "",
-                        IsExternal = true
-                    }
-                })
-            }
-        };
-        private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "Microsoft\\Kiota\\Abstractions", "RequestAdapter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "Microsoft\\Kiota\\Abstractions", "HttpMethod", "RequestInformation", "RequestOption"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "Microsoft\\Kiota\\Abstractions", "ResponseHandler"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
-                "Microsoft\\Kiota\\Abstractions\\Serialization", "AdditionalDataHolder"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "Microsoft\\Kiota\\Abstractions\\Serialization", "SerializationWriter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "Microsoft\\Kiota\\Abstractions\\Serialization", "ParseNode"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "Microsoft\\Kiota\\Abstractions\\Serialization", "Parsable", "ParsableFactory"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
-                "Microsoft\\Kiota\\Abstractions\\Serialization", "Parsable"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                      method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
-                "Microsoft\\Kiota\\Abstractions\\Store", "BackingStoreFactory", "BackingStoreFactorySingleton"),
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
-                "Microsoft\\Kiota\\Abstractions\\Store", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "Http\\Promise", "Promise", "RejectedPromise"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "", "Exception"),
-            new (x => x is CodeEnum, "Microsoft\\Kiota\\Abstractions\\", "Enum"),
-            new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTime", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
-            new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
-            new(x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor), "Microsoft\\Kiota\\Abstractions", "ApiClientBuilder"),
-            new(x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), "Microsoft\\Kiota\\Abstractions", "QueryParameter"),
-            new(x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration), "Microsoft\\Kiota\\Abstractions", "RequestOption")
-        };
-        private static void CorrectPropertyType(CodeProperty currentProperty) {
-            if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter)) {
-                currentProperty.Type.Name = "RequestAdapter";
-                currentProperty.Type.IsNullable = false;
-            }
-            else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
-                currentProperty.Type.Name = currentProperty.Type.Name[1..];
-            else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
-                currentProperty.Type.Name = "array";
-                currentProperty.Type.IsNullable = false;
-                currentProperty.DefaultValue = "[]";
-                currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
-            } else if(currentProperty.IsOfKind(CodePropertyKind.UrlTemplate)) {
-                currentProperty.Type.IsNullable = false;
-            } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
-                currentProperty.Type.IsNullable = false;
-                currentProperty.Type.Name = "array";
-                currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
-                if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
-                    currentProperty.DefaultValue = "[]";
-            } else if (currentProperty.IsOfKind(CodePropertyKind.RequestBuilder))
-            {
-                currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();
-            } else if (currentProperty.Type?.Name?.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase) ?? false)
-            {
-                currentProperty.Type.Name = "DateTime";
-            } else if (currentProperty.IsOfKind(CodePropertyKind.Options, CodePropertyKind.Headers))
-            {
-                currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
-                currentProperty.Type.Name = "array";
-            }
-            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
-        }
-
-        private static void CorrectMethodType(CodeMethod method)
+                    Name = "Microsoft\\Kiota\\Abstractions\\Types",
+                    IsExternal = true,
+                },
+            })
+        },
         {
-            if (method.IsOfKind(CodeMethodKind.Deserializer))
+            "TimeOnly",("Time", new CodeUsing
             {
-                method.ReturnType.Name = "array";
-            }
-            CorrectDateTypes(method.Parent as CodeClass, DateTypesReplacements, method.Parameters
-                .Select(static x => x.Type)
-                .Union(new[] { method.ReturnType})
-                .ToArray());
-        }
-        private static void CorrectParameterType(CodeElement codeElement)
-        {
-            var currentMethod = codeElement as CodeMethod;
-            var parameters = currentMethod?.Parameters;
-            var codeParameters = parameters as CodeParameter[] ?? parameters?.ToArray();
-            codeParameters?.Where(x => x.IsOfKind(CodeParameterKind.ParseNode)).ToList().ForEach(x =>
-            {
-                x.Type.Name = "ParseNode";
-            });
-            CrawlTree(codeElement, CorrectParameterType);
-        }
-        private static void CorrectImplements(ProprietableBlockDeclaration block) {
-            block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = x.Name[1..]); // skipping the I
-        }
-
-        private static void AliasUsingWithSameSymbol(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && currentClass.StartBlock != null && currentClass.StartBlock.Usings.Any(x => !x.IsExternal)) {
-                var duplicatedSymbolsUsings = currentClass.StartBlock.Usings
-                    .Distinct(usingComparer)
-                    .GroupBy(x => x.Declaration.Name, StringComparer.OrdinalIgnoreCase)
-                    .Where(x => x.Count() > 1)
-                    .SelectMany(x => x)
-                    .Union(currentClass.StartBlock
-                        .Usings
-                        .Where(x => !x.IsExternal)
-                        .Where(x => x.Declaration
-                            .Name
-                            .Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase)));
-                foreach (var usingElement in duplicatedSymbolsUsings)
+                Name = "Time",
+                Declaration = new CodeType
                 {
-                    var declaration = usingElement.Declaration.TypeDefinition?.Name;
-                    if (string.IsNullOrEmpty(declaration)) continue;
-                    var replacement = string.Join(string.Empty, usingElement.Declaration.TypeDefinition.GetImmediateParentOfType<CodeNamespace>().Name
-                        .Split(new[]{'\\', '.'}, StringSplitOptions.RemoveEmptyEntries)
-                        .Select(x => x.ToFirstCharacterUpperCase())
-                        .ToArray());
-                    usingElement.Alias = $"{replacement}{declaration.ToFirstCharacterUpperCase()}";
+                    Name = "Microsoft\\Kiota\\Abstractions\\Types",
+                    IsExternal = true,
+                },
+            })
+        },
+        {
+            "TimeSpan", ("DateInterval", new CodeUsing
+            {
+                Name = "DateInterval",
+                Declaration = new CodeType
+                {
+                    Name = "",
+                    IsExternal = true
                 }
-            }
-            CrawlTree(currentElement, AliasUsingWithSameSymbol);
+            })
+        },
+        {
+            "DateTimeOffset", ("DateTime", new CodeUsing
+            {
+                Name = "DateTime",
+                Declaration = new CodeType
+                {
+                    Name = "",
+                    IsExternal = true
+                }
+            })
         }
+    };
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            "Microsoft\\Kiota\\Abstractions", "RequestAdapter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "Microsoft\\Kiota\\Abstractions", "HttpMethod", "RequestInformation", "RequestOption"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "Microsoft\\Kiota\\Abstractions", "ResponseHandler"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            "Microsoft\\Kiota\\Abstractions\\Serialization", "AdditionalDataHolder"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            "Microsoft\\Kiota\\Abstractions\\Serialization", "SerializationWriter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "Microsoft\\Kiota\\Abstractions\\Serialization", "ParseNode"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "Microsoft\\Kiota\\Abstractions\\Serialization", "Parsable", "ParsableFactory"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
+            "Microsoft\\Kiota\\Abstractions\\Serialization", "Parsable"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
+                    method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
+            "Microsoft\\Kiota\\Abstractions\\Store", "BackingStoreFactory", "BackingStoreFactorySingleton"),
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
+            "Microsoft\\Kiota\\Abstractions\\Store", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "Http\\Promise", "Promise", "RejectedPromise"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "", "Exception"),
+        new (x => x is CodeEnum, "Microsoft\\Kiota\\Abstractions\\", "Enum"),
+        new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTime", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
+        new(x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase), "", "DateTime"),
+        new(x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor), "Microsoft\\Kiota\\Abstractions", "ApiClientBuilder"),
+        new(x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), "Microsoft\\Kiota\\Abstractions", "QueryParameter"),
+        new(x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration), "Microsoft\\Kiota\\Abstractions", "RequestOption")
+    };
+    private static void CorrectPropertyType(CodeProperty currentProperty) {
+        if(currentProperty.IsOfKind(CodePropertyKind.RequestAdapter)) {
+            currentProperty.Type.Name = "RequestAdapter";
+            currentProperty.Type.IsNullable = false;
+        }
+        else if(currentProperty.IsOfKind(CodePropertyKind.BackingStore))
+            currentProperty.Type.Name = currentProperty.Type.Name[1..];
+        else if(currentProperty.IsOfKind(CodePropertyKind.AdditionalData)) {
+            currentProperty.Type.Name = "array";
+            currentProperty.Type.IsNullable = false;
+            currentProperty.DefaultValue = "[]";
+            currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
+        } else if(currentProperty.IsOfKind(CodePropertyKind.UrlTemplate)) {
+            currentProperty.Type.IsNullable = false;
+        } else if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
+            currentProperty.Type.IsNullable = false;
+            currentProperty.Type.Name = "array";
+            currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
+            if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
+                currentProperty.DefaultValue = "[]";
+        } else if (currentProperty.IsOfKind(CodePropertyKind.RequestBuilder))
+        {
+            currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();
+        } else if (currentProperty.Type?.Name?.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase) ?? false)
+        {
+            currentProperty.Type.Name = "DateTime";
+        } else if (currentProperty.IsOfKind(CodePropertyKind.Options, CodePropertyKind.Headers))
+        {
+            currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
+            currentProperty.Type.Name = "array";
+        }
+        CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+    }
+
+    private static void CorrectMethodType(CodeMethod method)
+    {
+        if (method.IsOfKind(CodeMethodKind.Deserializer))
+        {
+            method.ReturnType.Name = "array";
+        }
+        CorrectDateTypes(method.Parent as CodeClass, DateTypesReplacements, method.Parameters
+            .Select(static x => x.Type)
+            .Union(new[] { method.ReturnType})
+            .ToArray());
+    }
+    private static void CorrectParameterType(CodeElement codeElement)
+    {
+        var currentMethod = codeElement as CodeMethod;
+        var parameters = currentMethod?.Parameters;
+        var codeParameters = parameters as CodeParameter[] ?? parameters?.ToArray();
+        codeParameters?.Where(x => x.IsOfKind(CodeParameterKind.ParseNode)).ToList().ForEach(x =>
+        {
+            x.Type.Name = "ParseNode";
+        });
+        CrawlTree(codeElement, CorrectParameterType);
+    }
+    private static void CorrectImplements(ProprietableBlockDeclaration block) {
+        block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = x.Name[1..]); // skipping the I
+    }
+
+    private static void AliasUsingWithSameSymbol(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && currentClass.StartBlock != null && currentClass.StartBlock.Usings.Any(x => !x.IsExternal)) {
+            var duplicatedSymbolsUsings = currentClass.StartBlock.Usings
+                .Distinct(usingComparer)
+                .GroupBy(x => x.Declaration.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(x => x.Count() > 1)
+                .SelectMany(x => x)
+                .Union(currentClass.StartBlock
+                    .Usings
+                    .Where(x => !x.IsExternal)
+                    .Where(x => x.Declaration
+                        .Name
+                        .Equals(currentClass.Name, StringComparison.OrdinalIgnoreCase)));
+            foreach (var usingElement in duplicatedSymbolsUsings)
+            {
+                var declaration = usingElement.Declaration.TypeDefinition?.Name;
+                if (string.IsNullOrEmpty(declaration)) continue;
+                var replacement = string.Join(string.Empty, usingElement.Declaration.TypeDefinition.GetImmediateParentOfType<CodeNamespace>().Name
+                    .Split(new[]{'\\', '.'}, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => x.ToFirstCharacterUpperCase())
+                    .ToArray());
+                usingElement.Alias = $"{replacement}{declaration.ToFirstCharacterUpperCase()}";
+            }
+        }
+        CrawlTree(currentElement, AliasUsingWithSameSymbol);
     }
 }
+

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
@@ -9,63 +10,72 @@ namespace Kiota.Builder.Refiners;
 public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
 {
     public PythonRefiner(GenerationConfiguration configuration) : base(configuration) {}
-    public override void Refine(CodeNamespace generatedCode)
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        AddDefaultImports(generatedCode, defaultUsingEvaluators);
-        DisableActionOf(generatedCode, 
-        CodeParameterKind.RequestConfiguration);
-        ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "_by_id");
-        RemoveCancellationParameter(generatedCode);
-        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
-        CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.__instance.create_backing_store()");
-        AddPropertiesAndMethodTypesImports(generatedCode, true, true, true, codeTypeFilter);           
-        AddParsableImplementsForModelClasses(generatedCode, "Parsable");
-        ReplaceBinaryByNativeType(generatedCode, "bytes",null);
-        ReplaceReservedNames(
-            generatedCode,
-            new PythonReservedNamesProvider(), x => $"{x}_escaped"
-        );
-        AddGetterAndSetterMethods(generatedCode,
-            new() {
-                CodePropertyKind.Custom,
-                CodePropertyKind.AdditionalData,
-            },
-            _configuration.UsesBackingStore,
-            false,
-            string.Empty,
-            string.Empty);
-        AddConstructorsForDefaultValues(generatedCode, true);
-        var defaultConfiguration = new GenerationConfiguration();
-        ReplaceDefaultSerializationModules(
-            generatedCode,
-            defaultConfiguration.Serializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "kiota_serialization_json.json_serialization_writer_factory.JsonSerializationWriterFactory",
-                "kiota_serialization_text.text_serialization_writer_factory.TextSerializationWriterFactory"
-            }
-        );
-        ReplaceDefaultDeserializationModules(
-            generatedCode,
-            defaultConfiguration.Deserializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "kiota_serialization_json.json_parse_node_factory.JsonParseNodeFactory",
-                "kiota_serialization_text.text_parse_node_factory.TextParseNodeFactory"
-            }
-        );
-        AddSerializationModulesImport(generatedCode,
-        new[] { $"{AbstractionsPackageName}.api_client_builder.register_default_serializer", 
-                $"{AbstractionsPackageName}.api_client_builder.enable_backing_store_for_serialization_writer_factory",
-                $"{AbstractionsPackageName}.serialization.SerializationWriterFactoryRegistry"},
-        new[] { $"{AbstractionsPackageName}.api_client_builder.register_default_deserializer",
-                $"{AbstractionsPackageName}.serialization.ParseNodeFactoryRegistry" });
-        AddParentClassToErrorClasses(
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
+            AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            DisableActionOf(generatedCode, 
+            CodeParameterKind.RequestConfiguration);
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "_by_id");
+            RemoveCancellationParameter(generatedCode);
+            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
+            cancellationToken.ThrowIfCancellationRequested();
+            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.__instance.create_backing_store()");
+            AddPropertiesAndMethodTypesImports(generatedCode, true, true, true, codeTypeFilter);           
+            AddParsableImplementsForModelClasses(generatedCode, "Parsable");
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceBinaryByNativeType(generatedCode, "bytes",null);
+            ReplaceReservedNames(
                 generatedCode,
-                "APIError",
-                $"{AbstractionsPackageName}.api_error"
-        );
-        AddQueryParameterMapperMethod(
-            generatedCode
-        );
+                new PythonReservedNamesProvider(), x => $"{x}_escaped"
+            );
+            cancellationToken.ThrowIfCancellationRequested();
+            AddGetterAndSetterMethods(generatedCode,
+                new() {
+                    CodePropertyKind.Custom,
+                    CodePropertyKind.AdditionalData,
+                },
+                _configuration.UsesBackingStore,
+                false,
+                string.Empty,
+                string.Empty);
+            AddConstructorsForDefaultValues(generatedCode, true);
+            var defaultConfiguration = new GenerationConfiguration();
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceDefaultSerializationModules(
+                generatedCode,
+                defaultConfiguration.Serializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "kiota_serialization_json.json_serialization_writer_factory.JsonSerializationWriterFactory",
+                    "kiota_serialization_text.text_serialization_writer_factory.TextSerializationWriterFactory"
+                }
+            );
+            ReplaceDefaultDeserializationModules(
+                generatedCode,
+                defaultConfiguration.Deserializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "kiota_serialization_json.json_parse_node_factory.JsonParseNodeFactory",
+                    "kiota_serialization_text.text_parse_node_factory.TextParseNodeFactory"
+                }
+            );
+            AddSerializationModulesImport(generatedCode,
+            new[] { $"{AbstractionsPackageName}.api_client_builder.register_default_serializer", 
+                    $"{AbstractionsPackageName}.api_client_builder.enable_backing_store_for_serialization_writer_factory",
+                    $"{AbstractionsPackageName}.serialization.SerializationWriterFactoryRegistry"},
+            new[] { $"{AbstractionsPackageName}.api_client_builder.register_default_deserializer",
+                    $"{AbstractionsPackageName}.serialization.ParseNodeFactoryRegistry" });
+            cancellationToken.ThrowIfCancellationRequested();
+            AddParentClassToErrorClasses(
+                    generatedCode,
+                    "APIError",
+                    $"{AbstractionsPackageName}.api_error"
+            );
+            AddQueryParameterMapperMethod(
+                generatedCode
+            );
+        }, cancellationToken);
     }
 
     private const string AbstractionsPackageName = "kiota_abstractions";

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -1,23 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
-namespace Kiota.Builder.Refiners {
-    public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
+namespace Kiota.Builder.Refiners;
+public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
+{
+    public RubyRefiner(GenerationConfiguration configuration) : base(configuration) {}
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        public RubyRefiner(GenerationConfiguration configuration) : base(configuration) {}
-        public override void Refine(CodeNamespace generatedCode)
-        {
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
             ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "_by_id");
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, true);
             RemoveCancellationParameter(generatedCode);
+            cancellationToken.ThrowIfCancellationRequested();
             AddParsableImplementsForModelClasses(generatedCode, "MicrosoftKiotaAbstractions::Parsable");
             AddInheritedAndMethodTypesImports(generatedCode);
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
+            cancellationToken.ThrowIfCancellationRequested();
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -31,6 +36,7 @@ namespace Kiota.Builder.Refiners {
             ReplaceReservedNames(generatedCode, new RubyReservedNamesProvider(), x => $"{x}_escaped");
             AddNamespaceModuleImports(generatedCode , _configuration.ClientNamespaceName);
             var defaultConfiguration = new GenerationConfiguration();
+            cancellationToken.ThrowIfCancellationRequested();
             ReplaceDefaultSerializationModules(
                 generatedCode,
                 defaultConfiguration.Serializers,
@@ -45,108 +51,108 @@ namespace Kiota.Builder.Refiners {
                                         new [] { "microsoft_kiota_abstractions.ApiClientBuilder",
                                                 "microsoft_kiota_abstractions.SerializationWriterFactoryRegistry" },
                                         new [] { "microsoft_kiota_abstractions.ParseNodeFactoryRegistry" });
+        }, cancellationToken);
+    }
+    private static void CorrectMethodType(CodeMethod currentMethod) {
+        if(currentMethod.IsOfKind(CodeMethodKind.Factory) && currentMethod.Parameters.OfKind(CodeParameterKind.ParseNode) is CodeParameter parseNodeParam)
+            parseNodeParam.Type.Name = parseNodeParam.Type.Name[1..];
+        CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
+                                    .Select(x => x.Type)
+                                    .Union(new[] { currentMethod.ReturnType})
+                                    .ToArray());
+    }
+    private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new (StringComparer.OrdinalIgnoreCase) {
+        {"DateTimeOffset", ("DateTime", new CodeUsing {
+                                        Name = "DateTime",
+                                        Declaration = new CodeType {
+                                            Name = "date",
+                                            IsExternal = true,
+                                        },
+                                    })},
+        {"TimeSpan", ("MicrosoftKiotaAbstractions::ISODuration", new CodeUsing {
+                                        Name = "MicrosoftKiotaAbstractions::ISODuration",
+                                        Declaration = new CodeType {
+                                            Name = "github.com/microsoft/kiota/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/serialization",
+                                            IsExternal = true,
+                                        },
+                                    })},
+        {"DateOnly", ("Date", new CodeUsing {
+                                Name = "Date",
+                                Declaration = new CodeType {
+                                    Name = "date",
+                                    IsExternal = true,
+                                },
+                            })},
+        {"TimeOnly", ("Time", new CodeUsing {
+                                Name = "Time",
+                                Declaration = new CodeType {
+                                    Name = "time",
+                                    IsExternal = true,
+                                },
+                            })},
+    };
+    private static void CorrectPropertyType(CodeProperty currentProperty) {
+        if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
+            currentProperty.Type.IsNullable = true;
+            if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
+                currentProperty.DefaultValue = "Hash.new";
+        } 
+        CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
+        
+    }
+    private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
+            "microsoft_kiota_abstractions", "RequestAdapter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
+            "microsoft_kiota_abstractions", "HttpMethod", "RequestInformation"), //TODO add request options once ruby supports it
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "microsoft_kiota_abstractions", "ResponseHandler"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
+            "microsoft_kiota_abstractions", "SerializationWriter"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
+            "microsoft_kiota_abstractions", "ParseNode"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
+            "microsoft_kiota_abstractions", "Parsable"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
+            "microsoft_kiota_abstractions", "Parsable"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+            "microsoft_kiota_abstractions", "AdditionalDataHolder"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
+                    method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
+            "microsoft_kiota_abstractions", "BackingStoreFactory", "BackingStoreFactorySingleton"),
+        new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
+            "microsoft_kiota_abstractions", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
+    };
+    protected static void AddInheritedAndMethodTypesImports(CodeElement currentElement) {
+        if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) 
+            && currentClass.StartBlock.Inherits != null) {
+            currentClass.AddUsing(new CodeUsing { Name = currentClass.StartBlock.Inherits.Name, Declaration = currentClass.StartBlock.Inherits});
         }
-        private static void CorrectMethodType(CodeMethod currentMethod) {
-            if(currentMethod.IsOfKind(CodeMethodKind.Factory) && currentMethod.Parameters.OfKind(CodeParameterKind.ParseNode) is CodeParameter parseNodeParam)
-                parseNodeParam.Type.Name = parseNodeParam.Type.Name[1..];
-            CorrectDateTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.Parameters
-                                        .Select(x => x.Type)
-                                        .Union(new[] { currentMethod.ReturnType})
-                                        .ToArray());
-        }
-        private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new (StringComparer.OrdinalIgnoreCase) {
-            {"DateTimeOffset", ("DateTime", new CodeUsing {
-                                            Name = "DateTime",
-                                            Declaration = new CodeType {
-                                                Name = "date",
-                                                IsExternal = true,
-                                            },
-                                        })},
-            {"TimeSpan", ("MicrosoftKiotaAbstractions::ISODuration", new CodeUsing {
-                                            Name = "MicrosoftKiotaAbstractions::ISODuration",
-                                            Declaration = new CodeType {
-                                                Name = "github.com/microsoft/kiota/abstractions/ruby/microsoft_kiota_abstractions/lib/microsoft_kiota_abstractions/serialization",
-                                                IsExternal = true,
-                                            },
-                                        })},
-            {"DateOnly", ("Date", new CodeUsing {
-                                    Name = "Date",
-                                    Declaration = new CodeType {
-                                        Name = "date",
-                                        IsExternal = true,
-                                    },
-                                })},
-            {"TimeOnly", ("Time", new CodeUsing {
-                                    Name = "Time",
-                                    Declaration = new CodeType {
-                                        Name = "time",
-                                        IsExternal = true,
-                                    },
-                                })},
-        };
-        private static void CorrectPropertyType(CodeProperty currentProperty) {
-            if(currentProperty.IsOfKind(CodePropertyKind.PathParameters)) {
-                currentProperty.Type.IsNullable = true;
-                if(!string.IsNullOrEmpty(currentProperty.DefaultValue))
-                    currentProperty.DefaultValue = "Hash.new";
-            } 
-            CorrectDateTypes(currentProperty.Parent as CodeClass, DateTypesReplacements, currentProperty.Type);
-            
-        }
-        private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
-                "microsoft_kiota_abstractions", "RequestAdapter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestGenerator),
-                "microsoft_kiota_abstractions", "HttpMethod", "RequestInformation"), //TODO add request options once ruby supports it
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "microsoft_kiota_abstractions", "ResponseHandler"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
-                "microsoft_kiota_abstractions", "SerializationWriter"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-                "microsoft_kiota_abstractions", "ParseNode"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
-                "microsoft_kiota_abstractions", "Parsable"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
-                "microsoft_kiota_abstractions", "Parsable"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
-                "microsoft_kiota_abstractions", "AdditionalDataHolder"),
-            new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
-                        method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
-                "microsoft_kiota_abstractions", "BackingStoreFactory", "BackingStoreFactorySingleton"),
-            new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
-                "microsoft_kiota_abstractions", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
-        };
-        protected static void AddInheritedAndMethodTypesImports(CodeElement currentElement) {
-            if(currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) 
-                && currentClass.StartBlock.Inherits != null) {
-                currentClass.AddUsing(new CodeUsing { Name = currentClass.StartBlock.Inherits.Name, Declaration = currentClass.StartBlock.Inherits});
-            }
-            CrawlTree(currentElement, x => AddInheritedAndMethodTypesImports(x));
-        }
+        CrawlTree(currentElement, x => AddInheritedAndMethodTypesImports(x));
+    }
 
-        protected void AddNamespaceModuleImports(CodeElement current, string clientNamespaceName) {
-            const string dot = ".";
-            if(current is CodeClass currentClass) {
-                var Module = currentClass.GetImmediateParentOfType<CodeNamespace>();
-                if(!string.IsNullOrEmpty(Module.Name)){
-                    var modulesProperties = Module.Name.Replace(clientNamespaceName+dot, string.Empty).Split(dot);
-                    for (int i = modulesProperties.Length - 1; i >= 0; i--){
-                        var prefix = string.Concat(Enumerable.Repeat("../", modulesProperties.Length -i-1));
-                        var usingName = modulesProperties[i].ToSnakeCase();
-                        currentClass.AddUsing(new CodeUsing { 
-                            Name = usingName,
-                            Declaration = new CodeType {
-                                IsExternal = false,
-                                Name = $"{(string.IsNullOrEmpty(prefix) ? "./" : prefix)}{usingName}",
-                            }
-                        });
-                    }
+    protected void AddNamespaceModuleImports(CodeElement current, string clientNamespaceName) {
+        const string dot = ".";
+        if(current is CodeClass currentClass) {
+            var Module = currentClass.GetImmediateParentOfType<CodeNamespace>();
+            if(!string.IsNullOrEmpty(Module.Name)){
+                var modulesProperties = Module.Name.Replace(clientNamespaceName+dot, string.Empty).Split(dot);
+                for (int i = modulesProperties.Length - 1; i >= 0; i--){
+                    var prefix = string.Concat(Enumerable.Repeat("../", modulesProperties.Length -i-1));
+                    var usingName = modulesProperties[i].ToSnakeCase();
+                    currentClass.AddUsing(new CodeUsing { 
+                        Name = usingName,
+                        Declaration = new CodeType {
+                            IsExternal = false,
+                            Name = $"{(string.IsNullOrEmpty(prefix) ? "./" : prefix)}{usingName}",
+                        }
+                    });
                 }
             }
-            CrawlTree(current, c => AddNamespaceModuleImports(c, clientNamespaceName));
         }
-        private static void CorrectImplements(ProprietableBlockDeclaration block) {
-            block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = "MicrosoftKiotaAbstractions::AdditionalDataHolder"); 
-            }
+        CrawlTree(current, c => AddNamespaceModuleImports(c, clientNamespaceName));
     }
+    private static void CorrectImplements(ProprietableBlockDeclaration block) {
+        block.Implements.Where(x => "IAdditionalDataHolder".Equals(x.Name, StringComparison.OrdinalIgnoreCase)).ToList().ForEach(x => x.Name = "MicrosoftKiotaAbstractions::AdditionalDataHolder"); 
+        }
 }

--- a/src/Kiota.Builder/Refiners/ShellRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ShellRefiner.cs
@@ -1,33 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
-namespace Kiota.Builder.Refiners
+namespace Kiota.Builder.Refiners;
+public class ShellRefiner : CSharpRefiner, ILanguageRefiner
 {
-    public class ShellRefiner : CSharpRefiner, ILanguageRefiner
+    public ShellRefiner(GenerationConfiguration configuration) : base(configuration) { }
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        public ShellRefiner(GenerationConfiguration configuration) : base(configuration) { }
-        public override void Refine(CodeNamespace generatedCode)
-        {
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             AddDefaultImports(generatedCode, additionalUsingEvaluators);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType);
+            cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode, 
                 _configuration.UsesBackingStore
             );
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
+            cancellationToken.ThrowIfCancellationRequested();
             AddInnerClasses(generatedCode, false);
             AddParsableImplementsForModelClasses(generatedCode, "IParsable");
             CapitalizeNamespacesFirstLetters(generatedCode);
+            cancellationToken.ThrowIfCancellationRequested();
             ReplaceBinaryByNativeType(generatedCode, "Stream", "System.IO");
             MakeEnumPropertiesNullable(generatedCode);
             /* Exclude the following as their names will be capitalized making the change unnecessary in this case sensitive language
-             * code classes, class declarations, property names, using declarations, namespace names
-             * Exclude CodeMethod as the return type will also be capitalized (excluding the CodeType is not enough since this is evaluated at the code method level)
+                * code classes, class declarations, property names, using declarations, namespace names
+                * Exclude CodeMethod as the return type will also be capitalized (excluding the CodeType is not enough since this is evaluated at the code method level)
             */
             ReplaceReservedNames(
                 generatedCode,
@@ -36,6 +41,7 @@ namespace Kiota.Builder.Refiners
             );
             // Replace the reserved types
             ReplaceReservedModelTypes(generatedCode, new CSharpReservedTypesProvider(), x => $"{x}Object");
+            cancellationToken.ThrowIfCancellationRequested();
             ReplaceReservedNamespaceTypeNames(generatedCode, new CSharpReservedTypesProvider(), static x => $"{x}Namespace");
             AddParentClassToErrorClasses(
                 generatedCode,
@@ -46,132 +52,134 @@ namespace Kiota.Builder.Refiners
                 generatedCode,
                 "IParseNode"
             );
+            cancellationToken.ThrowIfCancellationRequested();
             DisambiguatePropertiesWithClassNames(generatedCode);
             AddConstructorsForDefaultValues(generatedCode, false);
             AddSerializationModulesImport(generatedCode);
+            cancellationToken.ThrowIfCancellationRequested();
             CreateCommandBuilders(generatedCode);
-        }
+        }, cancellationToken);
+    }
 
-        private static void CreateCommandBuilders(CodeElement currentElement)
+    private static void CreateCommandBuilders(CodeElement currentElement)
+    {
+        if (currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.RequestBuilder))
         {
-            if (currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.RequestBuilder))
+            // Replace Nav Properties with BuildXXXCommand methods
+            var navProperties = currentClass.GetChildElements().OfType<CodeProperty>().Where(e => e.IsOfKind(CodePropertyKind.RequestBuilder));
+            foreach (var navProp in navProperties)
             {
-                // Replace Nav Properties with BuildXXXCommand methods
-                var navProperties = currentClass.GetChildElements().OfType<CodeProperty>().Where(e => e.IsOfKind(CodePropertyKind.RequestBuilder));
-                foreach (var navProp in navProperties)
-                {
-                    var method = CreateBuildCommandMethod(navProp, currentClass);
-                    currentClass.AddMethod(method);
-                    currentClass.RemoveChildElement(navProp);
-                }
-
-                // Build command for indexers
-                var indexers = currentClass.GetChildElements().OfType<CodeIndexer>();
-                var classHasIndexers = indexers.Any();
-                CreateCommandBuildersFromIndexers(currentClass, indexers);
-
-                // Clone executors & convert to build command
-                var requestExecutors = currentClass.GetChildElements().OfType<CodeMethod>().Where(e => e.IsOfKind(CodeMethodKind.RequestExecutor));
-                CreateCommandBuildersFromRequestExecutors(currentClass, classHasIndexers, requestExecutors);
-
-                // Build root command
-                var clientConstructor = currentClass.GetChildElements().OfType<CodeMethod>().FirstOrDefault(m => m.IsOfKind(CodeMethodKind.ClientConstructor));
-                if (clientConstructor != null)
-                {
-                    var rootMethod = new CodeMethod
-                    {
-                        Name = "BuildRootCommand",
-                        Description = clientConstructor.Description,
-                        IsAsync = false,
-                        Kind = CodeMethodKind.CommandBuilder,
-                        ReturnType = new CodeType { Name = "Command", IsExternal = true },
-                        OriginalMethod = clientConstructor,
-                    };
-                    currentClass.AddMethod(rootMethod);
-                }
+                var method = CreateBuildCommandMethod(navProp, currentClass);
+                currentClass.AddMethod(method);
+                currentClass.RemoveChildElement(navProp);
             }
-            CrawlTree(currentElement, CreateCommandBuilders);
-        }
 
-        private static void CreateCommandBuildersFromRequestExecutors(CodeClass currentClass, bool classHasIndexers, IEnumerable<CodeMethod> requestMethods)
-        {
-            foreach (var requestMethod in requestMethods)
+            // Build command for indexers
+            var indexers = currentClass.GetChildElements().OfType<CodeIndexer>();
+            var classHasIndexers = indexers.Any();
+            CreateCommandBuildersFromIndexers(currentClass, indexers);
+
+            // Clone executors & convert to build command
+            var requestExecutors = currentClass.GetChildElements().OfType<CodeMethod>().Where(e => e.IsOfKind(CodeMethodKind.RequestExecutor));
+            CreateCommandBuildersFromRequestExecutors(currentClass, classHasIndexers, requestExecutors);
+
+            // Build root command
+            var clientConstructor = currentClass.GetChildElements().OfType<CodeMethod>().FirstOrDefault(m => m.IsOfKind(CodeMethodKind.ClientConstructor));
+            if (clientConstructor != null)
             {
-                CodeMethod clone = requestMethod.Clone() as CodeMethod;
-                var cmdName = clone.HttpMethod switch
+                var rootMethod = new CodeMethod
                 {
-                    HttpMethod.Get when classHasIndexers => "List",
-                    HttpMethod.Post when classHasIndexers => "Create",
-                    _ => clone.Name,
-                };
-
-                clone.IsAsync = false;
-                clone.Name = $"Build{cmdName}Command";
-                clone.Description = requestMethod.Description;
-                clone.ReturnType = CreateCommandType();
-                clone.Kind = CodeMethodKind.CommandBuilder;
-                clone.OriginalMethod = requestMethod;
-                clone.SimpleName = cmdName;
-                clone.ClearParameters();
-                currentClass.AddMethod(clone);
-                currentClass.RemoveChildElement(requestMethod);
-            }
-        }
-
-        private static void CreateCommandBuildersFromIndexers(CodeClass currentClass, IEnumerable<CodeIndexer> indexers)
-        {
-            foreach (var indexer in indexers)
-            {
-                var method = new CodeMethod
-                {
-                    Name = "BuildCommand",
+                    Name = "BuildRootCommand",
+                    Description = clientConstructor.Description,
                     IsAsync = false,
                     Kind = CodeMethodKind.CommandBuilder,
-                    OriginalIndexer = indexer
+                    ReturnType = new CodeType { Name = "Command", IsExternal = true },
+                    OriginalMethod = clientConstructor,
                 };
-
-                // ReturnType setter assigns the parent
-                method.ReturnType = CreateCommandType();
-                currentClass.AddMethod(method);
-                currentClass.RemoveChildElement(indexer);
+                currentClass.AddMethod(rootMethod);
             }
         }
+        CrawlTree(currentElement, CreateCommandBuilders);
+    }
 
-        private static CodeType CreateCommandType()
+    private static void CreateCommandBuildersFromRequestExecutors(CodeClass currentClass, bool classHasIndexers, IEnumerable<CodeMethod> requestMethods)
+    {
+        foreach (var requestMethod in requestMethods)
         {
-            return new CodeType
+            CodeMethod clone = requestMethod.Clone() as CodeMethod;
+            var cmdName = clone.HttpMethod switch
             {
-                Name = "Command",
-                IsExternal = true,
+                HttpMethod.Get when classHasIndexers => "List",
+                HttpMethod.Post when classHasIndexers => "Create",
+                _ => clone.Name,
             };
-        }
 
-        private static CodeMethod CreateBuildCommandMethod(CodeProperty navProperty, CodeClass parent)
+            clone.IsAsync = false;
+            clone.Name = $"Build{cmdName}Command";
+            clone.Description = requestMethod.Description;
+            clone.ReturnType = CreateCommandType();
+            clone.Kind = CodeMethodKind.CommandBuilder;
+            clone.OriginalMethod = requestMethod;
+            clone.SimpleName = cmdName;
+            clone.ClearParameters();
+            currentClass.AddMethod(clone);
+            currentClass.RemoveChildElement(requestMethod);
+        }
+    }
+
+    private static void CreateCommandBuildersFromIndexers(CodeClass currentClass, IEnumerable<CodeIndexer> indexers)
+    {
+        foreach (var indexer in indexers)
         {
-            var codeMethod = new CodeMethod
+            var method = new CodeMethod
             {
+                Name = "BuildCommand",
                 IsAsync = false,
-                Name = $"Build{navProperty.Name.ToFirstCharacterUpperCase()}Command",
-                Kind = CodeMethodKind.CommandBuilder
+                Kind = CodeMethodKind.CommandBuilder,
+                OriginalIndexer = indexer
             };
-            codeMethod.ReturnType = CreateCommandType();
-            codeMethod.AccessedProperty = navProperty;
-            codeMethod.SimpleName = navProperty.Name;
-            codeMethod.Parent = parent;
-            return codeMethod;
-        }
 
-        private static readonly AdditionalUsingEvaluator[] additionalUsingEvaluators = {
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "System.CommandLine",  "Command", "RootCommand", "IConsole"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "Microsoft.Kiota.Cli.Commons.IO", "IOutputFormatter", "IOutputFormatterFactory", "FormatterType", "PageLinkData", "IPagingService"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "Microsoft.Extensions.Hosting", "IHost"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "Microsoft.Extensions.DependencyInjection", "IHost"),
-            new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
-                "System.Text",  "Encoding"),
+            // ReturnType setter assigns the parent
+            method.ReturnType = CreateCommandType();
+            currentClass.AddMethod(method);
+            currentClass.RemoveChildElement(indexer);
+        }
+    }
+
+    private static CodeType CreateCommandType()
+    {
+        return new CodeType
+        {
+            Name = "Command",
+            IsExternal = true,
         };
     }
+
+    private static CodeMethod CreateBuildCommandMethod(CodeProperty navProperty, CodeClass parent)
+    {
+        var codeMethod = new CodeMethod
+        {
+            IsAsync = false,
+            Name = $"Build{navProperty.Name.ToFirstCharacterUpperCase()}Command",
+            Kind = CodeMethodKind.CommandBuilder
+        };
+        codeMethod.ReturnType = CreateCommandType();
+        codeMethod.AccessedProperty = navProperty;
+        codeMethod.SimpleName = navProperty.Name;
+        codeMethod.Parent = parent;
+        return codeMethod;
+    }
+
+    private static readonly AdditionalUsingEvaluator[] additionalUsingEvaluators = {
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "System.CommandLine",  "Command", "RootCommand", "IConsole"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "Microsoft.Kiota.Cli.Commons.IO", "IOutputFormatter", "IOutputFormatterFactory", "FormatterType", "PageLinkData", "IPagingService"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "Microsoft.Extensions.Hosting", "IHost"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "Microsoft.Extensions.DependencyInjection", "IHost"),
+        new (x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder),
+            "System.Text",  "Encoding"),
+    };
 }

--- a/src/Kiota.Builder/Refiners/SwiftRefiner.cs
+++ b/src/Kiota.Builder/Refiners/SwiftRefiner.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
@@ -9,37 +10,43 @@ namespace Kiota.Builder.Refiners;
 public class SwiftRefiner : CommonLanguageRefiner
 {
     public SwiftRefiner(GenerationConfiguration configuration) : base(configuration) {}
-    public override void Refine(CodeNamespace generatedCode)
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        CapitalizeNamespacesFirstLetters(generatedCode);
-        AddRootClassForExtensions(generatedCode);
-        ReplaceIndexersByMethodsWithParameter(
-            generatedCode,
-            generatedCode,
-            false,
-            "ById");
-        ReplaceReservedNames(
-            generatedCode,
-            new SwiftReservedNamesProvider(),
-            x => $"{x}_escaped");
-        RemoveCancellationParameter(generatedCode);
-        ConvertUnionTypesToWrapper(
-            generatedCode,
-            _configuration.UsesBackingStore
-        );
-        AddPropertiesAndMethodTypesImports(
-            generatedCode,
-            true,
-            false,
-            true);
-        AddDefaultImports(
-            generatedCode,
-            defaultUsingEvaluators);
-        CorrectCoreType(
-            generatedCode,
-            CorrectMethodType,
-            CorrectPropertyType,
-            CorrectImplements);
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
+            CapitalizeNamespacesFirstLetters(generatedCode);
+            AddRootClassForExtensions(generatedCode);
+            ReplaceIndexersByMethodsWithParameter(
+                generatedCode,
+                generatedCode,
+                false,
+                "ById");
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceReservedNames(
+                generatedCode,
+                new SwiftReservedNamesProvider(),
+                x => $"{x}_escaped");
+            RemoveCancellationParameter(generatedCode);
+            ConvertUnionTypesToWrapper(
+                generatedCode,
+                _configuration.UsesBackingStore
+            );
+            cancellationToken.ThrowIfCancellationRequested();
+            AddPropertiesAndMethodTypesImports(
+                generatedCode,
+                true,
+                false,
+                true);
+            AddDefaultImports(
+                generatedCode,
+                defaultUsingEvaluators);
+            cancellationToken.ThrowIfCancellationRequested();
+            CorrectCoreType(
+                generatedCode,
+                CorrectMethodType,
+                CorrectPropertyType,
+                CorrectImplements);
+        }, cancellationToken);
     }
     private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = { 
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
@@ -9,95 +10,104 @@ namespace Kiota.Builder.Refiners;
 public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
 {
     public TypeScriptRefiner(GenerationConfiguration configuration) : base(configuration) {}
-    public override void Refine(CodeNamespace generatedCode)
+    public override Task Refine(CodeNamespace generatedCode, CancellationToken cancellationToken)
     {
-        ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
-        RemoveCancellationParameter(generatedCode);
-        CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
-        CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
-        AddInnerClasses(generatedCode, 
-            true, 
-            string.Empty,
-            true);
-        // `AddInnerClasses` will have inner classes moved to their own files, so  we add the imports after so that the files don't miss anything.
-        // This is because imports are added at the file level so nested classes would potentially use the higher level imports.
-        AddDefaultImports(generatedCode, defaultUsingEvaluators);
-        DisableActionOf(generatedCode, 
-            CodeParameterKind.RequestConfiguration);
-        AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
-        AliasUsingsWithSameSymbol(generatedCode);
-        AddParsableImplementsForModelClasses(generatedCode, "Parsable");
-        ReplaceBinaryByNativeType(generatedCode, "ArrayBuffer", null);
-        ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}_escaped");
-        AddGetterAndSetterMethods(generatedCode,
-            new() {
-                CodePropertyKind.Custom,
-                CodePropertyKind.AdditionalData,
-            },
-            _configuration.UsesBackingStore,
-            false,
-            string.Empty,
-            string.Empty);
-        AddConstructorsForDefaultValues(generatedCode, true);
-        var defaultConfiguration = new GenerationConfiguration();
-        ReplaceDefaultSerializationModules(
-            generatedCode,
-            defaultConfiguration.Serializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "@microsoft/kiota-serialization-json.JsonSerializationWriterFactory",
-                "@microsoft/kiota-serialization-text.TextSerializationWriterFactory"
-            }
-        );
-        ReplaceDefaultDeserializationModules(
-            generatedCode,
-            defaultConfiguration.Deserializers,
-            new (StringComparer.OrdinalIgnoreCase) {
-                "@microsoft/kiota-serialization-json.JsonParseNodeFactory",
-                "@microsoft/kiota-serialization-text.TextParseNodeFactory"
-            }
-        );
-        AddSerializationModulesImport(generatedCode,
-            new[] { $"{AbstractionsPackageName}.registerDefaultSerializer", 
-                    $"{AbstractionsPackageName}.enableBackingStoreForSerializationWriterFactory",
-                    $"{AbstractionsPackageName}.SerializationWriterFactoryRegistry"},
-            new[] { $"{AbstractionsPackageName}.registerDefaultDeserializer",
-                    $"{AbstractionsPackageName}.ParseNodeFactoryRegistry" });
-        AddParentClassToErrorClasses(
+        return Task.Run(() => {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceIndexersByMethodsWithParameter(generatedCode, generatedCode, false, "ById");
+            RemoveCancellationParameter(generatedCode);
+            CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
+            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
+            cancellationToken.ThrowIfCancellationRequested();
+            AddInnerClasses(generatedCode, 
+                true, 
+                string.Empty,
+                true);
+            // `AddInnerClasses` will have inner classes moved to their own files, so  we add the imports after so that the files don't miss anything.
+            // This is because imports are added at the file level so nested classes would potentially use the higher level imports.
+            AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            DisableActionOf(generatedCode, 
+                CodeParameterKind.RequestConfiguration);
+            cancellationToken.ThrowIfCancellationRequested();
+            AddPropertiesAndMethodTypesImports(generatedCode, true, true, true);
+            AliasUsingsWithSameSymbol(generatedCode);
+            AddParsableImplementsForModelClasses(generatedCode, "Parsable");
+            ReplaceBinaryByNativeType(generatedCode, "ArrayBuffer", null);
+            cancellationToken.ThrowIfCancellationRequested();
+            ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}_escaped");
+            AddGetterAndSetterMethods(generatedCode,
+                new() {
+                    CodePropertyKind.Custom,
+                    CodePropertyKind.AdditionalData,
+                },
+                _configuration.UsesBackingStore,
+                false,
+                string.Empty,
+                string.Empty);
+            AddConstructorsForDefaultValues(generatedCode, true);
+            cancellationToken.ThrowIfCancellationRequested();
+            var defaultConfiguration = new GenerationConfiguration();
+            ReplaceDefaultSerializationModules(
                 generatedCode,
-                "ApiError",
-                "@microsoft/kiota-abstractions"
-        );
-        AddDiscriminatorMappingsUsingsToParentClasses(
-            generatedCode,
-            "ParseNode",
-            addUsings: false
-        );
-        Func<string, string> factoryNameCallbackFromTypeName = static x => $"create{x.ToFirstCharacterUpperCase()}FromDiscriminatorValue";
-        ReplaceLocalMethodsByGlobalFunctions(
-            generatedCode,
-            x => factoryNameCallbackFromTypeName(x.Parent.Name),
-            x => x.Parent is CodeClass parentClass ? new List<CodeUsing>(parentClass.DiscriminatorInformation
-                                    .DiscriminatorMappings
-                                    .Select(static y => y.Value)
-                                    .OfType<CodeType>()
-                                    .Select(static y => new CodeUsing { Name = y.Name, Declaration = y })) {
-                    new() { Name = "ParseNode", Declaration = new() { Name = AbstractionsPackageName, IsExternal = true } },
-                    new() { Name = x.Parent.Parent.Name, Declaration = new() { Name = x.Parent.Name, TypeDefinition = x.Parent } },
-                }.ToArray() : Array.Empty<CodeUsing>(),
-            CodeMethodKind.Factory
-        );
-        Func<CodeType, string> factoryNameCallbackFromType = x => factoryNameCallbackFromTypeName(x.Name);
-        AddStaticMethodsUsingsForDeserializer(
-            generatedCode,
-            factoryNameCallbackFromType
-        );
-        AddStaticMethodsUsingsForRequestExecutor(
-            generatedCode,
-            factoryNameCallbackFromType
-        );
-        AddQueryParameterMapperMethod(
-            generatedCode
-        );
+                defaultConfiguration.Serializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "@microsoft/kiota-serialization-json.JsonSerializationWriterFactory",
+                    "@microsoft/kiota-serialization-text.TextSerializationWriterFactory"
+                }
+            );
+            ReplaceDefaultDeserializationModules(
+                generatedCode,
+                defaultConfiguration.Deserializers,
+                new (StringComparer.OrdinalIgnoreCase) {
+                    "@microsoft/kiota-serialization-json.JsonParseNodeFactory",
+                    "@microsoft/kiota-serialization-text.TextParseNodeFactory"
+                }
+            );
+            AddSerializationModulesImport(generatedCode,
+                new[] { $"{AbstractionsPackageName}.registerDefaultSerializer", 
+                        $"{AbstractionsPackageName}.enableBackingStoreForSerializationWriterFactory",
+                        $"{AbstractionsPackageName}.SerializationWriterFactoryRegistry"},
+                new[] { $"{AbstractionsPackageName}.registerDefaultDeserializer",
+                        $"{AbstractionsPackageName}.ParseNodeFactoryRegistry" });
+            cancellationToken.ThrowIfCancellationRequested();
+            AddParentClassToErrorClasses(
+                    generatedCode,
+                    "ApiError",
+                    "@microsoft/kiota-abstractions"
+            );
+            AddDiscriminatorMappingsUsingsToParentClasses(
+                generatedCode,
+                "ParseNode",
+                addUsings: false
+            );
+            Func<string, string> factoryNameCallbackFromTypeName = static x => $"create{x.ToFirstCharacterUpperCase()}FromDiscriminatorValue";
+            ReplaceLocalMethodsByGlobalFunctions(
+                generatedCode,
+                x => factoryNameCallbackFromTypeName(x.Parent.Name),
+                x => x.Parent is CodeClass parentClass ? new List<CodeUsing>(parentClass.DiscriminatorInformation
+                                        .DiscriminatorMappings
+                                        .Select(static y => y.Value)
+                                        .OfType<CodeType>()
+                                        .Select(static y => new CodeUsing { Name = y.Name, Declaration = y })) {
+                        new() { Name = "ParseNode", Declaration = new() { Name = AbstractionsPackageName, IsExternal = true } },
+                        new() { Name = x.Parent.Parent.Name, Declaration = new() { Name = x.Parent.Name, TypeDefinition = x.Parent } },
+                    }.ToArray() : Array.Empty<CodeUsing>(),
+                CodeMethodKind.Factory
+            );
+            Func<CodeType, string> factoryNameCallbackFromType = x => factoryNameCallbackFromTypeName(x.Name);
+            cancellationToken.ThrowIfCancellationRequested();
+            AddStaticMethodsUsingsForDeserializer(
+                generatedCode,
+                factoryNameCallbackFromType
+            );
+            AddStaticMethodsUsingsForRequestExecutor(
+                generatedCode,
+                factoryNameCallbackFromType
+            );
+            AddQueryParameterMapperMethod(
+                generatedCode
+            );
+        }, cancellationToken);
     }
     private static readonly CodeUsingDeclarationNameComparer usingComparer = new();
     private static void AliasUsingsWithSameSymbol(CodeElement currentElement) {

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -548,6 +548,7 @@ namespace Kiota.Builder.Writers.Go {
             if(fieldToSerialize.Any()) {
                 fieldToSerialize
                         .OrderBy(static x => x.Name)
+                        .Where(static x => x.Setter != null)
                         .ToList()
                         .ForEach(x => WriteFieldDeserializer(x, writer, parentClass));
             }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -272,7 +272,7 @@ namespace Kiota.Builder.Writers.Go {
                 writer.WriteLine($"err := m.{parentClass.StartBlock.Inherits.Name.ToFirstCharacterUpperCase()}.Serialize(writer)");
                 WriteReturnError(writer);
             }
-            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType && !x.ReadOnly)) {
+            foreach(var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType && !x.ReadOnly && x.Getter != null)) {
                 WriteSerializationMethodCall(otherProp.Type, parentClass, otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase(), $"m.{otherProp.Getter.Name.ToFirstCharacterUpperCase()}()", !inherits, writer);
             }
         }

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -379,7 +379,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         if(fieldToSerialize.Any()) {
             writer.IncreaseIndent();
             fieldToSerialize
-                    .Where(static x => !x.ExistsInBaseType)
+                    .Where(static x => !x.ExistsInBaseType && x.Setter != null)
                     .OrderBy(static x => x.Name)
                     .Select(x => 
                         $"this.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (n) -> {{ currentObject.{x.Setter.Name.ToFirstCharacterLowerCase()}(n.{GetDeserializationMethodName(x.Type, method)}); }});")

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -34,7 +34,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, JavaConvention
                     returnType = $"EnumSet<{returnType}>";
                 if(codeElement.Access != AccessModifier.Private)
                     writer.WriteLine(codeElement.Type.IsNullable ? "@javax.annotation.Nullable" : "@javax.annotation.Nonnull");
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{(codeElement.ReadOnly ? " final " : " ")}{returnType} {codeElement.NamePrefix}{codeElement.Name.ToFirstCharacterLowerCase()}{defaultValue};");
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.NamePrefix}{codeElement.Name.ToFirstCharacterLowerCase()}{defaultValue};");
             break;
         }
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -404,8 +404,8 @@ namespace Kiota.Builder.Writers.Php
             if(fieldToSerialize.Any()) {
                 writer.IncreaseIndent();
                 fieldToSerialize
-                    .Where(x => !x.ExistsInBaseType)
-                    .OrderBy(x => x.Name)
+                    .Where(static x => !x.ExistsInBaseType && x.Setter != null)
+                    .OrderBy(static x => x.Name)
                     .Select(x => 
                         $"'{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}' => function (ParseNode $n) use ({currentObjectName}) {{ {currentObjectName}->{x.Setter.Name.ToFirstCharacterLowerCase()}({GetDeserializationMethodName(x.Type, method)}); }},")
                     .ToList()

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -210,6 +210,57 @@ components:
         Assert.Equal("double", progressProp.Type.Name);
     }
     [Fact]
+    public void OData_doubles_as_one_of_format_inside(){
+        var node = OpenApiUrlTreeNode.Create();
+        node.Attach("tasks", new OpenApiPathItem
+        {
+            Operations = {
+                [OperationType.Get] = new OpenApiOperation
+                { 
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse
+                        {
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "object",
+                                        Properties = new Dictionary<string, OpenApiSchema> {
+                                            {
+                                                "progress", new OpenApiSchema{
+                                                    OneOf = new List<OpenApiSchema>{
+                                                        new OpenApiSchema{
+                                                            Type = "number",
+                                                            Format = "double"
+                                                        },
+                                                        new OpenApiSchema{
+                                                            Type = "string"
+                                                        },
+                                                        new OpenApiSchema {
+                                                            Enum = new List<IOpenApiAny> { new OpenApiString("-INF"), new OpenApiString("INF"), new OpenApiString("NaN") }
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } 
+        }, "default");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" });
+        var codeModel = builder.CreateSourceModel(node);
+        var progressProp = codeModel.FindChildByName<CodeProperty>("progress");
+        Assert.Equal("double", progressProp.Type.Name);
+    }
+    [Fact]
     public void OData_doubles_as_any_of(){
         var node = OpenApiUrlTreeNode.Create();
         node.Attach("tasks", new OpenApiPathItem

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Kiota.Builder.CodeDOM;
@@ -1675,7 +1676,7 @@ components:
         Assert.Single(entityClass.DiscriminatorInformation.DiscriminatorMappings);
     }
     [Fact]
-    public void AddsDiscriminatorMappingsOneOfImplicit(){
+    public async Task AddsDiscriminatorMappingsOneOfImplicit(){
         var entitySchema = new OpenApiSchema {
             Type = "object",
             Properties = new Dictionary<string, OpenApiSchema> {
@@ -1795,7 +1796,7 @@ components:
         var builder = new KiotaBuilder(mockLogger.Object, config);
         var node = builder.CreateUriSpace(document);
         var codeModel = builder.CreateSourceModel(node);
-        builder.ApplyLanguageRefinement(config, codeModel);
+        await builder.ApplyLanguageRefinement(config, codeModel, CancellationToken.None);
         var entityClass = codeModel.FindChildByName<CodeClass>("entity");
         var directoryObjectsClass = codeModel.FindChildByName<CodeClass>("directoryObjects");
         Assert.NotNull(entityClass);
@@ -1809,7 +1810,7 @@ components:
         Assert.Equal(2, directoryObjectsClass.DiscriminatorInformation.DiscriminatorMappings.Count());
     }
     [Fact]
-    public void AddsDiscriminatorMappingsAllOfImplicit(){
+    public async Task AddsDiscriminatorMappingsAllOfImplicit(){
         var entitySchema = new OpenApiSchema {
             Type = "object",
             Properties = new Dictionary<string, OpenApiSchema> {
@@ -1950,7 +1951,7 @@ components:
         var builder = new KiotaBuilder(mockLogger.Object, config);
         var node = builder.CreateUriSpace(document);
         var codeModel = builder.CreateSourceModel(node);
-        builder.ApplyLanguageRefinement(config, codeModel);
+        await builder.ApplyLanguageRefinement(config, codeModel, CancellationToken.None);
         var entityClass = codeModel.FindChildByName<CodeClass>("entity");
         var directoryObjectClass = codeModel.FindChildByName<CodeClass>("directoryObject");
         var userClass = codeModel.FindChildByName<CodeClass>("user");
@@ -1971,7 +1972,7 @@ components:
     }
     
     [Fact]
-    public void AddsDiscriminatorMappingsAllOfImplicitWithParentHavingMappingsWhileChildDoesNot(){
+    public async Task AddsDiscriminatorMappingsAllOfImplicitWithParentHavingMappingsWhileChildDoesNot(){
         var entitySchema = new OpenApiSchema {
             Type = "object",
             Properties = new Dictionary<string, OpenApiSchema> {
@@ -2121,7 +2122,7 @@ components:
         var builder = new KiotaBuilder(mockLogger.Object, config);
         var node = builder.CreateUriSpace(document);
         var codeModel = builder.CreateSourceModel(node);
-        builder.ApplyLanguageRefinement(config, codeModel);
+        await builder.ApplyLanguageRefinement(config, codeModel, CancellationToken.None);
         var entityClass = codeModel.FindChildByName<CodeClass>("entity");
         var directoryObjectClass = codeModel.FindChildByName<CodeClass>("directoryObject");
         var userClass = codeModel.FindChildByName<CodeClass>("user");

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 
@@ -12,7 +12,7 @@ namespace Kiota.Builder.Tests.Refiners
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
 
         [Fact]
-        public void ReplacesRequestBuilderPropertiesByMethods()
+        public async Task ReplacesRequestBuilderPropertiesByMethods()
         {
             var model = root.AddClass(new CodeClass
             {
@@ -29,13 +29,13 @@ namespace Kiota.Builder.Tests.Refiners
                     Name = "string"
                 }
             }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, root);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, root);
             Assert.Equal("breaks", requestBuilder.Name);
             Assert.Equal("userRequestBuilder", model.Name);
         }
 
         [Fact]
-        public void PrefixReservedWordPropertyNamesWith()
+        public async Task PrefixReservedWordPropertyNamesWith()
         {
             var model = root.AddClass(new CodeClass
             {
@@ -53,12 +53,12 @@ namespace Kiota.Builder.Tests.Refiners
                 }
             }).First();
             
-            ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, root);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, root);
             Assert.Equal("EscapedContinue",property.Name);
         }
         
         [Fact]
-        public void ReplacesBinaryWithNativeType()
+        public async Task ReplacesBinaryWithNativeType()
         {
             var model = root.AddClass(new CodeClass
             {
@@ -73,12 +73,12 @@ namespace Kiota.Builder.Tests.Refiners
             {
                 Name = "binary"
             };
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP}, root);
+            await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP}, root);
             Assert.Equal("StreamInterface", method.ReturnType.Name);
         }
 
         [Fact]
-        public void AddsDefaultImports() {
+        public async Task AddsDefaultImports() {
             var model = root.AddClass(new CodeClass
             {
                 Name = "model",
@@ -89,14 +89,8 @@ namespace Kiota.Builder.Tests.Refiners
                 Name = "rb",
                 Kind = CodeClassKind.RequestBuilder,
             }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
+            await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
             Assert.NotEmpty(model.StartBlock.Usings);
-        }
-
-        [Fact]
-        public void TestCanReturnCorrectAccess()
-        {
-            
         }
     }
 }

--- a/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
@@ -1,201 +1,200 @@
 ﻿using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 
 using Xunit;
 
-namespace Kiota.Builder.Tests.Refiners {
-    public class RubyLanguageRefinerTests {
+namespace Kiota.Builder.Tests.Refiners;
+public class RubyLanguageRefinerTests {
 
-        private readonly CodeNamespace graphNS;
-        private readonly CodeClass parentClass;
-        private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
-        public RubyLanguageRefinerTests() {
-            root = CodeNamespace.InitRootNamespace();
-            graphNS = root.AddNamespace("graph");
-            parentClass = new () {
-                Name = "parentClass"
-            };
-            graphNS.AddClass(parentClass);
-        }
-        #region CommonLanguageRefinerTests
-        [Fact]
-        public void DoesNotKeepCancellationParametersInRequestExecutors()
-        {
-            var model = root.AddClass(new CodeClass
-            {
-                Name = "model",
-                Kind = CodeClassKind.RequestBuilder
-            }).First();
-            var method = model.AddMethod(new CodeMethod
-            {
-                Name = "getMethod",
-                Kind = CodeMethodKind.RequestExecutor,
-                ReturnType = new CodeType
-                {
-                    Name = "string"
-                }
-            }).First();
-            var cancellationParam = new CodeParameter
-            {
-                Name = "cancelletionToken",
-                Optional = true,
-                Kind = CodeParameterKind.Cancellation,
-                Description = "Cancellation token to use when cancelling requests",
-                Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
-            };
-            method.AddParameter(cancellationParam);
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root); //using CSharp so the cancelletionToken doesn't get removed
-            Assert.False(method.Parameters.Any());
-            Assert.DoesNotContain(cancellationParam, method.Parameters);
-        }
-        [Fact]
-        public void AddsDefaultImports() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var requestBuilder = root.AddClass(new CodeClass {
-                Name = "rb",
-                Kind = CodeClassKind.RequestBuilder,
-            }).First();
-            requestBuilder.AddMethod(new CodeMethod {
-                Name = "get",
-                Kind = CodeMethodKind.RequestExecutor,
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.NotEmpty(requestBuilder.StartBlock.Usings);
-        
-        }
-        #endregion
-        #region RubyLanguageRefinerTests
-        [Fact]
-        public void CorrectsCoreTypes() {
-            var model = root.AddClass(new CodeClass {
-                Name = "rb",
-                Kind = CodeClassKind.RequestBuilder
-            }).First();
-            var property = model.AddProperty(new CodeProperty {
-                Name = "name",
-                Type = new CodeType {
-                    Name = "string",
-                    IsExternal = true
-                },
-                Kind = CodePropertyKind.PathParameters,
-                DefaultValue = "wrongDefaultValue"
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
-            Assert.Equal("Hash.new", property.DefaultValue);
-        }
-        [Fact]
-        public void EscapesReservedKeywords() {
-            var model = root.AddClass(new CodeClass {
-                Name = "break",
-                Kind = CodeClassKind.Model
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
-            Assert.NotEqual("break", model.Name);
-            Assert.Contains("escaped", model.Name);
-        }
-        [Fact]
-        public void AddInheritedAndMethodTypesImports() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var declaration = model.StartBlock;
-            declaration.Inherits = new (){
-                Name = "someInterface"
-            };
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
-            Assert.Equal("someInterface", declaration.Usings.First(usingDef => usingDef.Declaration != null).Declaration?.Name);
-        }
-        [Fact]
-        public void ReplacesDateTimeOffsetByNativeType() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method",
-                ReturnType = new CodeType {
-                    Name = "DateTimeOffset"
-                },
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.Equal("DateTime", method.ReturnType.Name);
-        }
-        [Fact]
-        public void ReplacesDateOnlyByNativeType() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method",
-                ReturnType = new CodeType {
-                    Name = "DateOnly"
-                },
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.Equal("Date", method.ReturnType.Name);
-        }
-        [Fact]
-        public void ReplacesTimeOnlyByNativeType() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method",
-                ReturnType = new CodeType {
-                    Name = "TimeOnly"
-                },
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.Equal("Time", method.ReturnType.Name);
-        }
-        [Fact]
-        public void ReplacesDurationByNativeType() {
-            var model = root.AddClass(new CodeClass {
-                Name = "model",
-                Kind = CodeClassKind.Model
-            }).First();
-            var method = model.AddMethod(new CodeMethod {
-                Name = "method",
-                ReturnType = new CodeType {
-                    Name = "TimeSpan"
-                },
-            }).First();
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
-            Assert.NotEmpty(model.StartBlock.Usings);
-            Assert.Equal("MicrosoftKiotaAbstractions::ISODuration", method.ReturnType.Name);
-        }
-        [Fact]
-        public void AddNamespaceModuleImports() {
-            var declaration = parentClass.StartBlock;
-            var subNS = graphNS.AddNamespace($"{graphNS.Name}.messages");
-            var messageClassDef = new CodeClass {
-                Name = "Message",
-            };
-            subNS.AddClass(messageClassDef);
-            declaration.AddUsings(new CodeUsing
-            {
-                Name = messageClassDef.Name,
-                Declaration = new() {
-                    Name = messageClassDef.Name,
-                    TypeDefinition = messageClassDef,
-                }
-            });
-            ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
-            Assert.Equal("Message", declaration.Usings.First().Declaration.Name);
-            Assert.Equal("./graph", declaration.Usings.Last().Declaration.Name);
-        }
-        #endregion
+    private readonly CodeNamespace graphNS;
+    private readonly CodeClass parentClass;
+    private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
+    public RubyLanguageRefinerTests() {
+        root = CodeNamespace.InitRootNamespace();
+        graphNS = root.AddNamespace("graph");
+        parentClass = new () {
+            Name = "parentClass"
+        };
+        graphNS.AddClass(parentClass);
     }
+    #region CommonLanguageRefinerTests
+    [Fact]
+    public async Task DoesNotKeepCancellationParametersInRequestExecutors()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "model",
+            Kind = CodeClassKind.RequestBuilder
+        }).First();
+        var method = model.AddMethod(new CodeMethod
+        {
+            Name = "getMethod",
+            Kind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var cancellationParam = new CodeParameter
+        {
+            Name = "cancellationToken",
+            Optional = true,
+            Kind = CodeParameterKind.Cancellation,
+            Description = "Cancellation token to use when cancelling requests",
+            Type = new CodeType { Name = "CancellationToken", IsExternal = true },
+        };
+        method.AddParameter(cancellationParam);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
+        Assert.False(method.Parameters.Any());
+        Assert.DoesNotContain(cancellationParam, method.Parameters);
+    }
+    [Fact]
+    public async Task AddsDefaultImports() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var requestBuilder = root.AddClass(new CodeClass {
+            Name = "rb",
+            Kind = CodeClassKind.RequestBuilder,
+        }).First();
+        requestBuilder.AddMethod(new CodeMethod {
+            Name = "get",
+            Kind = CodeMethodKind.RequestExecutor,
+        });
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.NotEmpty(requestBuilder.StartBlock.Usings);
+    
+    }
+    #endregion
+    #region RubyLanguageRefinerTests
+    [Fact]
+    public async Task CorrectsCoreTypes() {
+        var model = root.AddClass(new CodeClass {
+            Name = "rb",
+            Kind = CodeClassKind.RequestBuilder
+        }).First();
+        var property = model.AddProperty(new CodeProperty {
+            Name = "name",
+            Type = new CodeType {
+                Name = "string",
+                IsExternal = true
+            },
+            Kind = CodePropertyKind.PathParameters,
+            DefaultValue = "wrongDefaultValue"
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
+        Assert.Equal("Hash.new", property.DefaultValue);
+    }
+    [Fact]
+    public async Task EscapesReservedKeywords() {
+        var model = root.AddClass(new CodeClass {
+            Name = "break",
+            Kind = CodeClassKind.Model
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
+        Assert.NotEqual("break", model.Name);
+        Assert.Contains("escaped", model.Name);
+    }
+    [Fact]
+    public async Task AddInheritedAndMethodTypesImports() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var declaration = model.StartBlock;
+        declaration.Inherits = new (){
+            Name = "someInterface"
+        };
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
+        Assert.Equal("someInterface", declaration.Usings.First(usingDef => usingDef.Declaration != null).Declaration?.Name);
+    }
+    [Fact]
+    public async Task ReplacesDateTimeOffsetByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateTimeOffset"
+            },
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("DateTime", method.ReturnType.Name);
+    }
+    [Fact]
+    public async Task ReplacesDateOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "DateOnly"
+            },
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Date", method.ReturnType.Name);
+    }
+    [Fact]
+    public async Task ReplacesTimeOnlyByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeOnly"
+            },
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("Time", method.ReturnType.Name);
+    }
+    [Fact]
+    public async Task ReplacesDurationByNativeType() {
+        var model = root.AddClass(new CodeClass {
+            Name = "model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var method = model.AddMethod(new CodeMethod {
+            Name = "method",
+            ReturnType = new CodeType {
+                Name = "TimeSpan"
+            },
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby }, root);
+        Assert.NotEmpty(model.StartBlock.Usings);
+        Assert.Equal("MicrosoftKiotaAbstractions::ISODuration", method.ReturnType.Name);
+    }
+    [Fact]
+    public async Task AddNamespaceModuleImports() {
+        var declaration = parentClass.StartBlock;
+        var subNS = graphNS.AddNamespace($"{graphNS.Name}.messages");
+        var messageClassDef = new CodeClass {
+            Name = "Message",
+        };
+        subNS.AddClass(messageClassDef);
+        declaration.AddUsings(new CodeUsing
+        {
+            Name = messageClassDef.Name,
+            Declaration = new() {
+                Name = messageClassDef.Name,
+                TypeDefinition = messageClassDef,
+            }
+        });
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Ruby, ClientNamespaceName = graphNS.Name }, root);
+        Assert.Equal("Message", declaration.Usings.First().Declaration.Name);
+        Assert.Equal("./graph", declaration.Usings.Last().Declaration.Name);
+    }
+    #endregion
 }

--- a/tests/Kiota.Builder.Tests/Refiners/ShellRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/ShellRefinerTests.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 
@@ -11,7 +11,7 @@ public class ShellRefinerTests {
     private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
 
     [Fact]
-    public void AddsUsingsForCommandTypesUsedInCommandBuilder() {
+    public async Task AddsUsingsForCommandTypesUsedInCommandBuilder() {
         var requestBuilder = root.AddClass(new CodeClass {
             Name = "somerequestbuilder",
             Kind = CodeClassKind.RequestBuilder,
@@ -25,7 +25,7 @@ public class ShellRefinerTests {
                 IsExternal = true
             }
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Shell }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Shell }, root);
         
         var declaration = requestBuilder.StartBlock;
 
@@ -33,7 +33,7 @@ public class ShellRefinerTests {
     }
 
     [Fact]
-    public void CreatesCommandBuilders() {
+    public async Task CreatesCommandBuilders() {
         var requestBuilder = root.AddClass(new CodeClass {
             Name = "somerequestbuilder",
             Kind = CodeClassKind.RequestBuilder,
@@ -74,7 +74,7 @@ public class ShellRefinerTests {
             SerializerModules = new() {"com.microsoft.kiota.serialization.Serializer"}
         });
 
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Shell }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Shell }, root);
 
         var methods = root.GetChildElements().OfType<CodeClass>().SelectMany(c => c.GetChildElements().OfType<CodeMethod>());
         var methodNames = methods.Select(m => m.Name);

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 
@@ -21,7 +21,7 @@ public class TypeScriptLanguageRefinerTests {
     }
 #region commonrefiner
     [Fact]
-    public void AddsQueryParameterMapperMethod() {
+    public async Task AddsQueryParameterMapperMethod() {
         var model = graphNS.AddClass(new CodeClass {
             Name = "somemodel",
             Kind = CodeClassKind.QueryParameters,
@@ -37,11 +37,11 @@ public class TypeScriptLanguageRefinerTests {
 
         Assert.Empty(model.Methods);
 
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, graphNS);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, graphNS);
         Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.QueryParametersMapper)));
     }
     [Fact]
-    public void AddStaticMethodsUsingsForDeserializer() {
+    public async Task AddStaticMethodsUsingsForDeserializer() {
         var model = graphNS.AddClass(new CodeClass {
             Name = "somemodel",
             Kind = CodeClassKind.Model,
@@ -88,7 +88,7 @@ public class TypeScriptLanguageRefinerTests {
         Assert.Empty(graphNS.GetChildElements(true).OfType<CodeFunction>());
         Assert.Single(model.GetChildElements(true).OfType<CodeMethod>());
 
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, graphNS);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, graphNS);
         Assert.Empty(model.GetChildElements(true).OfType<CodeMethod>().Where(x => x.IsOfKind(CodeMethodKind.Factory)));
         Assert.Single(subNs.GetChildElements(true).OfType<CodeFunction>());
 
@@ -97,13 +97,13 @@ public class TypeScriptLanguageRefinerTests {
 
     }
     [Fact]
-    public void AddsExceptionInheritanceOnErrorClasses() {
+    public async Task AddsExceptionInheritanceOnErrorClasses() {
         var model = root.AddClass(new CodeClass {
             Name = "somemodel",
             Kind = CodeClassKind.Model,
             IsErrorDefinition = true,
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
 
         var declaration = model.StartBlock;
 
@@ -111,7 +111,7 @@ public class TypeScriptLanguageRefinerTests {
         Assert.Equal("ApiError", declaration.Inherits.Name);
     }
     [Fact]
-    public void FailsExceptionInheritanceOnErrorClassesWhichAlreadyInherit() {
+    public async Task FailsExceptionInheritanceOnErrorClassesWhichAlreadyInherit() {
         var model = root.AddClass(new CodeClass {
             Name = "somemodel",
             Kind = CodeClassKind.Model,
@@ -121,10 +121,10 @@ public class TypeScriptLanguageRefinerTests {
         declaration.Inherits = new CodeType {
             Name = "SomeOtherModel"
         };
-        Assert.Throws<InvalidOperationException>(() => ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root));
     }
     [Fact]
-    public void AddsUsingsForErrorTypesForRequestExecutor() {
+    public async Task AddsUsingsForErrorTypesForRequestExecutor() {
         var requestBuilder = root.AddClass(new CodeClass {
             Name = "somerequestbuilder",
             Kind = CodeClassKind.RequestBuilder,
@@ -146,14 +146,14 @@ public class TypeScriptLanguageRefinerTests {
                         Name = "Error4XX",
                         TypeDefinition = errorClass,
                     });
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
 
         var declaration = requestBuilder.StartBlock;
 
         Assert.Contains("Error4XX", declaration.Usings.Select(x => x.Declaration?.Name));
     }
     [Fact]
-    public void AddsUsingsForDiscriminatorTypes() {
+    public async Task AddsUsingsForDiscriminatorTypes() {
         var parentModel = root.AddClass(new CodeClass {
             Name = "parentModel",
             Kind = CodeClassKind.Model,
@@ -180,7 +180,7 @@ public class TypeScriptLanguageRefinerTests {
                         TypeDefinition = childModel,
                     });
         Assert.False(factoryMethod.Parent is CodeFunction);
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.Equal(childModel, (factoryMethod.Parent as CodeFunction).StartBlock.Usings.First(x => x.Name.Equals("childModel", StringComparison.OrdinalIgnoreCase)).Declaration.TypeDefinition);
     }
 #endregion
@@ -194,17 +194,17 @@ public class TypeScriptLanguageRefinerTests {
     private const string AddiationalDataDefaultName = "new Dictionary<string, object>()";
     private const string HandlerDefaultName = "IResponseHandler";
     [Fact]
-    public void EscapesReservedKeywords() {
+    public async Task EscapesReservedKeywords() {
         var model = root.AddClass(new CodeClass {
             Name = "break",
             Kind = CodeClassKind.Model
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEqual("break", model.Name);
         Assert.Contains("escaped", model.Name);
     }
     [Fact]
-    public void CorrectsCoreType() {
+    public async Task CorrectsCoreType() {
 
         var model = root.AddClass(new CodeClass
         {
@@ -281,7 +281,7 @@ public class TypeScriptLanguageRefinerTests {
                 Name = PathParametersDefaultName
             },
         });
-        ILanguageRefiner.Refine(new GenerationConfiguration{ Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration{ Language = GenerationLanguage.TypeScript }, root);
         Assert.Empty(model.Properties.Where(x => HttpCoreDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Properties.Where(x => FactoryDefaultName.Equals(x.Type.Name)));
         Assert.Empty(model.Properties.Where(x => DateTimeOffsetDefaultName.Equals(x.Type.Name)));
@@ -294,7 +294,7 @@ public class TypeScriptLanguageRefinerTests {
         Assert.Single(constructorMethod.Parameters.Where(x => x.Type is CodeComposedTypeBase));
     }
     [Fact]
-    public void ReplacesDateTimeOffsetByNativeType() {
+    public async Task ReplacesDateTimeOffsetByNativeType() {
         var model = root.AddClass(new CodeClass {
             Name = "model",
             Kind = CodeClassKind.Model
@@ -305,12 +305,12 @@ public class TypeScriptLanguageRefinerTests {
                 Name = "DateTimeOffset"
             },
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
         Assert.Equal("Date", method.ReturnType.Name);
     }
     [Fact]
-    public void ReplacesDateOnlyByNativeType() {
+    public async Task ReplacesDateOnlyByNativeType() {
         var model = root.AddClass(new CodeClass {
             Name = "model",
             Kind = CodeClassKind.Model
@@ -321,12 +321,12 @@ public class TypeScriptLanguageRefinerTests {
                 Name = "DateOnly"
             },
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
         Assert.Equal("DateOnly", method.ReturnType.Name);
     }
     [Fact]
-    public void ReplacesTimeOnlyByNativeType() {
+    public async Task ReplacesTimeOnlyByNativeType() {
         var model = root.AddClass(new CodeClass {
             Name = "model",
             Kind = CodeClassKind.Model
@@ -337,12 +337,12 @@ public class TypeScriptLanguageRefinerTests {
                 Name = "TimeOnly"
             },
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
         Assert.Equal("TimeOnly", method.ReturnType.Name);
     }
     [Fact]
-    public void ReplacesDurationByNativeType() {
+    public async Task ReplacesDurationByNativeType() {
         var model = root.AddClass(new CodeClass {
             Name = "model",
             Kind = CodeClassKind.Model
@@ -353,12 +353,12 @@ public class TypeScriptLanguageRefinerTests {
                 Name = "TimeSpan"
             },
         }).First();
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
         Assert.Equal("Duration", method.ReturnType.Name);
     }
     [Fact]
-    public void AliasesDuplicateUsingSymbols() {
+    public async Task AliasesDuplicateUsingSymbols() {
         var model = graphNS.AddClass(new CodeClass {
             Name = "model",
             Kind = CodeClassKind.Model
@@ -392,13 +392,13 @@ public class TypeScriptLanguageRefinerTests {
         };
         model.AddUsing(using1);
         model.AddUsing(using2);
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root);
         Assert.NotEmpty(using1.Alias);
         Assert.NotEmpty(using2.Alias);
         Assert.NotEqual(using1.Alias, using2.Alias);
     }
     [Fact]
-    public void DoesNotKeepCancellationParametersInRequestExecutors()
+    public async Task DoesNotKeepCancellationParametersInRequestExecutors()
     {
         var model = root.AddClass(new CodeClass
         {
@@ -423,7 +423,7 @@ public class TypeScriptLanguageRefinerTests {
             Type = new CodeType { Name = "CancelletionToken", IsExternal = true },
         };
         method.AddParameter(cancellationParam);
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root); //using CSharp so the cancelletionToken doesn't get removed
         Assert.False(method.Parameters.Any());
         Assert.DoesNotContain(cancellationParam, method.Parameters);
     }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -73,12 +73,19 @@ public class CodeMethodWriterTests : IDisposable {
         addData.Type = new CodeType {
             Name = "string"
         };
-        var dummyProp = parentClass.AddProperty(new CodeProperty {
+        parentClass.AddProperty(new CodeProperty {
             Name = "dummyProp",
-        }).First();
-        dummyProp.Type = new CodeType {
-            Name = "string"
-        };
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty{
+            Name = "noAccessors",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
         var dummyUCaseProp = parentClass.AddProperty(new CodeProperty {
             Name = "DummyUCaseProp",
         }).First();

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Refiners;
@@ -848,9 +848,7 @@ public class CodeMethodWriterTests : IDisposable {
     }
     private const string AbstractionsPackageHash = "i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f";
     [Fact]
-    public void WritesRequestGeneratorBodyForScalar() {
-        var configurationMock = new Mock<GenerationConfiguration>();
-        var refiner = new GoRefiner(configurationMock.Object);
+    public async Task WritesRequestGeneratorBodyForScalar() {
         method.Kind = CodeMethodKind.RequestGenerator;
         method.HttpMethod = HttpMethod.Get;
         var executor = parentClass.AddMethod(new CodeMethod {
@@ -865,7 +863,7 @@ public class CodeMethodWriterTests : IDisposable {
         AddRequestBodyParameters(executor);
         AddRequestBodyParameters();
         AddRequestProperties();
-        refiner.Refine(parentClass.Parent as CodeNamespace);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go}, parentClass.Parent as CodeNamespace);
         method.AcceptedResponseTypes.Add("application/json");
         writer.Write(method);
         var result = tw.ToString();
@@ -884,9 +882,7 @@ public class CodeMethodWriterTests : IDisposable {
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
-    public void WritesRequestGeneratorBodyForParsable() {
-        var configurationMock = new Mock<GenerationConfiguration>();
-        var refiner = new GoRefiner(configurationMock.Object);
+    public async Task WritesRequestGeneratorBodyForParsable() {
         method.Kind = CodeMethodKind.RequestGenerator;
         method.HttpMethod = HttpMethod.Get;
         var executor = parentClass.AddMethod(new CodeMethod {
@@ -901,7 +897,7 @@ public class CodeMethodWriterTests : IDisposable {
         AddRequestBodyParameters(executor, true);
         AddRequestBodyParameters(useComplexTypeForBody: true);
         AddRequestProperties();
-        refiner.Refine(parentClass.Parent as CodeNamespace);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go}, parentClass.Parent as CodeNamespace);
         method.AcceptedResponseTypes.Add("application/json");
         writer.Write(method);
         var result = tw.ToString();
@@ -1388,7 +1384,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("EnableBackingStore", result);
     }
     [Fact]
-    public void AccessorsTargetingEscapedPropertiesAreNotEscapedThemselves() {
+    public async Task AccessorsTargetingEscapedPropertiesAreNotEscapedThemselves() {
         var model = root.AddClass(new CodeClass {
             Name = "SomeClass",
             Kind = CodeClassKind.Model
@@ -1400,7 +1396,7 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodePropertyKind.Custom,
         });
         root.AddNamespace("ApiSdk/models"); // so the interface copy refiner goes through
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
         var getter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Getter));
         var setter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Setter));
         var tempWriter = LanguageWriter.GetLanguageWriter(GenerationLanguage.Go, DefaultPath, DefaultName);

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -98,6 +98,13 @@ public class CodeMethodWriterTests : IDisposable {
                 Name = "SetDummyProp",
             },
         });
+        parentClass.AddProperty(new CodeProperty{
+            Name = "noAccessors",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
         parentClass.AddProperty(new CodeProperty {
             Name = "dummyColl",
             Type = new CodeType {

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -96,6 +96,13 @@ public class CodeMethodWriterTests : IDisposable {
                 Name = "SetDummyProp",
             },
         });
+        parentClass.AddProperty(new CodeProperty{
+            Name = "noAccessors",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType {
+                Name = "string"
+            }
+        });
         parentClass.AddProperty(new CodeProperty {
             Name = "dummyColl",
             Type = new CodeType {

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Refiners;
@@ -1288,7 +1288,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("enableBackingStore", result);
     }
     [Fact]
-    public void AccessorsTargetingEscapedPropertiesAreNotEscapedThemselves() {
+    public async Task AccessorsTargetingEscapedPropertiesAreNotEscapedThemselves() {
         var model = root.AddClass(new CodeClass {
             Name = "SomeClass",
             Kind = CodeClassKind.Model
@@ -1299,7 +1299,7 @@ public class CodeMethodWriterTests : IDisposable {
             Access = AccessModifier.Public,
             Kind = CodePropertyKind.Custom,
         });
-        ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
         var getter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Getter));
         var setter = model.Methods.First(x => x.IsOfKind(CodeMethodKind.Setter));
         var tempWriter = LanguageWriter.GetLanguageWriter(GenerationLanguage.Java, DefaultPath, DefaultName);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 using Kiota.Builder.Writers;
@@ -18,12 +18,10 @@ namespace Kiota.Builder.Tests.Writers.Php
         private readonly LanguageWriter writer;
         private readonly CodeClassDeclarationWriter codeElementWriter;
         private readonly CodeClass parentClass;
-        private readonly ILanguageRefiner _refiner;
         public CodeClassDeclarationWriterTests() {
             codeElementWriter = new CodeClassDeclarationWriter(new PhpConventionService());
             writer = LanguageWriter.GetLanguageWriter(GenerationLanguage.PHP, DefaultPath, DefaultName);
             tw = new StringWriter();
-            _refiner = new PhpRefiner(new GenerationConfiguration {Language = GenerationLanguage.PHP});
             writer.SetTextWriter(tw);
             var root = CodeNamespace.InitRootNamespace();
             root.Name = "Microsoft\\Graph";
@@ -98,7 +96,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
 
         [Fact]
-        public void ImportRequiredClassesWhenContainsRequestExecutor()
+        public async Task ImportRequiredClassesWhenContainsRequestExecutor()
         {
             var declaration = parentClass;
             declaration?.AddMethod(new CodeMethod
@@ -115,7 +113,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             });
             var dec = declaration?.StartBlock;
             var namespaces = declaration?.Parent as CodeNamespace;
-            _refiner.Refine(namespaces);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, namespaces);
             codeElementWriter.WriteCodeElement(dec, writer);
             var result = tw.ToString();
             

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 using Kiota.Builder.Writers;
@@ -17,13 +17,11 @@ namespace Kiota.Builder.Tests.Writers.Php
         private readonly StringWriter tw;
         private readonly LanguageWriter writer;
         private readonly CodeEnum currentEnum;
-        private readonly ILanguageRefiner _languageRefiner;
         private const string EnumName = "someEnum";
         private readonly CodeEnumWriter _codeEnumWriter;
         public CodeEnumWriterTests(){
             writer = LanguageWriter.GetLanguageWriter(GenerationLanguage.PHP, DefaultPath, DefaultName);
             tw = new StringWriter();
-            _languageRefiner = new PhpRefiner(new GenerationConfiguration {Language = GenerationLanguage.PHP});
             writer.SetTextWriter(tw);
             var root = CodeNamespace.InitRootNamespace();
             root.Name = "Microsoft\\Graph";
@@ -37,12 +35,12 @@ namespace Kiota.Builder.Tests.Writers.Php
             GC.SuppressFinalize(this);
         }
         [Fact]
-        public void WritesEnum()
+        public async Task WritesEnum()
         {
             var declaration = currentEnum.Parent as CodeNamespace;
             const string optionName = "option1";
             currentEnum.AddOption(new CodeEnumOption { Name = optionName});
-            _languageRefiner.Refine(declaration);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, declaration);
             _codeEnumWriter.WriteCodeElement(currentEnum, writer);
             var result = tw.ToString();
             Assert.Contains("<?php", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 using Kiota.Builder.Writers;
@@ -360,7 +360,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
 
         [Fact]
-        public void WriteIndexerBody()
+        public async Task WriteIndexerBody()
         {
             parentClass.AddProperty(
                 new CodeProperty
@@ -439,7 +439,7 @@ namespace Kiota.Builder.Tests.Writers.Php
 
             parentClass.AddMethod(codeMethod);
             
-            _refiner.Refine(parentClass.Parent as CodeNamespace);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, parentClass.Parent as CodeNamespace);
             languageWriter.Write(codeMethod);
             var result = stringWriter.ToString();
 
@@ -504,7 +504,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         
         [Theory]
         [MemberData(nameof(DeserializerProperties))]
-        public void WriteDeserializer(CodeProperty property, string expected)
+        public async Task WriteDeserializer(CodeProperty property, string expected)
         {
             parentClass.Kind = CodeClassKind.Model;
             var deserializerMethod = new CodeMethod
@@ -528,7 +528,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             });
             parentClass.AddMethod(deserializerMethod);
             parentClass.AddProperty(property);
-            _refiner.Refine(parentClass.Parent as CodeNamespace);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, parentClass.Parent as CodeNamespace);
             languageWriter.Write(deserializerMethod);
             if (property.ExistsInBaseType)
                 Assert.DoesNotContain(expected, stringWriter.ToString());
@@ -537,7 +537,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
 
         [Fact]
-        public void WriteDeserializerMergeWhenHasParent()
+        public async Task WriteDeserializerMergeWhenHasParent()
         {
             var currentClass = parentClass;
             currentClass.Kind = CodeClassKind.Model;
@@ -578,7 +578,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             };
             currentClass.AddMethod(deserializerMethod);
             
-            _refiner.Refine(parentClass.Parent as CodeNamespace);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, parentClass.Parent as CodeNamespace);
             _codeMethodWriter.WriteCodeElement(deserializerMethod, languageWriter);
             var result = stringWriter.ToString();
             Assert.Contains("array_merge(parent::getFieldDeserializers()", result);
@@ -802,7 +802,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
         
         [Fact]
-        public void WriteFactoryMethod()
+        public async void WriteFactoryMethod()
         {
             var parentModel = root.AddClass(new CodeClass {
                 Name = "parentModel",
@@ -842,14 +842,14 @@ namespace Kiota.Builder.Tests.Writers.Php
                 },
                 Optional = false,
             });
-            _refiner.Refine(parentClass.Parent as CodeNamespace);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, parentClass.Parent as CodeNamespace);
             languageWriter.Write(factoryMethod);
             var result = stringWriter.ToString();
             Assert.Contains("case 'childModel': return new ChildModel();", result);
             Assert.Contains("$mappingValueNode = $parseNode->getChildNode(\"@odata.type\");", result);
         }
         [Fact]
-        public void WriteApiConstructor()
+        public async void WriteApiConstructor()
         {
             parentClass.AddProperty(new CodeProperty
             {
@@ -882,7 +882,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             codeMethod.DeserializerModules = new() {"Microsoft\\Kiota\\Serialization\\Deserializer"};
             codeMethod.SerializerModules = new() {"Microsoft\\Kiota\\Serialization\\Serializer"};
             parentClass.AddMethod(codeMethod);
-            _refiner.Refine(parentClass.Parent as CodeNamespace);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, parentClass.Parent as CodeNamespace);
             languageWriter.Write(codeMethod);
             var result = stringWriter.ToString();
             Assert.Contains("$this->requestAdapter = $requestAdapter", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -519,6 +519,13 @@ namespace Kiota.Builder.Tests.Writers.Php
                     Name = "array"
                 }
             };
+            parentClass.AddProperty(new CodeProperty{
+                Name = "noAccessors",
+                Kind = CodePropertyKind.Custom,
+                Type = new CodeType {
+                    Name = "string"
+                }
+            });
             parentClass.AddMethod(deserializerMethod);
             parentClass.AddProperty(property);
             _refiner.Refine(parentClass.Parent as CodeNamespace);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-
+using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Refiners;
 using Kiota.Builder.Writers;
@@ -18,7 +18,6 @@ namespace Kiota.Builder.Tests.Writers.Php
         private readonly CodePropertyWriter propertyWriter;
         private readonly LanguageWriter languageWriter;
         private readonly StringWriter stringWriter;
-        private readonly ILanguageRefiner _refiner;
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
 
         public CodePropertyWriterTests()
@@ -31,7 +30,6 @@ namespace Kiota.Builder.Tests.Writers.Php
                 Name = "ParentClass", Description = "This is an amazing class", Kind = CodeClassKind.Model
             };
             root.AddClass(parentClass);
-            _refiner = new PhpRefiner(new() {Language = GenerationLanguage.PHP});
             propertyWriter = new CodePropertyWriter(new PhpConventionService());
         }
         [Fact]
@@ -77,7 +75,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
 
         [Fact]
-        public void WriteCollectionKindProperty()
+        public async Task WriteCollectionKindProperty()
         {
             var property = new CodeProperty
             {
@@ -89,7 +87,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             };
             parentClass.Kind = CodeClassKind.Model;
             parentClass.AddProperty(property);
-            _refiner.Refine(root);
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP}, root);
             propertyWriter.WriteCodeElement(property, languageWriter);
             var result = stringWriter.ToString();
             Assert.Contains("private array $additionalData;", result);


### PR DESCRIPTION
- - fixes a bug where read only properties would derail deserializers generation
- - makes refiner step cancellable
- - further defensive programing for null accessor
- - fixes a concurrency issue with imports management
- - fixes a bug where odata primitive types would not be mapped properly anymore
- - adds changelog entry for multiple fixes
