### PR TITLE
Fixes setting default enum values if the symbol has been sanitized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where CSharp generation would fail if the input openApi contained schemas named 'TimeOnly' or 'DateOnly' [2671](https://github.com/microsoft/kiota/issues/2671)
 - Updated the reserved types for CSharp to include 'Stream' and 'Date' should be reserved names in CSharp [2369](https://github.com/microsoft/kiota/issues/2369)
 - Fix issue with request builders with parameters being excluded from commands output. (Shell)
-
+- Fixed a bug in setting default enum values fails if the symbol has been sanitized and the symbol only contains special characters [2360](https://github.com/microsoft/kiota/issues/2360)
 
 ## [1.2.1] - 2023-05-16
 

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -164,8 +164,18 @@ public static class StringExtensions
                                                                     .Aggregate(static (z, y) => z + y));
 
         result = NormalizeSymbolsAfterCleanup(result);
+        
+        // if the result is empty but the original wasn't, it only contained symbols which have been removed.
+        // So try to return a non empty string by replacing the symbols with words
+        if (string.IsNullOrEmpty(result) && !string.IsNullOrEmpty(original))
+        {
+            result = SpelledOutSymbols.Where(symbol => original.Contains(symbol.Key))
+                                      .Aggregate(original, (current, symbol) => current.Replace(symbol.Key.ToString(), symbol.Value));
+        }
+        
         return result;
     }
+    
     private static readonly Regex NumbersSpellingRegex = new(@"^(?<number>\d+)", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
     private static readonly Dictionary<char, string> SpelledOutNumbers = new() {
         {'0', "Zero"},
@@ -179,6 +189,32 @@ public static class StringExtensions
         {'8', "Eight"},
         {'9', "Nine"},
     };
+    
+    private static readonly Dictionary<char, string> SpelledOutSymbols = new() {
+        {'!', "Exclamation"},
+        {'"', "DoubleQuote"},
+        {'#', "Pound"},
+        {'$', "Dollar"},
+        {'%', "Percent"},
+        {'&', "Ampersand"},
+        {'\'', "Apostrophe"},
+        {'(', "LeftParenthesis"},
+        {')', "RightParenthesis"},
+        {'*', "Asterisk"},
+        {'+', "Plus"},
+        {',', "Comma"},
+        {'-', "Hyphen"},
+        {'.', "Period"},
+        {'/', "Slash"},
+        {'\\', "BackSlash"},
+        {':', "Colon"},
+        {';', "SemiColon"},
+        {'<', "LessThan"},
+        {'=', "Equal"},
+        {'>', "GreaterThan"},
+        {'?', "QuestionMark"},
+    };
+    
     /// <summary>
     /// Normalizing logic for custom symbols handling before cleanup
     /// </summary>

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 
 using Kiota.Builder.CodeDOM;
+using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers;
 
 using Xunit;
@@ -67,6 +68,19 @@ public class CodeEnumWriterTests : IDisposable
         writer.Write(currentEnum);
         var result = tw.ToString();
         Assert.DoesNotContain($"\"ValidName\"", result);
+    }
+    
+    [Theory]
+    [InlineData("\\","BackSlash")]
+    [InlineData("?","QuestionMark")]
+    [InlineData("$","Dollar")]
+    public void WritesEnumWithSanitizedName(string symbol, string expected)
+    {
+        currentEnum.Flags = true;
+        currentEnum.AddOption(new CodeEnumOption { Name = symbol.CleanupSymbolName()});
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains(expected, result);
     }
     
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1365,6 +1365,29 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains($"{propName.ToFirstCharacterUpperCase()} = {codeEnum.Name.ToFirstCharacterUpperCase()}.{defaultValue.CleanupSymbolName()}", result);//ensure symbol is cleaned up
     }
     [Fact]
+    public void WritesConstructorAndIncludesSanitizedEnumValue()
+    {
+        method.Kind = CodeMethodKind.Constructor;
+        var defaultValue = "/";
+        var propName = "size";
+        var codeEnum = new CodeEnum
+        {
+            Name = "pictureSize"
+        };
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = propName,
+            DefaultValue = defaultValue,
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { TypeDefinition = codeEnum }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains(parentClass.Name.ToFirstCharacterUpperCase(), result);
+        Assert.Contains("PictureSize.Slash", result);//ensure symbol is cleaned up
+        Assert.Contains($"{propName.ToFirstCharacterUpperCase()} = {codeEnum.Name.ToFirstCharacterUpperCase()}.{defaultValue.CleanupSymbolName()}", result);//ensure symbol is cleaned up
+    }
+    [Fact]
     public void DoesNotWriteConstructorWithDefaultFromComposedType()
     {
         method.Kind = CodeMethodKind.Constructor;


### PR DESCRIPTION
Closes https://github.com/microsoft/kiota/issues/2360

This PR updates the `CleanupSymbolName` function to return non-empty string when the input symbol only contains special characters. This in turn fixes issues where property names and enum members would fail to be generated to result in compilation errors in dotnet. 