### PR TITLE
Performance improvements

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeMethod.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeMethod.cs
@@ -200,7 +200,7 @@ public class CodeMethod : CodeTerminalWithKind<CodeMethodKind>, ICloneable, IDoc
     /// This is currently used for CommandBuilder methods to get the original name without the Build prefix & Command suffix.
     /// Avoids regex operations
     /// </summary>
-    public string SimpleName { get; set; } = String.Empty;
+    public string SimpleName { get; set; } = string.Empty;
 
     private ConcurrentDictionary<string, CodeTypeBase> errorMappings = new();
     

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -13,39 +13,39 @@ public class GenerationConfiguration {
     public string ApiRootUrl { get; set; }
     public bool UsesBackingStore { get; set; }
     public bool IncludeAdditionalData { get; set; } = true;
-    public HashSet<string> Serializers { get; set; } = new(StringComparer.OrdinalIgnoreCase){
+    public HashSet<string> Serializers { get; set; } = new(2, StringComparer.OrdinalIgnoreCase){
         "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
         "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory"
     };
-    public HashSet<string> Deserializers { get; set; } = new(StringComparer.OrdinalIgnoreCase) {
+    public HashSet<string> Deserializers { get; set; } = new(2, StringComparer.OrdinalIgnoreCase) {
         "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
         "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory"
     };
     public bool ShouldWriteNamespaceIndices { get { return BarreledLanguages.Contains(Language); } }
     public bool ShouldWriteBarrelsIfClassExists { get { return BarreledLanguagesWithConstantFileName.Contains(Language); } }
     public bool ShouldRenderMethodsOutsideOfClasses { get { return MethodOutsideOfClassesLanguages.Contains(Language); } }
-    private static readonly HashSet<GenerationLanguage> MethodOutsideOfClassesLanguages = new () {
+    private static readonly HashSet<GenerationLanguage> MethodOutsideOfClassesLanguages = new (1) {
         GenerationLanguage.Go,
     };
-    private static readonly HashSet<GenerationLanguage> BarreledLanguages = new () {
+    private static readonly HashSet<GenerationLanguage> BarreledLanguages = new (3) {
         GenerationLanguage.Ruby,
         GenerationLanguage.TypeScript,
         GenerationLanguage.Swift,
     };
-    private static readonly HashSet<GenerationLanguage> BarreledLanguagesWithConstantFileName = new () {
+    private static readonly HashSet<GenerationLanguage> BarreledLanguagesWithConstantFileName = new (1) {
         GenerationLanguage.TypeScript
     };
     public bool CleanOutput { get; set;}
-    public HashSet<string> StructuredMimeTypes { get; set; } = new(StringComparer.OrdinalIgnoreCase) {
+    public HashSet<string> StructuredMimeTypes { get; set; } = new(5, StringComparer.OrdinalIgnoreCase) {
         "application/json",
         "application/xml",
         "text/plain",
         "text/xml",
         "text/yaml",
     };
-    public HashSet<string> IncludePatterns { get; set; } = new(StringComparer.OrdinalIgnoreCase) {
+    public HashSet<string> IncludePatterns { get; set; } = new(0, StringComparer.OrdinalIgnoreCase) {
     };
-    public HashSet<string> ExcludePatterns { get; set; } = new(StringComparer.OrdinalIgnoreCase) {
+    public HashSet<string> ExcludePatterns { get; set; } = new(0, StringComparer.OrdinalIgnoreCase) {
     };
     public bool ClearCache { get; set; }
 }

--- a/src/Kiota.Builder/KiotaSearcher.cs
+++ b/src/Kiota.Builder/KiotaSearcher.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;

--- a/src/Kiota.Builder/KiotaSearcher.cs
+++ b/src/Kiota.Builder/KiotaSearcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;

--- a/src/Kiota.Builder/Refiners/CSharpReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedNamesProvider.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Kiota.Builder.Refiners;
 public class CSharpReservedNamesProvider : IReservedNamesProvider
 {
-    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase) {
+    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(105, StringComparer.OrdinalIgnoreCase) {
         "abstract",
         "add",
         "alias",

--- a/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Kiota.Builder.Refiners;
 public class CSharpReservedTypesProvider : IReservedNamesProvider
 {
-    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase)
+    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(6, StringComparer.OrdinalIgnoreCase)
     {
         "file", //system.io static types
         "directory",

--- a/src/Kiota.Builder/SearchProviders/MSGraph/MsGraphSearchProvider.cs
+++ b/src/Kiota.Builder/SearchProviders/MSGraph/MsGraphSearchProvider.cs
@@ -30,7 +30,7 @@ public class MSGraphSearchProvider : ISearchProvider
     private readonly HashSet<string> AcceptedVersions = new(StringComparer.OrdinalIgnoreCase) { "v1.0", "beta" };
     private const string ApiTitle = "Microsoft Graph";
     private const string ApiDescription = "Microsoft Graph is a unified API endpoint that enables developers to integrate with the data and intelligence in Microsoft 365, Windows 10, and Enterprise Mobility + Security.";
-    private readonly HashSet<string> Keywords = new (StringComparer.OrdinalIgnoreCase) {
+    private readonly HashSet<string> Keywords = new (20, StringComparer.OrdinalIgnoreCase) {
         "microsoft",
         "graph",
         "msgraph",
@@ -50,6 +50,6 @@ public class MSGraphSearchProvider : ISearchProvider
         "excel",
         "word",
         "powerpoint",
-        "onenote",
+        "onenote"
     };
 }

--- a/src/Kiota.Builder/SearchProviders/OpenApiSpec/OpenApiSpecSeachProvider.cs
+++ b/src/Kiota.Builder/SearchProviders/OpenApiSpec/OpenApiSpecSeachProvider.cs
@@ -24,7 +24,7 @@ public class OpenApiSpecSearchProvider : ISearchProvider
     }
     private const string ApiTitle = "Swagger Petstore";
     private const string ApiDescription = "Canonical API description used in many examples throughout the OpenAPI ecosystem.";
-    private readonly HashSet<string> Keywords = new (StringComparer.OrdinalIgnoreCase) {
+    private readonly HashSet<string> Keywords = new (10, StringComparer.OrdinalIgnoreCase) {
         "pet",
         "store",
         "petstore",

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -797,9 +797,9 @@ namespace Kiota.Builder.Writers.Go {
             }
             return propertyTypeNameWithoutImportSymbol switch {
                 _ when conventions.IsPrimitiveType(propertyTypeNameWithoutImportSymbol) => 
-                    ($"Get{propertyTypeNameWithoutImportSymbol.ToFirstCharacterUpperCase()}Value", String.Empty),
+                    ($"Get{propertyTypeNameWithoutImportSymbol.ToFirstCharacterUpperCase()}Value", string.Empty),
                 _ when conventions.StreamTypeName.Equals(propertyTypeNameWithoutImportSymbol, StringComparison.OrdinalIgnoreCase) =>
-                    ("GetByteArrayValue", String.Empty),
+                    ("GetByteArrayValue", string.Empty),
                 _ => ("GetObjectValue", GetTypeFactory(propType, parentClass, propertyTypeNameWithoutImportSymbol)),
             };
         }

--- a/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
@@ -504,7 +504,7 @@ namespace Kiota.Builder.Writers.Shell
                     bool indentParam = true;
                     if (isStringParam)
                     {
-                        writer.Write($"if (!String.IsNullOrEmpty({paramName})) ");
+                        writer.Write($"if (!string.IsNullOrEmpty({paramName})) ");
                         indentParam = false;
                     }
 

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -55,6 +55,9 @@ namespace Kiota.Builder.Tests.Extensions {
             Assert.Equal("toto", "Toto".ToSnakeCase());
             Assert.Equal("microsoft_graph_message_content", "microsoft-Graph-Message-Content".ToSnakeCase());
             Assert.Equal("microsoft_graph_message_content", "microsoftGraphMessageContent".ToSnakeCase());
+            Assert.Equal("microsoft_graph_message_content", "microsoft_Graph_Message_Content".ToSnakeCase());
+            Assert.Equal("test_value", "testValue<WithStrippedContent".ToSnakeCase());
+            Assert.Equal("test", "test<Value".ToSnakeCase());
         }
         [Fact]
         public void NormalizeNameSpaceName() {


### PR DESCRIPTION
This PR contains a bunch of minor performance and allocation improvements, such as specifying the known capacity in a `HashSet`'s constructor.
However it also contains a rewrite of the `ToSnakeCase` method, which reduces allocations by up to 14,5x and increases performance by up to 7,25x. I also added three unit tests, one of which does not pass in the current implementation.

<img width="920" alt="Screen Shot 2022-10-16 at 23 14 50" src="https://user-images.githubusercontent.com/14217185/196059113-d305af22-792c-42ca-92a0-a8fe71697307.png">
