### PR TITLE
Resolve unique names for properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved common RequestBuilder ((request_adapter, url_template and path_parameters)) and RequestConfiguration(headers, options) properties to respective base classes in Python.[2440](https://github.com/microsoft/kiota/issues/2440)
 - Fixed a bug where escaped package names would not be lowercased in Java.
 - Fix failing PHP integration tests [2378](https://github.com/microsoft/kiota/issues/2378)
+- Fixed generation of properties with identical names after symbol cleanup. 
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -30,7 +30,7 @@ public class CodeBlock<TBlockDeclaration, TBlockEnd> : CodeElement, IBlock where
             return InnerChildElements.Values;
         return new CodeElement[] { StartBlock, EndBlock }.Union(InnerChildElements.Values);
     }
-    public void RenameChildElement(string oldName, string newName)
+    public virtual void RenameChildElement(string oldName, string newName)
     {
         if (InnerChildElements.TryRemove(oldName, out var element))
         {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -138,22 +138,6 @@ public class CodeBlock<TBlockDeclaration, TBlockEnd> : CodeElement, IBlock where
             }
         return default;
     }
-    public T? FindChild<T>(Predicate<T> match, bool findInChildElements = true) where T : ICodeElement
-    {
-        if (!InnerChildElements.Any())
-            return default;
-
-        if (InnerChildElements.Select(x => x.Value).Where(x => x is T castX && match(castX)).FirstOrDefault() is T result)
-            return result;
-        if (findInChildElements)
-            foreach (var childElement in InnerChildElements.Values.OfType<IBlock>())
-            {
-                var childResult = childElement.FindChild<T>(match);
-                if (childResult != null)
-                    return childResult;
-            }
-        return default;
-    }
 }
 public class BlockDeclaration : CodeTerminal
 {

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -43,7 +43,7 @@ public class CodeBlock<TBlockDeclaration, TBlockEnd> : CodeElement, IBlock where
         if (elements == null) return;
         RemoveChildElementByName(elements.Select(x => x.Name).ToArray());
     }
-    public void RemoveChildElementByName(params string[] names)
+    public virtual void RemoveChildElementByName(params string[] names)
     {
         if (names == null) return;
 

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -143,7 +143,7 @@ public class CodeBlock<TBlockDeclaration, TBlockEnd> : CodeElement, IBlock where
         if (!InnerChildElements.Any())
             return default;
 
-        if (InnerChildElements.Select(x => x.Value).Where(x => x is T castX && match(castX)) is T result)
+        if (InnerChildElements.Select(x => x.Value).Where(x => x is T castX && match(castX)).FirstOrDefault() is T result)
             return result;
         if (findInChildElements)
             foreach (var childElement in InnerChildElements.Values.OfType<IBlock>())

--- a/src/Kiota.Builder/CodeDOM/CodeBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeBlock.cs
@@ -138,6 +138,22 @@ public class CodeBlock<TBlockDeclaration, TBlockEnd> : CodeElement, IBlock where
             }
         return default;
     }
