### PR TITLE
Fixes renaming of enum options in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevents method overloading for go getters and setters with different values. [#2719](https://github.com/microsoft/kiota/issues/2719)
 - Fixed PHP request executor methods that return enums.
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
+- Fixes regression where enum options would be renamed in CSharp.
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -66,7 +66,7 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum),typeof(CodeEnumOption) }
+                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum), typeof(CodeEnumOption) }
             );
             ReplaceReservedNames(
                 generatedCode,

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -66,7 +66,7 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum) }
+                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum),typeof(CodeEnumOption) }
             );
             ReplaceReservedNames(
                 generatedCode,

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -387,7 +387,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 !propertyType.IsExternal &&
                 provider.ReservedNames.Contains(currentProperty.Type.Name))
             propertyType.Name = replacement.Invoke(propertyType.Name);
-        
+
         // Check if the current name meets the following conditions to be replaced
         // 1. In the list of reserved names
         // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
@@ -407,7 +407,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             {
                 currentEnumOption.SerializationName = currentEnumOption.Name;
             }
-            
+
             var replacementName = replacement.Invoke(current.Name);
             if (current.Parent is IBlock parentBlock)
                 parentBlock.RenameChildElement(current.Name, replacementName);

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -387,11 +387,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 !propertyType.IsExternal &&
                 provider.ReservedNames.Contains(currentProperty.Type.Name))
             propertyType.Name = replacement.Invoke(propertyType.Name);
-        else if (current is CodeEnum currentEnum &&
-                isNotInExceptions &&
-                shouldReplace &&
-                currentEnum.Options.Any(x => provider.ReservedNames.Contains(x.Name)))
-            ReplaceReservedEnumNames(currentEnum, provider, replacement);
+        
         // Check if the current name meets the following conditions to be replaced
         // 1. In the list of reserved names
         // 2. If it is a reserved name, make sure that the CodeElement type is worth replacing(not on the blocklist)
@@ -406,6 +402,12 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             {
                 currentProperty.SerializationName = currentProperty.Name;
             }
+            if (current is CodeEnumOption currentEnumOption &&
+                string.IsNullOrEmpty(currentEnumOption.SerializationName))
+            {
+                currentEnumOption.SerializationName = currentEnumOption.Name;
+            }
+            
             var replacementName = replacement.Invoke(current.Name);
             if (current.Parent is IBlock parentBlock)
                 parentBlock.RenameChildElement(current.Name, replacementName);
@@ -416,18 +418,6 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         CrawlTree(current, x => ReplaceReservedNames(x, provider, replacement, codeElementExceptions, shouldReplaceCallback));
     }
 
-    private static void ReplaceReservedEnumNames(CodeEnum currentEnum, IReservedNamesProvider provider, Func<string, string> replacement)
-    {
-        currentEnum.Options
-                    .Where(x => provider.ReservedNames.Contains(x.Name))
-                    .ToList()
-                    .ForEach(x =>
-                    {
-                        if (string.IsNullOrEmpty(x.SerializationName))
-                            x.SerializationName = x.Name;
-                        currentEnum.RenameChildElement(x.Name, replacement.Invoke(x.Name));
-                    });
-    }
     private static void ReplaceReservedCodeUsingDeclarationNames(ClassDeclaration currentDeclaration, IReservedNamesProvider provider, Func<string, string> replacement)
     {
         // replace the using declaration type names that are internally defined by the generator

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -84,7 +84,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "set",
                 string.Empty
             );
-            ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped");
+            ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped", new HashSet<Type>{typeof(CodeEnumOption)});
             ReplaceReservedExceptionPropertyNames(generatedCode, new JavaExceptionsReservedNamesProvider(), x => $"{x}Escaped");
             LowerCaseNamespaceNames(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -84,7 +84,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "set",
                 string.Empty
             );
-            ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped", new HashSet<Type>{typeof(CodeEnumOption)});
+            ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped", new HashSet<Type> { typeof(CodeEnumOption) });
             ReplaceReservedExceptionPropertyNames(generatedCode, new JavaExceptionsReservedNamesProvider(), x => $"{x}Escaped");
             LowerCaseNamespaceNames(generatedCode);
             AddPropertiesAndMethodTypesImports(generatedCode, true, false, true);

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -42,7 +42,7 @@ public class PhpRefiner : CommonLanguageRefiner
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore,
                 false);
-            ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}");
+            ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}", new HashSet<Type>{typeof(CodeEnumOption)});
             AddQueryParameterFactoryMethod(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             AddParsableImplementsForModelClasses(generatedCode, "Parsable");

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -42,7 +42,7 @@ public class PhpRefiner : CommonLanguageRefiner
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore,
                 false);
-            ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}", new HashSet<Type>{typeof(CodeEnumOption)});
+            ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}", new HashSet<Type> { typeof(CodeEnumOption) });
             AddQueryParameterFactoryMethod(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             AddParsableImplementsForModelClasses(generatedCode, "Parsable");

--- a/src/Kiota.Builder/Refiners/ShellRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ShellRefiner.cs
@@ -66,7 +66,7 @@ public class ShellRefiner : CSharpRefiner, ILanguageRefiner
             ReplaceReservedNames(
                 generatedCode,
                 new CSharpReservedNamesProvider(), x => $"@{x.ToFirstCharacterUpperCase()}",
-                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum) }
+                new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeProperty), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum), typeof(CodeEnumOption) }
             );
             ReplaceReservedNames(
                 generatedCode,

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -28,6 +28,21 @@ public class CSharpLanguageRefinerTests
 
         Assert.Contains("EnumMemberAttribute", declaration.Usings.Select(x => x.Name));
     }
