### PR TITLE
PHP - Add constructor to query parameter and request configuration classes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added constructors and query parameter factory methods to request configuration classes and constructors to query parameter classes in PHP.
 
 ### Changed
 
@@ -29,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added constructors to request configuration and query parameter classes in PHP.
 - Updated the client constructor to set the base_url in path parameters from RequestAdapter's base_url(Python) [#2128](https://github.com/microsoft/kiota/issues/2128)
 - Added support for Raw Url in Request Builders for PHP Generation. [2205](https://github.com/microsoft/kiota/issues/2205)
 - Added support for external documentation links on request execution methods (PHP Generation). [2038](https://github.com/microsoft/kiota/issues/2038)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added constructors to request configuration and query parameter classes in PHP.
 - Updated the client constructor to set the base_url in path parameters from RequestAdapter's base_url(Python) [#2128](https://github.com/microsoft/kiota/issues/2128)
 - Added support for Raw Url in Request Builders for PHP Generation. [2205](https://github.com/microsoft/kiota/issues/2205)
 - Added support for external documentation links on request execution methods (PHP Generation). [2038](https://github.com/microsoft/kiota/issues/2038)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -228,10 +228,6 @@ public class PhpRefiner : CommonLanguageRefiner
             method.ReturnType.Name = "array";
             method.ReturnType.IsNullable = _configuration.UsesBackingStore;
         }
-        if (method.IsOfKind(CodeMethodKind.RequestExecutor))
-        {
-            method.ReturnType.Name = "Promise";
-        }
         CorrectCoreTypes(method.Parent as CodeClass, DateTypesReplacements, method.Parameters
             .Select(static x => x.Type)
             .Union(new[] { method.ReturnType })

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -316,9 +316,9 @@ public class PhpRefiner : CommonLanguageRefiner
             if (codeClass.IsOfKind(CodeClassKind.RequestConfiguration))
             {
                 constructor.AddParameter(propertyKindToParameterKind.Keys.Select(x => codeClass.GetPropertyOfKind(x))
-                    .Where(static x => x != null);
+                    .Where(static x => x != null)
                     .Select(static x =>
-                    (new CodeParameter
+                    new CodeParameter
                     {
                         DefaultValue = x!.DefaultValue,
                         Documentation = x.Documentation,

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -315,7 +315,6 @@ public class PhpRefiner : CommonLanguageRefiner
                     { CodePropertyKind.Options, CodeParameterKind.Options },
                     { CodePropertyKind.QueryParameters, CodeParameterKind.QueryParameter },
                 };
-                
                 var properties = propertyKindToParameterKind.Keys.Select(x => codeClass.GetPropertyOfKind(x))
                     .Where(x => x != null);
                 foreach (var property in properties)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -343,7 +343,7 @@ public class PhpRefiner : CommonLanguageRefiner
                         Optional = true,
                         Type = x.Type
                     });
-                constructorParams.ToList().ForEach(x => constructor.AddParameter(x));
+                constructor.AddParameter(constructorParams.ToArray());
             }
         }
         CrawlTree(codeElement, AddRequestConfigurationConstructors);

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -226,7 +226,7 @@ public class PhpRefiner : CommonLanguageRefiner
             && method.AccessedProperty.IsOfKind(CodePropertyKind.AdditionalData))
         {
             method.ReturnType.Name = "array";
-            method.ReturnType.IsNullable = _configuration.UsesBackingStore;
+            method.ReturnType.IsNullable = true;
         }
         CorrectCoreTypes(method.Parent as CodeClass, DateTypesReplacements, method.Parameters
             .Select(static x => x.Type)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -286,6 +286,12 @@ public class PhpRefiner : CommonLanguageRefiner
         CrawlTree(codeElement, CorrectBackingStoreSetterParam);
     }
 
+    private static readonly Dictionary<CodePropertyKind, CodeParameterKind> propertyKindToParameterKind = new Dictionary<CodePropertyKind, CodeParameterKind>()
+    {
+        { CodePropertyKind.Headers, CodeParameterKind.Headers },
+        { CodePropertyKind.Options, CodeParameterKind.Options },
+        { CodePropertyKind.QueryParameters, CodeParameterKind.QueryParameter },
+    };
     private static void AddRequestConfigurationConstructors(CodeElement codeElement)
     {
         if (codeElement is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration, CodeClassKind.QueryParameters))
@@ -309,12 +315,6 @@ public class PhpRefiner : CommonLanguageRefiner
 
             if (codeClass.IsOfKind(CodeClassKind.RequestConfiguration))
             {
-                var propertyKindToParameterKind = new Dictionary<CodePropertyKind, CodeParameterKind>()
-                {
-                    { CodePropertyKind.Headers, CodeParameterKind.Headers },
-                    { CodePropertyKind.Options, CodeParameterKind.Options },
-                    { CodePropertyKind.QueryParameters, CodeParameterKind.QueryParameter },
-                };
                 var properties = propertyKindToParameterKind.Keys.Select(x => codeClass.GetPropertyOfKind(x))
                     .Where(x => x != null);
                 foreach (var property in properties)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -373,7 +373,7 @@ public class PhpRefiner : CommonLanguageRefiner
             {
                 var queryParamFactoryMethod = new CodeMethod
                 {
-                    Name = "withQueryParameters",
+                    Name = "addQueryParameters",
                     IsStatic = true,
                     Access = AccessModifier.Public,
                     Kind = CodeMethodKind.Factory,

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -315,20 +315,19 @@ public class PhpRefiner : CommonLanguageRefiner
 
             if (codeClass.IsOfKind(CodeClassKind.RequestConfiguration))
             {
-                var properties = propertyKindToParameterKind.Keys.Select(x => codeClass.GetPropertyOfKind(x))
-                    .Where(x => x != null);
-                foreach (var property in properties)
-                {
-                    constructor.AddParameter(new CodeParameter
+                constructor.AddParameter(propertyKindToParameterKind.Keys.Select(x => codeClass.GetPropertyOfKind(x))
+                    .Where(static x => x != null);
+                    .Select(static x =>
+                    (new CodeParameter
                     {
-                        DefaultValue = property!.DefaultValue,
-                        Documentation = property.Documentation,
-                        Name = property.Name,
-                        Kind = propertyKindToParameterKind[property.Kind],
+                        DefaultValue = x!.DefaultValue,
+                        Documentation = x.Documentation,
+                        Name = x.Name,
+                        Kind = propertyKindToParameterKind[x.Kind],
                         Optional = true,
-                        Type = property.Type
-                    });
-                }
+                        Type = x.Type
+                    })
+                    .ToArray());
             }
 
             if (codeClass.IsOfKind(CodeClassKind.QueryParameters))

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -377,9 +377,8 @@ public class PhpRefiner : CommonLanguageRefiner
                     {
                         Description = $"Instantiates a new {queryParameterProperty.Type.Name}."
                     },
-                    ReturnType = queryParameterProperty.Type
+                    ReturnType = new CodeType { Name = queryParameterProperty.Type.Name, TypeDefinition = queryParameterProperty.Type, IsNullable = false }
                 };
-                queryParamFactoryMethod.ReturnType.IsNullable = false;
                 if (queryParameterProperty.Type is CodeType codeType && codeType.TypeDefinition is CodeClass queryParamsClass)
                 {
                     var properties = queryParamsClass.GetPropertiesOfKind(CodePropertyKind.QueryParameter);

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -188,7 +188,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (!isVoidable)
             returnDocString = (codeMethod.Kind == CodeMethodKind.RequestExecutor)
                 ? "@return Promise"
-                : $"@return {returnDocString}{(codeMethod.ReturnType.IsNullable? "|null" : "")}";
+                : $"@return {returnDocString}{(codeMethod.ReturnType.IsNullable ? "|null" : "")}";
         else returnDocString = String.Empty;
         conventions.WriteLongDescription(codeMethod.Documentation,
             writer,
@@ -245,7 +245,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             return;
         }
         var isVoidable = "void".Equals(conventions.GetTypeString(codeMethod.ReturnType, codeMethod), StringComparison.OrdinalIgnoreCase);
-        var optionalCharacterReturn = (codeMethod.ReturnType.IsNullable && !isVoidable) ? "?": "";
+        var optionalCharacterReturn = (codeMethod.ReturnType.IsNullable && !isVoidable) ? "?" : "";
         var returnValue = isConstructor ? string.Empty : $": {optionalCharacterReturn}{conventions.GetTypeString(codeMethod.ReturnType, codeMethod)}";
         if (isConstructor && codeMethod.Parent is CodeClass @class && @class.IsOfKind(CodeClassKind.RequestBuilder))
         {

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -235,9 +235,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         };
         var isVoid = "void".Equals(conventions.GetTypeString(codeMethod.ReturnType, codeMethod), StringComparison.OrdinalIgnoreCase);
         var optionalCharacterReturn = (codeMethod.ReturnType.IsNullable && !isVoid) ? "?" : "";
-        var returnValue = isConstructor ? string.Empty : $": {optionalCharacterReturn}{conventions.GetTypeString(codeMethod.ReturnType, codeMethod)}";
+        var returnValue = (codeMethod.Kind == CodeMethodKind.RequestExecutor) ? "Promise" : $"{optionalCharacterReturn}{conventions.GetTypeString(codeMethod.ReturnType, codeMethod)}";
         writer.WriteLine($"{conventions.GetAccessModifier(codeMethod.Access)} {(codeMethod.IsStatic ? "static " : string.Empty)}"
-            + $"function {methodName}({methodParameters}){returnValue} {{");
+            + $"function {methodName}({methodParameters}){(isConstructor ? "" : $": {returnValue}")} {{");
         writer.IncreaseIndent();
     }
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -114,7 +114,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         // Handles various query parameter properties in query parameter classes
         // Separate call because CodeParameterKind.QueryParameter key is already used in map initialization
         AssignPropertyFromParameter(parentClass, currentMethod, CodeParameterKind.QueryParameter, CodePropertyKind.QueryParameter, writer);
-        
+
         if (parentClass.IsOfKind(CodeClassKind.RequestBuilder) &&
             currentMethod.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor) &&
             currentMethod.Parameters.OfKind(CodeParameterKind.PathParameters) is CodeParameter pathParametersParameter &&

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1465,7 +1465,6 @@ public class CodeMethodWriterTests : IDisposable
 
         Assert.Contains("$this->backingStore = BackingStoreFactorySingleton::getInstance()->createBackingStore();", result);
     }
-    
     [Fact]
     public async void WritesGettersAndSettersWithBackingStore()
     {
@@ -1973,7 +1972,6 @@ public class CodeMethodWriterTests : IDisposable
             }
         };
     }
-    
     [Fact]
     public async void WritesRequestConfigurationConstructor()
     {
@@ -2050,7 +2048,6 @@ public class CodeMethodWriterTests : IDisposable
         Assert.NotEmpty(constructor);
         _codeMethodWriter.WriteCodeElement(constructor.First(), languageWriter);
         var result = stringWriter.ToString();
-        
         // params sorted in ascending order by default
         Assert.Contains("public function __construct(?bool $count = null, ?array $select = null, ?int $top = null)", result);
         Assert.Contains("$this->count = $count;", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1465,7 +1465,7 @@ public class CodeMethodWriterTests : IDisposable
 
         Assert.Contains("$this->backingStore = BackingStoreFactorySingleton::getInstance()->createBackingStore();", result);
     }
-
+    
     [Fact]
     public async void WritesGettersAndSettersWithBackingStore()
     {
@@ -1973,4 +1973,89 @@ public class CodeMethodWriterTests : IDisposable
             }
         };
     }
