### PR TITLE
Task/remove response handler param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removes the ResponseHandler parameter in RequestAdapter to be a RequestOption in Python [#1857](https://github.com/microsoft/kiota/issues/1857)
 - Updated the client constructor to set the baseUrl path parameter from RequestAdapter's baseUrl(PHP) [#2129](https://github.com/microsoft/kiota/issues/2129)
 - The Lock file uses a project version coming from a Source Generator instead of the one looked up with reflection. [#2147](https://github.com/microsoft/kiota/issues/2147)
 - Fixed a bug in ruby where file names or paths could be too long to be packaged.

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -76,6 +76,7 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddQueryParameterMapperMethod(
                 generatedCode
             );
+            RemoveHandlerFromRequestBuilder(generatedCode);
         }, cancellationToken);
     }
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -276,7 +276,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                         .Select(x => x?.Name.ToSnakeCase()).Where(x => x != null);
         if(requestInfoParameters.Any()) {
             writer.IncreaseIndent();
-            writer.WriteLine(requestInfoParameters.Aggregate((x,y) => $"{x}, {y}"));
+            writer.WriteLine(requestInfoParameters.Aggregate(static (x,y) => $"{x}, {y}"));
             writer.DecreaseIndent();
         }
         writer.WriteLine(")");
@@ -298,7 +298,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
     writer.IncreaseIndent();
     writer.WriteLine("raise Exception(\"Http core is null\") ");
     writer.DecreaseIndent();
-    writer.WriteLine($"return await self.request_adapter.{genericTypeForSendMethod}(request_info,{newFactoryParameter} response_handler, {errorMappingVarName})");
+    writer.WriteLine($"return await self.request_adapter.{genericTypeForSendMethod}(request_info,{newFactoryParameter} {errorMappingVarName})");
     }
     private string GetReturnTypeWithoutCollectionSymbol(CodeMethod codeElement, string fullTypeName) {
         if(!codeElement.ReturnType.IsCollection) return fullTypeName;


### PR DESCRIPTION
This PR closes #1857

Depends on 
- https://github.com/microsoft/kiota-abstractions-python/pull/30
- https://github.com/microsoft/kiota-http-python/pull/54

Changes include : 
- Update python refiner to call `RemoveHandlerFromRequestBuilder` to remove `response_handler` parameter
- Updates python code method writer to not write the parameter to align to new `RequestAdapter` interface.