### PR TITLE
Bugfix/hardcoded error module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where request information would always be set from scalar. [#1965](https://github.com/microsoft/kiota/pull/1965)
 - Fixed a bug where path parameters would be missing if no operation was present at the segment the parameter is defined. [#1940](https://github.com/microsoft/kiota/issues/1940)
 - Fixed a bug where generation would result in wrong indentation in some classes for Python [#1996]((https://github.com/microsoft/kiota/issues/1996).
+- Fixed a bug where error class modules were hardcoded for Python [#1999]((https://github.com/microsoft/kiota/issues/1999)
 
 ## [0.7.1] - 2022-11-01
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -289,7 +289,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         writer.WriteLine($"{errorMappingVarName}: Dict[str, ParsableFactory] = {{");
         writer.IncreaseIndent();
         foreach(var errorMapping in codeElement.ErrorMappings) {
-            writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": o_data_error.{errorMapping.Value.Name},");
+            writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": {errorMapping.Value.Name.ToSnakeCase()}.{errorMapping.Value.Name},");
         }
         writer.CloseBlock();
     }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -233,9 +233,9 @@ public class CodeMethodWriterTests : IDisposable {
         var result = tw.ToString();
         Assert.Contains("request_info", result);
         Assert.Contains("error_mapping: Dict[str, ParsableFactory] =", result);
-        Assert.Contains("\"4XX\": o_data_error.Error4XX", result);
-        Assert.Contains("\"5XX\": o_data_error.Error5XX", result);
-        Assert.Contains("\"403\": o_data_error.Error403", result);
+        Assert.Contains("\"4XX\": error4_x_x.Error4XX", result);
+        Assert.Contains("\"5XX\": error5_x_x.Error5XX", result);
+        Assert.Contains("\"403\": error403.Error403", result);
         Assert.Contains("send_async", result);
         Assert.Contains("raise Exception", result);
     }


### PR DESCRIPTION
Remove hardcoded `o_data_error` module and sets it dynamic based on the error class name

fixes #1999 