### PR TITLE
Php/refactor deserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed response handler parameter from Java executor methods.
+- Changed the generated PHP deserializer code to use `fn` instead of `function`. [#880](https://github.com/microsoft/kiota/pull/1880)
 
 ## [0.6.0] - 2022-10-06
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -291,7 +291,7 @@ namespace Kiota.Builder.Writers.Php
                         null => "$n->getCollectionOfPrimitiveValues()",
                         CodeEnum enumType =>
                             $"$n->getCollectionOfEnumValues({enumType.Name.ToFirstCharacterUpperCase()}::class)",
-                        _ => $"$n->getCollectionOfObjectValues(array({conventions.TranslateType(propType)}::class, '{CreateDiscriminatorMethodName}'))"
+                        _ => $"$n->getCollectionOfObjectValues([{conventions.TranslateType(propType)}::class, '{CreateDiscriminatorMethodName}'])"
                     };
                 if (currentType.TypeDefinition is CodeEnum)
                     return $"$n->getEnumValue({propertyType.ToFirstCharacterUpperCase()}::class)";
@@ -307,7 +307,7 @@ namespace Kiota.Builder.Writers.Php
                 "streaminterface" => "$n->getBinaryContent()",
                 "byte" => "$n->getByteValue()",
                 _ when conventions.PrimitiveTypes.Contains(lowerCaseType) => $"$n->get{propertyType.ToFirstCharacterUpperCase()}Value()",
-                _ => $"$n->getObjectValue(array({propertyType.ToFirstCharacterUpperCase()}::class, '{CreateDiscriminatorMethodName}'))",
+                _ => $"$n->getObjectValue([{propertyType.ToFirstCharacterUpperCase()}::class, '{CreateDiscriminatorMethodName}'])",
             };
         }
 
@@ -454,7 +454,7 @@ namespace Kiota.Builder.Writers.Php
                 writer.IncreaseIndent(2);
                 errorMappings.ToList().ForEach(errorMapping =>
                 {
-                    writer.WriteLine($"'{errorMapping.Key}' => array({errorMapping.Value.Name}::class, '{CreateDiscriminatorMethodName}'),");
+                    writer.WriteLine($"'{errorMapping.Key}' => [{errorMapping.Value.Name}::class, '{CreateDiscriminatorMethodName}'],");
                 });
                 writer.DecreaseIndent();
                 writer.WriteLine("];");
@@ -465,7 +465,7 @@ namespace Kiota.Builder.Writers.Php
             var isCollection = codeElement.ReturnType.IsCollection;
             var methodName = GetSendRequestMethodName(returnsVoid, isStream, isCollection, returnType);
             var returnTypeFactory = codeElement.ReturnType is CodeType {TypeDefinition: CodeClass returnTypeClass}
