### PR TITLE
Fixes error in generated dependency installations for .NET code.

### DIFF
--- a/src/Kiota.Web/wwwroot/appsettings.json
+++ b/src/Kiota.Web/wwwroot/appsettings.json
@@ -249,7 +249,7 @@
           "Version": "0.1.10-preview.1"
         }
       ],
-      "DependencyInstallCommand": "dotnet add package {0} --version {1} --prerelease"
+      "DependencyInstallCommand": "dotnet add package {0} --version {1}"
     }
   }
 }

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -249,7 +249,7 @@
           "Version": "0.1.10-preview.1"
         }
       ],
-      "DependencyInstallCommand": "dotnet add package {0} --version {1} --prerelease"
+      "DependencyInstallCommand": "dotnet add package {0} --version {1}"
     }
   }
 }


### PR DESCRIPTION
Fixes #2265 - removes the `--prerelease` option from the `DependencyInstallCommand`