### PR TITLE
Java/request info instantiation test change

### DIFF
--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -307,7 +307,25 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                                     .Where(static x => x.Type.ActionOf && x.IsOfKind(CodeParameterKind.RequestConfiguration))
                                     .SelectMany(static x => x.Type.AllTypes)
                                     .Select(static x => x.TypeDefinition)
-                                    .OfType<CodeClass>();
+                                    .OfType<CodeClass>()
+                                    .Where(x => x.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+                                    
+                                    // {
+                                    //      x => x.SelectMany(static x => x.Properties)
+                                    //     .Where(static x => x.IsOfKind(CodePropertyKind.QueryParameters))
+                                    //     .SelectMany(static x => x.Type.AllTypes)
+                                    //     .Select(static x => x.TypeDefinition)
+                                    //     .Select(static x => x.TypeDefinition)
+                                    //     .OfType<CodeClass>()
+                                    // )
+                                    // .Where(x => x.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+                                    // .SelectMany(static x => x.Properties)
+                                    // .Where(static x => x.IsOfKind(CodePropertyKind.QueryParameters))
+                                    // .SelectMany(static x => x.Type.AllTypes)
+                                    // .Select(static x => x.TypeDefinition)
+                                    // .OfType<CodeClass>()
+                                    // .Where(x => x.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
             // ensure we do not miss out the types present in request configuration objects i.e. the query parameters
             var nestedQueryParameters = innerClasses
@@ -315,14 +333,16 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                                     .Where(static x => x.IsOfKind(CodePropertyKind.QueryParameters))
                                     .SelectMany(static x => x.Type.AllTypes)
                                     .Select(static x => x.TypeDefinition)
-                                    .OfType<CodeClass>();
+                                    .OfType<CodeClass>().Union(innerClasses)
+                                    .Where(x => x.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
-            var nestedClasses = new List<CodeClass>();
-            nestedClasses.AddRange(innerClasses);
-            nestedClasses.AddRange(nestedQueryParameters);
+
+            // var nestedClasses = new List<CodeClass>();
+            // nestedClasses.AddRange(innerClasses);
+            // nestedClasses.AddRange(nestedQueryParameters);
             
-            foreach(var innerClass in nestedClasses) {
-                if(innerClass.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) 
+            foreach(var innerClass in nestedQueryParameters) {
+                //if(innerClass.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) 
                     innerClass.Name = innerClass.Name[prefix.Length..];
                 
                 if(innerClass.IsOfKind(CodeClassKind.RequestConfiguration))

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -485,11 +485,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
         var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
         var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-        writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation() {{{{");
-        writer.IncreaseIndent();
-        writer.WriteLine($"httpMethod = HttpMethod.{codeElement.HttpMethod?.ToString().ToUpperInvariant()};");
-        writer.DecreaseIndent();
-        writer.WriteLine("}};");
+        writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation();"); //{{{{");
+        //writer.IncreaseIndent();
+        writer.WriteLine($"{RequestInfoVarName}.httpMethod = HttpMethod.{codeElement.HttpMethod?.ToString().ToUpperInvariant()};");
+        //writer.DecreaseIndent();
+        //writer.WriteLine("}};");
         writer.WriteLines($"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "\"\"")};",
                         $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "null")};");
         if(codeElement.AcceptedResponseTypes.Any())

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -417,7 +417,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
         }
-        writer.WriteLine($"return {DeserializerVarName}");
+        writer.WriteLine($"return {DeserializerVarName};");
     }
     private const string FactoryMethodName = "createFromDiscriminatorValue";
     private const string ExecuterExceptionVar = "executionException";

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -431,12 +431,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var errorMappingVarName = "null";
         if(codeElement.ErrorMappings.Any()) {
             errorMappingVarName = "errorMapping";
-            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>({codeElement.ErrorMappings.Count()}) {{{{");
-            writer.IncreaseIndent();
+            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>()"); //{codeElement.ErrorMappings.Count()}) {{{{");
+            //writer.IncreaseIndent();
             foreach(var errorMapping in codeElement.ErrorMappings) {
-                writer.WriteLine($"put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");
+                writer.WriteLine($"{errorMappingVarName}.put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");
             }
-            writer.CloseBlock("}};");
+            //writer.CloseBlock("}};");
         }
         var factoryParameter = codeElement.ReturnType is CodeType returnCodeType && returnCodeType.TypeDefinition is CodeClass ? $"{returnType}::{FactoryMethodName}" : $"{returnType}.class";
         writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {factoryParameter}, {errorMappingVarName});");

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -431,7 +431,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var errorMappingVarName = "null";
         if(codeElement.ErrorMappings.Any()) {
             errorMappingVarName = "errorMapping";
-            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>()"); //{codeElement.ErrorMappings.Count()}) {{{{");
+            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>();"); //{codeElement.ErrorMappings.Count()}) {{{{");
             //writer.IncreaseIndent();
             foreach(var errorMapping in codeElement.ErrorMappings) {
                 writer.WriteLine($"{errorMappingVarName}.put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -402,25 +402,25 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         }
         writer.WriteLine($"return new {DeserializerReturnType}();");
     }
+    private const string DeserializerVarName = "deserializerMap";
     private void WriteDeserializerBodyForInheritedModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer, bool inherits) {
         var fieldToSerialize = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom);
         writer.WriteLines(
             $"final {parentClass.Name.ToFirstCharacterUpperCase()} currentObject = this;",
-            $"return new {DeserializerReturnType}({(inherits ? "super." + method.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())}) {{{{");
+            $"final {DeserializerReturnType} {DeserializerVarName} = new {DeserializerReturnType}({(inherits ? "super." + method.Name.ToFirstCharacterLowerCase()+ "()" : fieldToSerialize.Count())});");
         if(fieldToSerialize.Any()) {
-            writer.IncreaseIndent();
             fieldToSerialize
                     .Where(static x => !x.ExistsInBaseType && x.Setter != null)
                     .OrderBy(static x => x.Name)
                     .Select(x => 
-                        $"this.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (n) -> {{ currentObject.{x.Setter.Name.ToFirstCharacterLowerCase()}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
+                        $"{DeserializerVarName}.put(\"{x.SerializationName ?? x.Name.ToFirstCharacterLowerCase()}\", (n) -> {{ currentObject.{x.Setter.Name.ToFirstCharacterLowerCase()}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
-            writer.DecreaseIndent();
         }
-        writer.WriteLine("}};");
+        writer.WriteLine($"return {DeserializerVarName}");
     }
     private const string FactoryMethodName = "createFromDiscriminatorValue";
+    private const string ExecuterExceptionVar = "executionException";
     private void WriteRequestExecutorBody(CodeMethod codeElement, RequestParams requestParams, LanguageWriter writer) {
         if(codeElement.HttpMethod == null) throw new InvalidOperationException("http method cannot be null");
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement, false);
@@ -431,20 +431,18 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var errorMappingVarName = "null";
         if(codeElement.ErrorMappings.Any()) {
             errorMappingVarName = "errorMapping";
-            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>();"); //{codeElement.ErrorMappings.Count()}) {{{{");
-            //writer.IncreaseIndent();
+            writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>();");
             foreach(var errorMapping in codeElement.ErrorMappings) {
                 writer.WriteLine($"{errorMappingVarName}.put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");
             }
-            //writer.CloseBlock("}};");
         }
         var factoryParameter = codeElement.ReturnType is CodeType returnCodeType && returnCodeType.TypeDefinition is CodeClass ? $"{returnType}::{FactoryMethodName}" : $"{returnType}.class";
         writer.WriteLine($"return this.requestAdapter.{sendMethodName}({RequestInfoVarName}, {factoryParameter}, {errorMappingVarName});");
         writer.DecreaseIndent();
         writer.StartBlock("} catch (URISyntaxException ex) {");
-        writer.StartBlock($"return new java.util.concurrent.CompletableFuture<{returnType}>() {{{{");
-        writer.WriteLine("this.completeExceptionally(ex);");
-        writer.CloseBlock("}};");
+        writer.WriteLine($"java.util.concurrent.CompletableFuture<{returnType}> {ExecuterExceptionVar} = new java.util.concurrent.CompletableFuture<{returnType}>();");
+        writer.WriteLine($"{ExecuterExceptionVar}.completeExceptionally(ex);");
+        writer.WriteLine($"return {ExecuterExceptionVar};");
         writer.CloseBlock();
     }
     private string GetSendRequestMethodName(bool isCollection, string returnType, bool isEnum)
