### PR TITLE
PHP - Backing Store support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sets property defaults in constructor and removes duplicate properties defined in base types from model serialization and deserialization methods in Python. [#1726](https://github.com/microsoft/kiota/issues/1726)
 - Added support for scalar request bodies in PHP [#1937](https://github.com/microsoft/kiota/pull/1937)
 - Added accept header for all schematized requests Python. [#1617](https://github.com/microsoft/kiota/issues/1617)
+- Added optional backing store support for PHP. [#1976](https://github.com/microsoft/kiota/pull/1976)
 
 ### Changed
 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -120,32 +120,29 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 AccessedProperty = currentProperty,
             }).First();
             currentProperty.Getter.Name = $"{getterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
-            if (!currentProperty.IsOfKind(CodePropertyKind.BackingStore))
-            {
-                var setter = parentClass.AddMethod(new CodeMethod {
-                    Name = $"set-{accessorName}",
-                    Access = AccessModifier.Public,
-                    IsAsync = false,
-                    Kind = CodeMethodKind.Setter,
-                    Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
-                    AccessedProperty = currentProperty,
-                    ReturnType = new CodeType {
-                        Name = "void",
-                        IsNullable = false,
-                        IsExternal = true,
-                    },
-                }).First();
-                setter.Name = $"{setterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
-                currentProperty.Setter = setter;
-            
-                setter.AddParameter(new CodeParameter {
-                    Name = "value",
-                    Kind = CodeParameterKind.SetterValue,
-                    Description = $"Value to set for the {current.Name} property.",
-                    Optional = parameterAsOptional,
-                    Type = currentProperty.Type.Clone() as CodeTypeBase,
-                });
-            }
+            var setter = parentClass.AddMethod(new CodeMethod {
+                Name = $"set-{accessorName}",
+                Access = AccessModifier.Public,
+                IsAsync = false,
+                Kind = CodeMethodKind.Setter,
+                Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Description}",
+                AccessedProperty = currentProperty,
+                ReturnType = new CodeType {
+                    Name = "void",
+                    IsNullable = false,
+                    IsExternal = true,
+                },
+            }).First();
+            setter.Name = $"{setterPrefix}{accessorName}"; // so we don't get an exception for duplicate names when no prefix
+            currentProperty.Setter = setter;
+        
+            setter.AddParameter(new CodeParameter {
+                Name = "value",
+                Kind = CodeParameterKind.SetterValue,
+                Description = $"Value to set for the {current.Name} property.",
+                Optional = parameterAsOptional,
+                Type = currentProperty.Type.Clone() as CodeTypeBase,
+            });
         }
         CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors, removeProperty, parameterAsOptional, getterPrefix, setterPrefix));
     }

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -59,6 +59,10 @@ public class PhpRefiner: CommonLanguageRefiner
             AddSerializationModulesImport(generatedCode, new []{"Microsoft\\Kiota\\Abstractions\\ApiClientBuilder"}, null, '\\');
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             cancellationToken.ThrowIfCancellationRequested();
+            AddInnerClasses(generatedCode,
+                true,
+                string.Empty,
+                true);
             // Imports should be done before adding getters and setters since AddGetterAndSetterMethods can remove properties from classes when backing store is enabled
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
             AddGetterAndSetterMethods(generatedCode,
@@ -75,10 +79,6 @@ public class PhpRefiner: CommonLanguageRefiner
             ReplaceBinaryByNativeType(generatedCode, "StreamInterface", "Psr\\Http\\Message", true);
             cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
-            AddInnerClasses(generatedCode,
-                true,
-                string.Empty,
-                true);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton::getInstance()->createBackingStore()");
         }, cancellationToken);
     }

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -59,6 +59,8 @@ public class PhpRefiner: CommonLanguageRefiner
             AddSerializationModulesImport(generatedCode, new []{"Microsoft\\Kiota\\Abstractions\\ApiClientBuilder"}, null, '\\');
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             cancellationToken.ThrowIfCancellationRequested();
+            // Imports should be done before adding getters and setters since AddGetterAndSetterMethods can remove properties from classes when backing store is enabled
+            AddDefaultImports(generatedCode, defaultUsingEvaluators);
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -73,12 +75,11 @@ public class PhpRefiner: CommonLanguageRefiner
             ReplaceBinaryByNativeType(generatedCode, "StreamInterface", "Psr\\Http\\Message", true);
             cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
