### PR TITLE
Do not convert first char to upper on type names during code model construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
 - Add locking to writing to log files.
+- Typenames are not changed to first char upper case in comments in some cases.
 
 ## [1.3.0] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use schematized types for 206 response codes instead of binary. [#2880](https://github.com/microsoft/kiota/issues/2880)
+- Typenames are not changed to first char upper case in comments in some cases.
 
 ## [1.4.0] - 2023-07-07
 
@@ -43,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
 - Add locking to writing to log files.
-- Typenames are not changed to first char upper case in comments in some cases.
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Extensions/OpenApiReferenceExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiReferenceExtensions.cs
@@ -6,8 +6,7 @@ public static class OpenApiReferenceExtensions
     public static string GetClassName(this OpenApiReference? reference)
     {
         if (reference?.Id is string referenceId && !string.IsNullOrEmpty(referenceId))
-            return referenceId[(referenceId.LastIndexOf('.') + 1)..]
-                                    .ToFirstCharacterUpperCase();
+            return referenceId[(referenceId.LastIndexOf('.') + 1)..];
         return string.Empty;
     }
 }

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -562,7 +562,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
             writer.StartBlock($"{errorMappingVarName}: Dict[str, ParsableFactory] = {{");
             foreach (var errorMapping in codeElement.ErrorMappings)
             {
-                writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": {errorMapping.Value.Name},");
+                writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": {errorMapping.Value.Name.ToFirstCharacterUpperCase()},");
             }
             writer.CloseBlock();
         }

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiReferenceExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiReferenceExtensionsTests.cs
@@ -14,7 +14,7 @@ public class OpenApiReferenceExtensionsTests
         {
             Id = "microsoft.graph.user"
         };
-        Assert.Equal("User", reference.GetClassName());
+        Assert.Equal("user", reference.GetClassName());
     }
     [Fact]
     public void GetsClassNameDefensive()

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -362,6 +362,6 @@ public class OpenApiUrlTreeNodeExtensionsTests
             .GetClassName(new() { "application/json" }, schema: responseSchema);
 
         // validate that we get a valid class name
-        Assert.Equal("Json", responseClassName);
+        Assert.Equal("json", responseClassName);
     }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -3427,7 +3427,7 @@ paths:
         Assert.NotNull(requestExecutorMethod);
         var executorReturnType = requestExecutorMethod.ReturnType as CodeType;
         Assert.NotNull(executorReturnType);
-        Assert.Contains("DerivedObject", requestExecutorMethod.ReturnType.Name);
+        Assert.Contains("derivedObject", requestExecutorMethod.ReturnType.Name);
         var secondLevelDerivedClass = codeModel.FindChildByName<CodeClass>("derivedObject");
         Assert.NotNull(secondLevelDerivedObject);
         var factoryMethod = secondLevelDerivedClass.GetChildElements(true).OfType<CodeMethod>().FirstOrDefault(x => x.IsOfKind(CodeMethodKind.Factory));
@@ -4307,7 +4307,7 @@ paths:
         Assert.NotNull(rbClass);
         var executorMethod = rbClass.Methods.FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestExecutor) && x.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(executorMethod);
-        Assert.Equal("Myobject", executorMethod.ReturnType.Name);
+        Assert.Equal("myobject", executorMethod.ReturnType.Name);
     }
     [Fact]
     public void ModelsUseDescriptionWhenAvailable()
@@ -4374,15 +4374,15 @@ paths:
     [InlineData("application/json", "205", false, "default", "void")]
     [InlineData("application/json", "204", true, "default", "void")]
     [InlineData("application/json", "204", false, "default", "void")]
-    [InlineData("application/json", "203", true, "default", "Myobject")]
+    [InlineData("application/json", "203", true, "default", "myobject")]
     [InlineData("application/json", "203", false, "default", "binary")]
-    [InlineData("application/json", "202", true, "default", "Myobject")]
+    [InlineData("application/json", "202", true, "default", "myobject")]
     [InlineData("application/json", "202", false, "default", "void")]
