### PR TITLE
Python/bugfix datetypes annotations

### DIFF
--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -105,7 +105,7 @@ public class PythonConventionService : CommonLanguageConventionService
             "void" => "None",
             "DateTimeOffset" => "datetime",
             "boolean" => "bool",
-            "Object" or "object" or "float" or "bytes" or "datetime" or "timespan" => type.Name,
+            "Object" or "object" or "float" or "bytes" or "datetime" or "timedelta" or "date" or "time" => type.Name,
             _ => type.Name.ToFirstCharacterUpperCase() is string typeName && !string.IsNullOrEmpty(typeName) ? typeName : "object",
         };
     }
@@ -126,7 +126,7 @@ public class PythonConventionService : CommonLanguageConventionService
             "void" => "None",
             "DateTimeOffset" => "datetime",
             "boolean" => "bool",
-            "Object" or "object" or "float" or "bytes" or "datetime" or "timespan" => type.Name,
+            "Object" or "object" or "float" or "bytes" or "datetime" or "timedelta" or "date" or "time" => type.Name,
             _ => $"{type.Name.ToSnakeCase()}.{type.Name.ToFirstCharacterUpperCase()}" ?? "object",
         };
     }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -146,6 +146,38 @@ public class CodeMethodWriterTests : IDisposable
         });
         parentClass.AddProperty(new CodeProperty
         {
+            Name = "dummyTimespan",
+            Type = new CodeType
+            {
+                Name = "timedelta"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "dummyDateTime",
+            Type = new CodeType
+            {
+                Name = "datetime"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "dummyTime",
+            Type = new CodeType
+            {
+                Name = "time"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "dummyDate",
+            Type = new CodeType
+            {
+                Name = "date"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
             Name = "dummyClass",
             Type = new CodeType
             {
@@ -471,6 +503,10 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("get_float_value", result);
         Assert.Contains("get_bool_value", result);
         Assert.Contains("get_bytes_value", result);
+        Assert.Contains("get_date_value", result);
+        Assert.Contains("get_time_value", result);
+        Assert.Contains("get_timedelta_value", result);
+        Assert.Contains("get_datetime_value", result);
         Assert.Contains("get_object_value", result);
         Assert.Contains("get_collection_of_primitive_values", result);
         Assert.Contains("get_collection_of_object_values", result);
@@ -497,6 +533,10 @@ public class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("write_str_value", result);
+        Assert.Contains("write_datetime_value", result);
+        Assert.Contains("write_timedelta_value", result);
+        Assert.Contains("write_date_value", result);
+        Assert.Contains("write_time_value", result);
         Assert.Contains("write_collection_of_primitive_values", result);
         Assert.Contains("write_collection_of_object_values", result);
         Assert.Contains("write_enum_value", result);


### PR DESCRIPTION
Fixes translation of date types to lowercase when writing type annotations.