### PR TITLE
Adds the ability to configure MDOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing PHP integration tests [2378](https://github.com/microsoft/kiota/issues/2378)
 - Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
 - Fixed PHP request executor methods that return enums.
-- Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MDOP.
+- Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 
 ## [1.3.0] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing PHP integration tests [2378](https://github.com/microsoft/kiota/issues/2378)
 - Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
 - Fixed PHP request executor methods that return enums.
+- Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MDOP.
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -98,13 +98,6 @@ public class GenerationConfiguration : ICloneable
     }
     public HashSet<string> DisabledValidationRules { get; set; } = new(0, StringComparer.OrdinalIgnoreCase);
     public int MaxDegreeOfParallelism { get; set; } = -1;
-    public GenerationConfiguration()
-    {
-        if (Int32.TryParse(Environment.GetEnvironmentVariable("KIOTA_GENERATION_MDOP"), out var nrThreads))
-        {
-            MaxDegreeOfParallelism = nrThreads;
-        }
-    }
     public object Clone()
     {
         return new GenerationConfiguration

--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Kiota.Builder.Lock;
 
 namespace Kiota.Builder.Configuration;
@@ -14,6 +15,7 @@ public class GenerationConfiguration : ICloneable
     public string ClientClassName { get; set; } = "ApiClient";
     public string ClientNamespaceName { get; set; } = "ApiSdk";
     public string NamespaceNameSeparator { get; set; } = ".";
+
     public string ModelsNamespaceName
     {
         get => $"{ClientNamespaceName}{NamespaceNameSeparator}models";
@@ -95,6 +97,14 @@ public class GenerationConfiguration : ICloneable
         get; set;
     }
     public HashSet<string> DisabledValidationRules { get; set; } = new(0, StringComparer.OrdinalIgnoreCase);
+    public int MaxDegreeOfParallelism { get; set; } = -1;
+    public GenerationConfiguration()
+    {
+        if (Int32.TryParse(Environment.GetEnvironmentVariable("KIOTA_GENERATION_MDOP"), out var nrThreads))
+        {
+            MaxDegreeOfParallelism = nrThreads;
+        }
+    }
     public object Clone()
     {
         return new GenerationConfiguration
@@ -116,6 +126,7 @@ public class GenerationConfiguration : ICloneable
             ExcludePatterns = new(ExcludePatterns ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
             ClearCache = ClearCache,
             DisabledValidationRules = new(DisabledValidationRules ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase),
+            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
         };
     }
     private static readonly StringIEnumerableDeepComparer comparer = new();

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -41,6 +41,7 @@ public partial class KiotaBuilder
     private readonly HttpClient httpClient;
     private OpenApiDocument? originalDocument;
     private OpenApiDocument? openApiDocument;
+    private ParallelOptions parallelOptions;
     internal void SetOpenApiDocument(OpenApiDocument document) => openApiDocument = document ?? throw new ArgumentNullException(nameof(document));
 
     public KiotaBuilder(ILogger<KiotaBuilder> logger, GenerationConfiguration config, HttpClient client)
@@ -51,6 +52,14 @@ public partial class KiotaBuilder
         this.logger = logger;
         this.config = config;
         httpClient = client;
+        if (!Int32.TryParse(Environment.GetEnvironmentVariable("KIOTA_THREADS"), out var nrThreads))
+        {
+            nrThreads = 5;
+        }
+        parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = nrThreads
+        };
     }
     private async Task CleanOutputDirectory(CancellationToken cancellationToken)
     {
@@ -702,7 +711,7 @@ public partial class KiotaBuilder
         CreateUrlManagement(codeClass, currentNode, isApiClientClass);
 
         if (rootNamespace != null)
-            foreach (var childNode in currentNode.Children.Values)
+            Parallel.ForEach(currentNode.Children.Values, parallelOptions, childNode =>
             {
                 if (childNode.GetNodeNamespaceFromPath(config.ClientNamespaceName) is string targetNamespaceName &&
                     !string.IsNullOrEmpty(targetNamespaceName))
@@ -710,7 +719,7 @@ public partial class KiotaBuilder
                     var targetNamespace = rootNamespace.FindOrAddNamespace(targetNamespaceName);
                     CreateRequestBuilderClass(targetNamespace, childNode, rootNode);
                 }
-            };
+            });
     }
     private static void CreateMethod(string propIdentifier, string propType, CodeClass codeClass, OpenApiUrlTreeNode currentNode)
     {
@@ -914,7 +923,7 @@ public partial class KiotaBuilder
                                 x.Parent is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestBuilderWithParameters))
                                 .ToList();
 
