### PR TITLE
Bugfix datetime serialization method names

### DIFF
--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -783,10 +783,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         return propertyType switch
         {
             "str" or "bool" or "int" or "float" or "UUID" or "bytes" => $"write_{propertyType.ToLowerInvariant()}_value",
-            "datetime.datetime" => "write_datetime_value()",
-            "datetime.date" => "write_date_value()",
-            "datetime.time" => "write_time_value()",
-            "datetime.timedelta" => "write_timedelta_value()",
+            "datetime.datetime" => "write_datetime_value",
+            "datetime.date" => "write_date_value",
+            "datetime.time" => "write_time_value",
+            "datetime.timedelta" => "write_timedelta_value",
             _ => "write_object_value",
         };
     }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -876,6 +876,7 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("write_enum_value", result);
         Assert.Contains("write_additional_data_value(self.additional_data)", result);
         Assert.DoesNotContain("defined_in_parent", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("()", result);
     }
     [Fact]
     public void WritesMethodAsyncDescription()


### PR DESCRIPTION
Removes parenthesis from datetime serialization method names which would result in generated code `writer.write_datetime_value()("start", self.start)`