### PR TITLE
Fix inconsistent backing store property generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where properties copied from parent to child classes would not be cloned.
 - Fixed a bug where replacing reserved names would not propagate the rename to the inner child elements map of the parent class.
 - Fixed a bug where descriptions with multiple server URLs would use the HTTP one instead of HTTPs. [#2336](https://github.com/microsoft/kiota/issues/2336)
+- Fixed a bug where backing store properties would be sometimes duplicated in derived classes.
 
 ## [1.1.3] - 2023-04-18
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1566,6 +1566,8 @@ public class KiotaBuilder
         if (inheritsFrom != null)
             newClassStub.StartBlock.Inherits = new CodeType { TypeDefinition = inheritsFrom, Name = inheritsFrom.Name };
         
+        // Add the class to the namespace after the serialization members
+        // as other threads looking for the existence of the class may find the class but the additional data/backing store properties may not be fully populated causing duplication
         var includeAdditionalDataProperties = config.IncludeAdditionalData && schema.AdditionalPropertiesAllowed;
         AddSerializationMembers(newClassStub, includeAdditionalDataProperties, config.UsesBackingStore);
 


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1833#discussion_r1170827612

This PR fixes a bug where the backing store property would sometimes be repeated in inherited classes. 

This is caused by a race condition when a base class with multiple derived instances would be added to the code dom. As the base class would be immediately added to the namespace, one of the derived instances being generated at the same time would find the class when searching for the parent model but the class would not have its serialization properties set yet causing the check below to return different results. 

https://github.com/microsoft/kiota/blob/8b4d0035e4b262ff391294799710f46b2181da03/src/Kiota.Builder/KiotaBuilder.cs#L1836

This PR therefore ensures the call to `AddSerializationMembers` is done before adding the parent model class to the namespace so that the check always returns a true reflection of the model class to consistently generate the model. 

Sample generation at https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1844