-            AddInnerClasses(generatedCode, 
-                true, 
+            AddInnerClasses(generatedCode,
+                true,
                 string.Empty,
                 true);
-            AddDefaultImports(generatedCode, defaultUsingEvaluators);
-            CorrectCoreTypesForBackingStore(generatedCode, "null");
+            CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton::getInstance()->createBackingStore()");
         }, cancellationToken);
     }
     private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -80,6 +80,7 @@ public class PhpRefiner: CommonLanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton::getInstance()->createBackingStore()");
+            CorrectBackingStoreSetterParam(generatedCode);
         }, cancellationToken);
     }
     private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
@@ -251,6 +252,13 @@ public class PhpRefiner: CommonLanguageRefiner
             }
         }
         CrawlTree(currentElement, AliasUsingWithSameSymbol);
+    }
+
+    private static void CorrectBackingStoreSetterParam(CodeElement codeElement)
+    {
+        if (codeElement is CodeMethod method && method.Kind == CodeMethodKind.Setter && method.AccessedProperty?.Kind == CodePropertyKind.BackingStore)
+            method.Parameters.ToList().ForEach(param => param.Optional = false);
+        CrawlTree(codeElement, CorrectBackingStoreSetterParam);
     }
 }
 

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -76,7 +76,7 @@ public class PhpRefiner: CommonLanguageRefiner
                 "get",
                 "set");
             AddParsableImplementsForModelClasses(generatedCode, "Parsable");
-            ReplaceBinaryByNativeType(generatedCode, "StreamInterface", "Psr\\Http\\Message", true);
+            ReplaceBinaryByNativeType(generatedCode, "StreamInterface", "Psr\\Http\\Message", true, _configuration.UsesBackingStore);
             cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton::getInstance()->createBackingStore()");

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -78,6 +78,7 @@ public class PhpRefiner: CommonLanguageRefiner
                 string.Empty,
                 true);
             AddDefaultImports(generatedCode, defaultUsingEvaluators);
+            CorrectCoreTypesForBackingStore(generatedCode, "null");
         }, cancellationToken);
     }
     private static readonly Dictionary<string, (string, CodeUsing)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
@@ -211,6 +212,12 @@ public class PhpRefiner: CommonLanguageRefiner
         codeParameters?.Where(x => x.IsOfKind(CodeParameterKind.ParseNode)).ToList().ForEach(x =>
         {
             x.Type.Name = "ParseNode";
+        });
+        codeParameters?.Where(x => x.IsOfKind(CodeParameterKind.BackingStore)
+            && currentMethod.IsOfKind(CodeMethodKind.ClientConstructor)).ToList().ForEach(x =>
+        {
+            x.Type.Name = "BackingStoreFactory";
+            x.DefaultValue = "null";
         });
         CrawlTree(codeElement, CorrectParameterType);
     }

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -144,7 +144,7 @@ namespace Kiota.Builder.Writers
                 GenerationLanguage.Java => new JavaWriter(outputPath, clientNamespaceName),
                 GenerationLanguage.TypeScript => new TypeScriptWriter(outputPath, clientNamespaceName, usesBackingStore),
                 GenerationLanguage.Ruby => new RubyWriter(outputPath, clientNamespaceName),
