### PR TITLE
Use the name of the property as base for the accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed generation of properties with identical names after symbol cleanup. 
 - Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
 - Fixed PHP request executor methods that return enums.
+- Fix mixup of names between code model generation and code writing which could result in broken code for properties with identical names after symbol cleanup.
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -101,11 +101,6 @@ public class CodeProperty : CodeTerminalWithKind<CodePropertyKind>, IDocumentedE
         get => !string.IsNullOrEmpty(SerializationName);
     }
     /// <inheritdoc/>
-    public string SymbolName
-    {
-        get => IsNameEscaped ? SerializationName.CleanupSymbolName() : Name;
-    }
-    /// <inheritdoc/>
     public string WireName => IsNameEscaped ? SerializationName : Name.ToFirstCharacterLowerCase();
     public CodeProperty? OriginalPropertyFromBaseType
     {

--- a/src/Kiota.Builder/CodeDOM/IAlternativeName.cs
+++ b/src/Kiota.Builder/CodeDOM/IAlternativeName.cs
@@ -27,11 +27,4 @@ public interface IAlternativeName
     {
         get; set;
     }
-    /// <summary>
-    /// Gets the symbol name of the element.
-    /// </summary>
-    string SymbolName
-    {
-        get;
-    }
 }

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -223,7 +223,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             }
             var propertyOriginalName = (currentProperty.IsNameEscaped ? currentProperty.SerializationName : current.Name)
                                         .ToFirstCharacterLowerCase();
-            var accessorName = refineAccessorName(current, propertyOriginalName.CleanupSymbolName().ToFirstCharacterUpperCase());
+            var accessorName = refineAccessorName(current, currentProperty.Name.ToFirstCharacterUpperCase());
 
             currentProperty.Getter = parentClass.AddMethod(new CodeMethod
             {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -221,8 +221,6 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 if (!string.IsNullOrEmpty(fieldPrefix))
                     currentProperty.NamePrefix = fieldPrefix;
             }
-            var propertyOriginalName = (currentProperty.IsNameEscaped ? currentProperty.SerializationName : current.Name)
-                                        .ToFirstCharacterLowerCase();
             var accessorName = refineAccessorName(current, currentProperty.Name.ToFirstCharacterUpperCase());
 
             currentProperty.Getter = parentClass.AddMethod(new CodeMethod
@@ -234,7 +232,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 ReturnType = (CodeTypeBase)currentProperty.Type.Clone(),
                 Documentation = new()
                 {
-                    Description = $"Gets the {propertyOriginalName} property value. {currentProperty.Documentation.Description}",
+                    Description = $"Gets the {currentProperty.WireName} property value. {currentProperty.Documentation.Description}",
                 },
                 AccessedProperty = currentProperty,
                 Deprecation = currentProperty.Deprecation,
@@ -248,7 +246,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 Kind = CodeMethodKind.Setter,
                 Documentation = new()
                 {
-                    Description = $"Sets the {propertyOriginalName} property value. {currentProperty.Documentation.Description}",
+                    Description = $"Sets the {currentProperty.WireName} property value. {currentProperty.Documentation.Description}",
                 },
                 AccessedProperty = currentProperty,
                 ReturnType = new CodeType
@@ -268,7 +266,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 Kind = CodeParameterKind.SetterValue,
                 Documentation = new()
                 {
-                    Description = $"Value to set for the {current.Name} property.",
+                    Description = $"Value to set for the {currentProperty.WireName} property.",
                 },
                 Optional = parameterAsOptional,
                 Type = (CodeTypeBase)currentProperty.Type.Clone(),

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -521,7 +521,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
             var defaultValueReference = propWithDefault.DefaultValue;
             if (defaultValueReference.StartsWith("\"", StringComparison.OrdinalIgnoreCase))
             {
-                defaultValueReference = $"{propWithDefault.SymbolName.ToFirstCharacterLowerCase()}Value";
+                defaultValueReference = $"{propWithDefault.Name.ToFirstCharacterLowerCase()}Value";
                 var defaultValue = propWithDefault.DefaultValue;
                 if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
                 {
@@ -530,7 +530,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                 writer.WriteLine($"{defaultValueReference} := {defaultValue}");
                 defaultValueReference = $"&{defaultValueReference}";
             }
-            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterUpperCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"Set{propWithDefault.SymbolName.ToFirstCharacterUpperCase()}";
+            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterUpperCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"Set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
             writer.WriteLine($"m.{setterName}({defaultValueReference})");
         }
         if (parentClass.IsOfKind(CodeClassKind.RequestBuilder) && currentMethod.IsOfKind(CodeMethodKind.Constructor) &&

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -323,7 +323,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                         .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
                                         .OrderBy(static x => x.Name))
         {
-            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterLowerCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.SymbolName.ToFirstCharacterUpperCase()}";
+            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterLowerCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
             var defaultValue = propWithDefault.DefaultValue;
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -112,7 +112,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
             .OrderBy(static x => x.Name))
         {
-            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterLowerCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.SymbolName.ToFirstCharacterUpperCase()}";
+            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterLowerCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
             var defaultValue = propWithDefault.DefaultValue.ReplaceDoubleQuoteWithSingleQuote();
             if (propWithDefault.Type is CodeType codeType && codeType.TypeDefinition is CodeEnum enumDefinition)
             {


### PR DESCRIPTION
The original name may have been changed to prevent conflicts. The name of the getter and setter must match the name of the property, otherwise these will create new conflicts.