### PR TITLE
Python/accept header definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for scalar request bodies Python [#1571](https://github.com/microsoft/kiota/issues/1571)
 - Sets property defaults in constructor and removes duplicate properties defined in base types from model serialization and deserialization methods in Python. [#1726](https://github.com/microsoft/kiota/issues/1726)
 - Added support for scalar request bodies in PHP [#1937](https://github.com/microsoft/kiota/pull/1937)
-- Added accept header for all schematized requests Python. [#1615](https://github.com/microsoft/kiota/issues/1615)
+- Added accept header for all schematized requests Python. [#1617](https://github.com/microsoft/kiota/issues/1617)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for scalar request bodies Python [#1571](https://github.com/microsoft/kiota/issues/1571)
 - Sets property defaults in constructor and removes duplicate properties defined in base types from model serialization and deserialization methods in Python. [#1726](https://github.com/microsoft/kiota/issues/1726)
 - Added support for scalar request bodies in PHP [#1937](https://github.com/microsoft/kiota/pull/1937)
+- Added accept header for all schematized requests Python. [#1615](https://github.com/microsoft/kiota/issues/1615)
 
 ### Changed
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -316,6 +316,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                             $"{RequestInfoVarName}.url_template = {GetPropertyCall(urlTemplateProperty, "''")}",
                             $"{RequestInfoVarName}.path_parameters = {GetPropertyCall(urlTemplateParamsProperty, "''")}",
                             $"{RequestInfoVarName}.http_method = Method.{codeElement.HttpMethod.ToString().ToUpperInvariant()}");
+        if(codeElement.AcceptedResponseTypes.Any())
+            writer.WriteLine($"{RequestInfoVarName}.headers[\"Accept\"] = \"{string.Join(", ", codeElement.AcceptedResponseTypes)}\"");
         UpdateRequestInformationFromRequestConfiguration(requestParams, writer);
         UpdateRequestInformationFromRequestBody(codeElement, requestParams, requestAdapterProperty, writer);
         writer.WriteLine($"return {RequestInfoVarName}");

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -265,12 +265,14 @@ public class CodeMethodWriterTests : IDisposable {
         method.HttpMethod = HttpMethod.Get;
         AddRequestProperties();
         AddRequestBodyParameters();
+        method.AcceptedResponseTypes.Add("application/json");
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("request_info = RequestInformation()", result);
         Assert.Contains("request_info.http_method = Method", result);
         Assert.Contains("request_info.url_template = ", result);
         Assert.Contains("request_info.path_parameters = ", result);
+        Assert.Contains("request_info.headers[\"Accept\"] = \"application/json\"", result);
         Assert.Contains("if c:", result);
         Assert.Contains("request_info.add_request_headers", result);
         Assert.Contains("request_info.add_request_options", result);
@@ -292,6 +294,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("request_info.http_method = Method", result);
         Assert.Contains("request_info.url_template = ", result);
         Assert.Contains("request_info.path_parameters = ", result);
+        Assert.Contains("request_info.headers[\"Accept\"] = \"application/json\"", result);
         Assert.Contains("if c:", result);
         Assert.Contains("request_info.add_request_headers", result);
         Assert.Contains("request_info.add_request_options", result);


### PR DESCRIPTION
Read the response media type from the description and includes it in headers in the generated code.

closes #1617 