### PR TITLE
Bugfix/query parameters mapping python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixes a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names. 
+- Fixed a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names. 
 - Fixed a bug where date types annotations and guid's were not correctly translated in Python
 - Fixed the extension of downloaded files when using the default path. [#2316](https://github.com/microsoft/kiota/issues/2316)
 - Fixed a bug where lookup of reference ids failed for AllOf more than one level up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixes a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names. 
 - Fixed a bug where date types annotations and guid's were not correctly translated in Python
 - Fixed the extension of downloaded files when using the default path. [#2316](https://github.com/microsoft/kiota/issues/2316)
 - Fixed a bug where lookup of reference ids failed for AllOf more than one level up.

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -214,12 +214,12 @@ public class CSharpConventionService : CommonLanguageConventionService
             var targetClass = targetElement.GetImmediateParentOfType<CodeClass>();
             var importedNamespaces = targetClass.StartBlock.Usings
                 .Where(codeUsing => !codeUsing.IsExternal // 1. Are defined during generation(not external) 
-                                    && codeUsing.Declaration?.TypeDefinition != null 
+                                    && codeUsing.Declaration?.TypeDefinition != null
                                     && !codeUsing.Name.Equals(currentTypeNamespace.Name, StringComparison.OrdinalIgnoreCase))  // 2. Do not match the namespace of the current type
                 .Select(static codeUsing => codeUsing.Declaration!.TypeDefinition!.GetImmediateParentOfType<CodeNamespace>())
                 .DistinctBy(static declaredNamespace => declaredNamespace.Name);
 
-            return importedNamespaces.Any(importedNamespace => (importedNamespace.FindChildByName<CodeClass>(codeClass.Name, false) != null) 
+            return importedNamespaces.Any(importedNamespace => (importedNamespace.FindChildByName<CodeClass>(codeClass.Name, false) != null)
                                                                || (importedNamespace.FindChildByName<CodeEnum>(codeClass.Name, false) != null));
         }
         return false;

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -162,8 +162,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         }
         foreach (var unescapedProperty in unescapedProperties.Select(x => x.Name))
         {
-            writer.WriteLine($"if {parameterName} == \"{unescapedProperty.ToSnakeCase()}\":");
-            writer.IncreaseIndent();
+            writer.StartBlock($"if {parameterName} == \"{unescapedProperty.ToSnakeCase()}\":");
             writer.WriteLine($"return \"{unescapedProperty}\"");
             writer.DecreaseIndent();
         }

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -160,11 +160,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
             writer.WriteLine($"return \"{escapedProperty.SerializationName}\"");
             writer.DecreaseIndent();
         }
-        foreach (var unescapedProperty in unescapedProperties)
+        foreach (var unescapedProperty in unescapedProperties.Select(x => x.Name))
         {
-            writer.WriteLine($"if {parameterName} == \"{unescapedProperty.Name.ToSnakeCase()}\":");
+            writer.WriteLine($"if {parameterName} == \"{unescapedProperty.ToSnakeCase()}\":");
             writer.IncreaseIndent();
-            writer.WriteLine($"return \"{unescapedProperty.Name}\"");
+            writer.WriteLine($"return \"{unescapedProperty}\"");
             writer.DecreaseIndent();
         }
         writer.WriteLine($"return {parameterName}");

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -152,11 +152,19 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         if (parameter == null) throw new InvalidOperationException("QueryParametersMapper should have a parameter of type QueryParametersMapper");
         var parameterName = parameter.Name.ToSnakeCase();
         var escapedProperties = parentClass.Properties.Where(x => x.IsOfKind(CodePropertyKind.QueryParameter) && x.IsNameEscaped);
+        var unescapedProperties = parentClass.Properties.Where(x => x.IsOfKind(CodePropertyKind.QueryParameter) && !x.IsNameEscaped);
         foreach (var escapedProperty in escapedProperties)
         {
             writer.WriteLine($"if {parameterName} == \"{escapedProperty.Name.ToSnakeCase()}\":");
             writer.IncreaseIndent();
             writer.WriteLine($"return \"{escapedProperty.SerializationName}\"");
+            writer.DecreaseIndent();
+        }
+        foreach (var unescapedProperty in unescapedProperties)
+        {
+            writer.WriteLine($"if {parameterName} == \"{unescapedProperty.Name.ToSnakeCase()}\":");
+            writer.IncreaseIndent();
+            writer.WriteLine($"return \"{unescapedProperty.Name}\"");
             writer.DecreaseIndent();
         }
         writer.WriteLine($"return {parameterName}");

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -606,7 +606,7 @@ public class CodeMethodWriterTests : IDisposable
                         TypeDefinition = modelWithConflictingDiscriminatorTypes
                     }
                 }
