### PR TITLE
PHP - prevent exception field/methods from being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where errors/exceptions could override native exception type symbols for PHP Generation. [#2258](https://github.com/microsoft/kiota/issues/2258)
 - Fixed a bug where most of the Java fields have been prefixed with an underscore.
 - Mangle properties and/or accessors names per language to have more idiomatic APIs.
 - Using fully qualified identifier for java.util.function.Consumer to avoid conflicts in Java.

--- a/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
@@ -11,6 +11,8 @@ public class PhpExceptionsReservedNamesProvider : IReservedNamesProvider
         "code",
         "file",
         "line",
+        "response",
+        "responseStatusCode",
         "getMessage",
         "getPrevious",
         "getCode",

--- a/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kiota.Builder.Refiners;
+
+public class PhpExceptionsReservedNamesProvider : IReservedNamesProvider
+{
+    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase)
+    {
+        "message",
+        "code",
+        "file",
+        "line",
+        "getMessage",
+        "getPrevious",
+        "getCode",
+        "getFile",
+        "getLine",
+        "getTrace",
+        "getTraceAsString",
+    });
+    public HashSet<string> ReservedNames => _reservedNames.Value;
+}

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -22,12 +22,12 @@ public class PhpRefiner : CommonLanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             // Imports should be done before adding getters and setters since AddGetterAndSetterMethods can remove properties from classes when backing store is enabled
             ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}");
-            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(), static x => $"{x}Escaped");
             AddParentClassToErrorClasses(
                 generatedCode,
                 "ApiException",
                 "Microsoft\\Kiota\\Abstractions"
             );
+            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(),  x => $"escaped{x.ToFirstCharacterUpperCase()}");
             AddConstructorsForDefaultValues(generatedCode, true);
             cancellationToken.ThrowIfCancellationRequested();
             RemoveCancellationParameter(generatedCode);

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -27,7 +27,7 @@ public class PhpRefiner : CommonLanguageRefiner
                 "ApiException",
                 "Microsoft\\Kiota\\Abstractions"
             );
-            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(),  x => $"escaped{x.ToFirstCharacterUpperCase()}");
+            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(), x => $"escaped{x.ToFirstCharacterUpperCase()}");
             AddConstructorsForDefaultValues(generatedCode, true);
             cancellationToken.ThrowIfCancellationRequested();
             RemoveCancellationParameter(generatedCode);

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -22,6 +22,7 @@ public class PhpRefiner : CommonLanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             // Imports should be done before adding getters and setters since AddGetterAndSetterMethods can remove properties from classes when backing store is enabled
             ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}");
+            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(), static x => $"{x}Escaped");
             AddParentClassToErrorClasses(
                 generatedCode,
                 "ApiException",

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -27,7 +27,7 @@ public class PhpRefiner : CommonLanguageRefiner
                 "ApiException",
                 "Microsoft\\Kiota\\Abstractions"
             );
-            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(), x => $"escaped{x.ToFirstCharacterUpperCase()}");
+            ReplaceReservedExceptionPropertyNames(generatedCode, new PhpExceptionsReservedNamesProvider(), static x => $"escaped{x.ToFirstCharacterUpperCase()}");
             AddConstructorsForDefaultValues(generatedCode, true);
             cancellationToken.ThrowIfCancellationRequested();
             RemoveCancellationParameter(generatedCode);

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -93,7 +93,7 @@ public class PhpLanguageRefinerTests
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
     }
-    
+
     [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()
     {
@@ -103,12 +103,33 @@ public class PhpLanguageRefinerTests
             Kind = CodeClassKind.Model,
             IsErrorDefinition = true,
         }).First();
-        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+
+        model.AddProperty(
+            new CodeProperty
+            {
+                Type = new CodeType
+                {
+                    Name = "string"
+                },
+                Name = "code",
+            },
+            new CodeProperty
+            {
+                Type = new CodeType
+                {
+                    Name = "integer"
+                },
+                Name = "message",
+            }
+        );
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
 
         var declaration = model.StartBlock;
 
         Assert.Contains("ApiException", declaration.Usings.Select(x => x.Name));
         Assert.Equal("ApiException", declaration.Inherits.Name);
+        Assert.Contains("escapedMessage", model.Properties.Select(x => x.Name));
+        Assert.Contains("escapedCode", model.Properties.Select(x => x.Name));
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -93,6 +93,23 @@ public class PhpLanguageRefinerTests
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
         Assert.NotEmpty(model.StartBlock.Usings);
     }
+    
+    [Fact]
+    public async Task AddsExceptionInheritanceOnErrorClasses()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "SomeModel",
+            Kind = CodeClassKind.Model,
+            IsErrorDefinition = true,
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+
+        var declaration = model.StartBlock;
+
+        Assert.Contains("ApiException", declaration.Usings.Select(x => x.Name));
+        Assert.Equal("ApiException", declaration.Inherits.Name);
+    }
 
     [Fact]
     public async Task ChangesBackingStoreParameterTypeInApiClientConstructor()


### PR DESCRIPTION
- Exception fields replacements.
- Add CHANGELOG entry.
