### PR TITLE
- fixes an issue where the github release would fail to be created

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -415,7 +415,7 @@ stages:
               targetType: "inline"
               script: |
                 $xml = [Xml] (Get-Content $(Build.SourcesDirectory)/src/kiota/kiota.csproj)
-                $version = $xml.Project.PropertyGroup.Version
+                $version = $xml.Project.PropertyGroup.Version[0]
                 echo $version
                 Write-Host "##vso[task.setvariable variable=artifactVersion]$version"
           - pwsh: $(Build.SourcesDirectory)/scripts/update-vscode-releases.ps1 -version $(artifactVersion) -filePath $(Build.SourcesDirectory)/vscode/microsoft-kiota/package.json -binaryFolderPath $(Build.ArtifactStagingDirectory)/Binaries
@@ -491,10 +491,11 @@ stages:
                     targetType: "inline"
                     script: |
                       $xml = [Xml] (Get-Content $(Build.SourcesDirectory)/src/kiota/kiota.csproj)
-                      $version = $xml.Project.PropertyGroup.Version
+                      $version = $xml.Project.PropertyGroup.Version[0]
                       echo $version
                       Write-Host "##vso[task.setvariable variable=artifactVersion]$version"
                 - pwsh: $(Build.SourcesDirectory)/scripts/get-release-notes.ps1 -version $(artifactVersion) -filePath $(Build.SourcesDirectory)/CHANGELOG.md
+                  displayName: "Get release notes from CHANGELOG.md"
                 - task: GitHubRelease@1
                   inputs:
                     gitHubConnection: 'microsoftkiota'


### PR DESCRIPTION
it's been 3 releases that the GitHub release fails with "Validation Failed".

This error comes from the GitHub REST API and is caused by the fact that our tag/title had a trailing space (see example payload).

```json
{
  "tag_name": "v1.4.0 ",
  "target_commitish": "d94aa4133423c69a1ff34e6a10a139e41b519e1d",
  "name": "v1.4.0 ",
  "body": "## Added\\n\\n- Added support ...",
  "draft": false,
  "prerelease": false
}
```

This PR addresses the issue.