### PR TITLE
Fixes conflicting request builders

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -75,7 +75,7 @@ public class KiotaBuilder
         await using var input = await (originalDocument == null ?
                                         LoadStream(inputPath, cancellationToken) :
                                         Task.FromResult<Stream>(new MemoryStream()));
-        if (input == null)
+        if (input.Length == 0)
             return (0, null, false);
         StopLogAndReset(sw, $"step {++stepId} - reading the stream - took");
 
@@ -484,7 +484,7 @@ public class KiotaBuilder
         else
         {
             var targetNS = currentNode.DoesNodeBelongToItemSubnamespace() ? currentNamespace.EnsureItemNamespace() : currentNamespace;
-            var className = currentNode.DoesNodeBelongToItemSubnamespace() ? currentNode.GetClassName(config.StructuredMimeTypes, itemRequestBuilderSuffix) : currentNode.GetClassName(config.StructuredMimeTypes, requestBuilderSuffix);
+            var className = currentNode.DoesNodeBelongToItemSubnamespace() ? currentNode.GetNavigationPropertyName(config.StructuredMimeTypes, itemRequestBuilderSuffix) : currentNode.GetNavigationPropertyName(config.StructuredMimeTypes, requestBuilderSuffix);
             codeClass = targetNS.AddClass(new CodeClass
             {
                 Name = className.CleanupSymbolName(),
@@ -502,8 +502,8 @@ public class KiotaBuilder
         foreach (var child in currentNode.Children)
         {
             var propIdentifier = child.Value.GetNavigationPropertyName(config.StructuredMimeTypes);
-            var className = child.Value.GetClassName(config.StructuredMimeTypes);
-            var propType = child.Value.DoesNodeBelongToItemSubnamespace() ? className + itemRequestBuilderSuffix : className + requestBuilderSuffix;
+            var propType = child.Value.DoesNodeBelongToItemSubnamespace() ? propIdentifier + itemRequestBuilderSuffix : propIdentifier + requestBuilderSuffix;
+
             if (child.Value.IsPathSegmentWithSingleSimpleParameter())
                 codeClass.Indexer = CreateIndexer($"{propIdentifier}-indexer", propType, child.Value, currentNode);
             else if (child.Value.IsComplexPathMultipleParameters())

--- a/src/Kiota.Builder/Writers/Ruby/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeClassDeclarationWriter.cs
@@ -37,7 +37,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, Ru
 
             foreach (var relativePath in codeElement.Usings
                                         .Where(static x => !x.IsExternal)
-                                        .DistinctBy(static x => $"{x.Name}{x.Declaration.Name}", StringComparer.OrdinalIgnoreCase)
+                                        .DistinctBy(static x => $"{x.Name}{x.Declaration?.Name}", StringComparer.OrdinalIgnoreCase)
                                         .Select(x => x.Declaration?.Name?.StartsWith('.') ?? false ?
                                             (string.Empty, string.Empty, x.Declaration.Name) :
                                             relativeImportManager.GetRelativeImportPathForUsing(x, currentNamespace))

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -671,7 +671,7 @@ paths:
         Assert.Single(getEffectivePermissionsMethod.Parameters);
         var getEffectivePermissionsNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement.microsoftGraphGetEffectivePermissionsWithScope");
         Assert.NotNull(getEffectivePermissionsNS);
-        var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("GetEffectivePermissionsWithScopeRequestBuilder", false);
+        var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("microsoftGraphGetEffectivePermissionsWithScopeRequestBuilder", false);
         Assert.NotNull(getEffectivePermissionsRequestBuilder);
         var constructorMethod = getEffectivePermissionsRequestBuilder.FindChildByName<CodeMethod>("constructor", false);
         Assert.NotNull(constructorMethod);
@@ -822,7 +822,7 @@ paths:
         Assert.Single(getEffectivePermissionsMethod.Parameters);
         var getEffectivePermissionsNS = codeModel.FindNamespaceByName("ApiSdk.deviceManagement.microsoftGraphGetEffectivePermissionsWithScope");
         Assert.NotNull(getEffectivePermissionsNS);
-        var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("GetEffectivePermissionsWithScopeRequestBuilder", false);
+        var getEffectivePermissionsRequestBuilder = getEffectivePermissionsNS.FindChildByName<CodeClass>("microsoftGraphGetEffectivePermissionsWithScopeRequestBuilder", false);
         Assert.NotNull(getEffectivePermissionsRequestBuilder);
         var constructorMethod = getEffectivePermissionsRequestBuilder.FindChildByName<CodeMethod>("constructor", false);
         Assert.NotNull(constructorMethod);


### PR DESCRIPTION
This PR closes #2234 

Changes include :-

- Use the `GetNavigationPropertyName` property to generate class names to ensure RequestBuilder classes are disambiguated using the namespace. 
- Updates tests
- Updates a couple of scenarios with nullable ref types