### PR TITLE
Follow up to #1901

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing host/server is now considered a warning instead of a critical error. [#1896](https://github.com/microsoft/kiota/issues/1896)
 - Fixed a bug where info and show commands would crash in case of invalid description URL. [#1894](https://github.com/microsoft/kiota/issues/1894)
 - Show command now reads descriptions directly from APIs.guru instead of their origin. [#1897](https://github.com/microsoft/kiota/issues/1897)
+- Fixed a classnames having the same name as extensions would cause generation to fail. [#1892](https://github.com/microsoft/kiota/issues/1892)
 
 ## [0.6.0] - 2022-10-06
 

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -82,15 +82,15 @@ namespace Kiota.Builder.Extensions {
                                             .SkipLast(1)
                                             .Last()
                                             .ToFirstCharacterUpperCase();
-
             }
-            return (prefix + 
-                    rawClassName
-                            ?.Split('.', StringSplitOptions.RemoveEmptyEntries)
-                            .Except(SegmentsToSkipForClassNames, StringComparer.OrdinalIgnoreCase)
-                            .LastOrDefault() +
-                    suffix)
-                    .CleanupSymbolName();
+
+            var classNameSegments = rawClassName?.Split('.', StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
+            // only apply the exceptions if we had multiple segments.
+            // Otherwise a single segment class name like `Json` will be returned as an empty string.
+            if (classNameSegments != null && classNameSegments.Count() > 1)
+                classNameSegments =  classNameSegments.Except(SegmentsToSkipForClassNames, StringComparer.OrdinalIgnoreCase);
+
+            return (prefix + classNameSegments.LastOrDefault() +suffix).CleanupSymbolName();
         }
         private static readonly HashSet<string> SegmentsToSkipForClassNames = new(6, StringComparer.OrdinalIgnoreCase) {
             "json",

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -84,10 +84,10 @@ namespace Kiota.Builder.Extensions {
                                             .ToFirstCharacterUpperCase();
             }
 
-            var classNameSegments = rawClassName?.Split('.', StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
+            var classNameSegments = rawClassName?.Split('.', StringSplitOptions.RemoveEmptyEntries).AsEnumerable() ?? Enumerable.Empty<string>();
             // only apply the exceptions if we had multiple segments.
             // Otherwise a single segment class name like `Json` will be returned as an empty string.
-            if (classNameSegments != null && classNameSegments.Count() > 1)
+            if (classNameSegments.Count() > 1)
                 classNameSegments =  classNameSegments.Except(SegmentsToSkipForClassNames, StringComparer.OrdinalIgnoreCase);
 
             return (prefix + classNameSegments.LastOrDefault() +suffix).CleanupSymbolName();


### PR DESCRIPTION
This PR is a follow up to #1901 

It fixes an edge case where a type that is similar to a file extension exists in the reference input file that would cause generation to fail. Example is `microsoft.graph.json`.

This PR updates the `GetClassName` function to apply the extension exclusions if we have more than one segment in the name.
