### PR TITLE
Fix go shortened filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Shorten Go File names to a max of 252
 
 ## [1.2.0] - 2023-05-04
 

--- a/src/Kiota.Builder/PathSegmenters/GoPathSegmenter.cs
+++ b/src/Kiota.Builder/PathSegmenters/GoPathSegmenter.cs
@@ -22,7 +22,7 @@ public class GoPathSegmenter : CommonPathSegmenter
         return currentElement switch
         {
             CodeNamespace => "go",
-            _ => GetLastFileNameSegment(currentElement).ToSnakeCase().ShortenFileName(252),
+            _ => GetLastFileNameSegment(currentElement).ToSnakeCase().ShortenFileName(),
         };
     }
     public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToLowerInvariant();


### PR DESCRIPTION
Some Unix file system consider the trailing white space as part of the filename e.g documented [here](https://doc.owncloud.com/server/next/admin_manual/troubleshooting/path_filename_length.html). This leads to some builds failing with exactly 255 characters in the filenames. This PR reduces the max filename from 255 to 254 to allow instances when the terminal commands add an extra whitespace character to the filename to pass in such container. 
Partially address https://github.com/microsoftgraph/msgraph-beta-sdk-go/issues/260 