+    
+    [Fact]
+    public async void WritesRequestConfigurationConstructor()
+    {
+        var queryParamClass = new CodeClass { Name = "TestRequestQueryParameter", Kind = CodeClassKind.QueryParameters };
+        root.AddClass(queryParamClass);
+        parentClass.Kind = CodeClassKind.RequestConfiguration;
+        parentClass.AddProperty( new [] {
+            new CodeProperty
+            {
+                Name = "queryParameters",
+                Kind = CodePropertyKind.QueryParameters,
+                Documentation = new() { Description = "Request query parameters", },
+                Type = new CodeType { Name = queryParamClass.Name, TypeDefinition = queryParamClass },
+            },
+            new CodeProperty
+            {
+                Name = "headers",
+                Access = AccessModifier.Public,
+                Kind = CodePropertyKind.Headers,
+                Documentation = new() { Description = "Request headers", },
+                Type = new CodeType { Name = "RequestHeaders", IsExternal = true },
+            },
+            new CodeProperty
+            {
+                Name = "options",
+                Kind = CodePropertyKind.Options,
+                Documentation = new() { Description = "Request options", },
+                Type = new CodeType { Name = "IList<IRequestOption>", IsExternal = true },
+            }
+        });
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+        _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
+        var constructor = parentClass.GetMethodsOffKind(CodeMethodKind.Constructor).ToList();
+        Assert.NotEmpty(constructor);
+        _codeMethodWriter.WriteCodeElement(constructor.First(), languageWriter);
+        var result = stringWriter.ToString();
+
+        Assert.Contains("public function __construct(?array $headers = null, ?array $options = null, ?TestRequestQueryParameter $queryParameters = null)", result);
+        Assert.Contains("$this->headers = $headers;", result);
+        Assert.Contains("$this->options = $options;", result);
+        Assert.Contains("$this->queryParameters = $queryParameters;", result);
+    }
+
+    [Fact]
+    public async void WritesQueryParameterConstructor()
+    {
+        parentClass.Kind = CodeClassKind.QueryParameters;
+        parentClass.AddProperty( new [] {
+            new CodeProperty
+            {
+                Name = "select",
+                Kind = CodePropertyKind.QueryParameter,
+                Documentation = new() { Description = "Select properties to be returned", },
+                Type = new CodeType { Name = "string", CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array },
+            },
+            new CodeProperty
+            {
+                Name = "count",
+                Kind = CodePropertyKind.QueryParameter,
+                Documentation = new() { Description = "Include count of items", },
+                Type = new CodeType { Name = "boolean" },
+            },
+            new CodeProperty
+            {
+                Name = "top",
+                Kind = CodePropertyKind.QueryParameter,
+                Documentation = new() { Description = "Show only the first n items", },
+                Type = new CodeType { Name = "integer" },
+            }
+        });
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+        _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
+        var constructor = parentClass.GetMethodsOffKind(CodeMethodKind.Constructor).ToList();
+        Assert.NotEmpty(constructor);
+        _codeMethodWriter.WriteCodeElement(constructor.First(), languageWriter);
+        var result = stringWriter.ToString();
+        
+        // params sorted in ascending order by default
+        Assert.Contains("public function __construct(?bool $count = null, ?array $select = null, ?int $top = null)", result);
+        Assert.Contains("$this->count = $count;", result);
+        Assert.Contains("$this->select = $select;", result);
+        Assert.Contains("$this->top = $top;", result);
+    }
+
 }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1978,7 +1978,7 @@ public class CodeMethodWriterTests : IDisposable
         var queryParamClass = new CodeClass { Name = "TestRequestQueryParameter", Kind = CodeClassKind.QueryParameters };
         root.AddClass(queryParamClass);
         parentClass.Kind = CodeClassKind.RequestConfiguration;
