### PR TITLE
Use fully qualified identifiers for java.util.function.Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Using fully qualified identifier for java.util.function.Consumer to avoid conflicts in Java.
 - Removed response handler parameter from PHP request executor methods. [1856](https://github.com/microsoft/kiota/issues/1856)
 - Fixed minor typo in adding Accept header for PHP.
 - Fixed a bug with null reference types and composed types in CSharp.

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -170,8 +170,6 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor),
             "com.microsoft.kiota.serialization", "Parsable", "ParsableFactory"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
-            "java.util.function", "Consumer"),
-        new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer),
             "java.util", "HashMap", "Map"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor) &&
                     method.Parameters.Any(y => y.IsOfKind(CodeParameterKind.BackingStore)),
@@ -230,7 +228,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                     x.Type.Name = x.Type.Name[1..];
             });
         else if(currentMethod.IsOfKind(CodeMethodKind.Deserializer)) {
-            currentMethod.ReturnType.Name = "Map<String, Consumer<ParseNode>>";
+            currentMethod.ReturnType.Name = "Map<String, java.util.function.Consumer<ParseNode>>";
             currentMethod.Name = "getFieldDeserializers";
         }
         else if(currentMethod.IsOfKind(CodeMethodKind.ClientConstructor, CodeMethodKind.Constructor, CodeMethodKind.RawUrlConstructor)) {

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -360,7 +360,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         else
             WriteDeserializerBodyForInheritedModel(codeElement, parentClass, writer, inherits);
     }
-    private const string DeserializerReturnType = "HashMap<String, Consumer<ParseNode>>";
+    private const string DeserializerReturnType = "HashMap<String, java.util.function.Consumer<ParseNode>>";
     private static void WriteDeserializerBodyForUnionModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer)
     {
         var includeElse = false;

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1015,7 +1015,7 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodeMethodKind.Deserializer,
             IsAsync = false,
             ReturnType = new CodeType {
-                Name = "Map<String, Consumer<ParseNode>>",
+                Name = "Map<String, java.util.function.Consumer<ParseNode>>",
             },
         }).First();
         writer.Write(deserializationMethod);
@@ -1023,8 +1023,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.DoesNotContain("final UnionTypeWrapper res =", result);
         Assert.Contains("this.getComplexType1Value() != null", result);
         Assert.Contains("return this.getComplexType1Value().getFieldDeserializers()", result);
-        Assert.Contains("new HashMap<String, Consumer<ParseNode>>()", result);
-        AssertExtensions.Before("return this.getComplexType1Value().getFieldDeserializers()", "new HashMap<String, Consumer<ParseNode>>", result);
+        Assert.Contains("new HashMap<String, java.util.function.Consumer<ParseNode>>()", result);
+        AssertExtensions.Before("return this.getComplexType1Value().getFieldDeserializers()", "new HashMap<String, java.util.function.Consumer<ParseNode>>", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
@@ -1035,7 +1035,7 @@ public class CodeMethodWriterTests : IDisposable {
             Kind = CodeMethodKind.Deserializer,
             IsAsync = false,
             ReturnType = new CodeType {
-                Name = "Map<String, Consumer<ParseNode>>",
+                Name = "Map<String, java.util.function.Consumer<ParseNode>>",
             },
         }).First();
         writer.Write(deserializationMethod);
@@ -1043,8 +1043,8 @@ public class CodeMethodWriterTests : IDisposable {
         Assert.DoesNotContain("final IntersectionTypeWrapper res =", result);
         Assert.Contains("this.getComplexType1Value() != null || this.getComplexType3Value() != null", result);
         Assert.Contains("return ParseNodeHelper.mergeDeserializersForIntersectionWrapper(this.getComplexType1Value(), this.getComplexType3Value())", result);
-        Assert.Contains("new HashMap<String, Consumer<ParseNode>>()", result);
-        AssertExtensions.Before("return ParseNodeHelper.mergeDeserializersForIntersectionWrapper(this.getComplexType1Value(), this.getComplexType3Value())", "new HashMap<String, Consumer<ParseNode>>()", result);
+        Assert.Contains("new HashMap<String, java.util.function.Consumer<ParseNode>>()", result);
+        AssertExtensions.Before("return ParseNodeHelper.mergeDeserializersForIntersectionWrapper(this.getComplexType1Value(), this.getComplexType3Value())", "new HashMap<String, java.util.function.Consumer<ParseNode>>()", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Found the bug using Kiota on this spec file:
https://raw.githubusercontent.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/main/kafka-admin/.openapi/kafka-admin-rest.yaml

Don't take this as strong advice as I know that's a personal bias, but, to stay on the safe side, I always use full identifiers in the generated code.
Using imports, the code looks nicer, but, it becomes a matter of time before someone experiences a conflict with the domain model.