### PR TITLE
Error class parent fixes

### DIFF
--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -904,6 +904,16 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     var newP = (CodeProperty)p.Clone();
                     newP.Parent = currentClass;
                     currentClass.AddProperty(newP);
+                    if (newP.Setter != null)
+                    {
+                        newP.Setter.AccessedProperty = newP;
+                        currentClass.AddMethod(newP.Setter);
+                    }
+                    if (newP.Getter != null)
+                    {
+                        newP.Getter.AccessedProperty = newP;
+                        currentClass.AddMethod(newP.Getter);
+                    }
                 }
 
                 foreach (var m in currentParent

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -49,6 +49,11 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                 },
                 static s => s.ToSnakeCase());
+            AddParentClassToErrorClasses(
+                generatedCode,
+                "APIError",
+                $"{AbstractionsPackageName}.api_error"
+            );
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -85,11 +90,6 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
             new[] { $"{AbstractionsPackageName}.api_client_builder.register_default_deserializer",
                     $"{AbstractionsPackageName}.serialization.ParseNodeFactoryRegistry" });
             cancellationToken.ThrowIfCancellationRequested();
-            AddParentClassToErrorClasses(
-                    generatedCode,
-                    "APIError",
-                    $"{AbstractionsPackageName}.api_error"
-            );
             AddQueryParameterMapperMethod(
                 generatedCode
             );

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -63,6 +63,12 @@ public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                 },
                 static s => s.ToSnakeCase());
+            AddParentClassToErrorClasses(
+                generatedCode,
+                "ApiError",
+                "MicrosoftKiotaAbstractions",
+                true
+            );
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -102,12 +108,6 @@ public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
                                         new[] { "microsoft_kiota_abstractions.ParseNodeFactoryRegistry" });
             AddQueryParameterMapperMethod(
                 generatedCode
-            );
-            AddParentClassToErrorClasses(
-                    generatedCode,
-                    "ApiError",
-                    "MicrosoftKiotaAbstractions",
-                    true
             );
             cancellationToken.ThrowIfCancellationRequested();
             RemoveDiscriminatorMappingsThatDependOnSubNameSpace(generatedCode);

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -50,6 +50,11 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             ReplaceReservedNames(generatedCode, new TypeScriptReservedNamesProvider(), x => $"{x}Escaped");
             ReplaceReservedExceptionPropertyNames(generatedCode, new TypeScriptExceptionsReservedNamesProvider(), x => $"{x}Escaped");
+            AddParentClassToErrorClasses(
+                generatedCode,
+                "ApiError",
+                "@microsoft/kiota-abstractions"
+            );
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
@@ -88,11 +93,6 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
                 new[] { $"{AbstractionsPackageName}.registerDefaultDeserializer",
                         $"{AbstractionsPackageName}.ParseNodeFactoryRegistry" });
             cancellationToken.ThrowIfCancellationRequested();
-            AddParentClassToErrorClasses(
-                    generatedCode,
-                    "ApiError",
-                    "@microsoft/kiota-abstractions"
-            );
             AddDiscriminatorMappingsUsingsToParentClasses(
                 generatedCode,
                 "ParseNode",


### PR DESCRIPTION
This PR:
- After cloning properties from parent class, ensures the underlying cloned setter/getter also points to the newly cloned property
- Adds the getter/setter contained within the cloned property to the child class before methods are copied from parent to child. If we don't, the next steps add getters & setters that still point to the accessed property of the parent class since [we don't clone the accessed property](https://github.com/microsoft/kiota/blob/main/src/Kiota.Builder/CodeDOM/CodeMethod.cs#L272).
- For languages where getter/setter method names have a similar name to their properties (no prefix), [adding the getters/setters fails](https://github.com/microsoft/kiota/blob/philip/php/fix-generation/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs#L910) because an element with the getter/setter's name will already exist. For such languages, ensure adding error parent classes is done before adding getters/setters in the refiner