-        parentClass.AddProperty( new [] {
+        parentClass.AddProperty(new[] {
             new CodeProperty
             {
                 Name = "queryParameters",
@@ -2002,7 +2002,7 @@ public class CodeMethodWriterTests : IDisposable
                 Type = new CodeType { Name = "IList<IRequestOption>", IsExternal = true },
             }
         });
-        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true }, root);
         _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
         var constructor = parentClass.GetMethodsOffKind(CodeMethodKind.Constructor).ToList();
         Assert.NotEmpty(constructor);
@@ -2019,7 +2019,7 @@ public class CodeMethodWriterTests : IDisposable
     public async void WritesQueryParameterConstructor()
     {
         parentClass.Kind = CodeClassKind.QueryParameters;
-        parentClass.AddProperty( new [] {
+        parentClass.AddProperty(new[] {
             new CodeProperty
             {
                 Name = "select",
@@ -2042,7 +2042,7 @@ public class CodeMethodWriterTests : IDisposable
                 Type = new CodeType { Name = "integer" },
             }
         });
-        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true}, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true }, root);
         _codeMethodWriter = new CodeMethodWriter(new PhpConventionService(), true);
         var constructor = parentClass.GetMethodsOffKind(CodeMethodKind.Constructor).ToList();
         Assert.NotEmpty(constructor);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -197,7 +197,7 @@ public class CodeMethodWriterTests : IDisposable
     }
 
     [Fact]
