### PR TITLE
Python/multiple level properties bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for scalar request bodies Python [#1571](https://github.com/microsoft/kiota/issues/1571)
+- Sets property defaults in constructor and removes duplicate properties defined in base types from model serialization and deserialization methods in Python. [#1726](https://github.com/microsoft/kiota/issues/1726)
 
 ### Changed
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -170,18 +170,15 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
             writer.WriteLine();
         }
         foreach(var propWithDefault in parentClass.GetPropertiesOfKind(SetterAccessProperties)
-                                        .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
-                                        .OrderByDescending(static x => x.Kind)
-                                        .ThenBy(static x => x.Name)) {                                
-            writer.WriteLine($"self.{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue};");
-        }
-        foreach(var propWithoutDefault in parentClass.GetPropertiesOfKind(SetterAccessProperties)
-                                        .Where(static x => string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderByDescending(static x => x.Kind)
                                         .ThenBy(static x => x.Name)) {
-            var returnType = conventions.GetTypeString(propWithoutDefault.Type, propWithoutDefault, true, writer);
-            conventions.WriteInLineDescription(propWithoutDefault.Description, writer);
-            writer.WriteLine($"self.{conventions.GetAccessModifier(propWithoutDefault.Access)}{propWithoutDefault.NamePrefix}{propWithoutDefault.Name.ToSnakeCase()}: {(propWithoutDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithoutDefault.Type.IsNullable ? "]" : string.Empty)} = None");
+            var defaultValueReference = propWithDefault.DefaultValue;
+            if (string.IsNullOrEmpty(defaultValueReference)) {
+                var returnType = conventions.GetTypeString(propWithDefault.Type, propWithDefault, true, writer);
+                conventions.WriteInLineDescription(propWithDefault.Description, writer);
+                writer.WriteLine($"self.{conventions.GetAccessModifier(propWithDefault.Access)}{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()}: {(propWithDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithDefault.Type.IsNullable ? "]" : string.Empty)} = None");
+            }              
+            writer.WriteLine($"self.{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue}");
         }
         if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
             if(currentMethod.IsOfKind(CodeMethodKind.Constructor) &&

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -160,26 +160,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
     private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer, bool inherits) {
         if(inherits)
             writer.WriteLine("super().__init__()");
-        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(DirectAccessProperties)
-                                        .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
-                                        .OrderByDescending(static x => x.Kind)
-                                        .ThenBy(static x => x.Name)) {
-            var returnType = conventions.GetTypeString(propWithDefault.Type, propWithDefault, true, writer);
-            conventions.WriteInLineDescription(propWithDefault.Description, writer);
-            writer.WriteLine($"self.{conventions.GetAccessModifier(propWithDefault.Access)}{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()}: {(propWithDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithDefault.Type.IsNullable ? "]" : string.Empty)} = {propWithDefault.DefaultValue}");
-            writer.WriteLine();
-        }
-        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(SetterAccessProperties)
-                                        .OrderByDescending(static x => x.Kind)
-                                        .ThenBy(static x => x.Name)) {
-            var defaultValueReference = propWithDefault.DefaultValue;
-            if (string.IsNullOrEmpty(defaultValueReference)) {
-                var returnType = conventions.GetTypeString(propWithDefault.Type, propWithDefault, true, writer);
-                conventions.WriteInLineDescription(propWithDefault.Description, writer);
-                writer.WriteLine($"self.{conventions.GetAccessModifier(propWithDefault.Access)}{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()}: {(propWithDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithDefault.Type.IsNullable ? "]" : string.Empty)} = None");
-            }              
-            writer.WriteLine($"self.{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue}");
-        }
+        WriteDirectAccessProperties(parentClass, writer);
+        WriteSetterAccessProperties(parentClass, writer);
+        WriteSetterAccessPropertiesWithoutDefaults(parentClass, writer);
+
         if(parentClass.IsOfKind(CodeClassKind.RequestBuilder)) {
             if(currentMethod.IsOfKind(CodeMethodKind.Constructor) &&
             currentMethod.Parameters.FirstOrDefault(x => x.IsOfKind(CodeParameterKind.PathParameters)) is CodeParameter pathParametersParam) {
@@ -193,6 +177,35 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                 AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.PathParameters, CodePropertyKind.PathParameters, writer, conventions.TempDictionaryVarName);
             }
             AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.RequestAdapter, CodePropertyKind.RequestAdapter, writer);
