### PR TITLE
Add options to mangle the output colors of the CLI

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -8,8 +8,8 @@ has_children: false
 
 This is a list of available options for the Kiota CLI.
 
-| Environment Variable  | result  |
-|---|---|
-| KIOTA_TUTORIAL | Displays additional hints |
-| KIOTA_CONSOLE_SWAP_COLORS | Swap the color of the output |
-| KIOTA_CONSOLE_NO_COLORS | Turn off the output colorization |
+| Environment Variable  | Description | Default value |
+|---|---|---|
+| KIOTA_TUTORIAL | Displays additional hints | true |
+| KIOTA_CONSOLE_SWAP_COLORS | Swap the color of the output | false |
+| KIOTA_CONSOLE_NO_COLORS | Turn off the output colorization | false |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,15 @@
+---
+title: Configuration
+nav_order: 3
+has_children: false
+---
+
+# Kiota Configuration
+
+This is a list of available options for the Kiota CLI.
+
+| Environment Variable  | result  |
+|---|---|
+| KIOTA_TUTORIAL | Displays additional hints |
+| KIOTA_CONSOLE_SWAP_COLORS | Swap the color of the output |
+| KIOTA_CONSOLE_NO_COLORS | Turn off the output colorization |

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 3
+nav_order: 4
 has_children: true
 ---
 

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -123,28 +123,49 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler
         return true;
     });
     protected bool TutorialMode => tutorialMode.Value;
+    private readonly Lazy<bool> consoleSwapColors = new(() => {
+        var kiotaSwapColorsRaw = Environment.GetEnvironmentVariable("KIOTA_CONSOLE_SWAP_COLORS");
+        if (!string.IsNullOrEmpty(kiotaSwapColorsRaw) && bool.TryParse(kiotaSwapColorsRaw, out var kiotaSwapColors)) {
+            return kiotaSwapColors;
+        }
+        return false;
+    });
+    protected bool SwapColors => consoleSwapColors.Value;
+    private readonly Lazy<bool> consoleNoColors = new(() => {
+        var kiotaNoColorsRaw = Environment.GetEnvironmentVariable("KIOTA_CONSOLE_NO_COLORS");
+        if (!string.IsNullOrEmpty(kiotaNoColorsRaw) && bool.TryParse(kiotaNoColorsRaw, out var kiotaNoColors)) {
+            return kiotaNoColors;
+        }
+        return false;
+    });
+    protected bool NoColors => consoleNoColors.Value;
+    
     private void DisplayHint(params string[] messages) {
         if(TutorialMode) {
             Console.WriteLine();
             DisplayMessages(ConsoleColor.Blue, messages);
         }
     }
-    private static void DisplayMessages(ConsoleColor color, params string[] messages) {
-        Console.ForegroundColor = color;
+    private void DisplayMessages(ConsoleColor color, params string[] messages) {
+        if (SwapColors)
+            color = Enum.GetValues<ConsoleColor>()[ConsoleColor.White - color];
+        if (!NoColors)
+            Console.ForegroundColor = color;
         foreach(var message in messages)
             Console.WriteLine(message);
-        Console.ResetColor();
+        if (!NoColors)
+            Console.ResetColor();
     }
-    protected static void DisplayError(params string[] messages) {
+    protected void DisplayError(params string[] messages) {
         DisplayMessages(ConsoleColor.Red, messages);
     }
-    protected static void DisplayWarning(params string[] messages) {
+    protected void DisplayWarning(params string[] messages) {
         DisplayMessages(ConsoleColor.Yellow, messages);
     }
-    protected static void DisplaySuccess(params string[] messages) {
+    protected void DisplaySuccess(params string[] messages) {
         DisplayMessages(ConsoleColor.Green, messages);
     }
-    protected static void DisplayInfo(params string[] messages) {
+    protected void DisplayInfo(params string[] messages) {
         DisplayMessages(ConsoleColor.White, messages);
     }
     protected void DisplayDownloadHint(string searchTerm, string version) {
@@ -225,7 +246,7 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler
                         "Example: kiota login github");
         }
     }
-    protected static void DisplayGitHubDeviceCodeLoginMessage(Uri uri, string code) {
+    protected void DisplayGitHubDeviceCodeLoginMessage(Uri uri, string code) {
         DisplayInfo($"Please go to {uri} and enter the code {code} to authenticate.");
     }
 }

--- a/src/kiota/Handlers/KiotaGitHubDeviceLoginCommandHanlder.cs
+++ b/src/kiota/Handlers/KiotaGitHubDeviceLoginCommandHanlder.cs
@@ -58,7 +58,7 @@ internal class KiotaGitHubDeviceLoginCommandHandler : BaseKiotaCommandHandler
             return 1;
         }
     }
-    private static async Task ListOutRepositoriesAsync(IAuthenticationProvider authProvider, CancellationToken cancellationToken) {
+    private async Task ListOutRepositoriesAsync(IAuthenticationProvider authProvider, CancellationToken cancellationToken) {
         var requestAdapter = new HttpClientRequestAdapter(authProvider, httpClient: httpClient);
         var client = new GitHubClient(requestAdapter);
         var installations = await client.User.Installations.GetAsync(cancellationToken: cancellationToken);

--- a/src/kiota/Handlers/KiotaInfoCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaInfoCommandHandler.cs
@@ -81,7 +81,7 @@ internal class KiotaInfoCommandHandler : KiotaSearchBasedCommandHandler {
         var layout = new StackLayoutView { view };
         console.Append(layout);
     }
-    private static void ShowLanguageInformation(GenerationLanguage language, LanguagesInformation informationSource) {
+    private void ShowLanguageInformation(GenerationLanguage language, LanguagesInformation informationSource) {
         if (informationSource.TryGetValue(language.ToString(), out var languageInformation)) {
             DisplayInfo($"The language {language} is currently in {languageInformation.MaturityLevel} maturity level.",
                         "After generating code for this language, you need to install the following packages:");


### PR DESCRIPTION
Currently, the output color is invisible while using a white terminal:
![Screenshot 2023-01-18 at 12 58 49](https://user-images.githubusercontent.com/5792097/213177737-c719de74-2d5f-4398-b9bc-9df8aa717f9d.png)

I'm proposing adding 2 options:
 - swap the output color -> useful on terminals with light background
 - disable completely the colors -> useful for parsing the output from other/external tools