### PR TITLE
Lock the logger when writing the _logStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PHP request executor methods that return enums.
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
+- Add locking to writing to log files.
 
 ## [1.3.0] - 2023-06-09
 


### PR DESCRIPTION
The StreamWriter does not seem to be threadsafe. On my system I get a lot of crashes like metioned in #2878. This lock fixes the issues on my system. I'm not sure though if this the correct solution for this problem.