### PR TITLE
add koros to the github codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @andrueastman @baywet @darrelmiller @zengin @MichaelMainer @ddyett @peombwa @ramsessanchez @calebkiage @Ndiritu @rkodev @gavinbarron @coseguera
+* @andrueastman @baywet @darrelmiller @zengin @MichaelMainer @ddyett @peombwa @ramsessanchez @calebkiage @Ndiritu @rkodev @gavinbarron @coseguera @koros


### PR DESCRIPTION
This PR contains changes to add koros to the codowner list