### PR TITLE
Updated intro page to have a consumer focus

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,17 @@ nav_order: 1
 has_children: true
 ---
 
-# Welcome to Kiota
+# Welcome to the Kiota API Client generator
 
-Kiota is an OpenAPI based code generator for creating SDKs for HTTP APIs. The goal is to produce a lightweight, low maintenance, code generator that is fast enough to run as part of the compile time tool-chain but scalable enough to handle the largest APIs.
+Kiota is a command line tool for generating an API client to call any OpenAPI described API you are interested in. The goal is to eliminate the need to take a dependency on a different API SDK for every API that you need to call. Kiota API clients provide a strongly typed experience with all the features you expect from a high quality API SDK, but without having to learn a new library for every HTTP API.
+ 
+ Kiota is a lightweight and fast code generator that can help you discover, explore and call any HTTP API with minimal effort. Kiota also provides the ability to only generate code for the parts of an API that you care about. The footprint of the generated code is only what you need to make you productive. 
 
 For those looking to try it out rather than hearing why we built it, checkout out the [Get started with Kiota](get-started/index.md) section.
 
-Current SDK tooling forces the API provider to make choices about the granularity of how API consumers want to consume their APIs. However you can't please everyone. Some developers building mobile applications care deeply about binary footprint and want SDKs that only contain what they need. Other developers building enterprise experiences don't want have to worry about finding which one in a dozen SDKs contain the feature they are looking for. Many companies are beginning to use API Management gateways and portals to bring APIs across their organization together and provide a coherent and consistent experience across many APIs. However, traditional SDKs continue to be shipped based on the team that provided the API. Kiota has the flexibility to quickly and easily build SDKs the shape and size that our customers need regardless of size. Conway's law doesn't apply here.
+Creating and maintaining SDKs in many languages is expensive for API providers and often results in API consumers being disappointed in the quality of SDKs, or worse, they find their preferred programming language is not supported by the API they need to call. Even when API providers do investing in building high quality SDKs, there is no single agreed upon standard for how HTTP APIs should be exposed in native language libraries.  This translates into more learning for the API consumer.  Many developers who consume APIs have given up on using SDKs and have decided that it is easier for them to use a native HTTP library because of the a consistent experience.  The unfortunate side effect is there are many developers writing generic boilerplate HTTP code to handle HTTP retries, redirects, caching and authorization code.
+
+The lack of high quality, standardized tooling for calling HTTP APIs, has been a factor in some developers choosing to explore other protocol options such as GraphQL and gRPC. Both of these technologies offer generic client side tooling that depends on schema descriptions to make it possible to call any GraphQL or gRPC API with a consistent developer experience. Kiota fills this gap for HTTP APIs using OpenAPI as the API description language.  
 
 ## Goals
 


### PR DESCRIPTION
The intro page has been re-written to change the focus from helping API providers create SDKs to helping API consumers have a consistent experience when calling different HTTP APIs.

Our hypothesis is that 60% of developers don't use SDKs because they don't want to have to keep learning new SDKs for every API they touch.  To solve that problem we either convince every API provider to use Kiota to generate their SDKs, or we convince API consumers to generate their own API clients.  The later is a significantly easier way to deliver value to customers.

The net side effect of consumers using Kiota to call APIs, is it potentially eliminates the need for API providers to ship SDKs. It's a win-win.