-    [InlineData("application/json", "201", true, "default", "Myobject")]
+    [InlineData("application/json", "201", true, "default", "myobject")]
     [InlineData("application/json", "201", false, "default", "void")]
-    [InlineData("application/json", "200", true, "default", "Myobject")]
+    [InlineData("application/json", "200", true, "default", "myobject")]
     [InlineData("application/json", "200", false, "default", "binary")]
-    [InlineData("application/json", "2XX", true, "default", "Myobject")]
+    [InlineData("application/json", "2XX", true, "default", "myobject")]
     [InlineData("application/json", "2XX", false, "default", "binary")]
     [InlineData("application/xml", "204", true, "default", "void")]
     [InlineData("application/xml", "204", false, "default", "void")]
@@ -4410,7 +4410,7 @@ paths:
     [InlineData("*/*", "200", false, "default", "binary")]
     [InlineData("text/plain", "204", true, "default", "void")]
     [InlineData("text/plain", "204", false, "default", "void")]
-    [InlineData("text/plain", "200", true, "default", "Myobject")]
+    [InlineData("text/plain", "200", true, "default", "myobject")]
     [InlineData("text/plain", "200", false, "default", "string")]
     [InlineData("text/plain", "204", true, "application/json", "void")]
     [InlineData("text/plain", "204", false, "application/json", "void")]
@@ -4587,7 +4587,7 @@ paths:
         Assert.NotNull(rbClass);
         var executor = rbClass.Methods.FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
         Assert.NotNull(executor);
-        Assert.Equal("Myobject", executor.ReturnType.Name);
+        Assert.Equal("myobject", executor.ReturnType.Name);
     }
     [Fact]
     public void Considers2XXWithSchemaOver204WithNoSchema()
@@ -4660,7 +4660,7 @@ paths:
         Assert.NotNull(rbClass);
         var executor = rbClass.Methods.FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
         Assert.NotNull(executor);
-        Assert.Equal("Myobject", executor.ReturnType.Name);
+        Assert.Equal("myobject", executor.ReturnType.Name);
     }
     [Fact]
     public void Considers204WithNoSchemaOver206WithNoSchema()
@@ -4729,7 +4729,7 @@ paths:
         Assert.NotNull(executor);
         Assert.Equal("void", executor.ReturnType.Name);
     }
-    [InlineData("application/json", true, "default", "Myobject")]
+    [InlineData("application/json", true, "default", "myobject")]
     [InlineData("application/json", false, "default", "binary")]
     [InlineData("application/xml", false, "default", "binary")]
     [InlineData("application/xml", true, "default", "binary")] //MyObject when we support it
@@ -4744,7 +4744,7 @@ paths:
     [InlineData("*/*", true, "default", "binary")]
     [InlineData("*/*", false, "default", "binary")]
     [InlineData("text/plain", false, "default", "binary")]
-    [InlineData("text/plain", true, "default", "Myobject")]
+    [InlineData("text/plain", true, "default", "myobject")]
     [InlineData("text/plain", true, "application/json", "binary")]
     [InlineData("text/plain", false, "application/json", "binary")]
     [InlineData("text/yaml", true, "application/json", "binary")]

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -4368,7 +4368,7 @@ paths:
         Assert.Equal("some path item description", responseProperty.Documentation.Description);
     }
 
-    [InlineData("application/json", "206", true, "default", "Myobject")]
+    [InlineData("application/json", "206", true, "default", "myobject")]
     [InlineData("application/json", "206", false, "default", "binary")]
     [InlineData("application/json", "205", true, "default", "void")]
     [InlineData("application/json", "205", false, "default", "void")]


### PR DESCRIPTION
Types are sometimes created with an upper case type name and sometimes with a lower case type name. This has no functional effect on the resulting code, because the writers will do this, but the converted name can end up in the comment. The comment should follow the spec and should be stable as much as possible.

This pull request fixes spurious changes like in `models/group.go` in this PR https://github.com/microsoftgraph/msgraph-sdk-go/pull/523/files .