### PR TITLE
Bugfix/odata error python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for scalar request bodies in PHP [#1937](https://github.com/microsoft/kiota/pull/1937)
 - Added accept header for all schematized requests Python. [#1617](https://github.com/microsoft/kiota/issues/1617)
 - Added optional backing store support for PHP. [#1976](https://github.com/microsoft/kiota/pull/1976)
+- Fixed a bug where OdataErrors had wrong inherited class name in Python.
+- Fixed a bug where empty path parameters dictionary would throw an error in request builders in Python.
 
 ### Changed
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -31,7 +31,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         if(!codeElement.IsOfKind(CodeMethodKind.Setter))
             foreach(var parameter in codeElement.Parameters.Where(x => !x.Optional).OrderBy(x => x.Name)) {
                 var parameterName = parameter.Name.ToSnakeCase();
-                writer.WriteLine($"if not {parameterName}:");
+                writer.WriteLine($"if {parameterName} is None:");
                 writer.IncreaseIndent();
                 writer.WriteLine($"raise Exception(\"{parameterName} cannot be undefined\")");
                 writer.DecreaseIndent();
@@ -289,7 +289,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         writer.WriteLine($"{errorMappingVarName}: Dict[str, ParsableFactory] = {{");
         writer.IncreaseIndent();
         foreach(var errorMapping in codeElement.ErrorMappings) {
-            writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": o_data_error.{errorMapping.Value.Name}.get_from_discriminator_value(),");
+            writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": o_data_error.{errorMapping.Value.Name},");
         }
         writer.CloseBlock();
     }

--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -105,6 +105,8 @@ public class PythonConventionService : CommonLanguageConventionService
             return type.TypeDefinition?.Name.ToFirstCharacterUpperCase();
         if (type.Name.Contains("QueryParameters"))
             return type.Name;
+        if (type.Name.Contains("APIError"))
+            return type.Name;
         return type.Name switch  {
             "String" or "string" => "str",
             "integer" or "int32" or "int64" or "byte" or "sbyte" => "int",

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -233,9 +233,9 @@ public class CodeMethodWriterTests : IDisposable {
         var result = tw.ToString();
         Assert.Contains("request_info", result);
         Assert.Contains("error_mapping: Dict[str, ParsableFactory] =", result);
-        Assert.Contains("\"4XX\": o_data_error.Error4XX.get_from_discriminator_value()", result);
-        Assert.Contains("\"5XX\": o_data_error.Error5XX.get_from_discriminator_value()", result);
-        Assert.Contains("\"403\": o_data_error.Error403.get_from_discriminator_value()", result);
+        Assert.Contains("\"4XX\": o_data_error.Error4XX", result);
+        Assert.Contains("\"5XX\": o_data_error.Error5XX", result);
+        Assert.Contains("\"403\": o_data_error.Error403", result);
         Assert.Contains("send_async", result);
         Assert.Contains("raise Exception", result);
     }
@@ -734,7 +734,7 @@ public class CodeMethodWriterTests : IDisposable {
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains("if not original_name:", result);
+        Assert.Contains("if original_name is None:", result);
         Assert.Contains("if original_name == \"select\":", result);
         Assert.Contains("return \"%24select\"", result);
         Assert.Contains("if original_name == \"expand\":", result);


### PR DESCRIPTION
1. Fixes instantiation error in `ODataError` class due to wrong inherited class.
```py
#previously  
class ODataError(a_p_i_error.APIError):

# after fix
class ODataError(APIError):
```

2. Passes the right class to `errorMapping` dictionary 