### PR TITLE
Fix go method name conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where escaped package names would not be lowercased in Java.
 - Fix failing PHP integration tests [2378](https://github.com/microsoft/kiota/issues/2378)
 - Fixed generation of properties with identical names after symbol cleanup. 
+- Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -224,7 +224,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             var propertyOriginalName = (currentProperty.IsNameEscaped ? currentProperty.SerializationName : current.Name)
                                         .ToFirstCharacterLowerCase();
             var accessorName = refineAccessorName(current, propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase());
-            
+
             currentProperty.Getter = parentClass.AddMethod(new CodeMethod
             {
                 Name = $"get-{accessorName}",

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -203,7 +203,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         }
         CrawlTree(current, x => ReplacePropertyNames(x, propertyKindsToReplace!, refineAccessorName));
     }
-    protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, Func<string, string> refineAccessorName, bool removeProperty, bool parameterAsOptional, string getterPrefix, string setterPrefix, string fieldPrefix = "_", bool supportsOverloading = true)
+    protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, Func<CodeElement, string, string> refineAccessorName, bool removeProperty, bool parameterAsOptional, string getterPrefix, string setterPrefix, string fieldPrefix = "_")
     {
         ArgumentNullException.ThrowIfNull(refineAccessorName);
         if (!(propertyKindsToAddAccessors?.Any() ?? true)) return;
@@ -223,11 +223,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             }
             var propertyOriginalName = (currentProperty.IsNameEscaped ? currentProperty.SerializationName : current.Name)
                                         .ToFirstCharacterLowerCase();
-            var accessorName = refineAccessorName(propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase());
-            if (!supportsOverloading && parentClass.FindChildByName<CodeProperty>(accessorName) is not null)
-            {
-                accessorName = propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase();
-            }
+            var accessorName = refineAccessorName(current, propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase());
+            
             currentProperty.Getter = parentClass.AddMethod(new CodeMethod
             {
                 Name = $"get-{accessorName}",
@@ -277,7 +274,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 Type = (CodeTypeBase)currentProperty.Type.Clone(),
             });
         }
-        CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors!, refineAccessorName, removeProperty, parameterAsOptional, getterPrefix, setterPrefix, fieldPrefix, supportsOverloading));
+        CrawlTree(current, x => AddGetterAndSetterMethods(x, propertyKindsToAddAccessors!, refineAccessorName, removeProperty, parameterAsOptional, getterPrefix, setterPrefix, fieldPrefix));
     }
     protected static void AddConstructorsForDefaultValues(CodeElement current, bool addIfInherited, bool forceAdd = false, CodeClassKind[]? classKindsToExclude = null)
     {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Configuration;
 using Kiota.Builder.Extensions;
-using StringExtensions = Microsoft.Kiota.Abstractions.Extensions.StringExtensions;
 
 namespace Kiota.Builder.Refiners;
 public abstract class CommonLanguageRefiner : ILanguageRefiner

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -225,13 +225,9 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             var propertyOriginalName = (currentProperty.IsNameEscaped ? currentProperty.SerializationName : current.Name)
                                         .ToFirstCharacterLowerCase();
             var accessorName = refineAccessorName(propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase());
-            if (!supportsOverloading)
+            if (!supportsOverloading && parentClass.FindChildByName<CodeProperty>(accessorName) is not null)
             {
-                var existing = parentClass.FindChildByName<CodeProperty>(accessorName);
-                if (existing != null)
-                {
-                    accessorName = propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase();
-                }
+                accessorName = propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase();
             }
             currentProperty.Getter = parentClass.AddMethod(new CodeMethod
             {

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -99,11 +99,12 @@ public class GoRefiner : CommonLanguageRefiner
                 delegate(CodeElement element, string s)
                 {
                     var refinedName = s.ToPascalCase(UnderscoreArray);
-                    if (element.Parent is CodeClass parentClass && parentClass.FindChildByName<CodeProperty>(refinedName) is not null)
+                    if (element.Parent is CodeClass parentClass && 
+                        parentClass.FindChildByName<CodeProperty>(refinedName) is not null)
                     {
                         return s;
                     }
-                    return s.ToPascalCase(UnderscoreArray);
+                    return refinedName;
                 }, 
                 _configuration.UsesBackingStore,
                 false,

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -96,8 +96,7 @@ public class GoRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.Custom,
                     CodePropertyKind.BackingStore },
-                static delegate (CodeElement element, string s)
-                {
+                static (CodeElement element, string s) => {
                     var refinedName = s.ToPascalCase(UnderscoreArray);
                     if (element.Parent is CodeClass parentClass &&
                         parentClass.FindChildByName<CodeProperty>(refinedName) is not null)

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -100,7 +100,8 @@ public class GoRefiner : CommonLanguageRefiner
                 _configuration.UsesBackingStore,
                 false,
                 "Get",
-                "Set");
+                "Set",
+                supportsOverloading: false);
             AddConstructorsForDefaultValues(
                 generatedCode,
                 true,

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -96,16 +96,16 @@ public class GoRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.Custom,
                     CodePropertyKind.BackingStore },
-                delegate(CodeElement element, string s)
+                static delegate (CodeElement element, string s)
                 {
                     var refinedName = s.ToPascalCase(UnderscoreArray);
-                    if (element.Parent is CodeClass parentClass && 
+                    if (element.Parent is CodeClass parentClass &&
                         parentClass.FindChildByName<CodeProperty>(refinedName) is not null)
                     {
                         return s;
                     }
                     return refinedName;
-                }, 
+                },
                 _configuration.UsesBackingStore,
                 false,
                 "Get",

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -96,12 +96,19 @@ public class GoRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.Custom,
                     CodePropertyKind.BackingStore },
-                static s => s.ToPascalCase(UnderscoreArray),
+                delegate(CodeElement element, string s)
+                {
+                    var refinedName = s.ToPascalCase(UnderscoreArray);
+                    if (element.Parent is CodeClass parentClass && parentClass.FindChildByName<CodeProperty>(refinedName) is not null)
+                    {
+                        return s;
+                    }
+                    return s.ToPascalCase(UnderscoreArray);
+                }, 
                 _configuration.UsesBackingStore,
                 false,
                 "Get",
-                "Set",
-                supportsOverloading: false);
+                "Set");
             AddConstructorsForDefaultValues(
                 generatedCode,
                 true,

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -96,7 +96,8 @@ public class GoRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.Custom,
                     CodePropertyKind.BackingStore },
