### PR TITLE
Consider 206 as a success code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use schematized types for 206 response codes instead of binary. [#2880](https://github.com/microsoft/kiota/issues/2880)
+
 ## [1.4.0] - 2023-07-07
 
 ### Added
@@ -41,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
 - Add locking to writing to log files.
-- Use actual types for 206 response codes. [#2880](https://github.com/microsoft/kiota/issues/2880)
 
 ## [1.3.0] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow configuration of the number of threads via the environment variable KIOTA_GENERATION_MAXDEGREEOFPARALLELISM.
 - Fixes regression where enum options would be renamed in CSharp.
 - Add locking to writing to log files.
+- Use actual types for 206 response codes. [#2880](https://github.com/microsoft/kiota/issues/2880)
 
 ## [1.3.0] - 2023-06-09
 

--- a/src/Kiota.Builder/Extensions/OpenApiOperationExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiOperationExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.OpenApi.Models;
 namespace Kiota.Builder.Extensions;
 public static class OpenApiOperationExtensions
 {
-    internal static readonly HashSet<string> SuccessCodes = new(StringComparer.OrdinalIgnoreCase) { "200", "201", "202", "203", "2XX" }; //204 excluded as it won't have a schema
+    internal static readonly HashSet<string> SuccessCodes = new(StringComparer.OrdinalIgnoreCase) { "200", "201", "202", "203", "206", "2XX" }; //204 excluded as it won't have a schema
     /// <summary>
     /// cleans application/vnd.github.mercy-preview+json to application/json
     /// </summary>

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -4368,7 +4368,7 @@ paths:
         Assert.Equal("some path item description", responseProperty.Documentation.Description);
     }
 
-    [InlineData("application/json", "206", true, "default", "binary")]
+    [InlineData("application/json", "206", true, "default", "Myobject")]
     [InlineData("application/json", "206", false, "default", "binary")]
     [InlineData("application/json", "205", true, "default", "void")]
     [InlineData("application/json", "205", false, "default", "void")]


### PR DESCRIPTION
fixes #2880 

If the schema defines a 206 status code with a model, the request now returns the defined type rather than a byte stream. This can be useful if Content-Range is used with a unit other than bytes.