### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 📢📢📢 Go is now a stable language!
 - Added typescript interfaces for models and request config params. [#1013](https://github.com/microsoft/kiota/issues/1013) and [#1521](https://github.com/microsoft/kiota/issues/1521)
 - Added automatic loading of the lock file for the extension so quick edits of clients are supported.
 - Added a warning message when clients get upgraded from one kiota version to another. [#2598](https://github.com/microsoft/kiota/issues/2598)
@@ -66,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2023-04-05
 
 ### Added
-
+ 
 - Added Visual Studio Code preview extension. [#2333](https://github.com/microsoft/kiota/issues/2333)
 - Added support for searching in forks for API descriptions in GitHub. [#2429](https://github.com/microsoft/kiota/issues/2429)
 - Added the ability to filter on operations. [#2431](https://github.com/microsoft/kiota/issues/2431)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [1.2.0] - 2023-05-04
+
+### Added
+
 - Added typescript interfaces for models and request config params. [#1013](https://github.com/microsoft/kiota/issues/1013) and [#1521](https://github.com/microsoft/kiota/issues/1521)
 - Added automatic loading of the lock file for the extension so quick edits of clients are supported.
 - Added a warning message when clients get upgraded from one kiota version to another. [#2598](https://github.com/microsoft/kiota/issues/2598)

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -14,7 +14,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>1.1.3</Version>
+    <Version>1.2.0</Version>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases
     </PackageReleaseNotes>

--- a/src/Kiota.Web/wwwroot/appsettings.json
+++ b/src/Kiota.Web/wwwroot/appsettings.json
@@ -77,31 +77,31 @@
       "DependencyInstallCommand": "{0}:{1}"
     },
     "Go": {
-      "MaturityLevel": "Preview",
+      "MaturityLevel": "Stable",
       "Dependencies": [
         {
           "Name": "github.com/microsoft/kiota-abstractions-go",
-          "Version": "v0.20.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-http-go",
-          "Version": "v0.17.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-form-go",
-          "Version": "v0.9.1"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-json-go",
-          "Version": "v0.9.3"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-authentication-azure-go",
-          "Version": "v0.6.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-text-go",
-          "Version": "v0.7.1"
+          "Version": "v1.0.0"
         }
       ],
       "DependencyInstallCommand": "go get {0}@{1}"

--- a/src/Kiota.Web/wwwroot/appsettings.json
+++ b/src/Kiota.Web/wwwroot/appsettings.json
@@ -21,11 +21,11 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.1.0"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.1"
+          "Version": "1.0.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",
@@ -51,27 +51,27 @@
       "Dependencies": [
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-abstractions",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-http-okHttp",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-form",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-json",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-authentication-azure",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-text",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         }
       ],
       "DependencyInstallCommand": "{0}:{1}"
@@ -81,19 +81,19 @@
       "Dependencies": [
         {
           "Name": "github.com/microsoft/kiota-abstractions-go",
-          "Version": "v0.19.0"
+          "Version": "v0.20.0"
         },
         {
           "Name": "github.com/microsoft/kiota-http-go",
-          "Version": "v0.16.1"
+          "Version": "v0.17.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-form-go",
-          "Version": "v0.9.0"
+          "Version": "v0.9.1"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-json-go",
-          "Version": "v0.9.1"
+          "Version": "v0.9.3"
         },
         {
           "Name": "github.com/microsoft/kiota-authentication-azure-go",
@@ -101,7 +101,7 @@
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-text-go",
-          "Version": "v0.7.0"
+          "Version": "v0.7.1"
         }
       ],
       "DependencyInstallCommand": "go get {0}@{1}"
@@ -111,7 +111,7 @@
       "Dependencies": [
         {
           "Name": "@microsoft/kiota-abstractions",
-          "Version": "1.0.0-preview.14"
+          "Version": "1.0.0-preview.16"
         },
         {
           "Name": "@microsoft/kiota-http-fetchlibrary",
@@ -141,7 +141,7 @@
       "Dependencies": [
         {
           "Name": "microsoft/kiota-abstractions",
-          "Version": "0.6.3"
+          "Version": "0.6.5"
         },
         {
           "Name": "microsoft/kiota-http-guzzle",
@@ -149,7 +149,7 @@
         },
         {
           "Name": "microsoft/kiota-serialization-json",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "microsoft/kiota-authentication-phpleague",
@@ -167,7 +167,7 @@
       "Dependencies": [
         {
           "Name": "microsoft-kiota-abstractions",
-          "Version": "0.5.0"
+          "Version": "0.5.1"
         },
         {
           "Name": "microsoft-kiota-http",
@@ -175,7 +175,7 @@
         },
         {
           "Name": "microsoft-kiota-serialization-json",
-          "Version": "0.3.1"
+          "Version": "0.3.2"
         },
         {
           "Name": "microsoft-kiota-authentication-azure",
@@ -220,11 +220,11 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.1.0"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.1"
+          "Version": "1.0.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -77,31 +77,31 @@
       "DependencyInstallCommand": "{0}:{1}"
     },
     "Go": {
-      "MaturityLevel": "Preview",
+      "MaturityLevel": "Stable",
       "Dependencies": [
         {
           "Name": "github.com/microsoft/kiota-abstractions-go",
-          "Version": "v0.20.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-http-go",
-          "Version": "v0.17.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-form-go",
-          "Version": "v0.9.1"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-json-go",
-          "Version": "v0.9.3"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-authentication-azure-go",
-          "Version": "v0.6.0"
+          "Version": "v1.0.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-text-go",
-          "Version": "v0.7.1"
+          "Version": "v1.0.0"
         }
       ],
       "DependencyInstallCommand": "go get {0}@{1}"

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -21,11 +21,11 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.1.0"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.1"
+          "Version": "1.0.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",
@@ -51,27 +51,27 @@
       "Dependencies": [
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-abstractions",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-http-okHttp",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-form",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-json",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-authentication-azure",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-text",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         }
       ],
       "DependencyInstallCommand": "{0}:{1}"
@@ -81,19 +81,19 @@
       "Dependencies": [
         {
           "Name": "github.com/microsoft/kiota-abstractions-go",
-          "Version": "v0.19.0"
+          "Version": "v0.20.0"
         },
         {
           "Name": "github.com/microsoft/kiota-http-go",
-          "Version": "v0.16.1"
+          "Version": "v0.17.0"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-form-go",
-          "Version": "v0.9.0"
+          "Version": "v0.9.1"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-json-go",
-          "Version": "v0.9.1"
+          "Version": "v0.9.3"
         },
         {
           "Name": "github.com/microsoft/kiota-authentication-azure-go",
@@ -101,7 +101,7 @@
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-text-go",
-          "Version": "v0.7.0"
+          "Version": "v0.7.1"
         }
       ],
       "DependencyInstallCommand": "go get {0}@{1}"
@@ -111,7 +111,7 @@
       "Dependencies": [
         {
           "Name": "@microsoft/kiota-abstractions",
-          "Version": "1.0.0-preview.14"
+          "Version": "1.0.0-preview.16"
         },
         {
           "Name": "@microsoft/kiota-http-fetchlibrary",
@@ -141,7 +141,7 @@
       "Dependencies": [
         {
           "Name": "microsoft/kiota-abstractions",
-          "Version": "0.6.3"
+          "Version": "0.6.5"
         },
         {
           "Name": "microsoft/kiota-http-guzzle",
@@ -149,7 +149,7 @@
         },
         {
           "Name": "microsoft/kiota-serialization-json",
-          "Version": "0.4.2"
+          "Version": "0.4.3"
         },
         {
           "Name": "microsoft/kiota-authentication-phpleague",
@@ -167,7 +167,7 @@
       "Dependencies": [
         {
           "Name": "microsoft-kiota-abstractions",
-          "Version": "0.5.0"
+          "Version": "0.5.1"
         },
         {
           "Name": "microsoft-kiota-http",
@@ -175,7 +175,7 @@
         },
         {
           "Name": "microsoft-kiota-serialization-json",
-          "Version": "0.3.1"
+          "Version": "0.3.2"
         },
         {
           "Name": "microsoft-kiota-authentication-azure",
@@ -220,11 +220,11 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.1.0"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.1"
+          "Version": "1.0.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -14,7 +14,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>1.1.3</Version>
+    <Version>1.2.0</Version>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases
     </PackageReleaseNotes>


### PR DESCRIPTION
This PR creates the 1.2.0 release by : 

- bumping versions for 1.2.0 release
- updates kiota dependencies list
- updates the changelog. 

TODO
- [x] Merge after Go abstractions stable releases
