### PR TITLE
[java] Refine Model Names to be more idiomatic

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -126,10 +126,7 @@ jobs:
       - name: Build
         run: dotnet build kiota.sln --no-restore
       - name: Generate Java Code
-        run: |
-          ./src/kiota/bin/Debug/net7.0/kiota generate --language Java \
-            --openapi tests/Kiota.Builder.IntegrationTests/InheritingErrors.yaml \
-            --output it/java/src
+        run: ./it/java/generate.sh
       - uses: actions/cache@v3
         with:
           path: /root/.jbang

--- a/it/java/generate.sh
+++ b/it/java/generate.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=${SCRIPT_DIR}/../..
+
+${ROOT_DIR}/src/kiota/bin/Debug/net7.0/kiota generate --language Java \
+  --openapi ${ROOT_DIR}/tests/Kiota.Builder.IntegrationTests/InheritingErrors.yaml \
+  --output ${ROOT_DIR}/it/java/src
+
+${ROOT_DIR}/src/kiota/bin/Debug/net7.0/kiota generate --language Java \
+  --openapi ${ROOT_DIR}/tests/Kiota.Builder.IntegrationTests/NoUnderscoresInModel.yaml \
+  --output ${ROOT_DIR}/it/java/src \
+  --namespace-name "no.underscores"

--- a/it/java/test.java
+++ b/it/java/test.java
@@ -12,6 +12,9 @@ import static java.lang.System.*;
 public class test {
 
     public static void main(String... args) {
-        out.println("Everything compiles and classes are available in the compilation unit: " + new apisdk.models.Error());
+        var error = new apisdk.models.Error().getClass().getName();
+        var noUnderscores = new no.underscores.models.TestListItemsAdditional().getClass().getName();
+
+        out.println("Everything compiles and classes are available in the compilation unit.\n" + error + "\n" + noUnderscores);
     }
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -108,6 +108,28 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
 
         return false;
     }
+    protected static void CorrectClassNames(CodeElement current, Func<string, string> refineClassName)
+    {
+        if (current is CodeClass currentClass &&
+            refineClassName(currentClass.Name) is string refinedClassName &&
+            !currentClass.Name.Equals(refinedClassName))
+        {
+            currentClass.Name = refinedClassName;
+        }
+        else if (current is CodeProperty currentProperty &&
+                refineClassName(currentProperty.Type.Name) is string refinedPropertyTypeName &&
+                !currentProperty.Type.Name.Equals(refinedPropertyTypeName))
+        {
+            currentProperty.Type.Name = refinedPropertyTypeName;
+        }
+        else if (current is CodeMethod currentMethod &&
+                refineClassName(currentMethod.ReturnType.Name) is string refinedMethodTypeName &&
+                !currentMethod.ReturnType.Name.Equals(refinedMethodTypeName))
+        {
+            currentMethod.ReturnType.Name = refinedMethodTypeName;
+        }
+        CrawlTree(current, x => CorrectClassNames(x, refineClassName));
+    }
     protected static void ReplacePropertyNames(CodeElement current, HashSet<CodePropertyKind> propertyKindsToReplace, Func<string, string> refineAccessorName)
     {
         if (!(propertyKindsToReplace?.Any() ?? true)) return;

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -18,6 +18,14 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         {
             cancellationToken.ThrowIfCancellationRequested();
             LowerCaseNamespaceNames(generatedCode);
+            var reservedNamesProvider = new JavaReservedNamesProvider();
+            CorrectClassNames(generatedCode, s =>
+            {
+                if (!reservedNamesProvider.ReservedNames.Contains(s) && s.Contains('_'))
+                    return s.ToPascalCase(new[] { '_' });
+                else
+                    return s;
+            });
             RemoveClassNamePrefixFromNestedClasses(generatedCode);
             InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode, true);
@@ -48,7 +56,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "set",
                 string.Empty
             );
-            ReplaceReservedNames(generatedCode, new JavaReservedNamesProvider(), x => $"{x}_escaped");
+            ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}_escaped");
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
             cancellationToken.ThrowIfCancellationRequested();
             AddDefaultImports(generatedCode, defaultUsingEvaluators);

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Kiota.Builder.Configuration;
@@ -114,5 +115,25 @@ public class GenerateSample : IDisposable
             OutputPath = $".\\Generated\\ErrorInlineParents\\{language}",
         };
         await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
+    }
+    [InlineData(GenerationLanguage.Java)]
+    [Theory]
+    public async Task GeneratesIdiomaticChildrenNames(GenerationLanguage language)
+    {
+        var logger = LoggerFactory.Create(builder =>
+        {
+        }).CreateLogger<KiotaBuilder>();
+
+        var OutputPath = $".\\Generated\\NoUnderscoresInObjectNames\\{language}";
+        var configuration = new GenerationConfiguration
+        {
+            Language = language,
+            OpenAPIFilePath = "NoUnderscoresInModel.yaml",
+            OutputPath = OutputPath,
+            CleanOutput = true,
+        };
+        await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
+
+        Assert.Empty(Directory.GetFiles(OutputPath, "*_*", SearchOption.AllDirectories));
     }
 }

--- a/tests/Kiota.Builder.IntegrationTests/NoUnderscoresInModel.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/NoUnderscoresInModel.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+  description: something
+paths:
+  /api/metrics/v1:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestList'
+          description: Test
+      description: Returns a test list
+components:
+  schemas:
+    TestList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Value"
+    Value:
+      type: object
+      properties:
+        additional:
+          type: object
+          additionalProperties:
+            type: string
+        values:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
In Java generation, I noticed that in some cases the code generator is still producing class names with underscores.
You can notice it in generated code like this: https://github.com/bf2fc6cc711aee1a0c2a/e2e-test-suite/pull/463/files#diff-b6503fda47d63761a380b57b09a6b21bca5f0f8e7e2eb0aca297acfd7430d668R4

I believe that, at least for model classes, we should not have underscores around as the code is not going to be idiomatic for Java developers.
This is, hopefully, targeting all of the remaining cases when this is happening.
Happy to turn this around if I'm not covering some use cases or my code is not ideal to give a good answer to the original problem.