### PR TITLE
Add type descriptions for inherited types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PHP request executor methods that return enums.
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
+- Fixed missing type comments in many cases.
 
 ## [1.3.0] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed missing type comments in many cases.
+
 ## [1.4.0] - 2023-07-07
 
 ### Added
@@ -40,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PHP request executor methods that return enums.
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
-- Fixed missing type comments in many cases.
 - Add locking to writing to log files.
 
 ## [1.3.0] - 2023-06-09

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1636,7 +1636,7 @@ public partial class KiotaBuilder
             {
                 DocumentationLabel = schema.ExternalDocs?.Description ?? string.Empty,
                 DocumentationLink = schema.ExternalDocs?.Url,
-                Description = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf.LastOrDefault()?.Description : schema.Description).CleanupDescription(),
+                Description = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf.OrderBy(static x => x?.Reference.Id, StringComparer.OrdinalIgnoreCase).LastOrDefault(static x => !string.IsNullOrEmpty(x.Description))?.Description : schema.Description).CleanupDescription(),
             },
             Deprecation = schema.GetDeprecationInformation(),
         };

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1636,7 +1636,7 @@ public partial class KiotaBuilder
             {
                 DocumentationLabel = schema.ExternalDocs?.Description ?? string.Empty,
                 DocumentationLink = schema.ExternalDocs?.Url,
-                Description = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf.OrderBy(static x => x?.Reference.Id, StringComparer.OrdinalIgnoreCase).LastOrDefault(static x => !string.IsNullOrEmpty(x.Description))?.Description : schema.Description).CleanupDescription(),
+                Description = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf?.OrderBy(static x => x?.Reference?.Id, StringComparer.OrdinalIgnoreCase).LastOrDefault(static x => !string.IsNullOrEmpty(x.Description))?.Description : schema.Description).CleanupDescription(),
             },
             Deprecation = schema.GetDeprecationInformation(),
         };

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1636,7 +1636,7 @@ public partial class KiotaBuilder
             {
                 DocumentationLabel = schema.ExternalDocs?.Description ?? string.Empty,
                 DocumentationLink = schema.ExternalDocs?.Url,
-                Description = schema.Description.CleanupDescription(),
+                Description = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf.LastOrDefault()?.Description : schema.Description).CleanupDescription(),
             },
             Deprecation = schema.GetDeprecationInformation(),
         };


### PR DESCRIPTION
These were often missing in the generated code. AddModelClass only looked in schema.Discription and not in the list of AllOf.