### PR TITLE
Disambiguates imported Enum with same name imported Class in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed invalid schema behavior, invalid properties are now ignored with a warning instead of failed. [#2089](https://github.com/microsoft/kiota/issues/2089)
 - Fixed a bug where java refiner would not normalize inherited class names and interface types.
 - Fixed a bug where search based commands would not match exact matches when additional results are available.
+- Fixed a bug where imported classes and enums would not be disambiguated when they have the same name in dotnet.
 
 ## [1.0.1] - 2023-03-11
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -213,14 +213,14 @@ public class CSharpConventionService : CommonLanguageConventionService
         {
             var targetClass = targetElement.GetImmediateParentOfType<CodeClass>();
             var importedNamespaces = targetClass.StartBlock.Usings
-                .Where(codeUsing => !codeUsing.IsExternal                                                                      // 1. Are defined during generation(not external) 
-                                    && codeUsing.Declaration != null
-                                    && codeUsing.Declaration.TypeDefinition != null
+                .Where(codeUsing => !codeUsing.IsExternal // 1. Are defined during generation(not external) 
+                                    && codeUsing.Declaration?.TypeDefinition != null 
                                     && !codeUsing.Name.Equals(currentTypeNamespace.Name, StringComparison.OrdinalIgnoreCase))  // 2. Do not match the namespace of the current type
                 .Select(static codeUsing => codeUsing.Declaration!.TypeDefinition!.GetImmediateParentOfType<CodeNamespace>())
                 .DistinctBy(static declaredNamespace => declaredNamespace.Name);
 
-            return importedNamespaces.Any(importedNamespace => importedNamespace.FindChildByName<CodeClass>(codeClass.Name, false) != null);
+            return importedNamespaces.Any(importedNamespace => (importedNamespace.FindChildByName<CodeClass>(codeClass.Name, false) != null) 
+                                                               || (importedNamespace.FindChildByName<CodeEnum>(codeClass.Name, false) != null));
         }
         return false;
     }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -582,6 +582,108 @@ public class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void WritesModelFactoryBodyAndDisambiguateAmbiguousImportedTypes()
+    {
+        // Arrange : Adding a model with conflicting discriminator
+        var modelsNamespace = root.AddNamespace("models");
+        var modelWithConflictingDiscriminatorTypes = modelsNamespace.AddClass(
+            new CodeClass
+            {
+                Name = "ConflictingModelBaseClass"
+            }).First();
+        modelsNamespace.AddClass(modelWithConflictingDiscriminatorTypes);
+        // Adding a model in another namespace discriminator
+        var levelOneNameSpace = modelsNamespace.AddNamespace("namespaceLevelOne");
+        var conflictingModelInOtherNamespace = levelOneNameSpace.AddClass(
+            new CodeClass
+            {
+                Name = "ConflictingModel",
+                StartBlock = new ClassDeclaration()
+                {
+                    Inherits = new CodeType()
+                    {
+                        Name = modelWithConflictingDiscriminatorTypes.Name,
+                        TypeDefinition = modelWithConflictingDiscriminatorTypes
+                    }
+                }
+                
+            }).First();
+        levelOneNameSpace.AddClass(conflictingModelInOtherNamespace);
+        // Adding an enum in another namespace that conflicts
+        var levelTwoNameSpace = modelsNamespace.AddNamespace("namespaceLevelTwo");
+        var conflictingEnumInOtherNamespace = levelTwoNameSpace.AddEnum(
+            new CodeEnum()
+            {
+                Name = "ConflictingModel"
+            }).First();
+        modelsNamespace.AddEnum(conflictingEnumInOtherNamespace);// add enum to root models with same name
+
+        // setup the usings
+        modelWithConflictingDiscriminatorTypes.AddUsing(
+            new CodeUsing()
+            {
+                Name = levelOneNameSpace.Name,
+                Declaration = new CodeType()
+                {
+                    Name = conflictingModelInOtherNamespace.Name,
+                    TypeDefinition = conflictingModelInOtherNamespace
+                },
+            });
+        modelWithConflictingDiscriminatorTypes.AddUsing(
+            new CodeUsing()
+            {
+                Name = levelTwoNameSpace.Name,
+                Declaration = new CodeType()
+                {
+                    Name = conflictingEnumInOtherNamespace.Name,
+                    TypeDefinition = conflictingEnumInOtherNamespace
+                },
+            });
+        modelWithConflictingDiscriminatorTypes.DiscriminatorInformation = new DiscriminatorInformation()
+        {
+            Name = "type",
+            DiscriminatorPropertyName = "@odata.type"
+        };
+        modelWithConflictingDiscriminatorTypes.DiscriminatorInformation.AddDiscriminatorMapping(levelOneNameSpace.Name+".ConflictingModel",new CodeType()
+        {
+            Name = conflictingModelInOtherNamespace.Name,
+            TypeDefinition = conflictingModelInOtherNamespace
+        } );
+
+        var factoryMethod = modelWithConflictingDiscriminatorTypes.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "parentModel",
+                TypeDefinition = modelWithConflictingDiscriminatorTypes,
+            },
+            IsStatic = true,
+        }).First();
+        
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        
+        Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
+        Assert.Contains("return mappingValue switch {", result);
+        Assert.Contains("\"namespaceLevelOne.ConflictingModel\" => new namespaceLevelOne.ConflictingModel(),", result); //Assert the disambiguation happens due to the enum imported
+        Assert.Contains("_ => new ConflictingModelBaseClass()", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public void WritesModelFactoryBodyForInheritedModels()
     {
         var parentModel = root.AddClass(new CodeClass


### PR DESCRIPTION
Related to https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=111491&view=logs&j=fbf82ed0-029a-5388-186b-43225c9ecb54&t=5acdd042-8784-5c45-5c5c-4f54fbf44121

Imported enum with same name as class causes compilation failure due to ambiguous reference.

This PR updates the disamguation code to also include Enums in the lookup and adds test to validate. 