### PR TITLE
Fix writing of properties that exist in parent models when backing store is enabled

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeClass.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeClass.cs
@@ -63,6 +63,14 @@ public class CodeClass : ProprietableBlock<CodeClassKind, ClassDeclaration>, ITy
         }
         get => InnerChildElements.Values.OfType<CodeIndexer>().FirstOrDefault();
     }
+    public override IEnumerable<CodeProperty> AddProperty(params CodeProperty[] properties)
+    {
+        var result = base.AddProperty(properties);
+        foreach (var addedPropertyTuple in result.Select(x => new Tuple<CodeProperty, CodeProperty?>(x, StartBlock.GetOriginalPropertyDefinedFromBaseType(x.Name)))
+                                        .Where(static x => x.Item2 != null))
+            addedPropertyTuple.Item1.OriginalPropertyFromBaseType = addedPropertyTuple.Item2!;
+        return result;
+    }
     private CodeProperty? FindPropertyByNameInTypeHierarchy(string propertyName)
     {
         ArgumentException.ThrowIfNullOrEmpty(propertyName);

--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -105,12 +105,7 @@ public class CodeProperty : CodeTerminalWithKind<CodePropertyKind>, IDocumentedE
     public string WireName => IsNameEscaped ? SerializationName : Name.ToFirstCharacterLowerCase();
     public CodeProperty? OriginalPropertyFromBaseType
     {
-        get => IsOfKind(CodePropertyKind.Custom) ? Parent switch
-        {
-            CodeClass parentClass => parentClass.StartBlock.GetOriginalPropertyDefinedFromBaseType(Name),
-            CodeInterface parentInterface => parentInterface.StartBlock.GetOriginalPropertyDefinedFromBaseType(Name),
-            _ => default
-        } : default;
+        get; set;
     }
     public DeprecationInformation? Deprecation
     {
@@ -134,6 +129,7 @@ public class CodeProperty : CodeTerminalWithKind<CodePropertyKind>, IDocumentedE
             Documentation = (CodeDocumentation)Documentation.Clone(),
             SerializationName = SerializationName,
             NamePrefix = NamePrefix,
+            OriginalPropertyFromBaseType = OriginalPropertyFromBaseType?.Clone() as CodeProperty,
             Deprecation = Deprecation,
         };
         return property;

--- a/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
+++ b/src/Kiota.Builder/CodeDOM/ProprietableBlock.cs
@@ -31,7 +31,7 @@ public abstract class ProprietableBlock<TBlockKind, TBlockDeclaration> : CodeBlo
         }
     }
     public CodeDocumentation Documentation { get; set; } = new();
-    public IEnumerable<CodeProperty> AddProperty(params CodeProperty[] properties)
+    public virtual IEnumerable<CodeProperty> AddProperty(params CodeProperty[] properties)
     {
         if (properties == null || properties.Any(static x => x == null))
             throw new ArgumentNullException(nameof(properties));

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -392,7 +392,7 @@ public class CodeMethodWriterTests : IDisposable
         new object[] { new CodeProperty { Name = "dateValue", Type = new CodeType { Name = "DateTime" }, Access = AccessModifier.Private}, "$writer->writeDateTimeValue('dateValue', $this->getDateValue());" },
         new object[] { new CodeProperty { Name = "duration", Type = new CodeType { Name = "duration" }, Access = AccessModifier.Private}, "$writer->writeDateIntervalValue('duration', $this->getDuration());" },
         new object[] { new CodeProperty { Name = "stream", Type = new CodeType { Name = "binary" }, Access = AccessModifier.Private}, "$writer->writeBinaryContent('stream', $this->getStream());" },
-        new object[] { new CodeProperty { Name = "definedInParent", Type = new CodeType { Name = "string"}}, "$write->writeStringValue('definedInParent', $this->getDefinedInParent());"}
+        new object[] { new CodeProperty { Name = "definedInParent", Type = new CodeType { Name = "string"}}, "$writer->writeStringValue('definedInParent', $this->getDefinedInParent());"}
     };
 
     [Theory]
@@ -781,7 +781,7 @@ public class CodeMethodWriterTests : IDisposable
             "/** @var array<int>|null $val */",
             "$this->setYears($val);"
         },
-        new object[] { new CodeProperty{ Name = "definedInParent", Type = new CodeType { Name = "string"}}, "'definedInParent' => function (ParseNode $n) use ($o) { $o->setDefinedInParent($n->getStringValue())"}
+        new object[] { new CodeProperty{ Name = "definedInParent", Type = new CodeType { Name = "string"}}, "'definedInParent' => fn(ParseNode $n) => $o->setDefinedInParent($n->getStringValue())"}
     };
     private static CodeClass GetParentClassInStaticContext()
     {
@@ -825,12 +825,13 @@ public class CodeMethodWriterTests : IDisposable
         AddInheritanceClass();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.PHP }, parentClass.Parent as CodeNamespace);
         languageWriter.Write(deserializerMethod);
+        var result = stringWriter.ToString();
         foreach (var assertion in expected)
         {
             if (property.ExistsInBaseType)
-                Assert.DoesNotContain(assertion, stringWriter.ToString());
+                Assert.DoesNotContain(assertion, result);
             else
-                Assert.Contains(assertion, stringWriter.ToString());
+                Assert.Contains(assertion, result);
         }
     }
 


### PR DESCRIPTION
reverts some changes from https://github.com/microsoft/kiota/pull/2881

During the "refine" step, __with backing store enabled__, properties get removed from the parent models but the same property is not removed from the child class. In the "writing" step of the child class, the check whether the property exists in the base type fails because at that point the parent classes properties have already been removed.

Changes reverted:
- Makes `OriginalPropertyFromBaseType` in `CodeProperty` an instance rather than a dynamically derived value.
- 
