### PR TITLE
PHP - Add support for scalar types in request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for scalar request bodies Python [#1571](https://github.com/microsoft/kiota/issues/1571)
+- Added support for scalar request bodies in PHP [#1937](https://github.com/microsoft/kiota/pull/1937)
 
 ### Changed
 
 - Fixed a bug where array buffers nullability would wrongly be defined for TypeScript.
 - Fixed a bug where parameter comments would apprear in summary tag comments in dotnet. [#1945](https://github.com/microsoft/kiota/issues/1945)
+- Fixed a bug in PHP generation where request bodies would not serialize single elements properly. [#1937](https://github.com/microsoft/kiota/pull/1937)
 
 ## [0.7.1] - 2022-11-01
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -376,12 +376,13 @@ namespace Kiota.Builder.Writers.Php
             }
 
             if(requestParams.requestBody != null) {
+                var suffix = requestParams.requestBody.Type.IsCollection ? "Collection" : string.Empty;
                 if(requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"{RequestInfoVarName}->setStreamContent({conventions.GetParameterName(requestParams.requestBody)});");
-                else {
-                    var spreadOperator = requestParams.requestBody.Type.IsCollection ? "..." : string.Empty;
-                    var methodName = (requestParams.requestBody.Type is CodeType bodyType && bodyType.TypeDefinition is CodeClass) ? "setContentFromParsable" : "setContentFromScalarType";
-                    writer.WriteLine($"{RequestInfoVarName}->{methodName}($this->{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {spreadOperator}{conventions.GetParameterName(requestParams.requestBody)});");
+                else if (requestParams.requestBody.Type is CodeType bodyType && bodyType.TypeDefinition is CodeClass) {
+                    writer.WriteLine($"{RequestInfoVarName}->setContentFromParsable{suffix}($this->{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {conventions.GetParameterName(requestParams.requestBody)});");
+                } else {
+                    writer.WriteLine($"{RequestInfoVarName}->setContentFromScalar{suffix}($this->{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {conventions.GetParameterName(requestParams.requestBody)});");
                 }
             }
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -379,8 +379,9 @@ namespace Kiota.Builder.Writers.Php
                 if(requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                     writer.WriteLine($"{RequestInfoVarName}->setStreamContent({conventions.GetParameterName(requestParams.requestBody)});");
                 else {
-                    var spreadOperator = requestParams.requestBody.Type.AllTypes.First().IsCollection ? "..." : string.Empty;
-                    writer.WriteLine($"{RequestInfoVarName}->setContentFromParsable($this->{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {spreadOperator}{conventions.GetParameterName(requestParams.requestBody)});");
+                    var spreadOperator = requestParams.requestBody.Type.IsCollection ? "..." : string.Empty;
+                    var methodName = (requestParams.requestBody.Type is CodeType bodyType && bodyType.TypeDefinition is CodeClass) ? "setContentFromParsable" : "setContentFromScalarType";
+                    writer.WriteLine($"{RequestInfoVarName}->{methodName}($this->{requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {spreadOperator}{conventions.GetParameterName(requestParams.requestBody)});");
                 }
             }
 

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Configuration;
+using Kiota.Builder.Extensions;
 using Kiota.Builder.Refiners;
 using Kiota.Builder.Writers;
 using Kiota.Builder.Writers.Php;
@@ -56,6 +57,101 @@ namespace Kiota.Builder.Tests.Writers.Php
             _refiner = new PhpRefiner(new GenerationConfiguration {Language = GenerationLanguage.PHP});
             parentClass.AddMethod(method);
         }
+        
+        
+        private void AddRequestProperties()
+        {
+            parentClass.AddProperty(
+                new CodeProperty
+                {
+                    Name = "urlTemplate",
+                    Access = AccessModifier.Protected,
+                    DefaultValue = "https://graph.microsoft.com/v1.0/",
+                    Description = "The URL template",
+                    Kind = CodePropertyKind.UrlTemplate,
+                    Type = new CodeType {Name = "string"}
+                },
+                new CodeProperty
+                {
+                    Name = "pathParameters",
+                    Access = AccessModifier.Protected,
+                    DefaultValue = "[]",
+                    Description = "The Path parameters.",
+                    Kind = CodePropertyKind.PathParameters,
+                    Type = new CodeType {Name = "array"}
+                },
+                new CodeProperty
+                {
+                    Name = "requestAdapter",
+                    Access = AccessModifier.Protected,
+                    Description = "The request Adapter",
+                    Kind = CodePropertyKind.RequestAdapter,
+                    Type = new CodeType
+                    {
+                        IsNullable = false,
+                        Name = "RequestAdapter"
+                    }
+                }
+            );
+        }
+
+        private void AddRequestBodyParameters()
+        {
+            var stringType = new CodeType {
+                Name = "string",
+                IsNullable = false
+            };
+            var requestConfigClass = parentClass.AddInnerClass(new CodeClass {
+                Name = "RequestConfig",
+                Kind = CodeClassKind.RequestConfiguration,
+            }).First();
+            
+            requestConfigClass.AddProperty(new() {
+                    Name = "h",
+                    Kind = CodePropertyKind.Headers,
+                    Type = stringType,
+                },
+                new () {
+                    Name = "q",
+                    Kind = CodePropertyKind.QueryParameters,
+                    Type = stringType,
+                },
+                new () {
+                    Name = "o",
+                    Kind = CodePropertyKind.Options,
+                    Type = stringType,
+                }
+            );
+            
+            method.AddParameter(
+                new CodeParameter
+                {
+                    Name = "body",
+                    Kind = CodeParameterKind.RequestBody,
+                    Type = new CodeType
+                    {
+                        Name = "Message",
+                        IsExternal = true,
+                        IsNullable = false,
+                        TypeDefinition = root.AddClass(new CodeClass {
+                            Name = "SomeComplexTypeForRequestBody",
+                            Kind = CodeClassKind.Model,
+                        }).First()
+                    },
+                },
+                new CodeParameter{
+                    Name = "config",
+                    Kind = CodeParameterKind.RequestConfiguration,
+                    Type = new CodeType {
+                        Name = "RequestConfig",
+                        TypeDefinition = requestConfigClass,
+                        ActionOf = true,
+                    },
+                    Optional = true,
+                }
+            );
+        }
+        
         [Fact]
         public void WriteABasicMethod()
         {
@@ -67,17 +163,8 @@ namespace Kiota.Builder.Tests.Writers.Php
         [Fact]
         public void WriteMethodWithNoDescription()
         {
-            var codeMethod = new CodeMethod
-            {
-                Access = AccessModifier.Public,
-                Kind = CodeMethodKind.Custom,
-                ReturnType = new CodeType
-                {
-                    Name = "void"
-                },
-                Parent = parentClass
-            };
-            _codeMethodWriter.WriteCodeElement(codeMethod, languageWriter);
+            method.Description = null;
+            _codeMethodWriter.WriteCodeElement(method, languageWriter);
             var result = stringWriter.ToString();
             
             Assert.DoesNotContain("/*", result);
@@ -251,104 +338,20 @@ namespace Kiota.Builder.Tests.Writers.Php
         }
 
         [Fact]
-        public void WriteRequestGenerator()
+        public void WriteRequestGeneratorForParsable()
         {
             parentClass.Kind = CodeClassKind.RequestBuilder;
-            parentClass.AddProperty(
-                new CodeProperty
-                {
-                    Name = "urlTemplate",
-                    Access = AccessModifier.Protected,
-                    DefaultValue = "https://graph.microsoft.com/v1.0/",
-                    Description = "The URL template",
-                    Kind = CodePropertyKind.UrlTemplate,
-                    Type = new CodeType {Name = "string"}
-                },
-                new CodeProperty
-                {
-                    Name = "pathParameters",
-                    Access = AccessModifier.Protected,
-                    DefaultValue = "[]",
-                    Description = "The Path parameters.",
-                    Kind = CodePropertyKind.PathParameters,
-                    Type = new CodeType {Name = "array"}
-                },
-                new CodeProperty
-                {
-                    Name = "requestAdapter",
-                    Access = AccessModifier.Protected,
-                    Description = "The request Adapter",
-                    Kind = CodePropertyKind.RequestAdapter,
-                    Type = new CodeType
-                    {
-                        IsNullable = false,
-                        Name = "RequestAdapter"
-                    }
-                });
-            var codeMethod = new CodeMethod
+            method.Name = "createPostRequestInformation";
+            method.Kind = CodeMethodKind.RequestGenerator;
+            method.ReturnType = new CodeType()
             {
-                Name = "createPostRequestInformation",
-                ReturnType = new CodeType {Name = "RequestInformation", IsNullable = false},
-                Access = AccessModifier.Public,
-                Description = "This method creates request information for POST request.",
-                HttpMethod = HttpMethod.Post,
-                BaseUrl = "https://graph.microsoft.com/v1.0/",
-                Kind = CodeMethodKind.RequestGenerator,
+                Name = "RequestInformation", IsNullable = false
             };
-
-            var stringType = new CodeType {
-                Name = "string",
-                IsNullable = false
-            };
-            var requestConfigClass = parentClass.AddInnerClass(new CodeClass {
-                Name = "RequestConfig",
-                Kind = CodeClassKind.RequestConfiguration,
-            }).First();
-            requestConfigClass.AddProperty(new() {
-                Name = "h",
-                Kind = CodePropertyKind.Headers,
-                Type = stringType,
-            },
-            new () {
-                Name = "q",
-                Kind = CodePropertyKind.QueryParameters,
-                Type = stringType,
-            },
-            new () {
-                Name = "o",
-                Kind = CodePropertyKind.Options,
-                Type = stringType,
-            });
-            
-            codeMethod.AddParameter(
-                new CodeParameter
-                {
-                    Name = "body",
-                    Kind = CodeParameterKind.RequestBody,
-                    Type = new CodeType
-                    {
-                        Name = "Message",
-                        IsExternal = true,
-                        IsNullable = false
-                    }
-                },
-                new CodeParameter{
-                    Name = "config",
-                    Kind = CodeParameterKind.RequestConfiguration,
-                    Type = new CodeType {
-                        Name = "RequestConfig",
-                        TypeDefinition = requestConfigClass,
-                        ActionOf = true,
-                    },
-                    Optional = true,
-                });
-
-            
-            parentClass.AddMethod(codeMethod);
-            
-            _codeMethodWriter.WriteCodeElement(codeMethod, languageWriter);
+            method.HttpMethod = HttpMethod.Post;
+            AddRequestProperties();
+            AddRequestBodyParameters();
+            _codeMethodWriter.WriteCodeElement(method, languageWriter);
             var result = stringWriter.ToString();
-
             Assert.Contains(
                 "public function createPostRequestInformation(Message $body, ?RequestConfig $requestConfiguration = null): RequestInformation",
                 result);
@@ -357,6 +360,91 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
             Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
             Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
+            Assert.Contains("$requestInfo->setContentFromParsable($this->requestAdapter, \"\", $body);", result);
+            Assert.Contains("return $requestInfo;", result);
+        }
+
+        [Fact]
+        public void WritesRequestGeneratorBodyForParsableCollection()
+        {
+            parentClass.Kind = CodeClassKind.RequestBuilder;
+            method.Name = "createPostRequestInformation";
+            method.Kind = CodeMethodKind.RequestGenerator;
+            method.AcceptedResponseTypes.Add("application/json");
+            method.ReturnType = new CodeType() { Name = "RequestInformation", IsNullable = false };
+            method.HttpMethod = HttpMethod.Post;
+            AddRequestProperties();
+            AddRequestBodyParameters();
+            var bodyParameter = method.Parameters.OfKind(CodeParameterKind.RequestBody);
+            bodyParameter.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+            _codeMethodWriter.WriteCodeElement(method, languageWriter);
+            var result = stringWriter.ToString();
+            Assert.Contains(
+                "public function createPostRequestInformation(array $body, ?RequestConfig $requestConfiguration = null): RequestInformation",
+                result);
+            Assert.Contains("if ($requestConfiguration !== null", result);
+            Assert.Contains("if ($requestConfiguration->h !== null)", result);
+            Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
+            Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
+            Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
+            Assert.Contains("$requestInfo->setContentFromParsable($this->requestAdapter, \"\", ...$body);", result);
+            Assert.Contains("return $requestInfo;", result);
+        }
+        
+        [Fact]
+        public void WriteRequestGeneratorForScalarType()
+        {
+            parentClass.Kind = CodeClassKind.RequestBuilder;
+            method.Name = "createPostRequestInformation";
+            method.Kind = CodeMethodKind.RequestGenerator;
+            method.ReturnType = new CodeType() { Name = "RequestInformation", IsNullable = false };
+            method.HttpMethod = HttpMethod.Post;
+            AddRequestProperties();
+            AddRequestBodyParameters();
+            var bodyParameter = method.Parameters.OfKind(CodeParameterKind.RequestBody);
+            bodyParameter.Type = new CodeType() { Name = "string", IsNullable = false };
+            _codeMethodWriter.WriteCodeElement(method, languageWriter);
+            var result = stringWriter.ToString();
+            Assert.Contains(
+                "public function createPostRequestInformation(string $body, ?RequestConfig $requestConfiguration = null): RequestInformation",
+                result);
+            Assert.Contains("if ($requestConfiguration !== null", result);
+            Assert.Contains("if ($requestConfiguration->h !== null)", result);
+            Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
+            Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
+            Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
+            Assert.Contains("$requestInfo->setContentFromScalarType($this->requestAdapter, \"\", $body);", result);
+            Assert.Contains("return $requestInfo;", result);
+        }
+        
+        [Fact]
+        public void WritesRequestGeneratorBodyForScalarCollection()
+        {
+            parentClass.Kind = CodeClassKind.RequestBuilder;
+            method.Name = "createPostRequestInformation";
+            method.Kind = CodeMethodKind.RequestGenerator;
+            method.AcceptedResponseTypes.Add("application/json");
+            method.ReturnType = new CodeType()
+            {
+                Name = "RequestInformation", IsNullable = false
+            };
+            method.HttpMethod = HttpMethod.Post;
+            AddRequestProperties();
+            AddRequestBodyParameters();
+            var bodyParameter = method.Parameters.OfKind(CodeParameterKind.RequestBody);
+            bodyParameter.Type = new CodeType() { Name = "string", IsNullable = false };
+            bodyParameter.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
+            _codeMethodWriter.WriteCodeElement(method, languageWriter);
+            var result = stringWriter.ToString();
+            Assert.Contains(
+                "public function createPostRequestInformation(array $body, ?RequestConfig $requestConfiguration = null): RequestInformation",
+                result);
+            Assert.Contains("if ($requestConfiguration !== null", result);
+            Assert.Contains("if ($requestConfiguration->h !== null)", result);
+            Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
+            Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
+            Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
+            Assert.Contains("$requestInfo->setContentFromScalarType($this->requestAdapter, \"\", ...$body);", result);
             Assert.Contains("return $requestInfo;", result);
         }
 

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -387,7 +387,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
             Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
             Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
-            Assert.Contains("$requestInfo->setContentFromParsable($this->requestAdapter, \"\", ...$body);", result);
+            Assert.Contains("$requestInfo->setContentFromParsableCollection($this->requestAdapter, \"\", $body);", result);
             Assert.Contains("return $requestInfo;", result);
         }
         
@@ -413,7 +413,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
             Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
             Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
-            Assert.Contains("$requestInfo->setContentFromScalarType($this->requestAdapter, \"\", $body);", result);
+            Assert.Contains("$requestInfo->setContentFromScalar($this->requestAdapter, \"\", $body);", result);
             Assert.Contains("return $requestInfo;", result);
         }
         
@@ -444,7 +444,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("$requestInfo->headers = array_merge($requestInfo->headers, $requestConfiguration->h);", result);
             Assert.Contains("$requestInfo->setQueryParameters($requestConfiguration->q);", result);
             Assert.Contains("$requestInfo->addRequestOptions(...$requestConfiguration->o);", result);
-            Assert.Contains("$requestInfo->setContentFromScalarType($this->requestAdapter, \"\", ...$body);", result);
+            Assert.Contains("$requestInfo->setContentFromScalarCollection($this->requestAdapter, \"\", $body);", result);
             Assert.Contains("return $requestInfo;", result);
         }
 


### PR DESCRIPTION
- Validates support for Parsable collections in the request body
- Adds support for scalar values and collections of scalar values in request body
- Adds/Refactors tests for PHP method writers

closes https://github.com/microsoft/kiota/issues/1933

TODO:
- [x] Fix Code Smell
- [x] Merge & release https://github.com/microsoft/kiota-abstractions-php/pull/10