-    public void WriteRequestExecutor()
+    public async void WriteRequestExecutor()
     {
         CodeProperty[] properties =
         {
@@ -250,10 +250,11 @@ public class CodeMethodWriterTests : IDisposable
         codeMethod.AddErrorMapping("4XX", new CodeType { Name = "Error4XX", TypeDefinition = error4XX });
         codeMethod.AddErrorMapping("5XX", new CodeType { Name = "Error5XX", TypeDefinition = error5XX });
         codeMethod.AddErrorMapping("403", new CodeType { Name = "Error403", TypeDefinition = error401 });
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
         _codeMethodWriter.WriteCodeElement(codeMethod, languageWriter);
         var result = stringWriter.ToString();
 
-        Assert.Contains("Promise", result);
+        Assert.Contains("public function post(): Promise", result);
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
         Assert.Contains("RejectedPromise", result);
         Assert.Contains("@link https://learn.microsoft.com/ Learning", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -975,7 +975,7 @@ public class CodeMethodWriterTests : IDisposable
     }
 
     [Fact]
-    public void WriteGetterAdditionalData()
+    public async void WriteGetterAdditionalData()
     {
         var getter = new CodeMethod
         {
@@ -986,7 +986,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             ReturnType = new CodeType
             {
-                Name = "additionalData",
+                Name = "IDictionary<string, object>",
                 IsNullable = false
             },
             Kind = CodeMethodKind.Getter,
@@ -1000,9 +1000,10 @@ public class CodeMethodWriterTests : IDisposable
                     Name = "additionalData"
                 }
             },
-            Parent = parentClass
         };
+        parentClass.AddMethod(getter);
 
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true }, root);
         _codeMethodWriter.WriteCodeElement(getter, languageWriter);
         var result = stringWriter.ToString();
         Assert.Contains("public function getAdditionalData(): ?array", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -2062,7 +2062,7 @@ public class CodeMethodWriterTests : IDisposable
         _codeMethodWriter.WriteCodeElement(constructor.First(), languageWriter);
         var result = stringWriter.ToString();
 
-        Assert.Contains("public static function withQueryParameters(?bool $count = null, ?array $select = null, ?int $top = null)", result);
+        Assert.Contains("public static function addQueryParameters(?bool $count = null, ?array $select = null, ?int $top = null)", result);
         Assert.Contains("return new TestRequestQueryParameter($count, $select, $top);", result);
     }
 

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1004,7 +1004,7 @@ public class CodeMethodWriterTests : IDisposable
         };
         parentClass.AddMethod(getter);
 
