### PR TITLE
Fix issue with request builders with parameters being excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fix issue with command conflicts causing CLI crashes. (Shell)
 - Fix build error by splitting the ambiguous `--file` option into `--input-file` and `--output-file`. (Shell)
+- Fix issue with request builders with parameters being excluded from commands output. (Shell)
 
 ## [1.2.1] - 2023-05-16
 

--- a/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
@@ -541,7 +541,7 @@ partial class ShellCodeMethodWriter : CodeMethodWriter
 
     private void WriteNavCommand(CodeMethod codeElement, LanguageWriter writer, CodeClass parent, string name)
     {
-        if (((codeElement.AccessedProperty?.Type) is CodeType codeReturnType) && (codeReturnType.TypeDefinition is CodeClass typeDef))
+        if (((codeElement.AccessedProperty?.Type ?? codeElement.OriginalMethod?.ReturnType) is CodeType codeReturnType) && (codeReturnType.TypeDefinition is CodeClass typeDef))
         {
             var targetClass = conventions.GetTypeString(codeReturnType, codeElement);
 


### PR DESCRIPTION
Request builders with parameters were erroneously excluded from the generated commands.

Before:
![image](https://github.com/microsoft/kiota/assets/747955/2a6edf17-5d4d-4201-878d-642491d621e7)

After:
![image](https://github.com/microsoft/kiota/assets/747955/24f54d8d-5ce9-49e0-9fd0-595e9d36b3a1)
