### PR TITLE
Fix PHP request executor methods returning enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing PHP integration tests [2378](https://github.com/microsoft/kiota/issues/2378)
 - Fixed generation of properties with identical names after symbol cleanup. 
 - Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
+- Fixed PHP request executor methods that return enums.
 
 ## [1.3.0] - 2023-06-09
 


### PR DESCRIPTION
Calls `sendPrimitiveAsync` on the request adapter with the enum class name.

depends on https://github.com/microsoft/kiota-http-guzzle-php/pull/69
closes https://github.com/microsoftgraph/msgraph-beta-sdk-php/issues/182