### PR TITLE
- draft implementation of lock file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -213,6 +213,20 @@
             "stopAtEntry": false
         },
         {
+            "name": "Launch Update",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/kiota/bin/Debug/net6.0/kiota.dll",
+            "args": ["update",
+                    "-o",
+                    "${workspaceFolder}/samples"
+                ],
+            "cwd": "${workspaceFolder}/src/kiota",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/docs/using.md
+++ b/docs/using.md
@@ -17,6 +17,7 @@ Kiota offers the following commands to help you build your API client:
 - [download](#description-download): download an API description.
 - [show](#description-show): show the API paths tree for an API description.
 - [generate](#client-generation): generate a client for any API from its description.
+- [update](#client-update): update existing clients from previous generations.
 - [info](#language-information): show languages and runtime dependencies information.
 
 ## Description search
@@ -188,6 +189,8 @@ kiota generate (--openapi | -d) <path>
       [(--exclude-path | -e) <glob pattern>]
 ```
 
+> Note: the output directory will also contain a **kiota.lock** lock file in addition to client sources. This file contains all the generation parameters for future reference as well as a hash from the description. On subsequent generations, including updates, the generation will be skipped if the description and the parameters have not changed and if clean-output is **false**. The lock file is meant to be committed to the source control with the generated sources.
+
 ### Mandatory parameters
 
 - [openapi](#--openapi--d)
@@ -199,6 +202,8 @@ The generate command accepts optional parameters commonly available on the other
 
 - [--clear-cache](#--clear-cache---co)
 - [--clean-output](#--clean-output---co)
+- [--include-path](#--include-path--i)
+- [--exclude-path](#--exclude-path--e)
 - [--log-level](#--log-level---ll)
 - [--output](#--output--o)
 
@@ -249,26 +254,6 @@ One or more module names that implements `IParseNodeFactory`.
 ```shell
 kiota generate --deserializer Contoso.Json.CustomDeserializer
 ```
-
-#### `--exclude-path (-e)`
-
-A glob pattern to exclude paths from generation. Accepts multiple values. Defaults to no value which excludes nothing.
-
-```shell
-kiota generate --exclude-path **/users/** --exclude-path **/groups/**
-```
-
-> Note: exclude pattern can be used in combination with the include pattern argument. A path item is included when (no include pattern is included OR it matches an include pattern) AND (no exclude pattern is included OR it doesn't match an exclude pattern).
-
-#### `--include-path (-i)`
-
-A glob pattern to include paths from generation. Accepts multiple values. Defaults to no value which includes everything.
-
-```shell
-kiota generate --include-path **/users/** --include-path **/groups/**
-```
-
-> Note: include pattern can be used in combination with the exclude pattern argument. A path item is included when (no include pattern is included OR it matches an include pattern) AND (no exclude pattern is included OR it doesn't match an exclude pattern).
 
 #### `--namespace-name (-n)`
 
@@ -397,6 +382,26 @@ The info command accepts optional parameters commonly available on the other com
 - [--version](#--version--v)
 - [--search-key](#--search-key--k)
 
+## Client update
+
+Kiota update accepts the following parameters during the update of existing clients. This command will search for lock files in the output directory and all its subdirectories and trigger generations to refresh the existing clients using settings from the lock files.
+
+```shell
+kiota update [(--output | -o) <path>]
+      [(--log-level | --ll) <level>]
+      [--clean-output | --co]
+      [--clear-cache | --cc]
+```
+
+### Optional parameters
+
+The generate command accepts optional parameters commonly available on the other commands:
+
+- [--clear-cache](#--clear-cache---co)
+- [--clean-output](#--clean-output---co)
+- [--log-level](#--log-level---ll)
+- [--output](#--output--o)
+
 ## Common parameters
 
 The following parameters are available across multiple commands.
@@ -420,6 +425,26 @@ Cached files are stored under `%TEMP%/kiota/cache` and valid for one (1) hour af
 ```shell
 kiota <command name> --clear-cache
 ```
+
+### `--exclude-path (-e)`
+
+A glob pattern to exclude paths from generation. Accepts multiple values. Defaults to no value which excludes nothing.
+
+```shell
+kiota <command name> --exclude-path **/users/** --exclude-path **/groups/**
+```
+
+> Note: exclude pattern can be used in combination with the include pattern argument. A path item is included when (no include pattern is included OR it matches an include pattern) AND (no exclude pattern is included OR it doesn't match an exclude pattern).
+
+### `--include-path (-i)`
+
+A glob pattern to include paths from generation. Accepts multiple values. Defaults to no value which includes everything.
+
+```shell
+kiota <command name> --include-path **/users/** --include-path **/groups/**
+```
+
+> Note: include pattern can be used in combination with the exclude pattern argument. A path item is included when (no include pattern is included OR it matches an include pattern) AND (no exclude pattern is included OR it doesn't match an exclude pattern).
 
 ### `--openapi (-d)`
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -189,7 +189,7 @@ kiota generate (--openapi | -d) <path>
       [(--exclude-path | -e) <glob pattern>]
 ```
 
-> Note: the output directory will also contain a **kiota.lock** lock file in addition to client sources. This file contains all the generation parameters for future reference as well as a hash from the description. On subsequent generations, including updates, the generation will be skipped if the description and the parameters have not changed and if clean-output is **false**. The lock file is meant to be committed to the source control with the generated sources.
+> Note: the output directory will also contain a **kiota-lock.json** lock file in addition to client sources. This file contains all the generation parameters for future reference as well as a hash from the description. On subsequent generations, including updates, the generation will be skipped if the description and the parameters have not changed and if clean-output is **false**. The lock file is meant to be committed to the source control with the generated sources.
 
 ### Mandatory parameters
 

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 
 namespace Kiota.Builder.Configuration;
-public class GenerationConfiguration {
+public class GenerationConfiguration : ICloneable {
     public string OpenAPIFilePath { get; set; } = "openapi.yaml";
     public string OutputPath { get; set; } = "./output";
     public string ClientClassName { get; set; } = "ApiClient";
@@ -48,4 +48,25 @@ public class GenerationConfiguration {
     public HashSet<string> ExcludePatterns { get; set; } = new(0, StringComparer.OrdinalIgnoreCase) {
     };
     public bool ClearCache { get; set; }
+    public object Clone()
+    {
+        return new GenerationConfiguration {
+            OpenAPIFilePath = OpenAPIFilePath,
+            OutputPath = OutputPath,
+            ClientClassName = ClientClassName,
+            ClientNamespaceName = ClientNamespaceName,
+            NamespaceNameSeparator = NamespaceNameSeparator,
+            Language = Language,
+            ApiRootUrl = ApiRootUrl,
+            UsesBackingStore = UsesBackingStore,
+            IncludeAdditionalData = IncludeAdditionalData,
+            Serializers = new(Serializers, StringComparer.OrdinalIgnoreCase),
+            Deserializers = new(Deserializers, StringComparer.OrdinalIgnoreCase),
+            CleanOutput = CleanOutput,
+            StructuredMimeTypes = new(StructuredMimeTypes, StringComparer.OrdinalIgnoreCase),
+            IncludePatterns = new(IncludePatterns, StringComparer.OrdinalIgnoreCase),
+            ExcludePatterns = new(ExcludePatterns, StringComparer.OrdinalIgnoreCase),
+            ClearCache = ClearCache,
+        };
+    }
 }

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Kiota.Builder.Configuration;
 public class GenerationConfiguration : ICloneable {
@@ -60,12 +61,12 @@ public class GenerationConfiguration : ICloneable {
             ApiRootUrl = ApiRootUrl,
             UsesBackingStore = UsesBackingStore,
             IncludeAdditionalData = IncludeAdditionalData,
-            Serializers = new(Serializers, StringComparer.OrdinalIgnoreCase),
-            Deserializers = new(Deserializers, StringComparer.OrdinalIgnoreCase),
+            Serializers = new(Serializers ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
+            Deserializers = new(Deserializers ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
             CleanOutput = CleanOutput,
-            StructuredMimeTypes = new(StructuredMimeTypes, StringComparer.OrdinalIgnoreCase),
-            IncludePatterns = new(IncludePatterns, StringComparer.OrdinalIgnoreCase),
-            ExcludePatterns = new(ExcludePatterns, StringComparer.OrdinalIgnoreCase),
+            StructuredMimeTypes = new(StructuredMimeTypes ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
+            IncludePatterns = new(IncludePatterns ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
+            ExcludePatterns = new(ExcludePatterns ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
             ClearCache = ClearCache,
         };
     }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -88,7 +88,7 @@ public class KiotaBuilder
         StopLogAndReset(sw, $"step {++stepId} - checking whether the output should be updated - took");
         
         OpenApiUrlTreeNode openApiTree = null;
-        if(shouldGenerate && generating) {
+        if(shouldGenerate || !generating) {
         
             // filter paths
             sw.Start();

--- a/src/Kiota.Builder/Lock/ILockManagementService.cs
+++ b/src/Kiota.Builder/Lock/ILockManagementService.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kiota.Builder.Lock;
+/// <summary>
+/// A service that manages the lock file for a Kiota project.
+/// </summary>
+public interface ILockManagementService {
+    /// <summary>
+    /// Gets the lock file for a Kiota project by crawling the directory tree.
+    /// </summary>
+    /// <param name="root">The root directory to crawl</param>
+    IEnumerable<string> GetDirectoriesContainingLockFile(string searchDirectory);
+    /// <summary>
+    /// Gets the lock file for a Kiota project by reading it from the target directory.
+    /// </summary>
+    /// <param name="targetDirectory">The target directory to read the lock file from.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<KiotaLock> GetLockFromDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets the lock file for a Kiota project by reading it from a stream.
+    /// </summary>
+    /// <param name="stream">The stream to read the lock file from.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<KiotaLock> GetLockFromStreamAsync(Stream stream, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Writes the lock file for a Kiota project to the target directory.
+    /// </summary>
+    /// <param name="targetDirectory">The target directory to write the lock file to.</param>
+    /// <param name="lockInfo">The lock information to write.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task WriteLockFileAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken = default);
+}

--- a/src/Kiota.Builder/Lock/ILockManagementService.cs
+++ b/src/Kiota.Builder/Lock/ILockManagementService.cs
@@ -28,7 +28,7 @@ public interface ILockManagementService {
     /// <summary>
     /// Writes the lock file for a Kiota project to the target directory.
     /// </summary>
-    /// <param name="targetDirectory">The target directory to write the lock file to.</param>
+    /// <param name="directoryPath">The target directory to write the lock file to.</param>
     /// <param name="lockInfo">The lock information to write.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task WriteLockFileAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken = default);

--- a/src/Kiota.Builder/Lock/ILockManagementService.cs
+++ b/src/Kiota.Builder/Lock/ILockManagementService.cs
@@ -16,7 +16,7 @@ public interface ILockManagementService {
     /// <summary>
     /// Gets the lock file for a Kiota project by reading it from the target directory.
     /// </summary>
-    /// <param name="targetDirectory">The target directory to read the lock file from.</param>
+    /// <param name="directoryPath">The target directory to read the lock file from.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task<KiotaLock> GetLockFromDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default);
     /// <summary>

--- a/src/Kiota.Builder/Lock/ILockManagementService.cs
+++ b/src/Kiota.Builder/Lock/ILockManagementService.cs
@@ -11,7 +11,7 @@ public interface ILockManagementService {
     /// <summary>
     /// Gets the lock file for a Kiota project by crawling the directory tree.
     /// </summary>
-    /// <param name="root">The root directory to crawl</param>
+    /// <param name="searchDirectory">The root directory to crawl</param>
     IEnumerable<string> GetDirectoriesContainingLockFile(string searchDirectory);
     /// <summary>
     /// Gets the lock file for a Kiota project by reading it from the target directory.

--- a/src/Kiota.Builder/Lock/KiotaLock.cs
+++ b/src/Kiota.Builder/Lock/KiotaLock.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Kiota.Builder.Configuration;
+
+namespace Kiota.Builder.Lock;
+
+public class KiotaLock {
+    public string DescriptionHash { get; set; }
+    public string DescriptionLocation { get; set; }
+    public string LockFileVersion { get; set; } = "1.0.0";
+    public string KiotaVersion { get; set; } = Assembly.GetEntryAssembly().GetName().Version.ToString();
+    public string ClientClassName { get; set; }
+    public string ClientNamespaceName { get; set; }
+    public string Language { get; set; }
+    public bool UsesBackingStore { get; set; }
+    public bool IncludeAdditionalData { get; set; }
+    public HashSet<string> Serializers { get; set; } = new();
+    public HashSet<string> Deserializers { get; set; } = new();
+    public HashSet<string> StructuredMimeTypes { get; set; } = new();
+    public HashSet<string> IncludePatterns { get; set; } = new();
+    public HashSet<string> ExcludePatterns { get; set; } = new();
+    public void UpdateGenerationConfigurationFromLock(GenerationConfiguration config) {
+        config.ClientClassName = ClientClassName;
+        config.ClientNamespaceName = ClientNamespaceName;
+        config.Language = Enum.Parse<GenerationLanguage>(Language);
+        config.UsesBackingStore = UsesBackingStore;
+        config.IncludeAdditionalData = IncludeAdditionalData;
+        config.Serializers = Serializers;
+        config.Deserializers = Deserializers;
+        config.StructuredMimeTypes = StructuredMimeTypes;
+        config.IncludePatterns = IncludePatterns;
+        config.ExcludePatterns = ExcludePatterns;
+        config.OpenAPIFilePath = DescriptionLocation;
+    }
+    public KiotaLock() { }
+    public KiotaLock(GenerationConfiguration config)
+    {
+        Language = config.Language.ToString();
+        ClientClassName = config.ClientClassName;
+        ClientNamespaceName = config.ClientNamespaceName;
+        UsesBackingStore = config.UsesBackingStore;
+        IncludeAdditionalData = config.IncludeAdditionalData;
+        Serializers = config.Serializers;
+        Deserializers = config.Deserializers;
+        StructuredMimeTypes = config.StructuredMimeTypes;
+        IncludePatterns = config.IncludePatterns;
+        ExcludePatterns = config.ExcludePatterns;
+        DescriptionLocation = config.OpenAPIFilePath;
+    }
+}

--- a/src/Kiota.Builder/Lock/KiotaLock.cs
+++ b/src/Kiota.Builder/Lock/KiotaLock.cs
@@ -5,21 +5,70 @@ using Kiota.Builder.Configuration;
 
 namespace Kiota.Builder.Lock;
 
+/// <summary>
+/// A class that represents a lock file for a Kiota project.
+/// </summary>
 public class KiotaLock {
+    /// <summary>
+    /// The OpenAPI description hash that generated this client.
+    /// </summary>
     public string DescriptionHash { get; set; }
+    /// <summary>
+    /// The location of the OpenAPI description file.
+    /// </summary>
     public string DescriptionLocation { get; set; }
+    /// <summary>
+    /// The version of the lock file schema.
+    /// </summary>
     public string LockFileVersion { get; set; } = "1.0.0";
+    /// <summary>
+    /// The version of the Kiota generator that generated this client.
+    /// </summary>
     public string KiotaVersion { get; set; } = Assembly.GetEntryAssembly().GetName().Version.ToString();
+    /// <summary>
+    /// The main class name for this client.
+    /// </summary>
     public string ClientClassName { get; set; }
+    /// <summary>
+    /// The main namespace for this client.
+    /// </summary>
     public string ClientNamespaceName { get; set; }
+    /// <summary>
+    /// The language for this client.
+    /// </summary>
     public string Language { get; set; }
+    /// <summary>
+    /// Whether the backing store was used for this client.
+    /// </summary>
     public bool UsesBackingStore { get; set; }
+    /// <summary>
+    /// Whether additional data was used for this client.
+    /// </summary>
     public bool IncludeAdditionalData { get; set; }
+    /// <summary>
+    /// The serializers used for this client.
+    /// </summary>
     public HashSet<string> Serializers { get; set; } = new();
+    /// <summary>
+    /// The deserializers used for this client.
+    /// </summary>
     public HashSet<string> Deserializers { get; set; } = new();
+    /// <summary>
+    /// The structured mime types used for this client.
+    /// </summary>
     public HashSet<string> StructuredMimeTypes { get; set; } = new();
+    /// <summary>
+    /// The path patterns for API endpoints to include for this client.
+    /// </summary>
     public HashSet<string> IncludePatterns { get; set; } = new();
+    /// <summary>
+    /// The path patterns for API endpoints to exclude for this client.
+    /// </summary>
     public HashSet<string> ExcludePatterns { get; set; } = new();
+    /// <summary>
+    /// Updates the passed configuration with the values from the lock file.
+    /// </summary>
+    /// <param name="config">The configuration to update.</param>
     public void UpdateGenerationConfigurationFromLock(GenerationConfiguration config) {
         config.ClientClassName = ClientClassName;
         config.ClientNamespaceName = ClientNamespaceName;
@@ -33,7 +82,14 @@ public class KiotaLock {
         config.ExcludePatterns = ExcludePatterns;
         config.OpenAPIFilePath = DescriptionLocation;
     }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KiotaLock"/> class.
+    /// </summary>
     public KiotaLock() { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KiotaLock"/> class from the passed configuration.
+    /// </summary>
+    /// <param name="config">The configuration to use.</param>
     public KiotaLock(GenerationConfiguration config)
     {
         Language = config.Language.ToString();

--- a/src/Kiota.Builder/Lock/KiotaLock.cs
+++ b/src/Kiota.Builder/Lock/KiotaLock.cs
@@ -72,7 +72,8 @@ public class KiotaLock {
     public void UpdateGenerationConfigurationFromLock(GenerationConfiguration config) {
         config.ClientClassName = ClientClassName;
         config.ClientNamespaceName = ClientNamespaceName;
-        config.Language = Enum.Parse<GenerationLanguage>(Language);
+        if(Enum.TryParse<GenerationLanguage>(Language, out var parsedLanguage))
+            config.Language = parsedLanguage;
         config.UsesBackingStore = UsesBackingStore;
         config.IncludeAdditionalData = IncludeAdditionalData;
         config.Serializers = Serializers;

--- a/src/Kiota.Builder/Lock/KiotaLockComparer.cs
+++ b/src/Kiota.Builder/Lock/KiotaLockComparer.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kiota.Builder.Lock;
+
+/// <summary>
+/// Compares two <see cref="KiotaLock"/> instances.
+/// </summary>
+public class KiotaLockComparer : IEqualityComparer<KiotaLock>
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public bool Equals(KiotaLock x, KiotaLock y)
+    {
+        return GetHashCode(x) == GetHashCode(y);
+    }
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public int GetHashCode(KiotaLock obj)
+    {
+        if (obj == null) return 0;
+        return GetVersionHashCode(obj.KiotaVersion) * 43 +
+            GetVersionHashCode(obj.LockFileVersion) * 41 +
+            (obj.DescriptionLocation?.GetHashCode() ?? 0) * 37 +
+            (obj.DescriptionHash?.GetHashCode() ?? 0) * 31 +
+            (obj.ClientClassName?.GetHashCode() ?? 0) * 29 +
+            (obj.ClientNamespaceName?.GetHashCode() ?? 0) * 23 +
+            (obj.Language?.GetHashCode() ?? 0) * 19 +
+            obj.UsesBackingStore.GetHashCode() * 17 +
+            obj.IncludeAdditionalData.GetHashCode() * 13 +
+            string.Join(",", obj.Serializers?.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>()).GetHashCode() * 11 +
+            string.Join(",", obj.Deserializers?.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>()).GetHashCode() * 7 +
+            string.Join(",", obj.StructuredMimeTypes?.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>()).GetHashCode() * 5 +
+            string.Join(",", obj.IncludePatterns?.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>()).GetHashCode() * 3 +
+            string.Join(",", obj.ExcludePatterns?.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>()).GetHashCode() * 2;
+    }
+    private static int GetVersionHashCode(string version) {
+        if(string.IsNullOrEmpty(version)) return 0;
+        if(Version.TryParse(version, out var parsedVersion)) {
+            if (parsedVersion.Major > 0)
+                return parsedVersion.Major.GetHashCode();
+            if (parsedVersion.Minor > 0)
+                return parsedVersion.Minor.GetHashCode();
+        }
+        return 0;
+    }
+}

--- a/src/Kiota.Builder/Lock/KiotaLockComparer.cs
+++ b/src/Kiota.Builder/Lock/KiotaLockComparer.cs
@@ -9,16 +9,12 @@ namespace Kiota.Builder.Lock;
 /// </summary>
 public class KiotaLockComparer : IEqualityComparer<KiotaLock>
 {
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     public bool Equals(KiotaLock x, KiotaLock y)
     {
         return GetHashCode(x) == GetHashCode(y);
     }
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     public int GetHashCode(KiotaLock obj)
     {
         if (obj == null) return 0;

--- a/src/Kiota.Builder/Lock/LockManagementService.cs
+++ b/src/Kiota.Builder/Lock/LockManagementService.cs
@@ -26,7 +26,7 @@ public class LockManagementService : ILockManagementService {
             throw new ArgumentNullException(nameof(directoryPath));
         return GetLockFromDirectoryInternalAsync(directoryPath, cancellationToken);
     }
-    private async Task<KiotaLock> GetLockFromDirectoryInternalAsync(string directoryPath, CancellationToken cancellationToken) {
+    private static async Task<KiotaLock> GetLockFromDirectoryInternalAsync(string directoryPath, CancellationToken cancellationToken) {
         var lockFile = Path.Combine(directoryPath, LockFileName);
         if(File.Exists(lockFile)) {
             await using var fileStream = File.OpenRead(lockFile);
@@ -39,7 +39,7 @@ public class LockManagementService : ILockManagementService {
         ArgumentNullException.ThrowIfNull(stream);
         return await GetLockFromStreamInternalAsync(stream, cancellationToken);
     }
-    private ValueTask<KiotaLock> GetLockFromStreamInternalAsync(Stream stream, CancellationToken cancellationToken) {
+    private static ValueTask<KiotaLock> GetLockFromStreamInternalAsync(Stream stream, CancellationToken cancellationToken) {
         return JsonSerializer.DeserializeAsync<KiotaLock>(stream, options, cancellationToken);
     }
     /// <inheritdoc/>

--- a/src/Kiota.Builder/Lock/LockManagementService.cs
+++ b/src/Kiota.Builder/Lock/LockManagementService.cs
@@ -8,14 +8,19 @@ using System.Threading.Tasks;
 
 namespace Kiota.Builder.Lock;
 
-public class LockManagementService {
+/// <summary>
+/// A service that manages the lock file for a Kiota project implemented using the file system.
+/// </summary>
+public class LockManagementService : ILockManagementService {
     private const string LockFileName = "kiota-lock.json";
+    /// <inheritdoc/>
     public IEnumerable<string> GetDirectoriesContainingLockFile(string searchDirectory) {
         if(string.IsNullOrEmpty(searchDirectory))
             throw new ArgumentNullException(nameof(searchDirectory));
         var files = Directory.GetFiles(searchDirectory, LockFileName, SearchOption.AllDirectories);
         return files.Select(x => Path.GetDirectoryName(x));
     }
+    /// <inheritdoc/>
     public Task<KiotaLock> GetLockFromDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default) {
         if(string.IsNullOrEmpty(directoryPath))
             throw new ArgumentNullException(nameof(directoryPath));
@@ -29,6 +34,7 @@ public class LockManagementService {
         }
         return null;
     }
+    /// <inheritdoc/>
     public async Task<KiotaLock> GetLockFromStreamAsync(Stream stream, CancellationToken cancellationToken = default) {
         ArgumentNullException.ThrowIfNull(stream);
         return await GetLockFromStreamInternalAsync(stream, cancellationToken);
@@ -36,6 +42,7 @@ public class LockManagementService {
     private ValueTask<KiotaLock> GetLockFromStreamInternalAsync(Stream stream, CancellationToken cancellationToken) {
         return JsonSerializer.DeserializeAsync<KiotaLock>(stream, options, cancellationToken);
     }
+    /// <inheritdoc/>
     public Task WriteLockFileAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken = default) {
         if (string.IsNullOrEmpty(directoryPath))
             throw new ArgumentNullException(nameof(directoryPath));

--- a/src/Kiota.Builder/Lock/LockManagementService.cs
+++ b/src/Kiota.Builder/Lock/LockManagementService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kiota.Builder.Lock;
+
+public class LockManagementService {
+    private const string LockFileName = "kiota.lock";
+    public IEnumerable<string> GetDirectoriesContainingLockFile(string searchDirectory) {
+        if(string.IsNullOrEmpty(searchDirectory))
+            throw new ArgumentNullException(nameof(searchDirectory));
+        var files = Directory.GetFiles(searchDirectory, LockFileName, SearchOption.AllDirectories);
+        return files.Select(x => Path.GetDirectoryName(x));
+    }
+    public Task<KiotaLock> GetLockFromDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default) {
+        if(string.IsNullOrEmpty(directoryPath))
+            throw new ArgumentNullException(nameof(directoryPath));
+        return GetLockFromDirectoryInternalAsync(directoryPath, cancellationToken);
+    }
+    private async Task<KiotaLock> GetLockFromDirectoryInternalAsync(string directoryPath, CancellationToken cancellationToken) {
+        var lockFile = Path.Combine(directoryPath, LockFileName);
+        if(File.Exists(lockFile)) {
+            await using var fileStream = File.OpenRead(lockFile);
+            var result = await JsonSerializer.DeserializeAsync<KiotaLock>(fileStream, cancellationToken: cancellationToken);
+            return result;
+        }
+        return null;
+    }
+    public Task WriteLockFileAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrEmpty(directoryPath))
+            throw new ArgumentNullException(nameof(directoryPath));
+        ArgumentNullException.ThrowIfNull(lockInfo);
+        return WriteLockFileInternalAsync(directoryPath, lockInfo, cancellationToken);
+    }
+    private static async Task WriteLockFileInternalAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken) {
+        var lockFilePath = Path.Combine(directoryPath, LockFileName);
+        await using var fileStream = File.Open(lockFilePath, FileMode.Create);
+        await JsonSerializer.SerializeAsync(fileStream, lockInfo, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Kiota.Builder/Lock/LockManagementService.cs
+++ b/src/Kiota.Builder/Lock/LockManagementService.cs
@@ -25,7 +25,7 @@ public class LockManagementService {
         var lockFile = Path.Combine(directoryPath, LockFileName);
         if(File.Exists(lockFile)) {
             await using var fileStream = File.OpenRead(lockFile);
-            var result = await JsonSerializer.DeserializeAsync<KiotaLock>(fileStream, cancellationToken: cancellationToken);
+            var result = await JsonSerializer.DeserializeAsync<KiotaLock>(fileStream, options, cancellationToken);
             return result;
         }
         return null;
@@ -36,9 +36,14 @@ public class LockManagementService {
         ArgumentNullException.ThrowIfNull(lockInfo);
         return WriteLockFileInternalAsync(directoryPath, lockInfo, cancellationToken);
     }
+    private static readonly JsonSerializerOptions options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
     private static async Task WriteLockFileInternalAsync(string directoryPath, KiotaLock lockInfo, CancellationToken cancellationToken) {
         var lockFilePath = Path.Combine(directoryPath, LockFileName);
         await using var fileStream = File.Open(lockFilePath, FileMode.Create);
-        await JsonSerializer.SerializeAsync(fileStream, lockInfo, cancellationToken: cancellationToken);
+        await JsonSerializer.SerializeAsync(fileStream, lockInfo, options, cancellationToken);
     }
 }

--- a/src/Kiota.Web/Kiota.Web.csproj
+++ b/src/Kiota.Web/Kiota.Web.csproj
@@ -38,6 +38,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Show.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Update="Pages\Update.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Update.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="Shared\NavMenu.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>NavMenu.Designer.cs</LastGenOutput>

--- a/src/Kiota.Web/Pages/Generate.razor
+++ b/src/Kiota.Web/Pages/Generate.razor
@@ -56,16 +56,16 @@
 </div>
 
 @if(!string.IsNullOrEmpty(Dependencies)) {
-    <div>
+    <div class="log-container">
         <h2>@Loc["Dependencies"]</h2>
-        <pre>@Dependencies</pre>
+        <pre class="log-box">@Dependencies</pre>
     </div>
 }
 
 @if(!string.IsNullOrEmpty(Logs)) {
-    <div>
+    <div class="log-container">
         <h2>@Loc["Logs"]</h2>
-        <pre>@Logs</pre>
+        <pre class="log-box">@Logs</pre>
     </div>
 }
 

--- a/src/Kiota.Web/Pages/Generate.razor
+++ b/src/Kiota.Web/Pages/Generate.razor
@@ -37,9 +37,9 @@
         @foreach (var item in Enum.GetValues<GenerationLanguage>().OrderBy(static x => x.ToString(), StringComparer.OrdinalIgnoreCase))
         {
             if (configuration?.Languages?.TryGetValue(item.ToString(), out var languageInfo) ?? false) {
-                <FluentOption Value=@item>@item - @languageInfo.MaturityLevel</FluentOption>
+                <FluentOption Value=@item Selected=@(Language.HasValue && Language.Value == item)>@item - @languageInfo.MaturityLevel</FluentOption>
             } else {
-                <FluentOption Value=@item>@item</FluentOption>
+                <FluentOption Value=@item Selected=@(Language.HasValue && Language.Value == item)>@item</FluentOption>
             }
         }
     </FluentSelect>
@@ -98,12 +98,27 @@
     [SupplyParameterFromQuery(Name = "e")]
     public string? ExcludePatternsFromQuery { get; set; }
     private string? ExcludePatterns { get; set; }
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "l")]
+    public string? LanguageFromQuery { get; set; }
     private GenerationLanguage? Language { get; set; }
     private string? OutputPath { get; set; }
     private string? DownloadUrl { get; set; }
     private bool IsLoading { get; set; }
     private string? Dependencies { get; set; }
     private string? Logs { get; set; }
+    [Parameter]
+    [SupplyParameterFromQuery(Name="s")]
+    public string? SerializersFromQuery { get; set; }
+    private HashSet<string> Serializers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    [Parameter]
+    [SupplyParameterFromQuery(Name="ds")]
+    public string? DeserializersFromQuery { get; set; }
+    private HashSet<string> Deserializers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    [Parameter]
+    [SupplyParameterFromQuery(Name="m")]
+    public string? StructuredMimeTypesFromQuery { get; set; }
+    private HashSet<string> StructuredMimeTypes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     protected override async Task OnParametersSetAsync() {
         if(!string.IsNullOrEmpty(DescriptionUrlFromQuery))
             DescriptionUrl = DescriptionUrlFromQuery;
@@ -133,6 +148,26 @@
             NamespaceName = NamespaceNameFromQuery;
         else 
             NamespaceName = defaultConfiguration.ClientNamespaceName;
+
+        if(!string.IsNullOrEmpty(LanguageFromQuery) && Enum.TryParse<GenerationLanguage>(LanguageFromQuery, true, out var language))
+            Language = language;
+        else
+            Language = defaultConfiguration.Language;
+
+        if(!string.IsNullOrEmpty(SerializersFromQuery))
+            Serializers = new HashSet<string>(SerializersFromQuery.Split(',', StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
+        else
+            Serializers = defaultConfiguration.Serializers;
+
+        if(!string.IsNullOrEmpty(DeserializersFromQuery))
+            Deserializers = new HashSet<string>(DeserializersFromQuery.Split(',', StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
+        else
+            Deserializers = defaultConfiguration.Deserializers;
+
+        if(!string.IsNullOrEmpty(StructuredMimeTypesFromQuery))
+            StructuredMimeTypes = new HashSet<string>(StructuredMimeTypesFromQuery.Split(',', StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
+        else
+            StructuredMimeTypes = defaultConfiguration.StructuredMimeTypes;
         
         await GetConfiguration(ComponentDetached);
         await base.OnParametersSetAsync();
@@ -167,7 +202,10 @@
             ClientClassName = ClientClassName,
             ClientNamespaceName = NamespaceName,
             IncludeAdditionalData = AdditionalData,
-            UsesBackingStore = BackingStore
+            UsesBackingStore = BackingStore,
+            Serializers = Serializers,
+            Deserializers = Deserializers,
+            StructuredMimeTypes = StructuredMimeTypes,
         };
         var logBuilder = new StringBuilder();
         var builderLogger = new StringBuilderLogger<KiotaBuilder>(LoggerFactory.CreateLogger<KiotaBuilder>(), logBuilder, LogLevel.Warning);

--- a/src/Kiota.Web/Pages/Generate.razor.css
+++ b/src/Kiota.Web/Pages/Generate.razor.css
@@ -1,0 +1,7 @@
+.log-box {
+    white-space: pre-wrap;
+    overflow: auto;
+}
+.log-container {
+    max-width: fit-content;
+}

--- a/src/Kiota.Web/Pages/Update.fr.resx
+++ b/src/Kiota.Web/Pages/Update.fr.resx
@@ -58,19 +58,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Show" xml:space="preserve">
-    <value>Afficher</value>
-  </data>
-  <data name="Search" xml:space="preserve">
-    <value>Rechercher</value>
-  </data>
-  <data name="Generate" xml:space="preserve">
-    <value>Générer</value>
+  <data name="PageTitle" xml:space="preserve">
+    <value>Kiota - mettre à jour un client OpenAPI</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Mettre à jour</value>
+    <value>Mettre à jour un client</value>
   </data>
-  <data name="About" xml:space="preserve">
-    <value>A propos</value>
+  <data name="File" xml:space="preserve">
+    <value>Selectionez un fichier de sommaire kiota.</value>
+  </data>
+  <data name="InvalidLockFile" xml:space="preserve">
+    <value>Le fichier de sommaire n'a pas été reconnu.</value>
+  </data>
+  <data name="LockFileValid" xml:space="preserve">
+    <value>La description OpenAPI n'a pas été trouvée.</value>
   </data>
 </root>

--- a/src/Kiota.Web/Pages/Update.razor
+++ b/src/Kiota.Web/Pages/Update.razor
@@ -1,0 +1,60 @@
+@page "/update"
+@using Microsoft.Extensions.Localization
+@using Kiota.Builder.Lock
+@inject IStringLocalizer<Update> Loc
+@inject NavigationManager navManager
+
+
+<PageTitle>@Loc["PageTitle"]</PageTitle>
+
+<h1>@Loc["Update"]</h1>
+
+<div>
+    <label for="file">@Loc["File"]</label>
+    <InputFile OnChange="@LoadFiles" id="file" accept=".json" />
+@if(IsFileLoaded) {
+    @if(!IsLockFileValid) {
+        <p>@Loc["InvalidLockFile"]</p>
+    }
+    @if(!IsDocumentValid) {
+        <p>@Loc["LockFileValid"]</p>
+    }
+}
+</div>
+
+@code {
+    private bool IsFileLoaded { get; set; }
+    private bool IsLockFileValid { get; set; } = true;
+    private bool IsDocumentValid { get; set; } = true;
+    [Inject] private IApplicationInsights? AppInsights { get; set; }
+    private const string updateClientTelemetryKey = "updateclient";
+    private async Task LoadFiles(InputFileChangeEventArgs e)
+    {
+        IsFileLoaded = true;
+        var lockService = new LockManagementService();
+        if(AppInsights != null)
+            await AppInsights.StartTrackEvent(updateClientTelemetryKey).ConfigureAwait(false);
+        await using var stream = e.File.OpenReadStream();
+        try {
+            var lockInfo = await lockService.GetLockFromStreamAsync(stream, ComponentDetached).ConfigureAwait(false);
+            IsLockFileValid = true;
+            IsDocumentValid = lockInfo.DescriptionLocation.StartsWith("http", StringComparison.OrdinalIgnoreCase);
+            if (IsDocumentValid) {
+                var includeFilters = !(lockInfo.IncludePatterns?.Any() ?? false) ? string.Empty : string.Join(",", lockInfo.IncludePatterns);
+                var excludeFilters = !(lockInfo.ExcludePatterns?.Any() ?? false) ? string.Empty : string.Join(",", lockInfo.ExcludePatterns);
+                var serializers = !(lockInfo.Serializers?.Any() ?? false) ? string.Empty : string.Join(",", lockInfo.Serializers);
+                var deserializers = !(lockInfo.Deserializers?.Any() ?? false) ? string.Empty : string.Join(",", lockInfo.Deserializers);
+                var structuredMimeTypes = !(lockInfo.StructuredMimeTypes?.Any() ?? false) ? string.Empty : string.Join(",", lockInfo.StructuredMimeTypes);
+                navManager.NavigateTo($"/generate?d={lockInfo.DescriptionLocation}&i={includeFilters}&e={excludeFilters}" +
+                    $"&s={serializers}&ds={deserializers}&m={structuredMimeTypes}&l={lockInfo.Language}" +
+                    $"&b={lockInfo.UsesBackingStore}&n={lockInfo.ClientNamespaceName}&c={lockInfo.ClientClassName}"+
+                    $"&ad={lockInfo.IncludeAdditionalData}");
+            }
+        } catch (Exception) {
+            IsLockFileValid = false;
+        } finally {
+            if(AppInsights != null)
+                await AppInsights.StopTrackEvent(updateClientTelemetryKey).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Kiota.Web/Pages/Update.resx
+++ b/src/Kiota.Web/Pages/Update.resx
@@ -58,19 +58,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Show" xml:space="preserve">
-    <value>Afficher</value>
-  </data>
-  <data name="Search" xml:space="preserve">
-    <value>Rechercher</value>
-  </data>
-  <data name="Generate" xml:space="preserve">
-    <value>Générer</value>
+  <data name="PageTitle" xml:space="preserve">
+    <value>Kiota - update an OpenAPI client</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Mettre à jour</value>
+    <value>Update a client</value>
   </data>
-  <data name="About" xml:space="preserve">
-    <value>A propos</value>
+  <data name="File" xml:space="preserve">
+    <value>Select a kiota lock file</value>
+  </data>
+  <data name="InvalidLockFile" xml:space="preserve">
+    <value>The lock file couldn't be recognized.</value>
+  </data>
+  <data name="LockFileValid" xml:space="preserve">
+    <value>The OpenAPI description could not be found.</value>
   </data>
 </root>

--- a/src/Kiota.Web/Shared/MainLayout.razor.css
+++ b/src/Kiota.Web/Shared/MainLayout.razor.css
@@ -6,6 +6,7 @@
 
 main {
     flex: 1;
+    max-width: calc(100% - 100px);
 }
 
 .top-row {

--- a/src/Kiota.Web/Shared/NavMenu.razor
+++ b/src/Kiota.Web/Shared/NavMenu.razor
@@ -29,6 +29,10 @@
                 @Loc["Generate"]
                 <FluentIcon Name="@FluentIcons.Code" Slot="start" Size="@IconSize.Size24" Filled=false UseAccentColor=false />
             </FluentMenuItem>
+            <FluentMenuItem @onclick=@GoToUpdate>
+                @Loc["Update"]
+                <FluentIcon Name="@FluentIcons.ArrowSync" Slot="start" Size="@IconSize.Size24" Filled=false UseAccentColor=false />
+            </FluentMenuItem>
             <FluentMenuItem @onclick=@GoToAbout>
                 @Loc["About"]
                 <FluentIcon Name="@FluentIcons.Info" Slot="start" Size="@IconSize.Size24" Filled=false UseAccentColor=false />
@@ -47,18 +51,26 @@
         collapseNavMenu = !collapseNavMenu;
     }
     private void GoHome() {
-        navManager.NavigateTo("/");
+        GoTo("/");
     }
     private void GoToShow()
     {
-        navManager.NavigateTo("show");
+        GoTo("show");
     }
     private void GoToGenerate()
     {
-        navManager.NavigateTo("generate");
+        GoTo("generate");
+    }
+    private void GoToUpdate()
+    {
+        GoTo("update");
+    }
+    private void GoTo(string target)
+    {
+        navManager.NavigateTo(target);
     }
     private void GoToAbout()
     {
-        navManager.NavigateTo("https://microsoft.github.io/kiota");
+        GoTo("https://microsoft.github.io/kiota");
     }
 }

--- a/src/Kiota.Web/Shared/NavMenu.razor.css
+++ b/src/Kiota.Web/Shared/NavMenu.razor.css
@@ -21,6 +21,7 @@
     }
     .main-nav-menu {
         margin-top: 40px;
+        min-width: 100px;
     }
 
     .collapse {

--- a/src/Kiota.Web/Shared/NavMenu.resx
+++ b/src/Kiota.Web/Shared/NavMenu.resx
@@ -67,6 +67,9 @@
   <data name="Generate" xml:space="preserve">
     <value>Generate</value>
   </data>
+  <data name="Update" xml:space="preserve">
+    <value>Update</value>
+  </data>
   <data name="About" xml:space="preserve">
     <value>About</value>
   </data>

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -52,6 +52,10 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler
             return string.Empty;
         return Path.IsPathRooted(source) || source.StartsWith("http") ? source : NormalizeSlashesInPath(Path.Combine(Directory.GetCurrentDirectory(), source));
     }
+    protected void AssignIfNotNullOrEmpty(string input, Action<GenerationConfiguration, string> assignment) {
+        if (!string.IsNullOrEmpty(input))
+            assignment.Invoke(Configuration.Generation, input);
+    }
     protected static string NormalizeSlashesInPath(string path) {
         if (string.IsNullOrEmpty(path))
             return path;

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -149,6 +149,12 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler
                         $"Example: kiota info -d {path} -l {language}");
         }
     }
+    protected void DisplayCleanHint() {
+        if(TutorialMode) {
+            DisplayHint("Hint: to force the generation to overwrite an existing client pass the --clean-output switch.",
+                        $"Example: kiota generate --clean-output");
+        }
+    }
     protected void DisplayInfoAdvanced() {
         if(TutorialMode) {
             DisplayHint("Hint: use the language argument to get the list of dependencies you need to add to your project.",

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -149,10 +149,10 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler
                         $"Example: kiota info -d {path} -l {language}");
         }
     }
-    protected void DisplayCleanHint() {
+    protected void DisplayCleanHint(string commandName) {
         if(TutorialMode) {
             DisplayHint("Hint: to force the generation to overwrite an existing client pass the --clean-output switch.",
-                        $"Example: kiota generate --clean-output");
+                        $"Example: kiota {commandName} --clean-output");
         }
     }
     protected void DisplayInfoAdvanced() {

--- a/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
@@ -79,7 +79,7 @@ internal class KiotaGenerationCommandHandler : BaseKiotaCommandHandler
                     DisplaySuccess("Generation completed successfully");
                 else {
                     DisplaySuccess("Generation skipped as no changes were detected");
-                    DisplayCleanHint();
+                    DisplayCleanHint("generate");
                 }
                 DisplayInfoHint(language, Configuration.Generation.OpenAPIFilePath);
                 DisplayGenerateAdvancedHint(includePatterns, excludePatterns, Configuration.Generation.OpenAPIFilePath);

--- a/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Kiota.Builder;
-using Kiota.Builder.Configuration;
 using Kiota.Builder.Extensions;
 
 using Microsoft.Extensions.Logging;
@@ -90,10 +89,6 @@ internal class KiotaGenerationCommandHandler : BaseKiotaCommandHandler
     #endif
             }
         }
-    }
-    private void AssignIfNotNullOrEmpty(string input, Action<GenerationConfiguration, string> assignment) {
-        if (!string.IsNullOrEmpty(input))
-            assignment.Invoke(Configuration.Generation, input);
     }
     public Option<List<string>> IncludePatternsOption { get; set; }
     public Option<List<string>> ExcludePatternsOption { get; set; }

--- a/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerationCommandHandler.cs
@@ -74,8 +74,13 @@ internal class KiotaGenerationCommandHandler : BaseKiotaCommandHandler
             logger.LogTrace("configuration: {configuration}", JsonSerializer.Serialize(Configuration));
 
             try {
-                await new KiotaBuilder(logger, Configuration.Generation).GenerateClientAsync(cancellationToken);
-                DisplaySuccess("Generation completed successfully");
+                var result = await new KiotaBuilder(logger, Configuration.Generation).GenerateClientAsync(cancellationToken);
+                if (result)
+                    DisplaySuccess("Generation completed successfully");
+                else {
+                    DisplaySuccess("Generation skipped as no changes were detected");
+                    DisplayCleanHint();
+                }
                 DisplayInfoHint(language, Configuration.Generation.OpenAPIFilePath);
                 DisplayGenerateAdvancedHint(includePatterns, excludePatterns, Configuration.Generation.OpenAPIFilePath);
                 return 0;

--- a/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
@@ -41,12 +41,14 @@ internal class KiotaUpdateCommandHandler : BaseKiotaCommandHandler {
                                             config.OutputPath = x.lockDirectoryPath;
                                             return config;
                                         }).ToArray();
-                await Task.WhenAll(configurations
+                var results = await Task.WhenAll(configurations
                                         .Select(x => new KiotaBuilder(logger, x)
                                                     .GenerateClientAsync(cancellationToken)));
                 DisplaySuccess($"Update of {locks.Length} clients completed successfully");
                 foreach(var configuration in configurations)
                     DisplayInfoHint(configuration.Language, configuration.OpenAPIFilePath);
+                if(results.Any(x => x))
+                    DisplayCleanHint("update");
                 return 0;
             } catch (Exception ex) {
     #if DEBUG

--- a/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
@@ -44,6 +44,8 @@ internal class KiotaUpdateCommandHandler : BaseKiotaCommandHandler {
                 var results = await Task.WhenAll(configurations
                                         .Select(x => new KiotaBuilder(logger, x)
                                                     .GenerateClientAsync(cancellationToken)));
+                foreach (var (lockInfo, lockDirectoryPath) in locks)
+                    DisplaySuccess($"Update of {lockInfo.ClientClassName} client for {lockInfo.Language} at {lockDirectoryPath} completed");
                 DisplaySuccess($"Update of {locks.Length} clients completed successfully");
                 foreach(var configuration in configurations)
                     DisplayInfoHint(configuration.Language, configuration.OpenAPIFilePath);

--- a/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
@@ -1,0 +1,63 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Kiota.Builder;
+using Kiota.Builder.Configuration;
+using Kiota.Builder.Lock;
+using Microsoft.Extensions.Logging;
+
+namespace kiota.Handlers;
+
+internal class KiotaUpdateCommandHandler : BaseKiotaCommandHandler {
+    public Option<string> OutputOption { get;set; }
+    public Option<bool> CleanOutputOption { get;set; }
+    public Option<bool> ClearCacheOption { get; set; }
+    public override async Task<int> InvokeAsync(InvocationContext context) {
+        string output = context.ParseResult.GetValueForOption(OutputOption);
+        bool clearCache = context.ParseResult.GetValueForOption(ClearCacheOption);
+        bool cleanOutput = context.ParseResult.GetValueForOption(CleanOutputOption);
+        CancellationToken cancellationToken = (CancellationToken)context.BindingContext.GetService(typeof(CancellationToken));
+        AssignIfNotNullOrEmpty(output, (c, s) => c.OutputPath = s);
+        var searchPath = GetAbsolutePath(output);
+        var lockService = new LockManagementService();
+        var lockFileDirectoryPaths = lockService.GetDirectoriesContainingLockFile(searchPath);
+        if (!lockFileDirectoryPaths.Any()) {
+            DisplayError("No lock file found. Please run the generation command first.");
+            return 1;
+        }
+        Configuration.Generation.ClearCache = clearCache;
+        Configuration.Generation.CleanOutput = cleanOutput;
+        var (loggerFactory, logger) = GetLoggerAndFactory<KiotaBuilder>(context);
+        using (loggerFactory) {
+            try {
+                var locks = await Task.WhenAll(lockFileDirectoryPaths.Select(x => lockService.GetLockFromDirectoryAsync(x, cancellationToken)
+                                                                                .ContinueWith(t => (lockInfo: t.Result, lockDirectoryPath: x), cancellationToken)));
+                var configurations = locks.Select(x => {
+                                            var config = Configuration.Generation.Clone() as GenerationConfiguration;
+                                            x.lockInfo.UpdateGenerationConfigurationFromLock(config);
+                                            config.OutputPath = x.lockDirectoryPath;
+                                            return config;
+                                        }).ToArray();
+                await Task.WhenAll(configurations
+                                        .Select(x => new KiotaBuilder(logger, x)
+                                                    .GenerateClientAsync(cancellationToken)));
+                DisplaySuccess($"Update of {locks.Length} clients completed successfully");
+                foreach(var configuration in configurations)
+                    DisplayInfoHint(configuration.Language, configuration.OpenAPIFilePath);
+                return 0;
+            } catch (Exception ex) {
+    #if DEBUG
+                logger.LogCritical(ex, "error updating the client: {exceptionMessage}", ex.Message);
+                throw; // so debug tools go straight to the source of the exception when attached
+    #else
+                logger.LogCritical("error updating the client: {exceptionMessage}", ex.Message);
+                return 1;
+    #endif
+            }
+        }
+    }
+
+}

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -19,6 +19,7 @@ public class KiotaHost {
         rootCommand.AddCommand(GetDownloadCommand());
         rootCommand.AddCommand(GetShowCommand());
         rootCommand.AddCommand(GetInfoCommand());
+        rootCommand.AddCommand(GetUpdateCommand());
         return rootCommand;
     }
     private static Command GetInfoCommand() {
@@ -261,6 +262,31 @@ public class KiotaHost {
             StructuredMimeTypesOption = structuredMimeTypesOption,
             IncludePatternsOption = includePatterns,
             ExcludePatternsOption = excludePatterns,
+            ClearCacheOption = clearCacheOption,
+        };
+        return command;
+    }
+    private static Command GetUpdateCommand()
+    {
+        var defaultConfiguration = new GenerationConfiguration();
+        var outputOption = GetOutputPathOption(defaultConfiguration.OutputPath);
+
+        var logLevelOption = GetLogLevelOption();
+
+        var cleanOutputOption = GetCleanOutputOption(defaultConfiguration.CleanOutput);
+
+        var clearCacheOption = GetClearCacheOption(defaultConfiguration.ClearCache);
+
+        var command = new Command ("update", "Updates existing clients under the target directory using their lock files.") {
+            outputOption,
+            logLevelOption,
+            cleanOutputOption,
+            clearCacheOption,
+        };
+        command.Handler = new KiotaUpdateCommandHandler {
+            OutputOption = outputOption,
+            LogLevelOption = logLevelOption,
+            CleanOutputOption = cleanOutputOption,
             ClearCacheOption = clearCacheOption,
         };
         return command;

--- a/tests/Kiota.Builder.Tests/Configuration/GenerationConfigurationTests.cs
+++ b/tests/Kiota.Builder.Tests/Configuration/GenerationConfigurationTests.cs
@@ -1,0 +1,20 @@
+using Kiota.Builder.Configuration;
+using Xunit;
+
+namespace Kiota.Builder.Tests.Configuration;
+public class GenerationConfigurationTests {
+    [Fact]
+    public void Clones() {
+        var generationConfiguration = new GenerationConfiguration {
+            ClientClassName = "class1",
+            IncludePatterns = null,
+        };
+        var clone = generationConfiguration.Clone() as GenerationConfiguration;
+        Assert.NotNull(clone);
+        Assert.Equal(generationConfiguration.ClientClassName, clone.ClientClassName);
+        Assert.NotNull(clone.IncludePatterns);
+        Assert.Empty(clone.IncludePatterns);
+        clone.ClientClassName = "class2";
+        Assert.NotEqual(generationConfiguration.ClientClassName, clone.ClientClassName);
+    }
+}

--- a/tests/Kiota.Builder.Tests/Lock/KiotaLockTests.cs
+++ b/tests/Kiota.Builder.Tests/Lock/KiotaLockTests.cs
@@ -1,0 +1,17 @@
+using Kiota.Builder.Configuration;
+using Kiota.Builder.Lock;
+using Xunit;
+
+namespace Kiota.Builder.Tests.Lock;
+
+public class KiotaLockTests {
+    [Fact]
+    public void UpdatesAConfiguration() {
+        var kiotaLock = new KiotaLock {
+            DescriptionLocation = "description",
+        };
+        var generationConfiguration = new GenerationConfiguration();
+        kiotaLock.UpdateGenerationConfigurationFromLock(generationConfiguration);
+        Assert.Equal(kiotaLock.DescriptionLocation, generationConfiguration.OpenAPIFilePath);
+    }
+}

--- a/tests/Kiota.Builder.Tests/Lock/LockManagementServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Lock/LockManagementServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Kiota.Builder.Lock;
+using Xunit;
+
+namespace Kiota.Builder.Tests.Lock;
+
+public class LockManagementServiceTests {
+    [Fact]
+    public async Task DefensivePrograming() {
+        var lockManagementService = new LockManagementService();
+        Assert.Throws<ArgumentNullException>(() => lockManagementService.GetDirectoriesContainingLockFile(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => lockManagementService.GetLockFromDirectoryAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => lockManagementService.GetLockFromStreamAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => lockManagementService.WriteLockFileAsync(null, new KiotaLock()));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => lockManagementService.WriteLockFileAsync("path", null));
+    }
+    [Fact]
+    public async Task Identity() {
+        var lockManagementService = new LockManagementService();
+        var lockFile = new KiotaLock {
+            DescriptionLocation = "description",
+        };
+        var path = Path.GetTempPath();
+        await lockManagementService.WriteLockFileAsync(path, lockFile);
+        var result = await lockManagementService.GetLockFromDirectoryAsync(path);
+        Assert.Equal(lockFile, result, new KiotaLockComparer());
+    }
+}


### PR DESCRIPTION
fixes #105

## Example lock file

```json
{
  "descriptionHash": "3F59399C45001D3E1D8D074403A9DAE966F993F54945B6D0E6F8413EE6D3EA56F9C419C2640D85418C567A9931D591B0B5B1FDA2778BE140B33A7305B83C1416",
  "descriptionLocation": "https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/Mail.yml",
  "lockFileVersion": "1.0.0",
  "kiotaVersion": "0.6.0.0",
  "clientClassName": "ApiClient",
  "clientNamespaceName": "Graphdotnetv4",
  "language": "CSharp",
  "usesBackingStore": false,
  "includeAdditionalData": true,
  "serializers": [
    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory"
  ],
  "deserializers": [
    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory"
  ],
  "structuredMimeTypes": [
    "application/json",
    "application/xml",
    "text/plain",
    "text/xml",
    "text/yaml"
  ],
  "includePatterns": [],
  "excludePatterns": []
}
```

## TODO

- [x] update documentation for lock file behavior
- [x] add a ci command that scans for lock files and triggers multiple generations
- [x] add a "start from lockfile" page in kiota web
- [x] unit tests
- [x] lower camel case the properties names
