### PR TITLE
Fix possible StackOverflow exception

### DIFF
--- a/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
+++ b/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
@@ -37,10 +37,10 @@ public class DocumentCachingProvider {
                 Directory.CreateDirectory(directory);
             Stream content = null;
             try {
-                using var httpContent = await HttpClient.GetStreamAsync(documentUri, token);
+                await using var httpContent = await HttpClient.GetStreamAsync(documentUri, token);
                 content = new MemoryStream();
                 await httpContent.CopyToAsync(content, token);
-                using var fileStream = File.Create(target);
+                await using var fileStream = File.Create(target);
                 content.Position = 0;
                 await content.CopyToAsync(fileStream, token);
                 await fileStream.FlushAsync(token);

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -8,7 +8,10 @@ using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace Kiota.Builder.Extensions {
-    public static class StringExtensions {
+    public static class StringExtensions
+    {
+        private const int MaxStackLimit = 1024;
+
         public static string ToFirstCharacterLowerCase(this string input)
             => string.IsNullOrEmpty(input) ? input : char.ToLowerInvariant(input[0]) + input[1..];
         public static string ToFirstCharacterUpperCase(this string input)
@@ -62,7 +65,8 @@ namespace Kiota.Builder.Extensions {
                 return count;
             }
 
-            Span<char> span = stackalloc char[nameSpan.Length + CountNecessaryNewSeparators(nameSpan)];
+            var newStringLength = nameSpan.Length + CountNecessaryNewSeparators(nameSpan);
+            Span<char> span = Encoding.UTF8.GetMaxByteCount(newStringLength) <= MaxStackLimit ? stackalloc char[newStringLength] : new char[newStringLength];
             var current = nameSpan[0];
             span[0] = char.ToLowerInvariant(current);
             var counter = 1;


### PR DESCRIPTION
This PR prevents a possible StackOverflow exception by limiting the amount of memory allocated on the stack and falling back onto an array creation in the case of a string exceeding a certain length.