### PR TITLE
Fixes stackoverflow exception with self referencing schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Deprecated Visual Studio OpenAPI reference packages.
+- Fixes a bug where a stackoverflow exception occurs when inlined schemas have self-references [2656](https://github.com/microsoft/kiota/issues/2656)
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenApiSchemaExtensions
         if (schema.Items != null)
             return schema.Items.GetSchemaNames();
         if (!string.IsNullOrEmpty(schema.Reference?.Id))
-            return new[] { schema.Reference.Id.Split('/').Last().Split('.').Last() };
+            return new[] { schema.Reference.Id.Split('/')[^1].Split('.')[^1] };
         if (schema.AnyOf.Any())
             return schema.AnyOf.FlattenIfRequired(classNamesFlattener);
         if (schema.AllOf.Any())
@@ -32,7 +32,7 @@ public static class OpenApiSchemaExtensions
     }
     private static IEnumerable<string> FlattenIfRequired(this IList<OpenApiSchema> schemas, Func<OpenApiSchema, IList<OpenApiSchema>> subsequentGetter)
     {
-        return (schemas.Count == 1 && string.IsNullOrEmpty(schemas.First().Title) ?
+        return (schemas.Count == 1 && string.IsNullOrEmpty(schemas[0].Title) ?
                     schemas.FlattenEmptyEntries(subsequentGetter, 1) :
                     schemas)
             .Select(static x => x.Title).Where(static x => !string.IsNullOrEmpty(x));
@@ -196,7 +196,7 @@ public static class OpenApiSchemaExtensions
         if (schema.AnyOf.Select(GetDiscriminatorPropertyName).FirstOrDefault(static x => !string.IsNullOrEmpty(x)) is string anyOfDiscriminatorPropertyName)
             return anyOfDiscriminatorPropertyName;
         if (schema.AllOf.Any())
-            return GetDiscriminatorPropertyName(schema.AllOf.Last());
+            return GetDiscriminatorPropertyName(schema.AllOf[^1]);
 
         return string.Empty;
     }
@@ -209,7 +209,7 @@ public static class OpenApiSchemaExtensions
                 return schema.OneOf.SelectMany(x => GetDiscriminatorMappings(x, inheritanceIndex));
             else if (schema.AnyOf.Any())
                 return schema.AnyOf.SelectMany(x => GetDiscriminatorMappings(x, inheritanceIndex));
-            else if (schema.AllOf.Any(allOfEvaluatorForMappings) && schema.AllOf.Last().Equals(schema.AllOf.Last(allOfEvaluatorForMappings)))
+            else if (schema.AllOf.Any(allOfEvaluatorForMappings) && schema.AllOf[^1].Equals(schema.AllOf.Last(allOfEvaluatorForMappings)))
                 // ensure the matched AllOf entry is the last in the list
                 return GetDiscriminatorMappings(schema.AllOf.Last(allOfEvaluatorForMappings), inheritanceIndex);
             else if (!string.IsNullOrEmpty(schema.Reference?.Id))

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1463,6 +1463,13 @@ public partial class KiotaBuilder
             false => (parentElement.GetImmediateParentOfType<CodeNamespace>(), null, suffixForInlineSchema), // Inline schema, i.e. specific to the Operation
         };
 
+        // If typeNameForInlineSchema is not null and the schema is referenced, we have most likely unwrapped a referenced schema(most likely from an AllOf/OneOf/AnyOf).
+        // Therefore the current type/schema is not really inlined, so invalidate the typeNameForInlineSchema and let the work with the information from the schema reference.
+        if (schema.IsReferencedSchema() && !string.IsNullOrEmpty(typeNameForInlineSchema))
+        {
+            typeNameForInlineSchema = string.Empty;
+        }
+
         if (schema.IsInherited())
         {
             return CreateInheritedModelDeclaration(currentNode, schema, operation, suffix, codeNamespace, isRequestBody);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1464,7 +1464,7 @@ public partial class KiotaBuilder
         };
 
         // If typeNameForInlineSchema is not null and the schema is referenced, we have most likely unwrapped a referenced schema(most likely from an AllOf/OneOf/AnyOf).
-        // Therefore the current type/schema is not really inlined, so invalidate the typeNameForInlineSchema and let the work with the information from the schema reference.
+        // Therefore the current type/schema is not really inlined, so invalidate the typeNameForInlineSchema and just work with the information from the schema reference.
         if (schema.IsReferencedSchema() && !string.IsNullOrEmpty(typeNameForInlineSchema))
         {
             typeNameForInlineSchema = string.Empty;


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/2656

Lookup of schema names is not consistent when the schema has to be flattened. This causes infinite recursion in self referenced schemas that are defined as a single `allOf` without extra properties and therefore generates new models rather than detecting the same model is referenced. 