### PR TITLE
Fixes inconsistent request builder generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added constructors and query parameter factory methods to request configuration classes and constructors to query parameter classes in PHP.
 
 ### Changed
 
 - Fixed a bug where go refiner would fail with a null reference.
+- Fixes a bug where request builders would be incorrectly generated due to inconsistent suffix generation
 
 ## [0.11.1] - 2023-02-13
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -502,7 +502,7 @@ public class KiotaBuilder
         foreach (var child in currentNode.Children)
         {
             var propIdentifier = child.Value.GetNavigationPropertyName(config.StructuredMimeTypes);
-            var propType = child.Value.DoesNodeBelongToItemSubnamespace() ? propIdentifier + itemRequestBuilderSuffix : propIdentifier + requestBuilderSuffix;
+            var propType = child.Value.DoesNodeBelongToItemSubnamespace() ? child.Value.GetNavigationPropertyName(config.StructuredMimeTypes, itemRequestBuilderSuffix) : child.Value.GetNavigationPropertyName(config.StructuredMimeTypes, requestBuilderSuffix);
 
             if (child.Value.IsPathSegmentWithSingleSimpleParameter())
                 codeClass.Indexer = CreateIndexer($"{propIdentifier}-indexer", propType, child.Value, currentNode);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -502,7 +502,7 @@ public class KiotaBuilder
         foreach (var child in currentNode.Children)
         {
             var propIdentifier = child.Value.GetNavigationPropertyName(config.StructuredMimeTypes);
-            var propType = child.Value.DoesNodeBelongToItemSubnamespace() ? child.Value.GetNavigationPropertyName(config.StructuredMimeTypes, itemRequestBuilderSuffix) : child.Value.GetNavigationPropertyName(config.StructuredMimeTypes, requestBuilderSuffix);
+            var propType = child.Value.GetNavigationPropertyName(config.StructuredMimeTypes, child.Value.DoesNodeBelongToItemSubnamespace() ? itemRequestBuilderSuffix : requestBuilderSuffix);
 
             if (child.Value.IsPathSegmentWithSingleSimpleParameter())
                 codeClass.Indexer = CreateIndexer($"{propIdentifier}-indexer", propType, child.Value, currentNode);

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -5026,7 +5026,6 @@ components:
 
         File.Delete(tempFilePath);
     }
-    
     [Fact]
     public async Task IndexerAndRequestBuilderNamesMatch()
     {
@@ -5063,19 +5062,14 @@ components:
         var node = builder.CreateUriSpace(document!);
         var codeModel = builder.CreateSourceModel(node);
         var collectionRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.me.posts");
-        
         Assert.NotNull(collectionRequestBuilderNamespace);
         var collectionRequestBuilder = collectionRequestBuilderNamespace.FindChildByName<CodeClass>("postsRequestBuilder");
         var collectionIndexer = collectionRequestBuilder.Indexer;
-        
         Assert.NotNull(collectionIndexer);
         var itemRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.me.posts.item");
-        
         Assert.NotNull(itemRequestBuilderNamespace);
         var itemRequestBuilder = itemRequestBuilderNamespace.FindChildByName<CodeClass>("postItemRequestBuilder");
-        
-        Assert.Equal(collectionIndexer.ReturnType.Name,itemRequestBuilder.Name);
-
+        Assert.Equal(collectionIndexer.ReturnType.Name, itemRequestBuilder.Name);
         File.Delete(tempFilePath);
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -5026,4 +5026,56 @@ components:
 
         File.Delete(tempFilePath);
     }
+    
+    [Fact]
+    public async Task IndexerAndRequestBuilderNamesMatch()
+    {
+        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+        await File.WriteAllTextAsync(tempFilePath, @"openapi: 3.0.0
+info:
+  title: Microsoft Graph get user API
+  version: 1.0.0
+servers:
+  - url: https://graph.microsoft.com/v1.0/
+paths:
+  /me/posts/{post-id}:
+    get:
+      responses:
+        200:
+          description: Success!
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.post'
+components:
+  schemas:
+    microsoft.graph.post:
+      type: object
+      properties:
+        id:
+          type: string
+        displayName:
+          type: string");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath }, _httpClient);
+        await using var fs = new FileStream(tempFilePath, FileMode.Open);
+        var document = builder.CreateOpenApiDocument(fs);
+        var node = builder.CreateUriSpace(document!);
+        var codeModel = builder.CreateSourceModel(node);
+        var collectionRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.me.posts");
+        
+        Assert.NotNull(collectionRequestBuilderNamespace);
+        var collectionRequestBuilder = collectionRequestBuilderNamespace.FindChildByName<CodeClass>("postsRequestBuilder");
+        var collectionIndexer = collectionRequestBuilder.Indexer;
+        
+        Assert.NotNull(collectionIndexer);
+        var itemRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.me.posts.item");
+        
+        Assert.NotNull(itemRequestBuilderNamespace);
+        var itemRequestBuilder = itemRequestBuilderNamespace.FindChildByName<CodeClass>("postItemRequestBuilder");
+        
+        Assert.Equal(collectionIndexer.ReturnType.Name,itemRequestBuilder.Name);
+
+        File.Delete(tempFilePath);
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where request builder would be inconsistently generated due to the code below adding the requestBuilder suffix by calling `GetNavigationPropertyName`, 

https://github.com/microsoft/kiota/blob/ff77c899ac3e6ebdebe288b4a18a98ada242140e/src/Kiota.Builder/KiotaBuilder.cs#L487

This causes inconsistency as the indexer appends the suffix to the result of the  `GetNavigationPropertyName` without passing the suffix parameter causing the generation of an indexer called `PostPathRequestBuilder` and a type called `PostItemRequestBuilder`. 

This PR therefore aligns the type name generation to avoid compile issues detected due to this scenario.