-                
+
             }).First();
         levelOneNameSpace.AddClass(conflictingModelInOtherNamespace);
         // Adding an enum in another namespace that conflicts
@@ -644,11 +644,11 @@ public class CodeMethodWriterTests : IDisposable
             Name = "type",
             DiscriminatorPropertyName = "@odata.type"
         };
-        modelWithConflictingDiscriminatorTypes.DiscriminatorInformation.AddDiscriminatorMapping(levelOneNameSpace.Name+".ConflictingModel",new CodeType()
+        modelWithConflictingDiscriminatorTypes.DiscriminatorInformation.AddDiscriminatorMapping(levelOneNameSpace.Name + ".ConflictingModel", new CodeType()
         {
             Name = conflictingModelInOtherNamespace.Name,
             TypeDefinition = conflictingModelInOtherNamespace
-        } );
+        });
 
         var factoryMethod = modelWithConflictingDiscriminatorTypes.AddMethod(new CodeMethod
         {
@@ -661,7 +661,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             IsStatic = true,
         }).First();
-        
+
         factoryMethod.AddParameter(new CodeParameter
         {
             Name = "parseNode",
@@ -673,10 +673,10 @@ public class CodeMethodWriterTests : IDisposable
             },
             Optional = false,
         });
-        
+
         writer.Write(factoryMethod);
         var result = tw.ToString();
-        
+
         Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
         Assert.Contains("return mappingValue switch {", result);
         Assert.Contains("\"namespaceLevelOne.ConflictingModel\" => new namespaceLevelOne.ConflictingModel(),", result); //Assert the disambiguation happens due to the enum imported
@@ -1572,12 +1572,15 @@ public class CodeMethodWriterTests : IDisposable
         };
         method.Kind = CodeMethodKind.Constructor;
         parentClass.Kind = CodeClassKind.RequestBuilder;
-        parentClass.StartBlock.Inherits = new CodeType{
+        parentClass.StartBlock.Inherits = new CodeType
+        {
             Name = "BaseCliRequestBuilder",
             IsExternal = true
         };
-        parentClass.AddProperty(new CodeProperty {
-            Type = new CodeType {
+        parentClass.AddProperty(new CodeProperty
+        {
+            Type = new CodeType
+            {
                 Name = "string",
                 IsExternal = true
             },

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1237,15 +1237,6 @@ public class CodeMethodWriterTests : IDisposable
             {
                 Name = "string",
             },
-        },
-        new CodeProperty
-        {
-            Name = "startDateTime",
-            Kind = CodePropertyKind.QueryParameter,
-            Type = new CodeType
-            {
-                Name = "datetime",
-            },
         });
 
         method.AddParameter(new CodeParameter
@@ -1268,6 +1259,35 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("return \"select%2Dfrom\"", result);
         Assert.Contains("if original_name == \"filter\":", result);
         Assert.Contains("return \"%24filter\"", result);
+        Assert.Contains("return original_name", result);
+    }
+    [Fact]
+    public void WritesNameMapperMethodWithUnescapedProperties()
+    {
+        method.Kind = CodeMethodKind.QueryParametersMapper;
+        method.IsAsync = false;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "startDateTime",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "datetime",
+            },
+        });
+
+        method.AddParameter(new CodeParameter
+        {
+            Kind = CodeParameterKind.QueryParametersMapperParameter,
+            Name = "originalName",
+            Type = new CodeType
+            {
+                Name = "string",
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("if original_name is None:", result);
         Assert.Contains("if original_name == \"start_date_time\":", result);
         Assert.Contains("return \"startDateTime\"", result);
         Assert.Contains("return original_name", result);

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1237,6 +1237,15 @@ public class CodeMethodWriterTests : IDisposable
             {
                 Name = "string",
             },
+        },
+        new CodeProperty
+        {
+            Name = "startDateTime",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "datetime",
+            },
         });
 
         method.AddParameter(new CodeParameter
@@ -1259,6 +1268,8 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("return \"select%2Dfrom\"", result);
         Assert.Contains("if original_name == \"filter\":", result);
         Assert.Contains("return \"%24filter\"", result);
+        Assert.Contains("if original_name == \"start_date_time\":", result);
+        Assert.Contains("return \"startDateTime\"", result);
         Assert.Contains("return original_name", result);
     }
     [Fact]


### PR DESCRIPTION
Fixes a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing. Adds conditional statements to match the snake case name to the original name e.g

```py
if original_name == "end_date_time":
  return "endDateTime"
if original_name == "start_date_time":
  return "startDateTime"
```

fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/103