-        Parallel.ForEach(unmappedRequestBuilderTypes, x =>
+        Parallel.ForEach(unmappedRequestBuilderTypes, parallelOptions, x =>
         {
             var parentNS = x.Parent?.Parent?.Parent as CodeNamespace;
             x.TypeDefinition = parentNS?.FindChildrenByName<CodeClass>(x.Name).MinBy(shortestNamespaceOrder);
@@ -931,7 +940,7 @@ public partial class KiotaBuilder
             }
         });
 
-        Parallel.ForEach(unmappedTypesWithName.Where(static x => x.TypeDefinition == null).GroupBy(static x => x.Name), x =>
+        Parallel.ForEach(unmappedTypesWithName.Where(static x => x.TypeDefinition == null).GroupBy(static x => x.Name), parallelOptions, x =>
         {
             if (rootNamespace?.FindChildByName<ITypeDefinition>(x.First().Name) is CodeElement definition)
                 foreach (var type in x)
@@ -1687,8 +1696,8 @@ public partial class KiotaBuilder
         var classesInUse = derivedClassesInUse.Union(classesDirectlyInUse).Union(baseOfModelsInUse).ToHashSet();
         var reusableClassesDerivationIndex = GetDerivationIndex(reusableModels.OfType<CodeClass>());
         var reusableClassesInheritanceIndex = GetInheritanceIndex(allModelClassesIndex);
-        var relatedModels = classesInUse.AsParallel().SelectMany(x => GetRelatedDefinitions(x, reusableClassesDerivationIndex, reusableClassesInheritanceIndex)).Union(modelsDirectlyInUse.Where(x => x is CodeEnum).AsParallel()).ToHashSet();// re-including models directly in use for enums
-        Parallel.ForEach(reusableModels, x =>
+        var relatedModels = classesInUse.SelectMany(x => GetRelatedDefinitions(x, reusableClassesDerivationIndex, reusableClassesInheritanceIndex)).Union(modelsDirectlyInUse.Where(x => x is CodeEnum)).ToHashSet();// re-including models directly in use for enums
+        Parallel.ForEach(reusableModels, parallelOptions, x =>
         {
             if (relatedModels.Contains(x) || classesInUse.Contains(x)) return;
             if (x is CodeClass currentClass)
@@ -1704,20 +1713,20 @@ public partial class KiotaBuilder
         foreach (var leafNamespace in FindLeafNamespaces(modelsNamespace))
             RemoveEmptyNamespaces(leafNamespace, modelsNamespace);
     }
-    private static ConcurrentDictionary<CodeClass, List<CodeClass>> GetDerivationIndex(IEnumerable<CodeClass> models)
+    private ConcurrentDictionary<CodeClass, List<CodeClass>> GetDerivationIndex(IEnumerable<CodeClass> models)
     {
         var result = new ConcurrentDictionary<CodeClass, List<CodeClass>>();
-        Parallel.ForEach(models, x =>
+        Parallel.ForEach(models, parallelOptions, x =>
         {
             if (x.BaseClass is CodeClass parentClass && !result.TryAdd(parentClass, new() { x }))
                 result[parentClass].Add(x);
         });
         return result;
     }
-    private static ConcurrentDictionary<CodeClass, List<CodeClass>> GetInheritanceIndex(ConcurrentDictionary<CodeClass, List<CodeClass>> derivedIndex)
+    private ConcurrentDictionary<CodeClass, List<CodeClass>> GetInheritanceIndex(ConcurrentDictionary<CodeClass, List<CodeClass>> derivedIndex)
     {
         var result = new ConcurrentDictionary<CodeClass, List<CodeClass>>();
-        Parallel.ForEach(derivedIndex, entry =>
+        Parallel.ForEach(derivedIndex, parallelOptions, entry =>
         {
             foreach (var derivedClass in entry.Value)
                 if (!result.TryAdd(derivedClass, new() { entry.Key }))

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -702,7 +702,7 @@ public partial class KiotaBuilder
         CreateUrlManagement(codeClass, currentNode, isApiClientClass);
 
         if (rootNamespace != null)
-            Parallel.ForEach(currentNode.Children.Values, childNode =>
+            foreach (var childNode in currentNode.Children.Values)
             {
                 if (childNode.GetNodeNamespaceFromPath(config.ClientNamespaceName) is string targetNamespaceName &&
                     !string.IsNullOrEmpty(targetNamespaceName))
@@ -710,7 +710,7 @@ public partial class KiotaBuilder
                     var targetNamespace = rootNamespace.FindOrAddNamespace(targetNamespaceName);
                     CreateRequestBuilderClass(targetNamespace, childNode, rootNode);
                 }
-            });
+            };
     }
     private static void CreateMethod(string propIdentifier, string propType, CodeClass codeClass, OpenApiUrlTreeNode currentNode)
     {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -38,10 +38,10 @@ public partial class KiotaBuilder
 {
     private readonly ILogger<KiotaBuilder> logger;
     private readonly GenerationConfiguration config;
+    private readonly ParallelOptions parallelOptions;
     private readonly HttpClient httpClient;
     private OpenApiDocument? originalDocument;
     private OpenApiDocument? openApiDocument;
-    private ParallelOptions parallelOptions;
     internal void SetOpenApiDocument(OpenApiDocument document) => openApiDocument = document ?? throw new ArgumentNullException(nameof(document));
 
     public KiotaBuilder(ILogger<KiotaBuilder> logger, GenerationConfiguration config, HttpClient client)
@@ -52,13 +52,9 @@ public partial class KiotaBuilder
         this.logger = logger;
         this.config = config;
         httpClient = client;
-        if (!Int32.TryParse(Environment.GetEnvironmentVariable("KIOTA_THREADS"), out var nrThreads))
-        {
-            nrThreads = 5;
-        }
         parallelOptions = new ParallelOptions
         {
-            MaxDegreeOfParallelism = nrThreads
+            MaxDegreeOfParallelism = config.MaxDegreeOfParallelism,
         };
     }
     private async Task CleanOutputDirectory(CancellationToken cancellationToken)

--- a/src/Kiota.Web/wwwroot/appsettings.json
+++ b/src/Kiota.Web/wwwroot/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Generation": {
-    "IgnoredRequestContentTypes": ["multipart/form-data"]
+    "IgnoredRequestContentTypes": ["multipart/form-data"],
+    "MaxDegreeOfParallelism": -1
   },
   "Search": {
     "APIsGuruListUrl": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/gh-pages/v2/list.json",

--- a/src/kiota/KiotaConfigurationExtensions.cs
+++ b/src/kiota/KiotaConfigurationExtensions.cs
@@ -60,6 +60,7 @@ internal static class KiotaConfigurationExtensions
         configObject.Generation.IncludeAdditionalData = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.IncludeAdditionalData)}"], out var includeAdditionalData) && includeAdditionalData;
         configObject.Generation.CleanOutput = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.CleanOutput)}"], out var cleanOutput) && cleanOutput;
         configObject.Generation.ClearCache = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.ClearCache)}"], out var clearCache) && clearCache;
+        configObject.Generation.MaxDegreeOfParallelism = Int32.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.MaxDegreeOfParallelism)}"], out var maxDegreeOfParallelism) ? maxDegreeOfParallelism : configObject.Generation.MaxDegreeOfParallelism;
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.StructuredMimeTypes)}").LoadHashSet(configObject.Generation.StructuredMimeTypes);
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.Serializers)}").LoadHashSet(configObject.Generation.Serializers);
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.Deserializers)}").LoadHashSet(configObject.Generation.Deserializers);

