### PR TITLE
- fixes a bug where readonly properties would fail to deserialize for TypeScript.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where readonly properties would fail to deserialize for TypeScript.
 - Fixed a bug where array buffers nullability would wrongly be defined for TypeScript.
 - Fixed a bug where parameter comments would appear in summary tag comments in dotnet. [#1945](https://github.com/microsoft/kiota/issues/1945)
 - Fixed a bug in PHP generation where request bodies would not serialize single elements properly. [#1937](https://github.com/microsoft/kiota/pull/1937)

--- a/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
@@ -20,7 +20,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, TypeScriptConv
                 writer.WriteLine("}");
             break;
             default:
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{(codeElement.ReadOnly ? " readonly ": " ")}{codeElement.NamePrefix}{codeElement.Name.ToFirstCharacterLowerCase()}{(codeElement.Type.IsNullable ? "?" : string.Empty)}: {returnType}{(isFlagEnum ? "[]" : string.Empty)}{(codeElement.Type.IsNullable ? " | undefined" : string.Empty)};");
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {codeElement.NamePrefix}{codeElement.Name.ToFirstCharacterLowerCase()}{(codeElement.Type.IsNullable ? "?" : string.Empty)}: {returnType}{(isFlagEnum ? "[]" : string.Empty)}{(codeElement.Type.IsNullable ? " | undefined" : string.Empty)};");
             break;
         }
     }

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
@@ -60,14 +60,6 @@ namespace Kiota.Builder.Tests.Writers.TypeScript {
             Assert.Contains($"{PropertyName}?: {TypeName} | undefined", result);
         }
         [Fact]
-        public void WritesPrivateSetter() {
-            property.Kind = CodePropertyKind.Custom;
-            property.ReadOnly = true;
-            writer.Write(property);
-            var result = tw.ToString();
-            Assert.Contains("readonly", result);
-        }
-        [Fact]
         public void WritesFlagEnums() {
             property.Kind = CodePropertyKind.Custom;
             property.Type = new CodeType {


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
