### PR TITLE
Fixes NRT bug when return type is primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed response handler parameter from PHP request executor methods. [1856](https://github.com/microsoft/kiota/issues/1856)
 - Fixed minor typo in adding Accept header for PHP.
 - Fixed a bug with null reference types and composed types in CSharp.
+- Fixed a bug with null reference types scalar values in CSharp.
 - Fixed a bug where reserved names replacement wouldn't check whether the name was already in use (all languages).
 - Fixed a bug where default OpenAPI.net validation rules could not be disabled.
 - Fixed a race condition in namespace disambiguation for CSharp.

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -557,7 +557,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         var includeNullableReferenceType = code.Parameters.Any(static codeParameter => codeParameter.IsOfKind(CodeParameterKind.RequestConfiguration));
         if (includeNullableReferenceType)
         {
-            var completeReturnTypeWithNullable = string.IsNullOrEmpty(genericTypeSuffix) ? completeReturnType : $"{completeReturnType[..^2]}?{genericTypeSuffix} ";
+            var completeReturnTypeWithNullable = string.IsNullOrEmpty(genericTypeSuffix) ? completeReturnType : $"{completeReturnType[..^2].TrimEnd('?')}?{genericTypeSuffix} ";
             var nullableParameters = string.Join(", ", code.Parameters.OrderBy(static x => x, parameterOrderComparer)
                                                           .Select(p => p.IsOfKind(CodeParameterKind.RequestConfiguration) ? 
                                                                                         GetParameterSignatureWithNullableRefType(p,code): 

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -650,7 +650,7 @@ public class CodeMethodWriterTests : IDisposable {
         AssertExtensions.CurlyBracesAreClosed(result,1);
     }
     [Fact]
-    public void WritesRequestGeneratorBodyForScalar() {
+    public void WritesRequestGeneratorBodyForNullableScalar() {
         method.Kind = CodeMethodKind.RequestGenerator;
         method.HttpMethod = HttpMethod.Get;
         AddRequestProperties();
@@ -671,6 +671,33 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.Contains("requestInfo.AddRequestOptions(requestConfig.O)", result);
         Assert.Contains("SetContentFromScalar", result);
         Assert.Contains("return requestInfo;", result);
+        AssertExtensions.CurlyBracesAreClosed(result,1);
+    }
+    [Fact]
+    public void WritesRequestGeneratorBodyForScalar() {
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters();
+        method.AcceptedResponseTypes.Add("application/json");
+        method.ReturnType = new CodeType { Name = "double", IsNullable = true, IsExternal = true};//use a nullable value type
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("var requestInfo = new RequestInformation", result);
+        Assert.Contains("HttpMethod = Method.GET", result);
+        Assert.Contains("UrlTemplate = ", result);
+        Assert.Contains("PathParameters = ", result);
+        Assert.Contains("if (config != null)", result);
+        Assert.Contains("var requestConfig = new RequestConfig()", result);
+        Assert.Contains("config.Invoke(requestConfig)", result);
+        Assert.Contains("requestInfo.Headers.Add(\"Accept\", \"application/json\")", result);
+        Assert.Contains("requestInfo.AddHeaders(requestConfig.H)", result);
+        Assert.Contains("requestInfo.AddQueryParameters(requestConfig.Q)", result);
+        Assert.Contains("requestInfo.AddRequestOptions(requestConfig.O)", result);
+        Assert.Contains("SetContentFromScalar", result);
+        Assert.Contains("return requestInfo;", result);
+        Assert.Contains("async Task<double?>",result);//verify we only have one nullable marker
+        Assert.DoesNotContain("async Task<double??>",result);//verify we only have one nullable marker
         AssertExtensions.CurlyBracesAreClosed(result,1);
     }
     [Fact]


### PR DESCRIPTION
This PR fixes a bug where an extra nullable marker was added when method returned a primitive.