-                ? $", array({returnType}::class, '{CreateDiscriminatorMethodName}')"
+                ? $", [{returnType}::class, '{CreateDiscriminatorMethodName}']"
                 : string.Empty;
             var returnWithCustomType =
                 !returnsVoid && string.IsNullOrEmpty(returnTypeFactory) && conventions.CustomTypes.Contains(returnType)

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -407,7 +407,7 @@ namespace Kiota.Builder.Writers.Php
                     .Where(static x => !x.ExistsInBaseType && x.Setter != null)
                     .OrderBy(static x => x.Name)
                     .Select(x => 
-                        $"'{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}' => function (ParseNode $n) use ({currentObjectName}) {{ {currentObjectName}->{x.Setter.Name.ToFirstCharacterLowerCase()}({GetDeserializationMethodName(x.Type, method)}); }},")
+                        $"'{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}' => fn(ParseNode $n) => {currentObjectName}->{x.Setter.Name.ToFirstCharacterLowerCase()}({GetDeserializationMethodName(x.Type, method)}),")
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
                 writer.DecreaseIndent();

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -455,32 +455,32 @@ namespace Kiota.Builder.Tests.Writers.Php
             new object[]
             {
                 new CodeProperty { Name = "name", Type = new CodeType { Name = "string" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'name' => function (ParseNode $n) use ($o) { $o->setName($n->getStringValue()); },"
+                "'name' => fn(ParseNode $n) => $o->setName($n->getStringValue()),"
             },
             new object[]
             {
                 new CodeProperty { Name = "age", Type = new CodeType { Name = "int32" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'age' => function (ParseNode $n) use ($o) { $o->setAge($n->getIntegerValue()); },"
+                "'age' => fn(ParseNode $n) => $o->setAge($n->getIntegerValue()),"
             },
             new object[]
             {
                 new CodeProperty { Name = "height", Type = new CodeType { Name = "double" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'height' => function (ParseNode $n) use ($o) { $o->setHeight($n->getFloatValue()); },"
+                "'height' => fn(ParseNode $n) => $o->setHeight($n->getFloatValue()),"
             },
             new object[]
             {
                 new CodeProperty { Name = "height", Type = new CodeType { Name = "decimal" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'height' => function (ParseNode $n) use ($o) { $o->setHeight($n->getStringValue()); },"
+                "'height' => fn(ParseNode $n) => $o->setHeight($n->getStringValue()),"
             },
             new object[]
             {
                 new CodeProperty { Name = "DOB", Type = new CodeType { Name = "DateTimeOffset" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'dOB' => function (ParseNode $n) use ($o) { $o->setDOB($n->getDateTimeValue()); },"
+                "'dOB' => fn(ParseNode $n) => $o->setDOB($n->getDateTimeValue()),"
             },
             new object[]
             {
                 new CodeProperty { Name = "story", Type = new CodeType { Name = "binary" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "'story' => function (ParseNode $n) use ($o) { $o->setStory($n->getBinaryContent()); },"
+                "'story' => fn(ParseNode $n) => $o->setStory($n->getBinaryContent()),"
             },
             new object[] { new CodeProperty { Name = "users", Type = new CodeType
                 {
@@ -488,10 +488,10 @@ namespace Kiota.Builder.Tests.Writers.Php
                     {
                         Name = "EmailAddress", Kind = CodeClassKind.Model, Description = "Email", Parent = GetParentClassInStaticContext()
                     }, CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
-                "'users' => function (ParseNode $n) use ($o) { $o->setUsers($n->getCollectionOfObjectValues(array(EmailAddress::class, 'createFromDiscriminatorValue')));"
+                "'users' => fn(ParseNode $n) => $o->setUsers($n->getCollectionOfObjectValues(array(EmailAddress::class, 'createFromDiscriminatorValue'))),"
             },
             new object[] { new CodeProperty { Name = "years", Type = new CodeType { Name = "int", CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
-                "'years' => function (ParseNode $n) use ($o) { $o->setYears($n->getCollectionOfPrimitiveValues())"
+                "'years' => fn(ParseNode $n) => $o->setYears($n->getCollectionOfPrimitiveValues())"
             },
             new object[] { new CodeProperty{ Name = "definedInParent", Type = new CodeType { Name = "string"}, OriginalPropertyFromBaseType = new CodeProperty() }, "'definedInParent' => function (ParseNode $n) use ($o) { $o->setDefinedInParent($n->getStringValue())"}
         };

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -153,7 +153,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
             Assert.Contains("RejectedPromise", result);
             Assert.Contains("catch(Exception $ex)", result);
-            Assert.Contains("'403' => array(Error403::class, 'createFromDiscriminatorValue')", result);
+            Assert.Contains("'403' => [Error403::class, 'createFromDiscriminatorValue']", result);
             Assert.Contains("return $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $responseHandler, $errorMappings);", result);
         }
         
@@ -488,7 +488,7 @@ namespace Kiota.Builder.Tests.Writers.Php
                     {
                         Name = "EmailAddress", Kind = CodeClassKind.Model, Description = "Email", Parent = GetParentClassInStaticContext()
                     }, CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
-                "'users' => fn(ParseNode $n) => $o->setUsers($n->getCollectionOfObjectValues(array(EmailAddress::class, 'createFromDiscriminatorValue'))),"
+                "'users' => fn(ParseNode $n) => $o->setUsers($n->getCollectionOfObjectValues([EmailAddress::class, 'createFromDiscriminatorValue'])),"
             },
             new object[] { new CodeProperty { Name = "years", Type = new CodeType { Name = "int", CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
                 "'years' => fn(ParseNode $n) => $o->setYears($n->getCollectionOfPrimitiveValues())"


### PR DESCRIPTION
- Use `fn($arg)` instead of `function ($arg) use ($obj)` to reduce the number of tokens.
- Use `['a', 'b']` instead of `array('a', 'b')` to reduce tokens.

Generated diff https://github.com/microsoft/kiota-samples/pull/1085