### PR TITLE
Update developers.pipedrive.com integration test suppressions

### DIFF
--- a/it/config.json
+++ b/it/config.json
@@ -131,8 +131,28 @@
     ],
     "Suppressions": [
       {
-        "Language": "all",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2351"
+        "Language": "java",
+        "Rationale": "https://github.com/microsoft/kiota/issues/2954"
+      },
+      {
+        "Language": "go",
+        "Rationale": "https://github.com/microsoft/kiota/issues/2955"
+      },
+      {
+        "Language": "typescript",
+        "Rationale": "https://github.com/microsoft/kiota/issues/1812"
+      },
+      {
+        "Language": "ruby",
+        "Rationale": "https://github.com/microsoft/kiota/issues/2484"
+      },
+      {
+        "Language": "php",
+        "Rationale": "https://github.com/microsoft/kiota/issues/2956"
+      },
+      {
+        "Language": "python",
+        "Rationale": "https://github.com/microsoft/kiota/issues/2957"
       }
     ]
   },


### PR DESCRIPTION
- Removes legacy suppression linked to an unrelated PHP issue
- Adds new tracking issues for suppresions:
https://github.com/microsoft/kiota/issues/2954
https://github.com/microsoft/kiota/issues/2955
https://github.com/microsoft/kiota/issues/2956
https://github.com/microsoft/kiota/issues/2957