### PR TITLE
Add parent implements to inlined classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix issue where implements for error classes were not copied when inlining classes.
 - Move the common properties to a base class and remove properties(RequestAdapter, UrlTemplate and PathParameters) for the request builders and options and headers for RequestConfig classes PHP.[2439](https://github.com/microsoft/kiota/issues/2439)
 - Fix bugs with imports for PHP Generation.
 - Indexers replacement are now at the same level as the original indexer. e.g `client.userById("id").messagesById("id")...` is now `client.users.withId("id").messages.withId("id")...`.

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -935,7 +935,6 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     newU.Parent = currentClass;
                     currentClass.AddUsing(newU);
                 }
-                
                 currentClass.StartBlock.AddImplements(parentClass.StartBlock.Implements.ToArray());
             }
         }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -935,6 +935,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     newU.Parent = currentClass;
                     currentClass.AddUsing(newU);
                 }
+                
+                currentClass.StartBlock.AddImplements(parentClass.StartBlock.Implements.ToArray());
             }
         }
     }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -935,7 +935,13 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     newU.Parent = currentClass;
                     currentClass.AddUsing(newU);
                 }
-                currentClass.StartBlock.AddImplements(parentClass.StartBlock.Implements.ToArray());
+                foreach (var implement in currentParent
+                             .StartBlock
+                             .Implements
+                             .Where(pi => !currentClass.Usings.Any(ci => ci.Name.Equals(pi.Name, StringComparison.OrdinalIgnoreCase))))
+                {
+                    currentClass.StartBlock.AddImplements((CodeType)implement.Clone());
+                }
             }
         }
     }


### PR DESCRIPTION
The refiner method to inline parent classes copies properties, methods, usings but leaves `Implements` uncopied leading to methods that are supposed to be added when a class implements a given interface without implementing the interface.

Testing Document.
https://github.com/microsoft/kiota/blob/main/tests/Kiota.Builder.IntegrationTests/InheritingErrors.yaml