### PR TITLE
PHP - Make getAdditionalData return type nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where go refiner would fail with a null reference.
+- Fixed a bug where PHP model getAdditionalData() would not return nullable types.
 
 ## [0.11.1] - 2023-02-13
 

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -183,7 +183,7 @@ public class PhpRefiner : CommonLanguageRefiner
         else if (currentProperty.IsOfKind(CodePropertyKind.AdditionalData))
         {
             currentProperty.Type.Name = "array";
-            currentProperty.Type.IsNullable = false;
+            currentProperty.Type.IsNullable = true;
             currentProperty.DefaultValue = "[]";
             currentProperty.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex;
         }
@@ -220,13 +220,6 @@ public class PhpRefiner : CommonLanguageRefiner
         if (method.IsOfKind(CodeMethodKind.Deserializer))
         {
             method.ReturnType.Name = "array";
-        }
-        if (method.IsOfKind(CodeMethodKind.Getter)
-            && method.AccessedProperty != null
-            && method.AccessedProperty.IsOfKind(CodePropertyKind.AdditionalData))
-        {
-            method.ReturnType.Name = "array";
-            method.ReturnType.IsNullable = true;
         }
         CorrectCoreTypes(method.Parent as CodeClass, DateTypesReplacements, method.Parameters
             .Select(static x => x.Type)

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -978,33 +978,21 @@ public class CodeMethodWriterTests : IDisposable
     [Fact]
     public async void WriteGetterAdditionalData()
     {
-        var getter = new CodeMethod
+        var property = new CodeProperty
         {
-            Name = "getAdditionalData",
-            Documentation = new()
+            Name = "additionalData",
+            Access = AccessModifier.Private,
+            Kind = CodePropertyKind.AdditionalData,
+            Type = new CodeType
             {
-                Description = "This method gets the emailAddress",
-            },
-            ReturnType = new CodeType
-            {
-                Name = "IDictionary<string, object>",
-                IsNullable = false
-            },
-            Kind = CodeMethodKind.Getter,
-            AccessedProperty = new CodeProperty
-            {
-                Name = "additionalData",
-                Access = AccessModifier.Private,
-                Kind = CodePropertyKind.AdditionalData,
-                Type = new CodeType
-                {
-                    Name = "additionalData"
-                }
-            },
+                Name = "additionalData"
+            }
         };
-        parentClass.AddMethod(getter);
+        parentClass.AddProperty(property);
 
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
+        var getter = parentClass.GetMethodsOffKind(CodeMethodKind.Getter)
+            .First(x => x.AccessedProperty != null && x.AccessedProperty.IsOfKind(CodePropertyKind.AdditionalData));
         _codeMethodWriter.WriteCodeElement(getter, languageWriter);
         var result = stringWriter.ToString();
         Assert.Contains("public function getAdditionalData(): ?array", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
@@ -101,8 +101,8 @@ public class CodePropertyWriterTests
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
         propertyWriter.WriteCodeElement(property, languageWriter);
         var result = stringWriter.ToString();
-        Assert.Contains("private array $additionalData;", result);
-        Assert.Contains("@var array<string, mixed>", result);
+        Assert.Contains("private ?array $additionalData = null;", result);
+        Assert.Contains("@var array<string, mixed>|null", result);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/microsoft/kiota/pull/2280 where changing the method return type was not happening since it was being performed before getters are added to the class from the properties.

This PR makes the property type nullable which translates to the getter return type also being nullable.

Updated samples https://github.com/microsoft/kiota-samples/pull/1608