### PR TITLE
WIP order the inheritance index

### DIFF
--- a/src/Kiota.Builder/Extensions/OpenApiDocumentExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiDocumentExtensions.cs
@@ -8,7 +8,7 @@ namespace Kiota.Builder.Extensions;
 
 internal static class OpenApiDocumentExtensions
 {
-    internal static void InitializeInheritanceIndex(this OpenApiDocument openApiDocument, ConcurrentDictionary<string, ConcurrentDictionary<string, bool>> inheritanceIndex)
+    internal static void InitializeInheritanceIndex(this OpenApiDocument openApiDocument, ConcurrentDictionary<string, ConcurrentDictionary<string, (int, bool)>> inheritanceIndex)
     {
         ArgumentNullException.ThrowIfNull(inheritanceIndex);
         ArgumentNullException.ThrowIfNull(openApiDocument);
@@ -20,8 +20,12 @@ internal static class OpenApiDocumentExtensions
                 if (entry.Value.AllOf != null)
                     foreach (var allOfEntry in entry.Value.AllOf.Where(static x => !string.IsNullOrEmpty(x.Reference?.Id)))
                     {
-                        var dependents = inheritanceIndex.GetOrAdd(allOfEntry.Reference.Id, new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase));
-                        dependents.TryAdd(entry.Key, false);
+                        var dependents = inheritanceIndex.GetOrAdd(allOfEntry.Reference.Id, new ConcurrentDictionary<string, (int, bool)>(StringComparer.OrdinalIgnoreCase));
+                        // TODO: the following should be an atomic operation
+                        var max = 0;
+                        if (dependents.Any())
+                            max = dependents.Values.MaxBy(static x => x.Item1).Item1;
+                        dependents.TryAdd(entry.Key, (max + 1, false));
                     }
             });
         }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1481,7 +1481,7 @@ public class KiotaBuilder
                 .Where(static x => x.Value != null)
                 .Select(static x => KeyValuePair.Create(x.Key, x.Value!));
     }
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, bool>> inheritanceIndex = new();
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, (int, bool)>> inheritanceIndex = new();
     private void InitializeInheritanceIndex()
     {
         openApiDocument?.InitializeInheritanceIndex(inheritanceIndex);

--- a/src/Kiota.Builder/Validation/MissingDiscriminator.cs
+++ b/src/Kiota.Builder/Validation/MissingDiscriminator.cs
@@ -12,7 +12,7 @@ public class MissingDiscriminator : ValidationRule<OpenApiDocument>
 {
     public MissingDiscriminator(GenerationConfiguration configuration) : base((context, document) =>
     {
-        var idx = new ConcurrentDictionary<string, ConcurrentDictionary<string, bool>>(StringComparer.OrdinalIgnoreCase);
+        var idx = new ConcurrentDictionary<string, ConcurrentDictionary<string, (int, bool)>>(StringComparer.OrdinalIgnoreCase);
         document.InitializeInheritanceIndex(idx);
         if (document.Components != null)
             Parallel.ForEach(document.Components.Schemas, entry =>
@@ -31,7 +31,7 @@ public class MissingDiscriminator : ValidationRule<OpenApiDocument>
     })
     {
     }
-    private static void ValidateSchema(OpenApiSchema schema, IValidationContext context, ConcurrentDictionary<string, ConcurrentDictionary<string, bool>> idx, string address)
+    private static void ValidateSchema(OpenApiSchema schema, IValidationContext context, ConcurrentDictionary<string, ConcurrentDictionary<string, (int, bool)>> idx, string address)
     {
         if (!schema.IsAnyOf() && !schema.IsOneOf())
             return;


### PR DESCRIPTION
Opening this as draft for visibility, it would be great if someone with a deeper C# and Inheritance index knowledge can take over this rough implementation (no need for attributions, an alternative PR is perfectly fine 🙂 ).

This seems to be fixing #2442 , but it's missing:
- an atomic index increment (it's currently possible to end up with duplicated indexes when running the code in parallel)
- possibly a "more principled" ordering scheme, e.g. based on depth
- a proper explanation of the behavior