### PR TITLE
Normalize property names ignoring casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names. 
+- Fixed a bug where unescaped query parameters are not correctly matched to the original name due to python convention of snake casing parameter names.
 - Fixed a bug where date types annotations and guid's were not correctly translated in Python
 - Fixed the extension of downloaded files when using the default path. [#2316](https://github.com/microsoft/kiota/issues/2316)
 - Fixed a bug where lookup of reference ids failed for AllOf more than one level up.
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where search based commands would not match exact matches when additional results are available.
 - Fixed a bug where imported classes and enums would not be disambiguated when they have the same name in dotnet.
 - Fixed a bug where escaping enum names resulted in a loss of the original enum name. [#2488](https://github.com/microsoft/kiota/issues/2488)
+- Fixed a bug where properties names are not correctly normalized in Go.
 
 ## [1.0.1] - 2023-03-11
 

--- a/it/config.json
+++ b/it/config.json
@@ -141,10 +141,6 @@
     ],
     "Suppressions": [
       {
-        "Language": "go",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2373"
-      },
-      {
         "Language": "php",
         "Rationale": "https://github.com/microsoft/kiota/issues/2378"
       },

--- a/it/generate-code.ps1
+++ b/it/generate-code.ps1
@@ -40,8 +40,12 @@ switch ($dev)
 }
 
 $targetOpenapiPath = Join-Path -Path $scriptPath -ChildPath "openapi.yaml"
+if (Test-Path $targetOpenapiPath) {
+    Remove-Item $targetOpenapiPath
+}
+
 if ($descriptionUrl.StartsWith("./")) {
-    Copy-Item -Path $descriptionUrl -Destination $targetOpenapiPath
+    Copy-Item -Path $descriptionUrl -Destination $targetOpenapiPath -Force
 } elseif ($descriptionUrl.StartsWith("http")) {
     Invoke-WebRequest -Uri $descriptionUrl -OutFile $targetOpenapiPath
 } else {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -386,7 +386,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         // 1. In the list of reserved names
         // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
         // 3. There's not a very specific condition preventing from replacement
-        if (provider.ReservedNames.Contains(current.Name, StringComparer.OrdinalIgnoreCase) &&
+        if (provider.ReservedNames.Contains(current.Name) &&
             isNotInExceptions &&
             shouldReplace)
         {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -386,7 +386,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         // 1. In the list of reserved names
         // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
         // 3. There's not a very specific condition preventing from replacement
-        if (provider.ReservedNames.Contains(current.Name) &&
+        if (provider.ReservedNames.Contains(current.Name, StringComparer.OrdinalIgnoreCase) &&
             isNotInExceptions &&
             shouldReplace)
         {

--- a/src/Kiota.Builder/Refiners/GoReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/GoReservedNamesProvider.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Kiota.Builder.Refiners;
 public class GoReservedNamesProvider : IReservedNamesProvider
 {
-    private readonly Lazy<HashSet<string>> _reservedNames = new(() => new HashSet<string> {
+    private readonly Lazy<HashSet<string>> _reservedNames = new(() => new(StringComparer.OrdinalIgnoreCase) {
         "break",
         "case",
         "chan",


### PR DESCRIPTION
Fix #2373 

Plus a little improvement for running it tests scripts locally.