-                static (CodeElement element, string s) => {
+                static (element, s) =>
+                {
                     var refinedName = s.ToPascalCase(UnderscoreArray);
                     if (element.Parent is CodeClass parentClass &&
                         parentClass.FindChildByName<CodeProperty>(refinedName) is not null)

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -77,7 +77,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore,
                 },
-                static s => s.ToCamelCase(UnderscoreArray),
+                (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 true,
                 "get",

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -77,7 +77,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore,
                 },
-                (_, s) => s.ToCamelCase(UnderscoreArray),
+                static (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 true,
                 "get",

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -56,7 +56,7 @@ public class PhpRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore
                 },
-                (_, s) => s.ToCamelCase(UnderscoreArray),
+                static (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 true,
                 "get",

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -56,7 +56,7 @@ public class PhpRefiner : CommonLanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore
                 },
-                static s => s.ToCamelCase(UnderscoreArray),
+                (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 true,
                 "get",

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -80,7 +80,7 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
                 },
-                (_, s) => s.ToSnakeCase(),
+                static (_, s) => s.ToSnakeCase(),
                 _configuration.UsesBackingStore,
                 false,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -80,7 +80,7 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
                 },
-                static s => s.ToSnakeCase(),
+                (_, s) => s.ToSnakeCase(),
                 _configuration.UsesBackingStore,
                 false,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -76,7 +76,7 @@ public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore,
                 },
-                (_, s) => s.ToSnakeCase(),
+                static (_, s) => s.ToSnakeCase(),
                 _configuration.UsesBackingStore,
                 true,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -76,7 +76,7 @@ public class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore,
                 },
-                static s => s.ToSnakeCase(),
+                (_, s) => s.ToSnakeCase(),
                 _configuration.UsesBackingStore,
                 true,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -61,7 +61,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
                 },
-                (_, s) => s.ToCamelCase(UnderscoreArray),
+                static (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 false,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -61,7 +61,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
                 },
-                static s => s.ToCamelCase(UnderscoreArray),
+                (_, s) => s.ToCamelCase(UnderscoreArray),
                 _configuration.UsesBackingStore,
                 false,
                 string.Empty,

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -219,12 +219,12 @@ public class GoLanguageRefinerTests
             Name = "additional_data",
             Kind = CodePropertyKind.Custom,
             Type = new CodeType { Name = model.Name, TypeDefinition = model, },
-        },new CodeProperty
+        }, new CodeProperty
         {
             Name = "property_a",
             Kind = CodePropertyKind.Custom,
             Type = new CodeType { Name = model.Name, TypeDefinition = model, },
-        },new CodeProperty
+        }, new CodeProperty
         {
             Name = "propertyA",
             Kind = CodePropertyKind.Custom,

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -207,6 +207,37 @@ public class GoLanguageRefinerTests
         Assert.Equal(inter, executorMethodReturnType.TypeDefinition);
     }
     [Fact]
+    public async Task EnsuresMethodNamesAreNotOverLoaded()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "somemodel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        model.AddProperty(new CodeProperty
+        {
+            Name = "additional_data",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { Name = model.Name, TypeDefinition = model, },
+        },new CodeProperty
+        {
+            Name = "property_a",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { Name = model.Name, TypeDefinition = model, },
+        },new CodeProperty
+        {
+            Name = "propertyA",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { Name = model.Name, TypeDefinition = model, },
+        });
+
+        Assert.Empty(root.GetChildElements(true).OfType<CodeInterface>());
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+
+        Assert.Equal("SetProperty_a", model.FindChildByName<CodeMethod>("set-property_a").Name);
+        Assert.Equal("SetPropertyA", model.FindChildByName<CodeMethod>("set-propertyA").Name);
+    }
+    [Fact]
     public async Task ReplacesModelsByInnerInterfaces()
     {
         var model = root.AddClass(new CodeClass


### PR DESCRIPTION
Go does not support method overloading parameters with eventual similar pascal names e.g `additionalData` and `additional_data`  or  `propertyA` and `property_a` eventually coliding.

This change introduces a flag to prevent applying name refiner case when properties with eventual similar method names.

Resolves https://github.com/microsoft/kiota/issues/2719