### PR TITLE
Fixes conflicting properties generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add null checks in generated Shell language code.
 - Fixed a bug where Go indexers would fail to pass the index parameter.
 - Fixed a bug where path segments with parameters could be missing words. [#2209](https://github.com/microsoft/kiota/issues/2209)
+- Fixed a bug where refiners could generate duplicate properties.
 
 ## [0.10.0] - 2023-01-04
 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -120,7 +120,10 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         {
             if (string.IsNullOrEmpty(currentProperty.SerializationName))
                 currentProperty.SerializationName = currentProperty.Name;
-            currentProperty.Name = refineAccessorName(currentProperty.Name);
+            
+            var refinedName = refineAccessorName(currentProperty.Name);
+            if(!parentClass.Properties.Any( property => refinedName.Equals(property.Name,StringComparison.OrdinalIgnoreCase)))// ensure the refinement won't generate a duplicate
+                currentProperty.Name = refinedName;
         }
         CrawlTree(current, x => ReplacePropertyNames(x, propertyKindsToReplace!, refineAccessorName));
     }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -120,9 +120,9 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         {
             if (string.IsNullOrEmpty(currentProperty.SerializationName))
                 currentProperty.SerializationName = currentProperty.Name;
-            
+
             var refinedName = refineAccessorName(currentProperty.Name);
-            if(!parentClass.Properties.Any( property => refinedName.Equals(property.Name,StringComparison.OrdinalIgnoreCase)))// ensure the refinement won't generate a duplicate
+            if (!parentClass.Properties.Any(property => refinedName.Equals(property.Name, StringComparison.OrdinalIgnoreCase)))// ensure the refinement won't generate a duplicate
                 currentProperty.Name = refinedName;
         }
         CrawlTree(current, x => ReplacePropertyNames(x, propertyKindsToReplace!, refineAccessorName));

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -350,6 +350,43 @@ public class CSharpLanguageRefinerTests
         Assert.Equal("model", propToAdd.SerializationName);
     }
     [Fact]
+    public async Task AvoidsPropertyNameReplacementIfDuplicatedGenerated()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "Model",
+            Kind = CodeClassKind.Model
+        }).First();
+        var firstProperty = model.AddProperty(new CodeProperty
+        {
+            Name = "summary",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var secondProperty = model.AddProperty(new CodeProperty
+        {
+            Name = "_summary",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var thirdProperty = model.AddProperty(new CodeProperty
+        {
+            Name = "_replaced",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+        Assert.Equal("summary", firstProperty.Name);// remains as is. No refinement needed
+        Assert.Equal("_summary", secondProperty.Name);// No refinement as it will create a duplicate with firstProperty
+        Assert.Equal("Replaced", thirdProperty.Name);// Base case. Proper refinements
+    }
+    [Fact]
     public async Task DisambiguatePropertiesWithClassNames_DoesntReplaceSerializationName()
     {
         var serializationName = "serializationName";

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -137,7 +137,7 @@ public class CSharpLanguageRefinerTests
         // Assert
         Assert.Equal("break", model.Name);
         Assert.DoesNotContain("@", model.Name); // classname will be capitalized
-        Assert.Equal("Alias", property.Name);
+        Assert.Equal("alias", property.Name);
         Assert.DoesNotContain("@", property.Name); // classname will be capitalized
     }
 
@@ -174,7 +174,7 @@ public class CSharpLanguageRefinerTests
         Assert.NotEqual(typeName, model.Name);
         Assert.Equal($"{typeName}Object", model.Name);//our defined model is renamed
         Assert.Equal(typeName, property.Type.Name);//external type is unchanged
-        Assert.Equal(typeName.ToPascalCase(new[] { '_' }), property.Name);//external type property name is in pascal-case
+        Assert.Equal(typeName.ToPascalCase(new[] { '_' }), property.Name.ToFirstCharacterUpperCase());//external type property name is in pascal-case
     }
 
     [Fact]
@@ -346,7 +346,7 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("ModelProp", propToAdd.Name);
+        Assert.Equal("modelProp", propToAdd.Name);
         Assert.Equal("model", propToAdd.SerializationName);
     }
     [Fact]


### PR DESCRIPTION
This PR is a follow up to https://github.com/microsoft/kiota/pull/2202

It updates the `ReplacePropertyNames` method to avoid property name replacement if it will result in a duplicate property name as seen in the searchHit model where the property `summary` and the property `_summary` would conflict if replacement is done.

```xml
<ComplexType Name="searchHit">
  <Property Name="contentSource" Type="Edm.String"/>
  <Property Name="hitId" Type="Edm.String"/>
  <Property Name="isCollapsed" Type="Edm.Boolean"/>
  <Property Name="rank" Type="Edm.Int32"/>
  <Property Name="resultTemplateId" Type="Edm.String"/>
  <Property Name="summary" Type="Edm.String"/>
  <Property Name="_id" Type="Edm.String"/>
  <Property Name="_score" Type="Edm.Int32"/>
  <Property Name="_summary" Type="Edm.String"/>
  <NavigationProperty Name="resource" Type="graph.entity" ContainsTarget="true"/>
  <NavigationProperty Name="_source" Type="graph.entity" ContainsTarget="true"/>
</ComplexType>
```