### PR TITLE
Rsh/futures annotation

### DIFF
--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -21,12 +21,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         if(returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
         {
             if(codeElement.IsOfKind(CodeMethodKind.RequestExecutor))
-            {
-                returnType = "Void"; //generic type for the future    
-                writer.WriteLine("@javax.annotation.Nonnull");
-            }
-        } else if(!codeElement.IsAsync)
+                returnType = "Void"; //generic type for the future   
+        } else if(!codeElement.IsAsync) {
             writer.WriteLine(codeElement.ReturnType.IsNullable && !codeElement.IsAsync ? "@javax.annotation.Nullable" : "@javax.annotation.Nonnull");
+        } else if(codeElement.IsAsync) {
+            writer.WriteLine("@javax.annotation.Nonnull");
+        }
         WriteMethodPrototype(codeElement, writer, returnType);
         writer.IncreaseIndent();
         var parentClass = codeElement.Parent as CodeClass;

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -21,7 +21,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         if(returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
         {
             if(codeElement.IsOfKind(CodeMethodKind.RequestExecutor))
-                returnType = "Void"; //generic type for the future
+            {
+                returnType = "Void"; //generic type for the future    
+                writer.WriteLine("@javax.annotation.Nonnull");
+            }
         } else if(!codeElement.IsAsync)
             writer.WriteLine(codeElement.ReturnType.IsNullable && !codeElement.IsAsync ? "@javax.annotation.Nullable" : "@javax.annotation.Nonnull");
         WriteMethodPrototype(codeElement, writer, returnType);


### PR DESCRIPTION
- Adds @Non-null annotation for methods returning completable futures to prevent a big chunk of errors which are partially leading to overloading the heap space when compiling with android. 