### PR TITLE
Select unique query parameter names to add to url template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where CSharp generation would fail if the input openApi contained schemas named 'TimeOnly' or 'DateOnly' [2671](https://github.com/microsoft/kiota/issues/2671)
 - Updated the reserved types for CSharp to include 'Stream' and 'Date' should be reserved names in CSharp [2369](https://github.com/microsoft/kiota/issues/2369)
 - Fix issue with request builders with parameters being excluded from commands output. (Shell)
+- Fixed issue where duplicate query parameter names per path were added to the URL template. Now only distinct query parameter names are added. [2725](https://github.com/microsoft/kiota/issues/2725)
 
 
 ## [1.2.1] - 2023-05-16

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -177,6 +177,7 @@ public static class OpenApiUrlTreeNodeExtensions
                                         pathItem.Operations
                                                 .SelectMany(static x => x.Value.Parameters)
                                                 .Where(static x => x.In == ParameterLocation.Query))
+                                    .DistinctBy(static x => x.Name)
                                     .ToArray();
             if (parameters.Any())
                 queryStringParameters = "{?" +

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -125,6 +125,69 @@ public class OpenApiUrlTreeNodeExtensionsTests
     {
         Assert.Equal(result, original.SanitizeParameterNameForCodeSymbols());
     }
+
+    [Fact]
+    public void GetUrlTemplateSelectsDistinctQueryParameters()
+    {
+        var doc = new OpenApiDocument
+        {
+            Paths = new(),
+        };
+        doc.Paths.Add("{param-with-dashes}\\existing-segment", new()
+        {
+            Operations = new Dictionary<OperationType, OpenApiOperation> {
+                { OperationType.Get, new() {
+                        Parameters = new List<OpenApiParameter> {
+                            new() {
+                                Name = "param-with-dashes",
+                                In = ParameterLocation.Path,
+                                Required = true,
+                                Schema = new() {
+                                    Type = "string"
+                                },
+                                Style = ParameterStyle.Simple,
+                            },
+                            new (){
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new () {
+                                    Type = "string"
+                                },
+                                Style = ParameterStyle.Simple,
+                            }
+                        }
+                    }
+                },
+                {
+                    OperationType.Put, new() {
+                        Parameters = new List<OpenApiParameter> {
+                            new() {
+                                Name = "param-with-dashes",
+                                In = ParameterLocation.Path,
+                                Required = true,
+                                Schema = new() {
+                                    Type = "string"
+                                },
+                                Style = ParameterStyle.Simple,
+                            },
+                            new (){
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new () {
+                                    Type = "string"
+                                },
+                                Style = ParameterStyle.Simple,
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        Assert.Equal("{+baseurl}/{param%2Dwith%2Ddashes}/existing-segment{?%24select}", node.Children.First().Value.GetUrlTemplate());
+        // the query parameters will be decoded by a middleware at runtime before the request is executed
+    }
+    
     [Fact]
     public void GetUrlTemplateCleansInvalidParameters()
     {


### PR DESCRIPTION
Duplicate query parameter names would be added to the URL template of a request builder in cases where the OpenAPI spec contained the same query parameter names under different operations for the same path.

closes https://github.com/microsoft/kiota/issues/2725