### PR TITLE
Prevent type casting nil values in Go collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated Visual Studio OpenAPI reference packages.
 - Fixes a bug where a stackoverflow exception occurs when inlined schemas have self-references [2656](https://github.com/microsoft/kiota/issues/2656)
+- Fixes nil safety while type casting values in collections in Go
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -663,9 +663,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         writer.WriteLines($"{targetVarName} := make([]{propertyTypeImportName}, len({sourceVarName}))",
             $"for i, v := range {sourceVarName} {{");
         writer.IncreaseIndent();
+        writer.StartBlock("if v != nil {");
         var derefPrefix = dereference ? "*(" : string.Empty;
         var derefSuffix = dereference ? ")" : string.Empty;
         writer.WriteLine($"{targetVarName}[i] = {GetTypeAssertion(derefPrefix + "v", pointerSymbol + propertyTypeImportName)}{derefSuffix}");
+        writer.CloseBlock();
         writer.CloseBlock();
     }
 
@@ -919,11 +921,13 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
             writer.WriteLines($"cast := make([]{parsableSymbol}, len({valueGet}))",
                 $"for i, v := range {valueGet} {{");
             writer.IncreaseIndent();
+            writer.StartBlock("if v != nil {");
             if (isInterface)
                 writer.WriteLine($"cast[i] = {GetTypeAssertion("v", parsableSymbol)}");
             else
                 writer.WriteLines("temp := v", // temporary creating a new reference to avoid pointers to the same object
                     $"cast[i] = {parsableSymbol}(&temp)");
+            writer.CloseBlock();
             writer.CloseBlock();
         }
         var collectionPrefix = propType.IsCollection ? "CollectionOf" : string.Empty;

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -799,6 +799,7 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("result.SetStringValue(val)", result);
         Assert.Contains("else if val, err := parseNode.GetCollectionOfObjectValues(CreateComplexType2FromDiscriminatorValue); val != nil {", result);
         Assert.Contains("cast := make([]ComplexType2, len(val))", result);
+        Assert.Contains("if v != nil ", result);
         Assert.Contains("for i, v := range val", result);
         Assert.Contains("result.SetComplexType2Value(cast)", result);
         Assert.Contains("return result, nil", result);


### PR DESCRIPTION
Add nill safety check for go collection casting. Check if value is nill before attempting to cast collection. 

current example
```go
        for i, v := range m.GetToRecipients() {
               cast[i] = v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
        }
```
Adds nil check 

```go
        for i, v := range m.GetToRecipients() {
            if v != nil {
                cast[i] = v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
            }
        }
```

Fixes https://github.com/microsoft/kiota-serialization-json-go/issues/91
Fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/506