### PR TITLE
Fix for failed lookups by `GetReferenceIdFromOriginalSchema` in multilevel AllOfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where lookup of reference ids failed for AllOf more than one level up.
 - Fixed a bug where a CLI client would not set the content types for requests. (Shell)
-
 - Fixed a bug where boolean or number enums would be mapped to enums instead of primitive types. [#2367](https://github.com/microsoft/kiota/issues/2367)
 - Fixed a bug where CSharp inherited constructor name was incorrect. [#2351](https://github.com/microsoft/kiota/issues/2351)
 - Fixed a bug where java refiner would emit method's parameters types without normalizing the name.

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1253,16 +1253,7 @@ public class KiotaBuilder
         if (string.IsNullOrEmpty(title)) return string.Empty;
         if (parentSchema.Reference?.Id?.EndsWith(title, StringComparison.OrdinalIgnoreCase) ?? false) return parentSchema.Reference.Id;
         if (parentSchema.Items?.Reference?.Id?.EndsWith(title, StringComparison.OrdinalIgnoreCase) ?? false) return parentSchema.Items.Reference.Id;
-        return (parentSchema.
-                        AllOf
-                        .FirstOrDefault(x => x.Reference?.Id?.EndsWith(title, StringComparison.OrdinalIgnoreCase) ?? false) ??
-                parentSchema.
-                        AnyOf
-                        .FirstOrDefault(x => x.Reference?.Id?.EndsWith(title, StringComparison.OrdinalIgnoreCase) ?? false) ??
-                parentSchema.
-                        OneOf
-                        .FirstOrDefault(x => x.Reference?.Id?.EndsWith(title, StringComparison.OrdinalIgnoreCase) ?? false))
-            ?.Reference?.Id;
+        return parentSchema.GetSchemaReferenceIds().FirstOrDefault(refId => refId.EndsWith(title, StringComparison.OrdinalIgnoreCase));
     }
     private CodeTypeBase CreateComposedModelDeclaration(OpenApiUrlTreeNode currentNode, OpenApiSchema schema, OpenApiOperation? operation, string suffixForInlineSchema, CodeNamespace codeNamespace, bool isRequestBody)
     {


### PR DESCRIPTION
Related to failed build at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=110434&view=results

Currently `GetReferenceIdFromOriginalSchema` function would lookup reference ids from AllOf definitions only one level up. 

In the event that a lookup was more than once level up across different namespaces, this would cause failed lookups resulting to model duplication due in the two namespaces causing build errors.

This PR updates the `GetReferenceIdFromOriginalSchema` function to call the `GetSchemaReferenceIds` function which will find referenceIds recursively through AllOfs OneOfs and AnyOfs. 

Generation run at 
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=110634&view=logs&j=09be00da-8404-5a6e-d496-3b97eba1ba4f&t=8df1ae88-b8fc-5f10-3e45-77a7724c8a3f

Related to https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/634