### PR TITLE
Fix an issue with collection models failing type checking

### DIFF
--- a/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Shell/ShellCodeMethodWriter.cs
@@ -658,7 +658,7 @@ partial class ShellCodeMethodWriter : CodeMethodWriter
 
                 if (requestBodyParamType.IsCollection)
                 {
-                    writer.WriteLine($"var model = parseNode.GetCollectionOfObjectValues<{typeString}>({typeString}.CreateFromDiscriminatorValue);");
+                    writer.WriteLine($"var model = parseNode.GetCollectionOfObjectValues<{typeString}>({typeString}.CreateFromDiscriminatorValue)?.ToList();");
                 }
                 else
                 {

--- a/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Shell/ShellCodeMethodWriterTests.cs
@@ -1156,7 +1156,7 @@ public class ShellCodeMethodWriterTests : IDisposable
         Assert.Contains("command.AddOption(bodyOption);", result);
         Assert.Contains("var body = invocationContext.ParseResult.GetValueForOption(bodyOption) ?? string.Empty;", result);
         Assert.Contains("using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));", result);
-        Assert.Contains("var model = parseNode.GetCollectionOfObjectValues<Content>(Content.CreateFromDiscriminatorValue);", result);
+        Assert.Contains("var model = parseNode.GetCollectionOfObjectValues<Content>(Content.CreateFromDiscriminatorValue)?.ToList();", result);
         Assert.Contains("if (model is null) return;", result);
         Assert.Contains("var requestInfo = CreatePostRequestInformation", result);
         Assert.Contains("if (testPath is not null) requestInfo.PathParameters.Add(\"test%2Dpath\", testPath);", result);


### PR DESCRIPTION
IParseNode's `parseNode.GetCollectionOfObjectValues` returns IEnumerable<T> while `To(Put|Post)RequestInformation` accepts List<T>. This PR fixes the compilation error that arises from trying to pass an IEnumerable to a List parameter