-        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP, UsesBackingStore = true }, root);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
         _codeMethodWriter.WriteCodeElement(getter, languageWriter);
         var result = stringWriter.ToString();
         Assert.Contains("public function getAdditionalData(): ?array", result);


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-php/issues/952

### Context
Constructors will provide an autocompletion experience for PHP 8 developers that reduces the confusion when figuring out which query parameter namespace to import from.
It allows us to initialise the object inline while leveraging PHP 8's [named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments)
```php

$messages = $graphServiceClient->usersById(USER_ID)->messages()->get(new MessagesRequestBuilderGetRequestConfiguration(
        queryParameters: new MessagesRequestBuilderGetQueryParameters(
            select: [],
            top: 10
        )
    ));
```

### Generation Diff
Adds request config constructors:
![image](https://user-images.githubusercontent.com/10958912/217498755-536c3c8b-70d7-46cd-8b75-72eaa5bad243.png)

Adds query param constructors:
![image](https://user-images.githubusercontent.com/10958912/217498922-43c56792-9e6a-44a7-8bda-2362d4a53aef.png)

Adds query parameter factory methods in the request configuration classes:
![image](https://user-images.githubusercontent.com/10958912/218947742-a8891ef0-ea99-4165-a8cc-7e143c445d6c.png)


generation diff: https://github.com/microsoft/kiota-samples/pull/1608