-                GenerationLanguage.PHP => new PhpWriter(outputPath, clientNamespaceName),
+                GenerationLanguage.PHP => new PhpWriter(outputPath, clientNamespaceName, usesBackingStore),
                 GenerationLanguage.Python => new PythonWriter(outputPath, clientNamespaceName),
                 GenerationLanguage.Go => new GoWriter(outputPath, clientNamespaceName),
                 GenerationLanguage.Shell => new ShellWriter(outputPath, clientNamespaceName),

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -233,10 +233,10 @@ namespace Kiota.Builder.Writers.Php
                 writer.WriteLine($"parent::serialize({writerParameterName});");
             var customProperties = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType && !x.ReadOnly);
             foreach(var otherProp in customProperties) {
-                writer.WriteLine($"{writerParameterName}->{GetSerializationMethodName(otherProp.Type)}('{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}', $this->get{otherProp.Name.ToFirstCharacterUpperCase()}());");
+                writer.WriteLine($"{writerParameterName}->{GetSerializationMethodName(otherProp.Type)}('{otherProp.SerializationName ?? otherProp.Name.ToFirstCharacterLowerCase()}', $this->{otherProp.Getter.Name}());");
             }
             if(additionalDataProperty != null)
-                writer.WriteLine($"{writerParameterName}->writeAdditionalData($this->get{additionalDataProperty.Name.ToFirstCharacterUpperCase()}());");
+                writer.WriteLine($"{writerParameterName}->writeAdditionalData($this->{additionalDataProperty.Getter.Name}());");
         }
         
         private string GetSerializationMethodName(CodeTypeBase propType) {
@@ -309,7 +309,7 @@ namespace Kiota.Builder.Writers.Php
             var parentClass = codeElement.Parent as CodeClass;
             var isBackingStoreSetter = codeElement.AccessedProperty?.Kind == CodePropertyKind.BackingStore;
             if (UseBackingStore && !isBackingStoreSetter)
-                writer.WriteLine($"$this->get{parentClass.GetBackingStoreProperty()?.Name.ToFirstCharacterUpperCase()}()->set('{propertyName.ToFirstCharacterLowerCase()}', $value);");
+                writer.WriteLine($"$this->{parentClass.GetBackingStoreProperty()?.Getter.Name}()->set('{propertyName.ToFirstCharacterLowerCase()}', $value);");
             else
                 writer.WriteLine($"$this->{propertyName.ToFirstCharacterLowerCase()} = $value;");
         }
@@ -320,7 +320,7 @@ namespace Kiota.Builder.Writers.Php
             var parentClass = codeMethod.Parent as CodeClass;
             var isBackingStoreGetter = codeMethod.AccessedProperty?.Kind == CodePropertyKind.BackingStore;
             if (UseBackingStore && !isBackingStoreGetter)
-                writer.WriteLine($"return $this->get{parentClass.GetBackingStoreProperty()?.Name.ToFirstCharacterUpperCase()}()->get('{propertyName}');");
+                writer.WriteLine($"return $this->{parentClass.GetBackingStoreProperty()?.Getter.Name}()->get('{propertyName}');");
             else
                 writer.WriteLine($"return $this->{propertyName};");
         }

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -202,7 +202,7 @@ namespace Kiota.Builder.Writers.Php
 
             if (codeMethod.IsOfKind(CodeMethodKind.Getter) && codeMethod.AccessedProperty.IsOfKind(CodePropertyKind.AdditionalData))
             {
-                writer.WriteLine($"{conventions.GetAccessModifier(codeMethod.Access)} function {methodName}(): array {{");
+                writer.WriteLine($"{conventions.GetAccessModifier(codeMethod.Access)} function {methodName}(): ?array {{");
                 writer.IncreaseIndent();
                 return;
             }

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -96,7 +96,7 @@ namespace Kiota.Builder.Writers.Php
                 CodeParameterKind.ResponseHandler => $"ResponseHandler {GetParameterName(parameter)}",
                 CodeParameterKind.RequestConfiguration => $"{parameter!.Type.Name.ToFirstCharacterUpperCase()} {GetParameterName(parameter)}",
                 CodeParameterKind.Serializer => $"SerializationWriter {GetParameterName(parameter)}",
