### PR TITLE
Include types from System namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed colliding imports for factory methods in TypeScript. [#2009](https://github.com/microsoft/kiota/issues/2009)
+- Caters for type names being used from System namespace in CSharp generation [#2021](https://github.com/microsoft/kiota/issues/2021)
 
 ## [0.8.3] - 2022-12-01
 

--- a/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
@@ -1,10 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Kiota.Builder.Refiners;
 public class CSharpReservedTypesProvider : IReservedNamesProvider
 {
-    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(6, StringComparer.OrdinalIgnoreCase)
+    private static HashSet<string> GetSystemTypeNames()
+    {
+        return typeof(string).Assembly.GetTypes()
+                                .Where(static type => type.Namespace == "System" 
+                                                      && type.IsPublic // get public(we can only import public type in external code)
+                                                      && !type.IsGenericType)// non generic types(generic type names have special character like `)
+                                .Select(static type => type.Name)
+                                .ToHashSet();
+    }
+
+    private static readonly HashSet<string> CustomDefinedValues = new(6, StringComparer.OrdinalIgnoreCase)
     {
         "file", //system.io static types
         "directory",
@@ -12,6 +23,13 @@ public class CSharpReservedTypesProvider : IReservedNamesProvider
         "environment",
         "task",
         "thread",
+        "integer"
+    };
+    
+    private readonly Lazy<HashSet<string>> _reservedNames = new(static () =>
+    {
+        CustomDefinedValues.UnionWith(GetSystemTypeNames());
+        return CustomDefinedValues;
     });
     public HashSet<string> ReservedNames => _reservedNames.Value;
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -167,7 +167,14 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     }
 
     protected static void ReplaceReservedModelTypes(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement) => 
-        ReplaceReservedNames(current, provider, replacement,codeElementExceptions: new HashSet<Type>{typeof(CodeNamespace)} ,shouldReplaceCallback: codeElement => codeElement is CodeClass || codeElement is CodeMethod || codeElement is CodeProperty);
+        ReplaceReservedNames(current,
+            provider, 
+            replacement,
+            codeElementExceptions: new HashSet<Type>{typeof(CodeNamespace)} ,
+            shouldReplaceCallback: codeElement => codeElement is CodeClass 
+                                                || codeElement is CodeMethod 
+                                                || codeElement is CodeEnum codeEnum && provider.ReservedNames.Contains(codeEnum.Name) // only replace enum type names not enum member names
+                                                || (codeElement is CodeProperty currentProperty && currentProperty.Type is CodeType propertyType && !propertyType.IsExternal && provider.ReservedNames.Contains(propertyType.Name)));// only replace property type names not property names
     
     protected static void ReplaceReservedNamespaceTypeNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement) => 
         ReplaceReservedNames(current, provider, replacement, shouldReplaceCallback: codeElement => codeElement is CodeNamespace || codeElement is CodeClass);

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -90,6 +90,41 @@ public class CSharpLanguageRefinerTests {
         Assert.Equal("alias", property.Name);
         Assert.DoesNotContain("@", property.Name); // classname will be capitalized
     }
+    
+    [Theory]
+    [InlineData("integer")]
+    [InlineData("boolean")]
+    [InlineData("tuple")]
+    [InlineData("single")]
+    [InlineData("random")]
+    [InlineData("buffer")]
+    [InlineData("convert")]
+    [InlineData("action")]
+    [InlineData("valueType")]
+    public async Task EscapesReservedTypeNames(string typeName) {
+        // Arrange
+        var model = root.AddClass(new CodeClass {
+            Name = typeName,
+            Kind = CodeClassKind.Model,
+        }).First();
+        var property = model.AddProperty(new CodeProperty
+        {
+            Name = typeName,// this a keyword
+            Type = new CodeType
+            {
+                Name = typeName,
+                IsExternal = true
+            }
+        }).First();
+        // Act
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+        // Assert
+        Assert.NotEqual(typeName, model.Name);
+        Assert.Equal($"{typeName}Object", model.Name);//our defined model is renamed
+        Assert.Equal(typeName, property.Type.Name);//external type is unchanged
+        Assert.Equal(typeName, property.Name);//external type property name is unchanged
+    }
+    
     [Fact]
     public async Task EscapesReservedKeywordsForReservedNamespaceNameSegments() {
         var subNS = root.AddNamespace($"{root.Name}.task"); // otherwise the import gets trimmed


### PR DESCRIPTION
This PR Closes #2021

Changes include

- Include types from the System namespace in the `CSharpReservedTypesProvider`
- Fixes `ReplaceReservedModelTypes` to disambiguate enum type names
- Fixes `ReplaceReservedModelTypes` to avoid disambiguation of property names. Only the types should be an issue for compilation.
- Adds tests to validate