### PR TITLE
Java - Normalize CodeIndexer return types and errorMappings' types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fixed a bug where a CLI client would not set the content types for requests. (Shell)
 
 - Fixed a bug where boolean or number enums would be mapped to enums instead of primitive types. [#2367](https://github.com/microsoft/kiota/issues/2367)
 - Fixed a bug where CSharp inherited constructor name was incorrect. [#2351](https://github.com/microsoft/kiota/issues/2351)
 - Fixed a bug where java refiner would emit method's parameters types without normalizing the name.
+- Fixed a bug where java refiner would emit incorrect returning types without normalizing the name.
 
 ## [1.0.1] - 2023-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where boolean or number enums would be mapped to enums instead of primitive types. [#2367](https://github.com/microsoft/kiota/issues/2367)
 - Fixed a bug where CSharp inherited constructor name was incorrect. [#2351](https://github.com/microsoft/kiota/issues/2351)
 - Fixed a bug where java refiner would emit method's parameters types without normalizing the name.
-- Fixed a bug where java refiner would emit incorrect returning types without normalizing the name.
+- Fixed a bug where java refiner would emit incorrect returning types and error mappings without normalizing the name.
 
 ## [1.0.1] - 2023-03-11
 

--- a/it/config.json
+++ b/it/config.json
@@ -64,10 +64,6 @@
         "Rationale": "https://github.com/microsoft/kiota/issues/2360"
       },
       {
-        "Language": "java",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2372"
-      },
-      {
         "Language": "php",
         "Rationale": "https://github.com/microsoft/kiota/issues/2378"
       }
@@ -133,10 +129,6 @@
       }
     ],
     "Suppressions": [
-      {
-        "Language": "java",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2372"
-      },
       {
         "Language": "php",
         "Rationale": "https://github.com/microsoft/kiota/issues/2378"
@@ -284,10 +276,6 @@
         "Rationale": "https://github.com/microsoft/kiota/issues/2369"
       },
       {
-        "Language": "java",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2372"
-      },
-      {
         "Language": "php",
         "Rationale": "https://github.com/microsoft/kiota/issues/2378"
       },
@@ -299,10 +287,6 @@
   },
   "https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/twitter.com/current/2.61/openapi.yaml": {
     "Suppressions": [
-      {
-        "Language": "java",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2372"
-      },
       {
         "Language": "typescript",
         "Rationale": "https://github.com/microsoft/kiota/issues/1812"

--- a/it/java/test.java
+++ b/it/java/test.java
@@ -1,10 +1,10 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS com.microsoft.kiota:microsoft-kiota-abstractions:0.3.0
-//DEPS com.microsoft.kiota:microsoft-kiota-serialization-json:0.3.0
-//DEPS com.microsoft.kiota:microsoft-kiota-serialization-text:0.3.0
-//DEPS com.microsoft.kiota:microsoft-kiota-serialization-form:0.3.0
-//DEPS com.google.code.findbugs:jsr305:3.0.0
+//DEPS com.microsoft.kiota:microsoft-kiota-abstractions:0.3.1
+//DEPS com.microsoft.kiota:microsoft-kiota-serialization-json:0.3.1
+//DEPS com.microsoft.kiota:microsoft-kiota-serialization-text:0.3.1
+//DEPS com.microsoft.kiota:microsoft-kiota-serialization-form:0.3.1
+//DEPS com.google.code.findbugs:jsr305:3.0.2
 //SOURCES src/**/*.java
 
 import static java.lang.System.*;

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -134,7 +134,7 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
             "Microsoft.Kiota.Abstractions.Store",  "IBackingStore", "IBackedModel", "BackingStoreFactorySingleton" ),
         new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(prop.SerializationName),
             "Microsoft.Kiota.Abstractions", "QueryParameterAttribute"),
-        new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal) && intersectionType.DiscriminatorInformation.HasBasicDiscriminatorInformation,
+        new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal),
             "Microsoft.Kiota.Abstractions.Serialization", "ParseNodeHelper"),
         new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.Headers),
             "Microsoft.Kiota.Abstractions", "RequestHeaders"),

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -144,6 +144,14 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     param.Type.Name = refinedTypeName;
                 }
             };
+            foreach (var errorMapping in currentMethod.ErrorMappings)
+            {
+                if (refineName(errorMapping.Value.Name) is string refinedTypeName &&
+                    !errorMapping.Value.Name.Equals(refinedTypeName, StringComparison.Ordinal))
+                {
+                    errorMapping.Value.Name = refinedTypeName;
+                }
+            }
             if (refineName(currentMethod.ReturnType.Name) is string refinedMethodTypeName &&
                 !currentMethod.ReturnType.Name.Equals(refinedMethodTypeName, StringComparison.Ordinal))
             {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -120,6 +120,12 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         {
             currentClass.Name = refinedClassName;
         }
+        else if (current is CodeIndexer currentIndexer &&
+                refineName(currentIndexer.ReturnType.Name) is string refinedIndexerName &&
+                !currentIndexer.ReturnType.Name.Equals(refinedIndexerName, StringComparison.Ordinal))
+        {
+            currentIndexer.ReturnType.Name = refinedIndexerName;
+        }
         else if (current is CodeProperty currentProperty &&
                 classNames &&
                 refineName(currentProperty.Type.Name) is string refinedPropertyTypeName &&

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -216,7 +216,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "com.microsoft.kiota", "QueryParameter"),
         new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.Headers),
                 "com.microsoft.kiota", "RequestHeaders"),
-        new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal) && intersectionType.DiscriminatorInformation.HasBasicDiscriminatorInformation,
+        new (static x => x is CodeClass @class && @class.OriginalComposedType is CodeIntersectionType intersectionType && intersectionType.Types.Any(static y => !y.IsExternal),
             "com.microsoft.kiota.serialization", "ParseNodeHelper"),
     };
     private static void CorrectPropertyType(CodeProperty currentProperty)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -168,7 +168,7 @@ public class PhpRefiner : CommonLanguageRefiner
         new(x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor), "Microsoft\\Kiota\\Abstractions", "ApiClientBuilder"),
         new(x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), "Microsoft\\Kiota\\Abstractions", "QueryParameter"),
         new(x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration), "Microsoft\\Kiota\\Abstractions", "RequestOption"),
-        new (static x => x is CodeClass { OriginalComposedType: CodeIntersectionType intersectionType } && intersectionType.Types.Any(static y => !y.IsExternal) && intersectionType.DiscriminatorInformation.HasBasicDiscriminatorInformation,
+        new (static x => x is CodeClass { OriginalComposedType: CodeIntersectionType intersectionType } && intersectionType.Types.Any(static y => !y.IsExternal),
             "Microsoft\\Kiota\\Serialization", "ParseNodeHelper"),
     };
     private static void CorrectPropertyType(CodeProperty currentProperty)


### PR DESCRIPTION
This should finally completely fix #2372

Depends on #2411 for the suppression removals.