+    public T? FindChild<T>(Predicate<T> match, bool findInChildElements = true) where T : ICodeElement
+    {
+        if (!InnerChildElements.Any())
+            return default;
+
+        if (InnerChildElements.Select(x => x.Value).Where(x => x is T castX && match(castX)) is T result)
+            return result;
+        if (findInChildElements)
+            foreach (var childElement in InnerChildElements.Values.OfType<IBlock>())
+            {
+                var childResult = childElement.FindChild<T>(match);
+                if (childResult != null)
+                    return childResult;
+            }
+        return default;
+    }
 }
 public class BlockDeclaration : CodeTerminal
 {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -172,7 +172,7 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
 
         if (PropertiesByWireName.TryGetValue(wireName, out var result))
             return result;
-        return InnerChildElements.Values.OfType<CodeClass>().Select(x => x.FindPropertyByWireName(wireName)).Where(x => x != null).FirstOrDefault();
+        return InnerChildElements.Values.OfType<CodeClass>().Select(x => x.FindPropertyByWireName(wireName)).OfType<CodeProperty>().FirstOrDefault();
     }
     public bool ContainsPropertyWithWireName(string wireName)
     {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -99,14 +99,28 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
     }
     private string ResolveUniquePropertyName(string name)
     {
-        if (StartBlock.FindPropertyByNameInTypeHierarchy(name) == null)
+        if (FindPropertyByNameInTypeHierarchy(name) == null)
             return name;
-        if (StartBlock.FindPropertyByNameInTypeHierarchy(Name + name) == null)
+        if (FindPropertyByNameInTypeHierarchy(Name + name) == null)
             return Name + name;
         var i = 0;
-        while (StartBlock.FindPropertyByNameInTypeHierarchy(Name + name + i) != null)
+        while (FindPropertyByNameInTypeHierarchy(Name + name + i) != null)
             i++;
         return Name + name + i;
+    }
+    private CodeProperty? FindPropertyByNameInTypeHierarchy(string propertyName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(propertyName);
+
+        if (FindChildByName<CodeProperty>(propertyName, findInChildElements: false) is CodeProperty result)
+        {
+            return result;
+        }
+        if (ParentClass is CodeClass currentParentClass)
+        {
+            return currentParentClass.FindPropertyByNameInTypeHierarchy(propertyName);
+        }
+        return default;
     }
     public IEnumerable<CodeClass> AddInnerClass(params CodeClass[] codeClasses)
     {
@@ -200,24 +214,6 @@ public class ClassDeclaration : ProprietableBlockDeclaration
                 return currentProperty;
             else
                 return currentParentClass.StartBlock.GetOriginalPropertyDefinedFromBaseType(serializationName);
-        return default;
-    }
-    public CodeProperty? FindPropertyByNameInTypeHierarchy(string propertyName)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(propertyName);
-
-        if (Parent is CodeClass thisClass)
-        {
-            if (thisClass.FindChildByName<CodeProperty>(propertyName, findInChildElements: false) is CodeProperty result)
-            {
-                return result;
-            }
-        }
-        if (inherits is CodeType currentInheritsType &&
-            currentInheritsType.TypeDefinition is CodeClass currentParentClass)
-        {
-            return currentParentClass.StartBlock.FindPropertyByNameInTypeHierarchy(propertyName);
-        }
         return default;
     }
     public bool InheritsFrom(CodeClass candidate)

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -96,6 +96,22 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
             return PropertiesByWireName.GetOrAdd(result.WireName, result);
         }).ToArray();
     }
+    public override void RenameChildElement(string oldName, string newName)
+    {
+        if (InnerChildElements.TryRemove(oldName, out var element))
+        {
+            if (element is CodeProperty removedProperty)
+            {
+                PropertiesByWireName.TryRemove(removedProperty.WireName, out _);
+            }
+            element.Name = newName;
+            InnerChildElements.TryAdd(newName, element);
+            if (element is CodeProperty propertyToAdd)
+            {
+                PropertiesByWireName.TryAdd(propertyToAdd.WireName, propertyToAdd);
+            }
+        }
+    }
     public override void RemoveChildElementByName(params string[] names)
     {
         if (names == null) return;

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -70,11 +70,8 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         if (!properties.Any())
             throw new ArgumentOutOfRangeException(nameof(properties));
 
-        var result = new CodeProperty[properties.Length];
-
-        for (var i = 0; i < properties.Length; i++)
+        return properties.Select(property =>
         {
-            var property = properties[i];
             if (property.IsOfKind(CodePropertyKind.Custom, CodePropertyKind.QueryParameter))
             {
                 var original = GetOriginalPropertyDefinedFromBaseType(property.WireName);
@@ -93,9 +90,8 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
                     property.OriginalPropertyFromBaseType = original!;
                 }
             }
-            result[i] = base.AddProperty(new[] { property }).First();
-        }
-        return result;
+            return base.AddProperty(new[] { property }).First();
+        }).ToArray();
     }
     private string ResolveUniquePropertyName(string name)
     {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -99,12 +99,12 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
     }
     private string ResolveUniquePropertyName(string name)
     {
-        if (FindChildByName<CodeProperty>(name) == null)
+        if (StartBlock.FindPropertyByNameInTypeHierarchy(name) == null)
             return name;
-        if (FindChildByName<CodeProperty>(Name + name) == null)
+        if (StartBlock.FindPropertyByNameInTypeHierarchy(Name + name) == null)
             return Name + name;
         var i = 0;
-        while (FindChildByName<CodeProperty>(Name + name + i) != null)
+        while (StartBlock.FindPropertyByNameInTypeHierarchy(Name + name + i) != null)
             i++;
         return Name + name + i;
     }
@@ -202,7 +202,24 @@ public class ClassDeclaration : ProprietableBlockDeclaration
                 return currentParentClass.StartBlock.GetOriginalPropertyDefinedFromBaseType(serializationName);
         return default;
     }