+        }
+    }
+    private void WriteDirectAccessProperties(CodeClass parentClass, LanguageWriter writer) {
+        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(DirectAccessProperties)
+                                        .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderByDescending(static x => x.Kind)
+                                        .ThenBy(static x => x.Name)) {
+            var returnType = conventions.GetTypeString(propWithDefault.Type, propWithDefault, true, writer);
+            conventions.WriteInLineDescription(propWithDefault.Description, writer);
+            writer.WriteLine($"self.{conventions.GetAccessModifier(propWithDefault.Access)}{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()}: {(propWithDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithDefault.Type.IsNullable ? "]" : string.Empty)} = {propWithDefault.DefaultValue}");
+            writer.WriteLine();
+        }
+    }
+    private void WriteSetterAccessProperties(CodeClass parentClass, LanguageWriter writer) {
+        foreach(var propWithDefault in parentClass.GetPropertiesOfKind(SetterAccessProperties)
+                                        .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderByDescending(static x => x.Kind)
+                                        .ThenBy(static x => x.Name)) {                                
+            writer.WriteLine($"self.{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue}");
+        }
+    }
+    private void WriteSetterAccessPropertiesWithoutDefaults(CodeClass parentClass, LanguageWriter writer) {
+        foreach(var propWithoutDefault in parentClass.GetPropertiesOfKind(SetterAccessProperties)
+                                        .Where(static x => string.IsNullOrEmpty(x.DefaultValue))
+                                        .OrderByDescending(static x => x.Kind)
+                                        .ThenBy(static x => x.Name)) {
+            var returnType = conventions.GetTypeString(propWithoutDefault.Type, propWithoutDefault, true, writer);
+            conventions.WriteInLineDescription(propWithoutDefault.Description, writer);
+            writer.WriteLine($"self.{conventions.GetAccessModifier(propWithoutDefault.Access)}{propWithoutDefault.NamePrefix}{propWithoutDefault.Name.ToSnakeCase()}: {(propWithoutDefault.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(propWithoutDefault.Type.IsNullable ? "]" : string.Empty)} = None");
         }
     }
     private static void AssignPropertyFromParameter(CodeClass parentClass, CodeMethod currentMethod, CodeParameterKind parameterKind, CodePropertyKind propertyKind, LanguageWriter writer, string variableName = default) {

--- a/src/Kiota.Builder/Writers/Python/PythonWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonWriter.cs
@@ -3,14 +3,14 @@ using Kiota.Builder.PathSegmenters;
 namespace Kiota.Builder.Writers.Python;
 public class PythonWriter : LanguageWriter
 {
-    public PythonWriter(string rootPath, string clientNamespaceName)
+    public PythonWriter(string rootPath, string clientNamespaceName, bool usesBackingStore = false)
     {
         PathSegmenter = new PythonPathSegmenter(rootPath, clientNamespaceName);
         var conventionService = new PythonConventionService();
         AddOrReplaceCodeElementWriter(new CodeClassDeclarationWriter(conventionService, clientNamespaceName));
         AddOrReplaceCodeElementWriter(new CodeBlockEndWriter());
         AddOrReplaceCodeElementWriter(new CodeEnumWriter(conventionService));
-        AddOrReplaceCodeElementWriter(new CodeMethodWriter(conventionService));
+        AddOrReplaceCodeElementWriter(new CodeMethodWriter(conventionService, usesBackingStore));
         AddOrReplaceCodeElementWriter(new CodePropertyWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeTypeWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeNameSpaceWriter(conventionService));

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -313,13 +313,6 @@ public class CodeMethodWriterTests : IDisposable {
     }
     [Fact]
     public void WritesDeSerializerBody() {
-        var parameter = new CodeParameter{
-            Description = ParamDescription,
-            Name = ParamName
-        };
-        parameter.Type = new CodeType {
-            Name = "string"
-        };
         method.Kind = CodeMethodKind.Deserializer;
         method.IsAsync = false;
         AddSerializationProperties();
@@ -334,6 +327,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("get_collection_of_primitive_values", result);
         Assert.Contains("get_collection_of_object_values", result);
         Assert.Contains("get_enum_value", result);
+        Assert.DoesNotContain("defined_in_Parent", result, StringComparison.OrdinalIgnoreCase);
     }
     [Fact]
     public void WritesInheritedSerializerBody() {
@@ -347,13 +341,6 @@ public class CodeMethodWriterTests : IDisposable {
     }
     [Fact]
     public void WritesSerializerBody() {
-        var parameter = new CodeParameter{
-            Description = ParamDescription,
-            Name = ParamName
-        };
-        parameter.Type = new CodeType {
-            Name = "string"
-        };
         method.Kind = CodeMethodKind.Serializer;
         method.IsAsync = false;
         AddSerializationProperties();
@@ -364,6 +351,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("write_collection_of_object_values", result);
         Assert.Contains("write_enum_value", result);
         Assert.Contains("write_additional_data_value(self.additional_data)", result);
+        Assert.DoesNotContain("defined_in_parent", result, StringComparison.OrdinalIgnoreCase);
     }
     [Fact]
     public void WritesMethodAsyncDescription() {
@@ -411,7 +399,7 @@ public class CodeMethodWriterTests : IDisposable {
     }
     [Fact]
     public void Defensive() {
-        var codeMethodWriter = new CodeMethodWriter(new PythonConventionService());
+        var codeMethodWriter = new CodeMethodWriter(new PythonConventionService(), false);
         Assert.Throws<ArgumentNullException>(() => codeMethodWriter.WriteCodeElement(null, writer));
         Assert.Throws<ArgumentNullException>(() => codeMethodWriter.WriteCodeElement(method, null));
         var originalParent = method.Parent;


### PR DESCRIPTION
fixes #1726
Implements properties defaults and multi-definition trimming in Python.