-                CodeParameterKind.BackingStore => $"BackingStore {GetParameterName(parameter)}",
+                CodeParameterKind.BackingStore => $"{parameter.Type.Name.ToFirstCharacterUpperCase()} {GetParameterName(parameter)}",
                 _ => $"{typeString} {GetParameterName(parameter)}"
 
             };

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -102,7 +102,7 @@ namespace Kiota.Builder.Writers.Php
             };
             var qualified = parameter?.Optional != null && parameter.Optional &&
                             targetElement is CodeMethod methodTarget && !methodTarget.IsOfKind(CodeMethodKind.Setter);
-            return parameter?.Optional != null && parameter.Optional ? $"?{parameterSuffix} {(qualified ?  "= null" : string.Empty)}" : parameterSuffix;
+            return parameter?.Optional != null && parameter.Optional ? $"?{parameterSuffix}{(qualified ?  " = null" : string.Empty)}" : parameterSuffix;
         }
         public string GetParameterDocNullable(CodeParameter parameter, CodeElement codeElement)
         {

--- a/src/Kiota.Builder/Writers/Php/PhpWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpWriter.cs
@@ -10,7 +10,7 @@ namespace Kiota.Builder.Writers.Php
             var conventionService = new PhpConventionService();
             AddOrReplaceCodeElementWriter(new CodeClassDeclarationWriter(conventionService));
             AddOrReplaceCodeElementWriter(new CodePropertyWriter(conventionService));
-            AddOrReplaceCodeElementWriter(new CodeMethodWriter(conventionService));
+            AddOrReplaceCodeElementWriter(new CodeMethodWriter(conventionService, useBackingStore));
             AddOrReplaceCodeElementWriter(new CodeBlockEndWriter());
             AddOrReplaceCodeElementWriter(new CodeEnumWriter(conventionService));
         }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -27,7 +27,7 @@ namespace Kiota.Builder.Tests.Writers.Php
         private const string MethodDescription = "some description";
         private const string ParamDescription = "some parameter description";
         private const string ParamName = "paramName";
-        private readonly CodeMethodWriter _codeMethodWriter;
+        private CodeMethodWriter _codeMethodWriter;
         private readonly ILanguageRefiner _refiner;
         private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
 
@@ -249,7 +249,7 @@ namespace Kiota.Builder.Tests.Writers.Php
             new object[]
             {
                 new CodeProperty { Name = "name", Type = new CodeType { Name = "string" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "$writer->writeStringValue('name', $this->name);"
+                "$writer->writeStringValue('name', $this->getName());"
             },
             new object[]
             {
@@ -257,7 +257,7 @@ namespace Kiota.Builder.Tests.Writers.Php
                 {
                     Name = "EmailAddress", TypeDefinition = new CodeClass { Name = "EmailAddress", Kind = CodeClassKind.Model}
                 }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "$writer->writeObjectValue('email', $this->email);"
+                "$writer->writeObjectValue('email', $this->getEmail());"
             },
             new object[]
             {
@@ -265,7 +265,7 @@ namespace Kiota.Builder.Tests.Writers.Php
                 {
                     Name = "Status", Description = "Status Enum"
                 }}, Access = AccessModifier.Private },
-                "$writer->writeEnumValue('status', $this->status);"
+                "$writer->writeEnumValue('status', $this->getStatus());"
             },
             new object[]
             {
@@ -273,34 +273,34 @@ namespace Kiota.Builder.Tests.Writers.Php
                 {
                     Name = "Architecture", CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array, TypeDefinition = new CodeEnum { Name = "Architecture", Description = "Arch Enum, accepts x64, x86, hybrid"}
                 }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
-                "$writer->writeCollectionOfEnumValues('architectures', $this->architectures);"
+                "$writer->writeCollectionOfEnumValues('architectures', $this->getArchitectures());"
             },
             new object[] { new CodeProperty { Name = "emails", Type = new CodeType
             {
                 Name = "Email", TypeDefinition = new CodeClass { Name = "Email", Kind = CodeClassKind.Model}, CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
-                "$writer->writeCollectionOfObjectValues('emails', $this->emails);"
+                "$writer->writeCollectionOfObjectValues('emails', $this->getEmails());"
             },
             new object[] { new CodeProperty { Name = "temperatures", Type = new CodeType { Name = "int", CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array }, Access = AccessModifier.Private},
-                "$writer->writeCollectionOfPrimitiveValues('temperatures', $this->temperatures);"
+                "$writer->writeCollectionOfPrimitiveValues('temperatures', $this->getTemperatures());"
             },
             // Primitive int tests
-            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "integer" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->age);" },
-            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "int32" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->age);" },
-            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "int64" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->age);" },
-            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "sbyte" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->age);" },
+            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "integer" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->getAge());" },
+            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "int32" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->getAge());" },
+            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "int64" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->getAge());" },
+            new object[] { new CodeProperty { Name = "age", Type = new CodeType { Name = "sbyte" }, Access = AccessModifier.Private}, "$writer->writeIntegerValue('age', $this->getAge());" },
             // Float tests
