### PR TITLE
feature/commands enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added compatibility all the way down to android API level 26 for Java.
 - Added support for enum and collection of enum return types for Java.
 - Added support for types with more than 500 discriminator entries in Java.
+- Added a confirmation message once the generation is successful. [#1898](https://github.com/microsoft/kiota/issues/1898)
 
 ### Changed
 
@@ -19,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the generated PHP deserializer code to use `fn` instead of `function`. [#1880](https://github.com/microsoft/kiota/pull/1880)
 - Fixes compile errors due to type ambiguity in generated models in dotnet. [#1881](https://github.com/microsoft/kiota/issues/1881)
 - Changes the ResponeHandler parameter in IRequestAdapter to be a RequestOption in dotnet [#1858](https://github.com/microsoft/kiota/issues/1858)
+- File extensions are now stripped from property/namespace/class names. [#1892](https://github.com/microsoft/kiota/issues/1892)
+- Missing host/server is now considered a warning instead of a critical error. [#1896](https://github.com/microsoft/kiota/issues/1896)
+- Fixed a bug where info and show commands would crash in case of invalid description URL. [#1894](https://github.com/microsoft/kiota/issues/1894)
+- Show command now reads descriptions directly from APIs.guru instead of their origin. [#1897](https://github.com/microsoft/kiota/issues/1897)
 
 ## [0.6.0] - 2022-10-06
 

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -92,7 +92,7 @@ namespace Kiota.Builder.Extensions {
                     suffix)
                     .CleanupSymbolName();
         }
-        private static readonly HashSet<string> SegmentsToSkipForClassNames = new(StringComparer.OrdinalIgnoreCase) {
+        private static readonly HashSet<string> SegmentsToSkipForClassNames = new(6, StringComparer.OrdinalIgnoreCase) {
             "json",
             "xml",
             "csv",

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -18,9 +18,11 @@ namespace Kiota.Builder.Extensions {
                              + currentPath
                                 ?.Split(pathNameSeparator, StringSplitOptions.RemoveEmptyEntries)
                                 ?.Select(replaceSingleParameterSegmentByItem)
-                                ?.Select(static x => CleanupParametersFromPath((x ?? string.Empty).Split('.', StringSplitOptions.RemoveEmptyEntries)
-                                ?.Select(static x => x.TrimStart('$')) //$ref from OData
-                                                                .Last()))
+                                ?.Select(static x => CleanupParametersFromPath((x ?? string.Empty)
+                                                        .Split('.', StringSplitOptions.RemoveEmptyEntries)
+                                                        .Select(static x => x.TrimStart('$')) //$ref from OData
+                                                        .Except(SegmentsToSkipForClassNames, StringComparer.OrdinalIgnoreCase)
+                                                        .Last()))
                                 ?.Select(static x => x.CleanupSymbolName())
                                 ?.Aggregate(string.Empty, 
                                     static (x, y) => $"{x}{GetDotIfBothNotNullOfEmpty(x, y)}{y}") :
@@ -70,6 +72,8 @@ namespace Kiota.Builder.Extensions {
                                 (requestBody ? null : response?.GetResponseSchema(structuredMimeTypes)?.Reference?.GetClassName()) ??
                                 (requestBody ? operation?.GetRequestSchema(structuredMimeTypes) : operation?.GetResponseSchema(structuredMimeTypes))?.Reference?.GetClassName() ?? 
                                 CleanupParametersFromPath(currentNode.Segment)?.ReplaceValueIdentifier();
+            if(stripExtensionForIndexersRegex.IsMatch(rawClassName))
+                rawClassName = stripExtensionForIndexersRegex.Replace(rawClassName, string.Empty);
             if((currentNode?.DoesNodeBelongToItemSubnamespace() ?? false) && idClassNameCleanup.IsMatch(rawClassName)) {
                 rawClassName = idClassNameCleanup.Replace(rawClassName, string.Empty);
                 if(rawClassName == WithKeyword) // in case the single parameter doesn't follow {classname-id} we get the previous segment
@@ -80,9 +84,22 @@ namespace Kiota.Builder.Extensions {
                                             .ToFirstCharacterUpperCase();
 
             }
-            return (prefix + rawClassName?.Split('.', StringSplitOptions.RemoveEmptyEntries)?.LastOrDefault() + suffix)
+            return (prefix + 
+                    rawClassName
+                            ?.Split('.', StringSplitOptions.RemoveEmptyEntries)
+                            .Except(SegmentsToSkipForClassNames, StringComparer.OrdinalIgnoreCase)
+                            .LastOrDefault() +
+                    suffix)
                     .CleanupSymbolName();
         }
+        private static readonly HashSet<string> SegmentsToSkipForClassNames = new(StringComparer.OrdinalIgnoreCase) {
+            "json",
+            "xml",
+            "csv",
+            "yaml",
+            "yml",
+            "txt",
+        };
         private static readonly Regex descriptionCleanupRegex = new (@"[\r\n\t]", RegexOptions.Compiled);
         public static string CleanupDescription(this string description) => string.IsNullOrEmpty(description) ? description : descriptionCleanupRegex.Replace(description, string.Empty);
         public static string GetPathItemDescription(this OpenApiUrlTreeNode currentNode, string label, string defaultValue = default) =>
@@ -96,10 +113,14 @@ namespace Kiota.Builder.Extensions {
             currentNode?.Segment.IsPathSegmentWithSingleSimpleParameter() ?? false;
         private static bool IsPathSegmentWithSingleSimpleParameter(this string currentSegment)
         {
-            return (currentSegment?.StartsWith(requestParametersChar) ?? false) &&
-                    currentSegment.EndsWith(requestParametersEndChar) &&
-                    currentSegment.Count(x => x == requestParametersChar) == 1;
+            if (string.IsNullOrEmpty(currentSegment)) return false;
+
+            var segmentWithoutExtension = stripExtensionForIndexersRegex.Replace(currentSegment, string.Empty);
+            return segmentWithoutExtension.StartsWith(requestParametersChar) &&
+                    segmentWithoutExtension.EndsWith(requestParametersEndChar) &&
+                    segmentWithoutExtension.Count(x => x == requestParametersChar) == 1;
         }
+        private static readonly Regex stripExtensionForIndexersRegex = new(@"\.(?:json|yaml|yml|csv|txt)$", RegexOptions.Compiled); // so {param-name}.json is considered as indexer
         public static bool IsComplexPathWithAnyNumberOfParameters(this OpenApiUrlTreeNode currentNode)
         {
             return (currentNode?.Segment?.Contains(requestParametersSectionChar) ?? false) && currentNode.Segment.EndsWith(requestParametersSectionEndChar);
@@ -139,7 +160,8 @@ namespace Kiota.Builder.Extensions {
         }
         public static string SanitizeParameterNameForUrlTemplate(this string original) {
             if(string.IsNullOrEmpty(original)) return original;
-            return Uri.EscapeDataString(original
+            return Uri.EscapeDataString(stripExtensionForIndexersRegex
+                                            .Replace(original, string.Empty) // {param-name}.json becomes {param-name}
                                     .TrimStart('{')
                                     .TrimEnd('}'))
                         .Replace("-", "%2D")

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -154,7 +154,7 @@ public class KiotaBuilder
     private void SetApiRootUrl() {
         config.ApiRootUrl = openApiDocument.Servers.FirstOrDefault()?.Url.TrimEnd('/');
         if(string.IsNullOrEmpty(config.ApiRootUrl))
-            throw new InvalidOperationException("A servers entry (v3) or host + basePath + schemes properties (v2) must be present in the OpenAPI description.");
+            logger.LogWarning("A servers entry (v3) or host + basePath + schemes properties (v2) was not present in the OpenAPI description. The root URL will need to be set manually with the request adapter.");
     }
     private void StopLogAndReset(Stopwatch sw, string prefix) {
         sw.Stop();

--- a/src/Kiota.Builder/SearchProviders/APIsGuru/APIEntry.cs
+++ b/src/Kiota.Builder/SearchProviders/APIsGuru/APIEntry.cs
@@ -12,9 +12,6 @@ public record ApiInformation {
     public ApiContact contact { get; set;}
     public string description { get; set;}
     public string title { get; set;}
-    public string version { get; set;}
-    [JsonPropertyName("x-origin")]
-    public List<ApiOrigin> origin { get; set;}
 }
 
 public record ApiContact(string email, string name, Uri url);

--- a/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
+++ b/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
@@ -42,7 +42,7 @@ public class APIsGuruSearchProvider : ISearchProvider
                                 .Select(x => x.Value.versions.TryGetValue(GetVersionKey(singleCandidate, version, x), out var versionInfo) ? (x.Key, versionInfo, x.Value.versions.Keys.ToList()) : (x.Key, default, default))
                                 .Where(static x => x.versionInfo is not null)
                                 .ToDictionary(static x => x.Key,
-                                            static x => new SearchResult(x.versionInfo.info?.title, x.versionInfo.info?.description, x.versionInfo.info?.contact?.url, x.versionInfo.info?.origin?.FirstOrDefault()?.url, x.Item3),
+                                            static x => new SearchResult(x.versionInfo.info?.title, x.versionInfo.info?.description, x.versionInfo.info?.contact?.url, x.versionInfo.swaggerUrl, x.Item3),
                                             StringComparer.OrdinalIgnoreCase);
         return results;
     }

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -186,10 +186,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterUpperCase();
         WriteSerializationRegistration(method.SerializerModules, writer, "RegisterDefaultSerializer");
         WriteSerializationRegistration(method.DeserializerModules, writer, "RegisterDefaultDeserializer");
-        writer.WriteLine($"if (string.IsNullOrEmpty({requestAdapterPropertyName}.BaseUrl)) {{");
-        writer.IncreaseIndent();
-        writer.WriteLine($"{requestAdapterPropertyName}.BaseUrl = \"{method.BaseUrl}\";");
-        writer.CloseBlock();
+        if (!string.IsNullOrEmpty(method.BaseUrl)) {
+            writer.WriteLine($"if (string.IsNullOrEmpty({requestAdapterPropertyName}.BaseUrl)) {{");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{requestAdapterPropertyName}.BaseUrl = \"{method.BaseUrl}\";");
+            writer.CloseBlock();
+        }
         if (backingStoreParameter != null)
             writer.WriteLine($"{requestAdapterPropertyName}.EnableBackingStore({backingStoreParameter.Name});");
     }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -397,10 +397,12 @@ namespace Kiota.Builder.Writers.Go {
             var backingStoreParameter = method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.BackingStore));
             WriteSerializationRegistration(method.SerializerModules, writer, parentClass, "RegisterDefaultSerializer", "SerializationWriterFactory");
             WriteSerializationRegistration(method.DeserializerModules, writer, parentClass, "RegisterDefaultDeserializer", "ParseNodeFactory");
-            writer.WriteLine($"if m.{requestAdapterPropertyName}.GetBaseUrl() == \"\" {{");
-            writer.IncreaseIndent();
-            writer.WriteLine($"m.{requestAdapterPropertyName}.SetBaseUrl(\"{method.BaseUrl}\")");
-            writer.CloseBlock();
+            if (!string.IsNullOrEmpty(method.BaseUrl)) {
+                writer.WriteLine($"if m.{requestAdapterPropertyName}.GetBaseUrl() == \"\" {{");
+                writer.IncreaseIndent();
+                writer.WriteLine($"m.{requestAdapterPropertyName}.SetBaseUrl(\"{method.BaseUrl}\")");
+                writer.CloseBlock();
+            }
             if(backingStoreParameter != null)
                 writer.WriteLine($"m.{requestAdapterPropertyName}.EnableBackingStore({backingStoreParameter.Name});");
         }

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -248,10 +248,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
         WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
         WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
-        writer.WriteLine($"if ({requestAdapterPropertyName}.getBaseUrl() == null || {requestAdapterPropertyName}.getBaseUrl().isEmpty()) {{");
-        writer.IncreaseIndent();
-        writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
-        writer.CloseBlock();
+        if(!string.IsNullOrEmpty(method.BaseUrl)) {
+            writer.WriteLine($"if ({requestAdapterPropertyName}.getBaseUrl() == null || {requestAdapterPropertyName}.getBaseUrl().isEmpty()) {{");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
+            writer.CloseBlock();
+        }
         if(backingStoreParameter != null)
             writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
     }

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -498,10 +498,12 @@ namespace Kiota.Builder.Writers.Php
             var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
             WriteSerializationRegistration(codeMethod.SerializerModules, writer, "registerDefaultSerializer");
             WriteSerializationRegistration(codeMethod.DeserializerModules, writer, "registerDefaultDeserializer");
-            writer.WriteLines($"if (empty({GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl())) {{");
-            writer.IncreaseIndent();
-            writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->setBaseUrl('{codeMethod.BaseUrl}');");
-            writer.CloseBlock();
+            if(!string.IsNullOrEmpty(codeMethod.BaseUrl)) {
+                writer.WriteLines($"if (empty({GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl())) {{");
+                writer.IncreaseIndent();
+                writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->setBaseUrl('{codeMethod.BaseUrl}');");
+                writer.CloseBlock();
+            }
         }
         
         private static void WriteSerializationRegistration(HashSet<string> serializationModules, LanguageWriter writer, string methodName) {

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -97,10 +97,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         var requestAdapterPropertyName = requestAdapterProperty.Name.ToSnakeCase();
         WriteSerializationRegistration(method.SerializerModules, writer, "register_default_serializer");
         WriteSerializationRegistration(method.DeserializerModules, writer, "register_default_deserializer");
-        writer.WriteLine($"if not {requestAdapterPropertyName}.base_url:");
-        writer.IncreaseIndent();
-        writer.WriteLine($"{requestAdapterPropertyName}.base_url = \"{method.BaseUrl}\"");
-        writer.DecreaseIndent();
+        if(!string.IsNullOrEmpty(method.BaseUrl)) {
+            writer.WriteLine($"if not {requestAdapterPropertyName}.base_url:");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{requestAdapterPropertyName}.base_url = \"{method.BaseUrl}\"");
+            writer.DecreaseIndent();
+        }
         if(backingStoreParameter != null)
             writer.WriteLine($"self.{requestAdapterPropertyName}.enable_backing_store({backingStoreParameter.Name})");
     }

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -79,7 +79,8 @@ namespace Kiota.Builder.Writers.Ruby {
             var requestAdapterPropertyName = requestAdapterProperty.Name.ToSnakeCase();
             if (method.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.RequestAdapter)) is CodeParameter requestAdapterParameter)
                 writer.WriteLine($"@{requestAdapterPropertyName} = {requestAdapterParameter.Name.ToSnakeCase()}");
-            writer.WriteLine($"{requestAdapterPropertyName}.set_base_url('{method.BaseUrl}')");
+            if(!string.IsNullOrEmpty(method.BaseUrl))
+                writer.WriteLine($"{requestAdapterPropertyName}.set_base_url('{method.BaseUrl}')");
         }
         private static void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
             if(inherits)

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -124,10 +124,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
         var requestAdapterPropertyName = requestAdapterProperty.Name.ToFirstCharacterLowerCase();
         WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
         WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
-        writer.WriteLine($"if ({requestAdapterPropertyName}.baseUrl === undefined || {requestAdapterPropertyName}.baseUrl === \"\") {{");
-        writer.IncreaseIndent();
-        writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = \"{method.BaseUrl}\";");
-        writer.CloseBlock();
+        if(!string.IsNullOrEmpty(method.BaseUrl)) {
+            writer.WriteLine($"if ({requestAdapterPropertyName}.baseUrl === undefined || {requestAdapterPropertyName}.baseUrl === \"\") {{");
+            writer.IncreaseIndent();
+            writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = \"{method.BaseUrl}\";");
+            writer.CloseBlock();
+        }
         if(backingStoreParameter != null)
             writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
     }

--- a/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
@@ -82,10 +82,10 @@ internal class KiotaGenerationCommandHandler : BaseKiotaCommandHandler
                 return 0;
             } catch (Exception ex) {
     #if DEBUG
-                logger.LogCritical(ex, "error generating the SDK: {exceptionMessage}", ex.Message);
+                logger.LogCritical(ex, "error generating the client: {exceptionMessage}", ex.Message);
                 throw; // so debug tools go straight to the source of the exception when attached
     #else
-                logger.LogCritical("error generating the SDK: {exceptionMessage}", ex.Message);
+                logger.LogCritical("error generating the client: {exceptionMessage}", ex.Message);
                 return 1;
     #endif
             }

--- a/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
@@ -76,6 +76,7 @@ internal class KiotaGenerationCommandHandler : BaseKiotaCommandHandler
 
             try {
                 await new KiotaBuilder(logger, Configuration.Generation).GenerateClientAsync(cancellationToken);
+                Console.WriteLine("Generation completed successfully");
                 DisplayInfoHint(language, Configuration.Generation.OpenAPIFilePath);
                 DisplayGenerateAdvancedHint(includePatterns, excludePatterns, Configuration.Generation.OpenAPIFilePath);
                 return 0;

--- a/src/kiota/Handlers/KiotaShowCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaShowCommandHandler.cs
@@ -53,17 +53,28 @@ internal class KiotaShowCommandHandler : KiotaSearchBasedCommandHandler
             Configuration.Generation.IncludePatterns = includePatterns.ToHashSet();
             Configuration.Generation.ExcludePatterns = excludePatterns.ToHashSet();
             Configuration.Generation.ClearCache = clearCache;
-            var urlTreeNode = await new KiotaBuilder(logger, Configuration.Generation).GetUrlTreeNodeAsync(cancellationToken);
+            try {
+                var urlTreeNode = await new KiotaBuilder(logger, Configuration.Generation).GetUrlTreeNodeAsync(cancellationToken);
 
-            var builder = new StringBuilder();
-            RenderNode(urlTreeNode, maxDepth, builder);
-            var tree = builder.ToString();
-            Console.Write(tree);
-            if(descriptionProvided)
-                DisplayShowAdvancedHint(string.Empty, string.Empty, includePatterns, excludePatterns, openapi);
-            else
-                DisplayShowAdvancedHint(searchTerm, version, includePatterns, excludePatterns, openapi);
-            DisplayGenerateHint(openapi, includePatterns, excludePatterns);
+                var builder = new StringBuilder();
+                RenderNode(urlTreeNode, maxDepth, builder);
+                var tree = builder.ToString();
+                Console.Write(tree);
+                if(descriptionProvided)
+                    DisplayShowAdvancedHint(string.Empty, string.Empty, includePatterns, excludePatterns, openapi);
+                else
+                    DisplayShowAdvancedHint(searchTerm, version, includePatterns, excludePatterns, openapi);
+                DisplayGenerateHint(openapi, includePatterns, excludePatterns);
+            } catch (Exception ex) {
+#if DEBUG
+                logger.LogCritical(ex, "error showing the description: {exceptionMessage}", ex.Message);
+                throw; // so debug tools go straight to the source of the exception when attached
+#else
+                logger.LogCritical("error showing the description: {exceptionMessage}", ex.Message);
+                return 1;
+#endif
+            }
+
         }
         return 0;
     }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -24,15 +24,6 @@ namespace Kiota.Builder.Tests;
 public class KiotaBuilderTests
 {
     [Fact]
-    public async Task ThrowsOnMissingServer() {
-        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
-        await File.WriteAllLinesAsync(tempFilePath, new[] {"openapi: 3.0.0", "info:", "  title: \"Todo API\"", "  version: \"1.0.0\""});
-        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
-        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath });
-        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.GenerateClientAsync(new()));
-        File.Delete(tempFilePath);
-    }
-    [Fact]
     public async Task ParsesEnumDescriptions() {
         var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
         await File.WriteAllTextAsync(tempFilePath, @"openapi: 3.0.1


### PR DESCRIPTION
- - fixes #1898 adds a message for successful generation
- - fixes #1897 reads descriptions from APIs.guru instead of origin
- - fixes #1894 a bug where kiota would crash in case of invalid URL for descriptions with show and info commands
- - fixes #1896 replaces exception by warn for missing host in descriptions
- - fixes #1892 strips file extensions from class/property/namespace name generation
- - adds changelog entry for multiple usability fixes
