### PR TITLE
Python|Ruby - Fix query parameter mapper generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed an issue with query parameter name normalization in Ruby and Python. [#2825](https://github.com/microsoft/kiota/issues/2825)
 - Deprecated Visual Studio OpenAPI reference packages.
 - Fixes a bug where a stackoverflow exception occurs when inlined schemas have self-references [2656](https://github.com/microsoft/kiota/issues/2656)
 - Fixes nil safety while type casting values in collections in Go

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -192,7 +192,6 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             !currentProperty.ExistsInBaseType &&
             propertyKindsToReplace!.Contains(currentProperty.Kind) &&
             current.Parent is CodeClass parentClass &&
-            !parentClass.IsOfKind(CodeClassKind.QueryParameters) &&
             currentProperty.Access == AccessModifier.Public)
         {
             if (string.IsNullOrEmpty(currentProperty.SerializationName))

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -67,6 +67,7 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
             ReplacePropertyNames(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
+                    CodePropertyKind.QueryParameter,
                 },
                 static s => s.ToSnakeCase());
             AddParentClassToErrorClasses(

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -61,6 +61,7 @@ public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
             ReplacePropertyNames(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
+                    CodePropertyKind.QueryParameter,
                 },
                 static s => s.ToSnakeCase());
             AddParentClassToErrorClasses(

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -136,4 +136,31 @@ public class GenerateSample : IDisposable
 
         Assert.Empty(Directory.GetFiles(OutputPath, "*_*", SearchOption.AllDirectories));
     }
+    [InlineData(GenerationLanguage.Python)]
+    [InlineData(GenerationLanguage.Ruby)]
+    [Theory]
+    public async Task GeneratesQueryParametersMapper(GenerationLanguage language)
+    {
+        var logger = LoggerFactory.Create(builder =>
+        {
+        }).CreateLogger<KiotaBuilder>();
+
+        var OutputPath = $".\\Generated\\GeneratesQueryParametersMapper\\{language}";
+        var configuration = new GenerationConfiguration
+        {
+            Language = language,
+            OpenAPIFilePath = "GeneratesQueryMappers.yaml",
+            OutputPath = OutputPath,
+            CleanOutput = true,
+        };
+        await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
+
+        var fullText = "";
+        foreach (var file in Directory.GetFiles(OutputPath, "*.*", SearchOption.AllDirectories))
+        {
+            fullText += File.ReadAllText(file);
+        }
+
+        Assert.Contains("get_query_parameter", fullText);
+    }
 }

--- a/tests/Kiota.Builder.IntegrationTests/GeneratesQueryMappers.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/GeneratesQueryMappers.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+  description: something
+paths:
+  /api/something/v1:
+    get:
+      parameters:
+        - name: "ifExists"
+          schema:
+            type: boolean
+          in: "query"
+      responses:
+        "200":
+          description: "something"
+          content:
+            application/json: {}

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -46,6 +46,9 @@
     <None Update="NoUnderscoresInModel.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="GeneratesQueryMappers.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
@@ -63,6 +63,32 @@ public class PythonLanguageRefinerTests
         Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.QueryParametersMapper)));
     }
     [Fact]
+    public async Task AddsQueryParameterMapperMethodAfterMangling()
+    {
+        var model = graphNS.AddClass(new CodeClass
+        {
+            Name = "somemodel",
+            Kind = CodeClassKind.QueryParameters,
+        }).First();
+
+        model.AddProperty(new CodeProperty
+        {
+            Name = "ifExists",
+            Type = new CodeType
+            {
+                Name = "string"
+            },
+            Kind = CodePropertyKind.QueryParameter
+        });
+
+        Assert.Empty(model.Methods);
+
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Python }, graphNS);
+        Assert.Single(model.Properties.Where(x => x.Name.Equals("if_exists")));
+        Assert.Single(model.Properties.Where(x => x.IsNameEscaped));
+        Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.QueryParametersMapper)));
+    }
+    [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()
     {
         var model = root.AddClass(new CodeClass


### PR DESCRIPTION
Fix #2824 for Ruby and Python.
