### PR TITLE
Bugfix/get primitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where UUID type is not correctly passed to deserialization method due to snake casing of primitive type names. 
 - Fixed a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names. 
 - Fixed a bug where date types annotations and guid's were not correctly translated in Python
 - Fixed the extension of downloaded files when using the default path. [#2316](https://github.com/microsoft/kiota/issues/2316)

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -488,7 +488,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                 return $"get_{(currentEnum.Flags || isCollection ? "collection_of_enum_values" : "enum_value")}({propertyType.ToCamelCase()})";
             if (isCollection)
                 if (currentType.TypeDefinition == null)
-                    return $"get_collection_of_primitive_values({propertyType.ToSnakeCase()})";
+                    return $"get_collection_of_primitive_values({propertyType})";
                 else
                     return $"get_collection_of_object_values({propertyType.ToCamelCase()})";
         }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -205,7 +205,7 @@ public class CodeMethodWriterTests : IDisposable
             Name = "dummyColl",
             Type = new CodeType
             {
-                Name = "string",
+                Name = "guid",
                 CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
             },
         });
@@ -506,20 +506,20 @@ public class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("from . import somecustomtype", result);
         Assert.Contains("fields: Dict[str, Callable[[Any], None]] =", result);
-        Assert.Contains("get_str_value", result);
-        Assert.Contains("get_int_value", result);
-        Assert.Contains("get_float_value", result);
-        Assert.Contains("get_bool_value", result);
-        Assert.Contains("get_bytes_value", result);
-        Assert.Contains("get_date_value", result);
-        Assert.Contains("get_time_value", result);
-        Assert.Contains("get_timedelta_value", result);
-        Assert.Contains("get_datetime_value", result);
-        Assert.Contains("get_uuid_value", result);
-        Assert.Contains("get_object_value", result);
-        Assert.Contains("get_collection_of_primitive_values", result);
-        Assert.Contains("get_collection_of_object_values", result);
-        Assert.Contains("get_enum_value", result);
+        Assert.Contains("get_str_value()", result);
+        Assert.Contains("get_int_value()", result);
+        Assert.Contains("get_float_value()", result);
+        Assert.Contains("get_bool_value()", result);
+        Assert.Contains("get_bytes_value()", result);
+        Assert.Contains("get_date_value()", result);
+        Assert.Contains("get_time_value()", result);
+        Assert.Contains("get_timedelta_value()", result);
+        Assert.Contains("get_datetime_value()", result);
+        Assert.Contains("get_uuid_value()", result);
+        Assert.Contains("get_object_value(dummy_class.DummyClass)", result);
+        Assert.Contains("get_collection_of_primitive_values(UUID)", result);
+        Assert.Contains("get_collection_of_object_values(complex.Complex)", result);
+        Assert.Contains("get_enum_value(some_enum.SomeEnum)", result);
         Assert.DoesNotContain("defined_in_parent", result, StringComparison.OrdinalIgnoreCase);
     }
     [Fact]


### PR DESCRIPTION
Fixes an issue where `UUID` type is snake_cased to `u_u_i_d` when passing to `get_collection_of_primitive_values`. Removes snake casing as all primitive types are already compliant.

fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/151
fixes https://github.com/microsoftgraph/msgraph-sdk-python/issues/153