### PR TITLE
PHP - Fix base URL path parameter casing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,6 +44,7 @@ jobs:
         run: dotnet restore kiota.sln
       - name: Check formatting
         run: dotnet format --verify-no-changes
+        continue-on-error: true # locking until https://github.com/dotnet/sdk/issues/30742
       - name: Build
         run: dotnet build kiota.sln --no-restore
       - name: Install PlayWright browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where java writer would emit incorrect serialization values for escaped enums
 - Fixed a bug where java writer would emit incorrect type names in case of compound types
 - Fixed a bug where go refiner would emit incorrect code when inlining error parents
+- Fixed a bug in PHP where the base URL path parameter key didn't match the URI template.
 
 ## [1.0.1] - 2023-03-11
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -661,7 +661,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->setBaseUrl('{codeMethod.BaseUrl}');");
             writer.CloseBlock();
             if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty)
-                writer.WriteLine($"{GetPropertyCall(pathParametersProperty, string.Empty)}['baseUrl'] = {GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl();");
+                writer.WriteLine($"{GetPropertyCall(pathParametersProperty, string.Empty)}['baseurl'] = {GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl();");
         }
         if (codeMethod.Parameters.OfKind(CodeParameterKind.BackingStore) is CodeParameter backingStoreParam)
             writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->enableBackingStore(${backingStoreParam.Name} ?? BackingStoreFactorySingleton::getInstance());");

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1357,7 +1357,7 @@ public class CodeMethodWriterTests : IDisposable
         var result = stringWriter.ToString();
         Assert.Contains("$this->requestAdapter = $requestAdapter", result);
         Assert.Contains("public function __construct(RequestAdapter $requestAdapter)", result);
-        Assert.Contains($"$this->pathParameters['baseUrl'] = $this->requestAdapter->getBaseUrl();", result);
+        Assert.Contains($"$this->pathParameters['baseurl'] = $this->requestAdapter->getBaseUrl();", result);
     }
 
     [Fact]


### PR DESCRIPTION
The URI template uses a lower-cased "baseurl" variable while our ApiClient constructor would set a camel-cased `baseUrl` path parameter property causing URL template expansion to fail.

This error wasn't previously discovered since when making requests via the fluent methods the RequestAdapter [sets the correct path parameter key](https://github.com/microsoft/kiota-http-guzzle-php/blob/dev/src/GuzzleRequestAdapter.php#L326) before a request is sent.

This bug was caught when making batch requests where individual RequestInformation objects from the request builders are unpacked into [BatchRequestItem](https://github.com/microsoftgraph/msgraph-sdk-php-core/blob/dev/src/Requests/BatchRequestItem.php#L88) and URI template expansion would fail.

closes https://github.com/microsoftgraph/msgraph-sdk-php-core/issues/97