+    [Theory]
+    [InlineData("operator")]
+    [InlineData("string")]
+    public async Task EnumWithReservedName_IsNotRenamed(string input)
+    {
+        var model = root.AddEnum(new CodeEnum
+        {
+            Name = "someenum"
+        }).First();
+        var option = new CodeEnumOption { Name = input, SerializationName = input };
+        model.AddOption(option);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+
+        Assert.Equal(input, model.Options.First().Name);
+    }
     [Fact]
     public async Task EnumDoesntHaveEscapedOption_DoesntUseEnumMemberAttribute()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -47,6 +47,21 @@ public class GoLanguageRefinerTests
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
         Assert.Equal(2, model.GetChildElements(true).Count());
     }
+    [Theory(Skip = "Fixing this test is a breaking change - https://github.com/microsoft/kiota/issues/2877")]
+    [InlineData("break")]
+    [InlineData("case")]
+    public async Task EnumWithReservedName_IsNotRenamed(string input)
+    {
+        var model = root.AddEnum(new CodeEnum
+        {
+            Name = "someenum"
+        }).First();
+        var option = new CodeEnumOption { Name = input, SerializationName = input };
+        model.AddOption(option);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+
+        Assert.Equal(input, model.Options.First().Name);
+    }
     [Fact]
     public async Task TrimsCircularDiscriminatorReferences()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -26,7 +26,7 @@ public class JavaLanguageRefinerTests
         model.AddOption(option);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
         Assert.Equal("break", option.Name);
-        Assert.Equal("", option.SerializationName);
+        Assert.Empty(option.SerializationName);
     }
     [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -13,7 +13,7 @@ public class JavaLanguageRefinerTests
     private readonly CodeNamespace root = CodeNamespace.InitRootNamespace();
     #region CommonLanguageRefinerTests
     [Fact]
-    public async Task ReplacesReservedEnumOptions()
+    public async Task DoesNotReplacesReservedEnumOptions()
     {
         var model = root.AddEnum(new CodeEnum
         {
@@ -25,8 +25,8 @@ public class JavaLanguageRefinerTests
         };
         model.AddOption(option);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-        Assert.Equal("breakEscaped", option.Name);
-        Assert.Equal("break", option.SerializationName);
+        Assert.Equal("break", option.Name);
+        Assert.Equal("", option.SerializationName);
     }
     [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -49,7 +49,7 @@ public class PhpLanguageRefinerTests
 
         Assert.Equal(input, model.Options.First().Name);
     }
-    
+
     [Fact]
     public async Task PrefixReservedWordPropertyNamesWith()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -34,6 +34,22 @@ public class PhpLanguageRefinerTests
         Assert.Equal("userRequestBuilder", model.Name);
     }
 
+    [Theory]
+    [InlineData("break")]
+    [InlineData("case")]
+    public async Task EnumWithReservedName_IsNotRenamed(string input)
+    {
+        var model = root.AddEnum(new CodeEnum
+        {
+            Name = "someenum"
+        }).First();
+        var option = new CodeEnumOption { Name = input, SerializationName = input };
+        model.AddOption(option);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root);
+
+        Assert.Equal(input, model.Options.First().Name);
+    }
+    
     [Fact]
     public async Task PrefixReservedWordPropertyNamesWith()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
@@ -88,6 +88,21 @@ public class PythonLanguageRefinerTests
         Assert.Single(model.Properties.Where(x => x.IsNameEscaped));
         Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.QueryParametersMapper)));
     }
+    [Theory]
+    [InlineData("None")]
+    [InlineData("while")]
+    public async Task EnumWithReservedName_IsRenamed(string input)
+    {
+        var model = root.AddEnum(new CodeEnum
+        {
+            Name = "someenum"
+        }).First();
+        var option = new CodeEnumOption { Name = input, SerializationName = input };
+        model.AddOption(option);
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Python }, root);
+
+        Assert.Equal(input+"_", model.Options.First().Name);// we need to escape this in python
+    }
     [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PythonLanguageRefinerTests.cs
@@ -101,7 +101,7 @@ public class PythonLanguageRefinerTests
         model.AddOption(option);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Python }, root);
 
-        Assert.Equal(input+"_", model.Options.First().Name);// we need to escape this in python
+        Assert.Equal(input + "_", model.Options.First().Name);// we need to escape this in python
     }
     [Fact]
     public async Task AddsExceptionInheritanceOnErrorClasses()

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -74,6 +74,8 @@ public class CodeEnumWriterTests : IDisposable
     [InlineData("\\", "BackSlash")]
     [InlineData("?", "QuestionMark")]
     [InlineData("$", "Dollar")]
+    [InlineData("double", "Double")]
+    [InlineData("string", "String")]
     public void WritesEnumWithSanitizedName(string symbol, string expected)
     {
         currentEnum.Flags = true;


### PR DESCRIPTION
`CodeEnumOption` was recently changed to derive from `CodeElement` and therefore lead to changing(double processing) of the type in the `ReplaceReservedNames` function in the `CommonLanguageRefiner`.

This Pr streamlines the handling of the `CodeEnumOption` type to be handled like other `CodeElement` instances and adds tests to validate.