### PR TITLE
Bugfix/original query parameter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where request information would always be set from scalar. [#1965](https://github.com/microsoft/kiota/pull/1965)
 - Fixed a bug where path parameters would be missing if no operation was present at the segment the parameter is defined. [#1940](https://github.com/microsoft/kiota/issues/1940)
 - Fixed a bug where generation would result in wrong indentation in some classes for Python [#1996]((https://github.com/microsoft/kiota/issues/1996).
+- Fixed a bug where generation would sometimes result in wrong original names for query parameters in Python [#2000]((https://github.com/microsoft/kiota/issues/2000).
+
 
 ## [0.7.1] - 2022-11-01
 

--- a/src/Kiota.Builder/Writers/Php/CodeBlockEndWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeBlockEndWriter.cs
@@ -6,8 +6,7 @@ namespace Kiota.Builder.Writers.Php
     {
         public void WriteCodeElement(BlockEnd codeElement, LanguageWriter writer)
         {
-            if(codeElement.Parent is CodeNamespace) return;
-            writer.CloseBlock(string.Empty);
+            writer.CloseBlock();
         }
     }
 }

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -115,7 +115,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         var parameterName = parameter.Name.ToSnakeCase();
         var escapedProperties = parentClass.Properties.Where(x => x.IsOfKind(CodePropertyKind.QueryParameter) && x.IsNameEscaped);
         foreach(var escapedProperty in escapedProperties) {
-            writer.WriteLine($"if {parameterName} == \"{escapedProperty.Name}\":");
+            writer.WriteLine($"if {parameterName} == \"{escapedProperty.Name.ToSnakeCase()}\":");
             writer.IncreaseIndent();
             writer.WriteLine($"return \"{escapedProperty.SerializationName}\"");
             writer.DecreaseIndent();

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -721,10 +721,16 @@ public class CodeMethodWriterTests : IDisposable {
             SerializationName = "%24expand"
         },
         new CodeProperty {
+            Name = "select-from",
+            Kind = CodePropertyKind.QueryParameter,
+            SerializationName = "select%2Dfrom"
+        },
+        new CodeProperty {
             Name = "filter",
             Kind = CodePropertyKind.QueryParameter,
             SerializationName = "%24filter"
         });
+        
         method.AddParameter(new CodeParameter{
             Kind = CodeParameterKind.QueryParametersMapperParameter,
             Name = "originalName",
@@ -739,6 +745,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("return \"%24select\"", result);
         Assert.Contains("if original_name == \"expand\":", result);
         Assert.Contains("return \"%24expand\"", result);
+        Assert.Contains("if original_name == \"select_from\":", result);
+        Assert.Contains("return \"select%2Dfrom\"", result);
         Assert.Contains("if original_name == \"filter\":", result);
         Assert.Contains("return \"%24filter\"", result);
         Assert.Contains("return original_name", result);


### PR DESCRIPTION
Set original query parameter names in `get_query_parameter` to snake case to conform to naming convention of properties in `QueryParameter` classes.