### PR TITLE
Fix parameter comment placement in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where array buffers nullability would wrongly be defined for TypeScript.
+- Fixed a bug where parameter comments would apprear in summary tag comments in dotnet. [#1945](https://github.com/microsoft/kiota/issues/1945)
 
 ## [0.7.1] - 2022-11-01
 

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -532,9 +532,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             writer.WriteLine($"{conventions.DocCommentPrefix}<summary>");
             if (isDescriptionPresent)
                 writer.WriteLine($"{conventions.DocCommentPrefix}{code.Description.CleanupXMLString()}");
+            writer.WriteLine($"{conventions.DocCommentPrefix}</summary>");
             foreach (var paramWithDescription in parametersWithDescription.OrderBy(x => x.Name))
                 writer.WriteLine($"{conventions.DocCommentPrefix}<param name=\"{paramWithDescription.Name.ToFirstCharacterLowerCase()}\">{paramWithDescription.Description.CleanupXMLString()}</param>");
-            writer.WriteLine($"{conventions.DocCommentPrefix}</summary>");
         }
     }
     private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();


### PR DESCRIPTION
This PR closes https://github.com/microsoft/kiota/issues/1945

It fixes the placement of parameter comments in dotnet to be outside the summary tag to avoid generated warnings.

Samples have also been updated via https://github.com/microsoft/kiota-samples/pull/1173