### PR TITLE
fix: add 'method' to CSharpReservedClassNamesProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use schematized types for 206 response codes instead of binary. [#2880](https://github.com/microsoft/kiota/issues/2880)
 - Typenames are not changed to first char upper case in comments in some cases.
 - Updated `getEnumValues` method name to `getCollectionOfEnumValues`. [#2907](https://github.com/microsoft/kiota/pull/2907)
+- Added `Method` to the list of `CSharpReservedClassNames`. [#2939](https://github.com/microsoft/kiota/pull/2939)
 
 
 ## [1.4.0] - 2023-07-07

--- a/src/Kiota.Builder/Refiners/CSharpReservedClassNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedClassNamesProvider.cs
@@ -8,7 +8,8 @@ public class CSharpReservedClassNamesProvider : IReservedNamesProvider
     private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase)
     {
         "BaseRequestBuilder",
-        "BaseCliRequestBuilder"
+        "BaseCliRequestBuilder",
+        "Method"
     });
     public HashSet<string> ReservedNames => _reservedNames.Value;
 }


### PR DESCRIPTION
- this fixes an issue, where generated class and namespace names would collide with the HTTP Method enum in Microsoft.Kiota.Abstractions

Closes #2917 