-            new object[] { new CodeProperty { Name = "height", Type = new CodeType { Name = "float" }, Access = AccessModifier.Private}, "$writer->writeFloatValue('height', $this->height);" },
-            new object[] { new CodeProperty { Name = "height", Type = new CodeType { Name = "double" }, Access = AccessModifier.Private}, "$writer->writeFloatValue('height', $this->height);" },
+            new object[] { new CodeProperty { Name = "height", Type = new CodeType { Name = "float" }, Access = AccessModifier.Private}, "$writer->writeFloatValue('height', $this->getHeight());" },
+            new object[] { new CodeProperty { Name = "height", Type = new CodeType { Name = "double" }, Access = AccessModifier.Private}, "$writer->writeFloatValue('height', $this->getHeight());" },
             // Bool tests
-            new object[] { new CodeProperty { Name = "married", Type = new CodeType { Name = "boolean" }, Access = AccessModifier.Private}, "$writer->writeBooleanValue('married', $this->married);" },
-            new object[] { new CodeProperty { Name = "slept", Type = new CodeType { Name = "bool" }, Access = AccessModifier.Private}, "$writer->writeBooleanValue('slept', $this->slept);" },
+            new object[] { new CodeProperty { Name = "married", Type = new CodeType { Name = "boolean" }, Access = AccessModifier.Private}, "$writer->writeBooleanValue('married', $this->getMarried());" },
+            new object[] { new CodeProperty { Name = "slept", Type = new CodeType { Name = "bool" }, Access = AccessModifier.Private}, "$writer->writeBooleanValue('slept', $this->getSlept());" },
             // Decimal and byte tests