@@ -485,11 +483,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var urlTemplateParamsProperty = currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
         var urlTemplateProperty = currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate);
         var requestAdapterProperty = currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
-        writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation();"); //{{{{");
-        //writer.IncreaseIndent();
+        writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation();");
         writer.WriteLine($"{RequestInfoVarName}.httpMethod = HttpMethod.{codeElement.HttpMethod?.ToString().ToUpperInvariant()};");
-        //writer.DecreaseIndent();
-        //writer.WriteLine("}};");
         writer.WriteLines($"{RequestInfoVarName}.urlTemplate = {GetPropertyCall(urlTemplateProperty, "\"\"")};",
                         $"{RequestInfoVarName}.pathParameters = {GetPropertyCall(urlTemplateParamsProperty, "null")};");
         if(codeElement.AcceptedResponseTypes.Any())

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -500,7 +500,7 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("put(\"5XX\", Error5XX::createFromDiscriminatorValue);", result);
         Assert.Contains("put(\"403\", Error403::createFromDiscriminatorValue);", result);
         Assert.Contains("sendAsync", result);
-        Assert.Contains($"java.util.concurrent.CompletableFuture<Somecustomtype> {ExecuterExceptionVar} =  = new java.util.concurrent.CompletableFuture<Somecustomtype>();", result);
+        Assert.Contains($"java.util.concurrent.CompletableFuture<Somecustomtype> {ExecuterExceptionVar} = new java.util.concurrent.CompletableFuture<Somecustomtype>();", result);
         Assert.Contains($"{ExecuterExceptionVar}.completeExceptionally(ex);", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -20,6 +20,7 @@ public class CodeMethodWriterTests : IDisposable {
     private readonly CodeMethod method;
     private readonly CodeClass parentClass;
     private readonly CodeNamespace root;
+    private const string ExecuterExceptionVar = "executionException";
     private const string MethodName = "methodName";
     private const string ReturnTypeName = "Somecustomtype";
     private const string MethodDescription = "some description";
@@ -499,9 +500,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("put(\"5XX\", Error5XX::createFromDiscriminatorValue);", result);
         Assert.Contains("put(\"403\", Error403::createFromDiscriminatorValue);", result);
         Assert.Contains("sendAsync", result);
-        Assert.Contains("return new java.util.concurrent.CompletableFuture<Somecustomtype>() {{", result);
-        Assert.Contains("this.completeExceptionally(ex);", result);
-        Assert.Contains("}};", result);
+        Assert.Contains($"java.util.concurrent.CompletableFuture<Somecustomtype> {ExecuterExceptionVar} =  = new java.util.concurrent.CompletableFuture<Somecustomtype>();", result);
+        Assert.Contains($"{ExecuterExceptionVar}.completeExceptionally(ex);", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Reduce our use of anonymous classes in java to hopefully free up heap space. 
Change the way we set http method to avoid anonymous classes.
Change the way we set our error mapping to also avoid anonymous classes. 