### PR TITLE
PHP - Add `getResponseStatusCode` to PHP exceptions reserved names provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for multi-valued headers in Python. [#2051](https://github.com/microsoft/kiota/issues/2051)
+- Added `getResponseStatusCode` to PHP exceptions reserved names provider. [#2243](https://github.com/microsoft/kiota/issues/2243)
 
 ### Changed
 

--- a/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/PhpExceptionsReservedNamesProvider.cs
@@ -20,6 +20,7 @@ public class PhpExceptionsReservedNamesProvider : IReservedNamesProvider
         "getLine",
         "getTrace",
         "getTraceAsString",
+        "getResponseStatusCode",
     });
     public HashSet<string> ReservedNames => _reservedNames.Value;
 }


### PR DESCRIPTION
part of https://github.com/microsoft/kiota/issues/2243