### PR TITLE
Remove python suppression for inheriting errors

### DIFF
--- a/it/config.json
+++ b/it/config.json
@@ -71,10 +71,6 @@
       {
         "Language": "ruby",
         "Rationale": "https://github.com/microsoft/kiota/issues/2484"
-      },
-      {
-        "Language": "python",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2492"
       }
     ]
   },


### PR DESCRIPTION
Removes suppression for python inheriting errors integration test.

fixes #2492 