-            new object[] { new CodeProperty { Name = "money", Type = new CodeType { Name = "decimal" }, Access = AccessModifier.Private}, "$writer->writeStringValue('money', $this->money);" },
-            new object[] { new CodeProperty { Name = "money", Type = new CodeType { Name = "byte" }, Access = AccessModifier.Private}, "$writer->writeStringValue('money', $this->money);" },
-            new object[] { new CodeProperty { Name = "dateValue", Type = new CodeType { Name = "DateTime" }, Access = AccessModifier.Private}, "$writer->writeDateTimeValue('dateValue', $this->dateValue);" },
-            new object[] { new CodeProperty { Name = "duration", Type = new CodeType { Name = "duration" }, Access = AccessModifier.Private}, "$writer->writeDateIntervalValue('duration', $this->duration);" },
-            new object[] { new CodeProperty { Name = "stream", Type = new CodeType { Name = "binary" }, Access = AccessModifier.Private}, "$writer->writeBinaryContent('stream', $this->stream);" },
-            new object[] { new CodeProperty { Name = "definedInParent", Type = new CodeType { Name = "string"}, OriginalPropertyFromBaseType = new CodeProperty() }, "$write->writeStringValue('definedInParent', $this->definedInParent);"}
+            new object[] { new CodeProperty { Name = "money", Type = new CodeType { Name = "decimal" }, Access = AccessModifier.Private}, "$writer->writeStringValue('money', $this->getMoney());" },
+            new object[] { new CodeProperty { Name = "money", Type = new CodeType { Name = "byte" }, Access = AccessModifier.Private}, "$writer->writeStringValue('money', $this->getMoney());" },
+            new object[] { new CodeProperty { Name = "dateValue", Type = new CodeType { Name = "DateTime" }, Access = AccessModifier.Private}, "$writer->writeDateTimeValue('dateValue', $this->getDateValue());" },
+            new object[] { new CodeProperty { Name = "duration", Type = new CodeType { Name = "duration" }, Access = AccessModifier.Private}, "$writer->writeDateIntervalValue('duration', $this->getDuration());" },
+            new object[] { new CodeProperty { Name = "stream", Type = new CodeType { Name = "binary" }, Access = AccessModifier.Private}, "$writer->writeBinaryContent('stream', $this->getStream());" },
+            new object[] { new CodeProperty { Name = "definedInParent", Type = new CodeType { Name = "string"}, OriginalPropertyFromBaseType = new CodeProperty() }, "$write->writeStringValue('definedInParent', $this->getDefinedInParent());"}
         };
         
         [Theory]
@@ -976,6 +976,138 @@ namespace Kiota.Builder.Tests.Writers.Php
             var result = stringWriter.ToString();
             Assert.Contains("$this->requestAdapter = $requestAdapter", result);
             Assert.Contains("public function __construct(RequestAdapter $requestAdapter)", result);
