### PR TITLE
Moves "method" to CSharpReservedTypesProvider

### DIFF
--- a/src/Kiota.Builder/Refiners/CSharpReservedClassNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedClassNamesProvider.cs
@@ -8,8 +8,7 @@ public class CSharpReservedClassNamesProvider : IReservedNamesProvider
     private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase)
     {
         "BaseRequestBuilder",
-        "BaseCliRequestBuilder",
-        "Method"
+        "BaseCliRequestBuilder"
     });
     public HashSet<string> ReservedNames => _reservedNames.Value;
 }

--- a/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedTypesProvider.cs
@@ -118,6 +118,7 @@ public class CSharpReservedTypesProvider : IReservedNamesProvider
             "MarshalByRefObject",
             "Math",
             "MathF",
+            "Method",
             "MemberAccessException",
             "MemoryExtensions",
             "MethodAccessException",


### PR DESCRIPTION
Follow up to https://github.com/microsoft/kiota/pull/2939

Moves the string to CSharpReservedTypesProvider to avoid renaming of property names and only types and namespaces. 