### PR TITLE
Convert Java package names to lower case after escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where a stackoverflow exception occurs when inlined schemas have self-references [2656](https://github.com/microsoft/kiota/issues/2656)
 - Fixes nil safety while type casting values in collections in Go
 - Moved common RequestBuilder ((request_adapter, url_template and path_parameters)) and RequestConfiguration(headers, options) properties to respective base classes in Python.[2440](https://github.com/microsoft/kiota/issues/2440)
+- Fixed a bug where escaped package names would not be lowercased in Java.
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -17,7 +17,6 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         return Task.Run(() =>
         {
             cancellationToken.ThrowIfCancellationRequested();
-            LowerCaseNamespaceNames(generatedCode);
             MoveRequestBuilderPropertiesToBaseType(generatedCode,
                 new CodeUsing
                 {
@@ -84,6 +83,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             );
             ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped");
             ReplaceReservedExceptionPropertyNames(generatedCode, new JavaExceptionsReservedNamesProvider(), x => $"{x}Escaped");
+            LowerCaseNamespaceNames(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);
             cancellationToken.ThrowIfCancellationRequested();
             AddDefaultImports(generatedCode, defaultUsingEvaluators);

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -166,6 +166,13 @@ public class JavaLanguageRefinerTests
         Assert.Contains("Escaped", model.Name);
     }
     [Fact]
+    public async Task EscapeReservedKeywordsInNamespaceToLowercase()
+    {
+        var ns = root.AddNamespace("new");
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
+        Assert.Equal(ns.Name.ToLower(), ns.Name);
+    }
+    [Fact]
     public async Task ConvertEnumsToPascalCase()
     {
         var model = root.AddEnum(new CodeEnum


### PR DESCRIPTION
When a reserved keyword is used in a place where it will put in a package name, the keyword is escaped like: new -> newEscaped. However, the package names are converted to lower case prior to this conversion, resulting in package names with an upper case character. This is not idiomatic Java and also causes compilation issues, because the package directory is created in lower case. The conversion to lower case must be done after escaping keywords.

This PR adds a testcase for the issue and moves the `LowerCaseNamespaceNames` to after escaping.