### PR TITLE
Missing Microsoft.Kiota.Serialization.Form from dependencies section in "Build SDKs for .NET"

### DIFF
--- a/docs/get-started/dotnet.md
+++ b/docs/get-started/dotnet.md
@@ -10,7 +10,7 @@ parent: Get started
 
 ## Target project requirements
 
-Before you can compile and run the generated files, you will need to make sure they are part of a project with the required dependencies. After creating a new project, or reusing an existing one, you will need to add references to the [abstraction](https://github.com/microsoft/kiota-abstractions-dotnet), [authentication](https://github.com/microsoft/kiota-authentication-azure-dotnet), [http](https://github.com/microsoft/kiota-http-dotnet), and [JSON](https://github.com/microsoft/kiota-serialization-json-dotnet) and [text](https://github.com/microsoft/kiota-serialization-text-dotnet) serialization packages from the GitHub feed.
+Before you can compile and run the generated files, you will need to make sure they are part of a project with the required dependencies. After creating a new project, or reusing an existing one, you will need to add references to the [abstraction](https://github.com/microsoft/kiota-abstractions-dotnet), [authentication](https://github.com/microsoft/kiota-authentication-azure-dotnet), [http](https://github.com/microsoft/kiota-http-dotnet), and [FORM](https://github.com/microsoft/kiota-serialization-form-dotnet), [JSON](https://github.com/microsoft/kiota-serialization-json-dotnet) and [text](https://github.com/microsoft/kiota-serialization-text-dotnet) serialization packages from the GitHub feed.
 
 ## Creating target projects
 

--- a/docs/get-started/dotnet.md
+++ b/docs/get-started/dotnet.md
@@ -30,6 +30,7 @@ dotnet new gitignore
 ```bash
 dotnet add package Microsoft.Kiota.Abstractions --prerelease
 dotnet add package Microsoft.Kiota.Http.HttpClientLibrary --prerelease
+dotnet add package Microsoft.Kiota.Serialization.Form --prerelease
 dotnet add package Microsoft.Kiota.Serialization.Json --prerelease
 dotnet add package Microsoft.Kiota.Serialization.Text --prerelease
 dotnet add package Microsoft.Kiota.Authentication.Azure --prerelease


### PR DESCRIPTION
I stumbled upon Kiota recently and I absolutely love this. I started experimenting with the tool over the weekend and I couldn't get it build by following the [Build SDK's for .NET guide](https://microsoft.github.io/kiota/get-started/dotnet)

All that was missing for me was adding a package reference to `Microsoft.Kiota.Serialization.Form`. Hence, this pull request 😄 

I can verify that the code that this tool generates builds on the following versions of .NET
- .NET Core 7.0 and 6.0
- .NET Standard 2.0
- .NET Framework 4.5.2, 4.6.2, 4.7.2, 4.8, and 4.8.1

I can see why it's best to recommend to use .NET 7.0, as its states in the [Build SDK's for .NET guide](https://microsoft.github.io/kiota/get-started/dotnet) since that is the current and recommended version of .NET but I can't really see what's preventing those who are maybe interested in targeting the LTS version (currently 6.0)

I'm thinking of building some Visual Studio tooling support for this code generator via my [REST API Client Code Generator](https://github.com/christianhelle/apiclientcodegen) extension. I have already started working on my CLI tool, [Rapicgen](https://www.nuget.org/packages/rapicgen) and will work on the Visual Studio extension at some point this week.