--- a/src/kiota/KiotaConfigurationExtensions.cs
+++ b/src/kiota/KiotaConfigurationExtensions.cs
@@ -60,7 +60,7 @@ internal static class KiotaConfigurationExtensions
         configObject.Generation.IncludeAdditionalData = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.IncludeAdditionalData)}"], out var includeAdditionalData) && includeAdditionalData;
         configObject.Generation.CleanOutput = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.CleanOutput)}"], out var cleanOutput) && cleanOutput;
         configObject.Generation.ClearCache = bool.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.ClearCache)}"], out var clearCache) && clearCache;
-        configObject.Generation.MaxDegreeOfParallelism = Int32.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.MaxDegreeOfParallelism)}"], out var maxDegreeOfParallelism) ? maxDegreeOfParallelism : configObject.Generation.MaxDegreeOfParallelism;
+        configObject.Generation.MaxDegreeOfParallelism = int.TryParse(configuration[$"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.MaxDegreeOfParallelism)}"], out var maxDegreeOfParallelism) ? maxDegreeOfParallelism : configObject.Generation.MaxDegreeOfParallelism;
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.StructuredMimeTypes)}").LoadHashSet(configObject.Generation.StructuredMimeTypes);
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.Serializers)}").LoadHashSet(configObject.Generation.Serializers);
         configuration.GetSection($"{nameof(configObject.Generation)}:{nameof(GenerationConfiguration.Deserializers)}").LoadHashSet(configObject.Generation.Deserializers);

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Generation": {
-    "IgnoredRequestContentTypes": ["multipart/form-data"]
+    "IgnoredRequestContentTypes": ["multipart/form-data"],
+    "MaxDegreeOfParallelism": -1
   },
   "Search": {
     "APIsGuruListUrl": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/gh-pages/v2/list.json",


### PR DESCRIPTION
This causes quite severe corruption of the CodeModel. Many threads concurrently start creating the same models and start adding properties. The result is undefined for larger models and will be different on every run.

This probably fixes (or at least improves the situation for) #2442.

I ran into this trying to build an SDK with the fix for the renaming of properties, which sometimes worked and sometimes didn't work.