+        }
+
+        [Fact]
+        public async void WritesApiClientWithBackingStoreConstructor()
+        {
+            var constructor = new CodeMethod { 
+                Name = "construct", 
+                Kind = CodeMethodKind.ClientConstructor, 
+                ReturnType = new CodeType
+                {
+                    Name = "void",
+                    IsNullable = false
+                }
+            };
+            constructor.DeserializerModules = new() {"Microsoft\\Kiota\\Serialization\\Deserializer"};
+            constructor.SerializerModules = new() {"Microsoft\\Kiota\\Serialization\\Serializer"};
+            var parameter = new CodeParameter
+            {
+                Name = "backingStore",
+                Optional = true,
+                Description = "The backing store to use for the models.",
+                Kind = CodeParameterKind.BackingStore,
+                Type = new CodeType
+                {
+                    Name = "IBackingStoreFactory", IsNullable = true,
+                }
+            };
+            
+            parentClass.AddProperty(new CodeProperty
+            {
+                Name = "requestAdapter",
+                Kind = CodePropertyKind.RequestAdapter,
+                Type = new CodeType {Name = "RequestAdapter"}
+            });
+            constructor.AddParameter(new CodeParameter
+            {
+                Kind = CodeParameterKind.RequestAdapter,
+                Name = "requestAdapter",
+                Type = new CodeType
+                {
+                    Name = "RequestAdapter"
+                },
+                SerializationName = "rawUrl"
+            });
+            
+            constructor.AddParameter(parameter);
+            parentClass.AddMethod(constructor);
+            parentClass.Kind = CodeClassKind.RequestBuilder;
+            
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+            _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
+            _codeMethodWriter.WriteCodeElement(constructor, languageWriter);
+            var result = stringWriter.ToString();
+
+            Assert.Contains("public function __construct(RequestAdapter $requestAdapter, ?BackingStoreFactory $backingStore = null)", result);
+            Assert.Contains("$this->requestAdapter->enableBackingStore($backingStore ?? BackingStoreFactorySingleton::getInstance());", result);
+        }
+
+        [Fact]
+        public async void WritesModelWithBackingStoreConstructor()
+        {
+            parentClass.Kind = CodeClassKind.Model;
+            var constructor = new CodeMethod
+            {
+                Name = "constructor",
+                Access = AccessModifier.Public,
+                Description = "The constructor for this class",
+                ReturnType = new CodeType {Name = "void"},
+                Kind = CodeMethodKind.Constructor
+            };
+            parentClass.AddMethod(constructor);
+
+            var propWithDefaultValue = new CodeProperty
+            {
+                Name = "backingStore",
+                Access = AccessModifier.Public,
+                DefaultValue = "BackingStoreFactorySingleton.Instance.CreateBackingStore()",
+                Kind = CodePropertyKind.BackingStore,
+                Type = new CodeType { Name = "IBackingStore", IsExternal = true, IsNullable = false }
+            };
+            parentClass.AddProperty(propWithDefaultValue);
+            
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+            _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
+            _codeMethodWriter.WriteCodeElement(constructor, languageWriter);
+            var result = stringWriter.ToString();
+
+            Assert.Contains("$this->backingStore = BackingStoreFactorySingleton::getInstance()->createBackingStore();", result);
+        }
+
+        [Fact]
+        public async void WritesGettersAndSettersWithBackingStore()
+        {
+            parentClass.Kind = CodeClassKind.Model;
+            var backingStoreProperty = new CodeProperty
+            {
+                Name = "backingStore",
+                Access = AccessModifier.Public,
+                DefaultValue = "BackingStoreFactorySingleton.Instance.CreateBackingStore()",
+                Kind = CodePropertyKind.BackingStore,
+                Type = new CodeType { Name = "IBackingStore", IsExternal = true, IsNullable = false }
+            };
+            parentClass.AddProperty(backingStoreProperty);
+            var modelProperty = new CodeProperty
+            {
+                Name = "name",
+                Access = AccessModifier.Public,
+                Kind = CodePropertyKind.Custom,
+                Type = new CodeType { Name = "string", IsNullable = true }
+            };
+            parentClass.AddProperty(modelProperty);
+            
+            await ILanguageRefiner.Refine(new GenerationConfiguration {Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+            _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
+            // Refiner adds setters & getters for properties
+            foreach (var getter in parentClass.GetMethodsOffKind(CodeMethodKind.Getter, CodeMethodKind.Setter))
+            {
+                _codeMethodWriter.WriteCodeElement(getter, languageWriter);
+            }
+            var result = stringWriter.ToString();
+
+            Assert.Contains("public function getName(): ?string", result);
+            Assert.Contains("return $this->getBackingStore()->get('name');", result);
+
+            Assert.Contains("public function getBackingStore(): BackingStore", result);
+            Assert.Contains("return $this->backingStore;", result);
+
+            Assert.Contains("public function setName(?string $value )", result);
+            Assert.Contains("$this->getBackingStore()->set('name', $value);", result);
+            
+            // Backing store should NOT contain setter
+            Assert.DoesNotContain("private function setBackingStore(BackingStore $value )", result);
         }
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1106,8 +1106,8 @@ namespace Kiota.Builder.Tests.Writers.Php
             Assert.Contains("public function setName(?string $value)", result);
             Assert.Contains("$this->getBackingStore()->set('name', $value);", result);
             
-            // Backing store should NOT contain setter
-            Assert.DoesNotContain("private function setBackingStore(BackingStore $value )", result);
+            Assert.Contains("public function setBackingStore(BackingStore $value)", result);
+            Assert.Contains("$this->backingStore = $value;", result);
         }
 
         [Fact]


### PR DESCRIPTION
This PR:
- Adds backing store logic to the `PHPRefiner` & writers
- Ensures stream property and additional data property getters return nullable types when backing store is enabled. Backing store can return null when a property hasn't changed since initialisation.
- Changes generated `serialize()` logic to use property getters
- Prevents adding setters for backing store properties
- Adds tests

Sample Generated Diffs (with backing store enabled)
https://github.com/microsoftgraph/msgraph-sdk-php/pull/1069
https://github.com/microsoftgraph/msgraph-beta-sdk-php/pull/114/

closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/979