+    public CodeProperty? FindPropertyByNameInTypeHierarchy(string propertyName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
+        if (Parent is CodeClass thisClass)
+        {
+            if (thisClass.FindChildByName<CodeProperty>(propertyName, findInChildElements: false) is CodeProperty result)
+            {
+                return result;
+            }
+        }
+        if (inherits is CodeType currentInheritsType &&
+            currentInheritsType.TypeDefinition is CodeClass currentParentClass)
+        {
+            return currentParentClass.StartBlock.FindPropertyByNameInTypeHierarchy(propertyName);
+        }
+        return default;
+    }
     public bool InheritsFrom(CodeClass candidate)
     {
         ArgumentNullException.ThrowIfNull(candidate);

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -101,12 +101,13 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
     {
         if (FindPropertyByNameInTypeHierarchy(name) == null)
             return name;
-        if (FindPropertyByNameInTypeHierarchy(Name + name) == null)
-            return Name + name;
+        var nameWithTypeName = Name + name.ToFirstCharacterUpperCase();
+        if (FindPropertyByNameInTypeHierarchy(nameWithTypeName) == null)
+            return nameWithTypeName;
         var i = 0;
-        while (FindPropertyByNameInTypeHierarchy(Name + name + i) != null)
+        while (FindPropertyByNameInTypeHierarchy(nameWithTypeName + i) != null)
             i++;
-        return Name + name + i;
+        return nameWithTypeName + i;
     }
     private CodeProperty? FindPropertyByNameInTypeHierarchy(string propertyName)
     {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -159,26 +159,20 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         ArgumentException.ThrowIfNullOrEmpty(serializationName);
 
         if (ParentClass is CodeClass currentParentClass)
-            if (currentParentClass.FindPropertyByWireName<CodeProperty>(serializationName) is CodeProperty currentProperty && !currentProperty.ExistsInBaseType)
+            if (currentParentClass.FindPropertyByWireName(serializationName) is CodeProperty currentProperty && !currentProperty.ExistsInBaseType)
                 return currentProperty;
             else
                 return currentParentClass.GetOriginalPropertyDefinedFromBaseType(serializationName);
         return default;
     }
-    private CodeProperty? FindPropertyByWireName<T>(string wireName)
+    private CodeProperty? FindPropertyByWireName(string wireName)
     {
         if (!PropertiesByWireName.Any())
             return default;
 
         if (PropertiesByWireName.TryGetValue(wireName, out var result))
             return result;
-        foreach (var childElement in InnerChildElements.Values.OfType<CodeClass>())
-        {
-            var childResult = childElement.FindPropertyByWireName<T>(wireName);
-            if (childResult != null)
-                return childResult;
-        }
-        return default;
+        return InnerChildElements.Values.OfType<CodeClass>().Select(x => x.FindPropertyByWireName(wireName)).Where(x => x != null).FirstOrDefault();
     }
     public bool ContainsPropertyWithWireName(string wireName)
     {

--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -128,9 +128,13 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
     {
         if (FindPropertyByNameInTypeHierarchy(name) == null)
             return name;
-        var nameWithTypeName = Name + name.ToFirstCharacterUpperCase();
-        if (FindPropertyByNameInTypeHierarchy(nameWithTypeName) == null)
-            return nameWithTypeName;
+        // the CodeClass.Name is not very useful as prefix for the property name, so keep the original name and add a number
+        var nameWithTypeName = Kind == CodeClassKind.QueryParameters ? name : Name + name.ToFirstCharacterUpperCase();
+        if (Kind != CodeClassKind.QueryParameters)
+        {
+            if (FindPropertyByNameInTypeHierarchy(nameWithTypeName) == null)
+                return nameWithTypeName;
+        }
         var i = 0;
         while (FindPropertyByNameInTypeHierarchy(nameWithTypeName + i) != null)
             i++;
@@ -176,7 +180,10 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         }
         return default;
     }
-
+    public bool ContainsPropertyWithWireName(string wireName)
+    {
+        return PropertiesByWireName.ContainsKey(wireName);
+    }
     public IEnumerable<CodeClass> AddInnerClass(params CodeClass[] codeClasses)
     {
         if (codeClasses == null || codeClasses.Any(x => x == null))

--- a/src/Kiota.Builder/CodeDOM/IBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/IBlock.cs
@@ -9,7 +9,6 @@ namespace Kiota.Builder.CodeDOM;
 public interface IBlock
 {
     T? FindChildByName<T>(string childName, bool findInChildElements = true) where T : ICodeElement;
-    T? FindChild<T>(Predicate<T> match, bool findInChildElements = true) where T : ICodeElement;
     IEnumerable<T> FindChildrenByName<T>(string childName) where T : ICodeElement;
     void AddUsing(params CodeUsing[] codeUsings);
     CodeElement? Parent

--- a/src/Kiota.Builder/CodeDOM/IBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/IBlock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Kiota.Builder.CodeDOM;
 
@@ -8,6 +9,7 @@ namespace Kiota.Builder.CodeDOM;
 public interface IBlock
 {
     T? FindChildByName<T>(string childName, bool findInChildElements = true) where T : ICodeElement;
+    T? FindChild<T>(Predicate<T> match, bool findInChildElements = true) where T : ICodeElement;
     IEnumerable<T> FindChildrenByName<T>(string childName) where T : ICodeElement;
     void AddUsing(params CodeUsing[] codeUsings);
     CodeElement? Parent

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2038,7 +2038,7 @@ public partial class KiotaBuilder
             prop.SerializationName = parameter.Name.SanitizeParameterNameForUrlTemplate();
         }
 
-        if (!parameterClass.ContainsMember(parameter.Name))
+        if (!parameterClass.ContainsPropertyWithWireName(prop.WireName))
         {
             parameterClass.AddProperty(prop);
         }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -6109,7 +6109,8 @@ components:
         Assert.Equal("@type", atType.WireName);
         var subtypeClass = codeModel.FindChildByName<CodeClass>("Subtype");
         Assert.NotNull(subtypeClass);
-        var type = subtypeClass.FindChildByName<CodeProperty>("Subtypetype");
+        var type = subtypeClass.FindChildByName<CodeProperty>("SubtypeType");
         Assert.Equal("type", type.WireName);
+        Assert.Equal("SubtypeType", type.Name);
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -6113,4 +6113,47 @@ components:
         Assert.Equal("type", type.WireName);
         Assert.Equal("SubtypeType", type.Name);
     }
+    [Fact]
+    public async Task CleanupSymbolNameDoesNotCauseNameConflictsInQueryParameters()
+    {
+        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+        await using var fs = await GetDocumentStream(@"openapi: 3.0.1
+info:
+  title: Example
+  description: Example
+  version: 1.0.1
+servers:
+  - url: https://example.org
+paths:
+  /directoryObject:
+    get:
+      parameters:
+        - name: $select
+          in: query
+          schema:
+            type: string
+        - name: select
+          in: query
+          schema:
+            type: int64
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath, IncludeAdditionalData = false }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var parametersClass = codeModel.FindChildByName<CodeClass>("directoryObjectRequestBuilderGetQueryParameters");
+        Assert.NotNull(parametersClass);
+        var dollarSelect = parametersClass.FindChildByName<CodeProperty>("Select");
+        Assert.Equal("%24select", dollarSelect.WireName);
+        Assert.Equal("string", dollarSelect.Type.Name);
+        var select = parametersClass.FindChildByName<CodeProperty>("select0");
+        Assert.Equal("select", select.WireName);
+        Assert.Equal("int64", select.Type.Name);
+    }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -6056,4 +6056,60 @@ components:
         Assert.NotNull(resultClass);
         Assert.Equal(2, resultClass.Properties.Count());
     }
+    [Fact]
+    public async Task CleanupSymbolNameDoesNotCauseNameConflictsWithSuperType()
+    {
+        var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+        await using var fs = await GetDocumentStream(@"openapi: 3.0.1
+info:
+  title: Example
+  description: Example
+  version: 1.0.1
+servers:
+  - url: https://example.org
+paths:
+  /directoryObject:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subtype'
+components:
+  schemas:
+    entity:
+      title: entity
+      type: object
+      required: ['@type']
+      properties:
+        '@type':
+          type: integer
+      discriminator:
+        propertyName: '@type'
+        mapping:
+          'subtype': '#/components/schemas/subtype'
+    subtype:
+      allOf:
+        - $ref: '#/components/schemas/entity'
+        - title: subtype
+          type: object
+          required: ['type', '@type']
+          properties:
+            'type':
+              type: string");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath, IncludeAdditionalData = false }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var entityClass = codeModel.FindChildByName<CodeClass>("Entity");
+        Assert.NotNull(entityClass);
+        var atType = entityClass.FindChildByName<CodeProperty>("Type");
+        Assert.Equal("@type", atType.WireName);
+        var subtypeClass = codeModel.FindChildByName<CodeClass>("Subtype");
+        Assert.NotNull(subtypeClass);
+        var type = subtypeClass.FindChildByName<CodeProperty>("Subtypetype");
+        Assert.Equal("type", type.WireName);
+    }
 }


### PR DESCRIPTION
In some cases multiple properties from the API spec can end with the same name in the generated code. The most likely cause is the removal of special symbols from the name. These properties can then cause conflicts and result in incorrectly generated code.

This change builds a new name for those properties, and also keeps track these renamed properties in subtypes.

This PR is not yet entirely finished. It still needs some test coverage, mostly related to subtypes, but I decided to already submit it to get some feedback.