### PR TITLE
[java] Use the method signature type in the exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where path parameters would be missing if no operation was present at the segment the parameter is defined. [#1940](https://github.com/microsoft/kiota/issues/1940)
 - Fixed a bug where generation would result in wrong indentation in some classes for Python [#1996]((https://github.com/microsoft/kiota/issues/1996).
 - Fixed a bug where generation would sometimes result in wrong original names for query parameters in Python [#2000]((https://github.com/microsoft/kiota/issues/2000).
+- Fixed a bug where Java would fail to compile for endpoints that return collections.
 
 
 ## [0.7.1] - 2022-11-01

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -910,6 +910,7 @@ public class CodeMethodWriterTests : IDisposable {
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("sendCollectionAsync", result);
+        Assert.Contains("return new java.util.concurrent.CompletableFuture<Iterable<Somecustomtype>>() {{", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
This is needed to take into consideration collections as return type, without propagating it the generated code won't compile.