### PR TITLE
Added Intellij client classes generation functionality

### DIFF
--- a/intellij/src/main/java/services/GenerateClientHandler.java
+++ b/intellij/src/main/java/services/GenerateClientHandler.java
@@ -1,0 +1,38 @@
+package services;
+import com.github.arteam.simplejsonrpc.client.builder.RequestBuilder;
+
+
+
+public class GenerateClientHandler {
+
+     KiotaJavaClient c;
+
+
+     public void generateclient(String DescriptionPath, String output, KiotaGenerationLanguage language,String[] include, String[] exclude, String clientclassname, String clientclassnamespace){
+         c = new KiotaJavaClient();
+         // Create the RequestBuilder
+         RequestBuilder<Object> requestBuilder = c.createRequest("Generate", Object.class);
+         Object response = requestBuilder.params(
+                 DescriptionPath ,output, language, include, include,clientclassname,clientclassnamespace
+         ).execute();
+
+         //System.out.println(response);
+     }
+//        public static void main(String[] args) {
+//            String descriptionpath = "C:\\Users\\v-malhossain\\Documents\\Eoutput\\posts-api.yml";
+//            String OutputPath = "C:\\Users\\v-malhossain\\Documents\\example\\app\\src\\main\\java\\kiotaposts";
+//            KiotaGenerationLanguage lan = KiotaGenerationLanguage.Java;
+//            String[] include = new String[0];
+//            String[] exclude = new String[0];
+//            String clientname = "PostsClient";
+//            String clientclassnamespace = "kiotaposts.client";
+//
+//            GenerateClientHandler handler = new GenerateClientHandler();
+//
+//            // Call the generateclient method with the provided parameters
+//            handler.generateclient(descriptionpath, OutputPath, lan, include, exclude, "PostsClient", "kiotaposts.client");
+//
+//
+//
+//        }
+}

--- a/intellij/src/main/java/services/GenerateClientHandler.java
+++ b/intellij/src/main/java/services/GenerateClientHandler.java
@@ -1,38 +1,26 @@
 package services;
 import com.github.arteam.simplejsonrpc.client.builder.RequestBuilder;
-
-
-
 public class GenerateClientHandler {
 
-     KiotaJavaClient c;
+    KiotaJavaClient myClient;
 
-
-     public void generateclient(String DescriptionPath, String output, KiotaGenerationLanguage language,String[] include, String[] exclude, String clientclassname, String clientclassnamespace){
-         c = new KiotaJavaClient();
-         // Create the RequestBuilder
-         RequestBuilder<Object> requestBuilder = c.createRequest("Generate", Object.class);
-         Object response = requestBuilder.params(
-                 DescriptionPath ,output, language, include, include,clientclassname,clientclassnamespace
-         ).execute();
-
-         //System.out.println(response);
-     }
-//        public static void main(String[] args) {
-//            String descriptionpath = "C:\\Users\\v-malhossain\\Documents\\Eoutput\\posts-api.yml";
-//            String OutputPath = "C:\\Users\\v-malhossain\\Documents\\example\\app\\src\\main\\java\\kiotaposts";
-//            KiotaGenerationLanguage lan = KiotaGenerationLanguage.Java;
-//            String[] include = new String[0];
-//            String[] exclude = new String[0];
-//            String clientname = "PostsClient";
-//            String clientclassnamespace = "kiotaposts.client";
-//
-//            GenerateClientHandler handler = new GenerateClientHandler();
-//
-//            // Call the generateclient method with the provided parameters
-//            handler.generateclient(descriptionpath, OutputPath, lan, include, exclude, "PostsClient", "kiotaposts.client");
-//
-//
-//
-//        }
+    /**
+     * A method to generate clientClasses.
+     * must pass a list of params where the 0th position must start with a string as the params in the kiota server are positional
+     * @param DescriptionPath
+     * @param output
+     * @param language
+     * @param include
+     * @param exclude
+     * @param clientclassname
+     * @param clientclassnamespace
+     */
+    public void generateclient(String DescriptionPath, String output, KiotaGenerationLanguage language, String[] include, String[] exclude, String clientclassname, String clientclassnamespace) {
+        myClient = new KiotaJavaClient();
+        // Create the RequestBuilder
+        RequestBuilder<Object> requestBuilder = myClient.createRequest("Generate", Object.class);
+        Object response = requestBuilder.params(
+                DescriptionPath, output, language, include, include, clientclassname, clientclassnamespace
+        ).execute();
+    }
 }

--- a/intellij/src/main/java/services/GenerateClientHandler.java
+++ b/intellij/src/main/java/services/GenerateClientHandler.java
@@ -22,5 +22,7 @@ public class GenerateClientHandler {
         Object response = requestBuilder.params(
                 DescriptionPath, output, language, include, include, clientclassname, clientclassnamespace
         ).execute();
+
+        System.out.print(response);
     }
 }

--- a/intellij/src/main/java/services/GenerateClientHandler.java
+++ b/intellij/src/main/java/services/GenerateClientHandler.java
@@ -23,6 +23,5 @@ public class GenerateClientHandler {
                 DescriptionPath, output, language, include, include, clientclassname, clientclassnamespace
         ).execute();
 
-        System.out.print(response);
     }
 }

--- a/intellij/src/main/java/services/KiotaGenerationLanguage.java
+++ b/intellij/src/main/java/services/KiotaGenerationLanguage.java
@@ -13,7 +13,6 @@ public enum KiotaGenerationLanguage {
     Ruby(6),
     Shell(7);
 
-
      private final int value;
 
     KiotaGenerationLanguage(int value) {

--- a/intellij/src/main/java/services/KiotaGenerationLanguage.java
+++ b/intellij/src/main/java/services/KiotaGenerationLanguage.java
@@ -1,0 +1,24 @@
+package services;
+
+public enum KiotaGenerationLanguage {
+    CSharp(0),
+    Java(1),
+    TypeScript(2),
+    Python(3),
+    Go(4),
+    Swift(5),
+    Ruby(6),
+    Shell(7);
+
+
+
+    private final int value;
+
+    KiotaGenerationLanguage(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/intellij/src/main/java/services/KiotaGenerationLanguage.java
+++ b/intellij/src/main/java/services/KiotaGenerationLanguage.java
@@ -1,5 +1,8 @@
 package services;
 
+/**
+ * This is a Enum class representing languages for kiota code generation
+ */
 public enum KiotaGenerationLanguage {
     CSharp(0),
     Java(1),
@@ -11,8 +14,7 @@ public enum KiotaGenerationLanguage {
     Shell(7);
 
 
-
-    private final int value;
+     private final int value;
 
     KiotaGenerationLanguage(int value) {
         this.value = value;

--- a/intellij/src/main/java/toolWindow/MyToolWindow.java
+++ b/intellij/src/main/java/toolWindow/MyToolWindow.java
@@ -4,17 +4,25 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.panels.VerticalLayout;
+import services.GenerateClientHandler;
+import services.KiotaGenerationLanguage;
 import services.VersionHandler;
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.io.IOException;
 
 public class MyToolWindow {
     private final JBPanel<JBPanel<?>> ParentPanel;
     VersionHandler versionHandler ;
+
+    GenerateClientHandler generateClientHandler;
     public MyToolWindow(ToolWindow toolWindow) {
         ParentPanel = new JBPanel<>();
         versionHandler = new VersionHandler();
+         generateClientHandler = new GenerateClientHandler();
+
     }
     public JComponent Addpanel() throws IOException {
         ParentPanel.setLayout(new BorderLayout());
@@ -35,17 +43,46 @@ public class MyToolWindow {
     public JComponent getInput() {
         JBPanel<JBPanel<?>> mainPanel = new JBPanel<>();
         mainPanel.setLayout(new VerticalLayout(10));
+        TextFieldWithBrowseButton yamlFilePathField = new TextFieldWithBrowseButton();
+        TextFieldWithBrowseButton outputpath = new TextFieldWithBrowseButton();
+        TextFieldWithBrowseButton clientClassField = new TextFieldWithBrowseButton();
+        TextFieldWithBrowseButton postClientNameField = new TextFieldWithBrowseButton();
+        mainPanel.setLayout(new VerticalLayout(10));
 
-        LabeledComponent<TextFieldWithBrowseButton> labeledField1 = LabeledComponent.create(new TextFieldWithBrowseButton(), "Enter the YAML file Path");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField2 = LabeledComponent.create(new TextFieldWithBrowseButton(), "Enter the name of the client class");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField3 = LabeledComponent.create(new TextFieldWithBrowseButton(), "Enter the name of the postclient to generate");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField4 = LabeledComponent.create(new TextFieldWithBrowseButton(), "Enter the output directory");
-
+        LabeledComponent<TextFieldWithBrowseButton> labeledField1 = LabeledComponent.create(yamlFilePathField, "Enter the YAML file Path");
+        LabeledComponent<TextFieldWithBrowseButton> labeledField4 = LabeledComponent.create(outputpath, "Enter the output directory");
+        LabeledComponent<TextFieldWithBrowseButton> labeledField2 = LabeledComponent.create(clientClassField, "Enter the name of the client class");
+        LabeledComponent<TextFieldWithBrowseButton> labeledField3 = LabeledComponent.create(postClientNameField, "Enter the name of the postclient to generate");
         mainPanel.add(labeledField1);
+        mainPanel.add(labeledField4);
         mainPanel.add(labeledField2);
         mainPanel.add(labeledField3);
-        mainPanel.add(labeledField4);
 
+        KiotaGenerationLanguage language = KiotaGenerationLanguage.Java;
+        String[] include = new String[0];
+        String[] exclude = new String[0];
+
+        // Add an action listener to the button to perform an action when clicked
+        JButton executeButton = new JButton("Execute");
+        executeButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String descriptionPath = yamlFilePathField.getText();
+                String output = outputpath.getText();
+                String clientClass = clientClassField.getText();
+                String clientClassNamespace = postClientNameField.getText();
+
+                generateClientHandler.generateclient(descriptionPath, output, language, include, exclude, clientClass, clientClassNamespace);
+
+                System.out.println(descriptionPath);
+                System.out.println(output);
+                System.out.println(language);
+                System.out.println(clientClass);
+                System.out.print(clientClassNamespace);
+
+            }
+        });
+        mainPanel.add(executeButton);
         return mainPanel;
     }
 }

--- a/intellij/src/main/java/toolWindow/MyToolWindow.java
+++ b/intellij/src/main/java/toolWindow/MyToolWindow.java
@@ -1,4 +1,5 @@
 package toolWindow;
+import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.wm.ToolWindow;
@@ -11,25 +12,32 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.io.IOException;
 
 public class MyToolWindow {
     private final JBPanel<JBPanel<?>> ParentPanel;
     VersionHandler versionHandler ;
-
     GenerateClientHandler generateClientHandler;
     public MyToolWindow(ToolWindow toolWindow) {
         ParentPanel = new JBPanel<>();
         versionHandler = new VersionHandler();
-         generateClientHandler = new GenerateClientHandler();
+        generateClientHandler = new GenerateClientHandler();
 
     }
+
     public JComponent Addpanel() throws IOException {
         ParentPanel.setLayout(new BorderLayout());
         ParentPanel.add(getInput(), BorderLayout.CENTER);
         ParentPanel.add(getversion(), BorderLayout.SOUTH);
         return ParentPanel;
     }
+
+    /**
+     * This method displays version of kiota.
+     * @return versionpanel
+     * @throws IOException
+     */
     public JComponent getversion() throws IOException {
         JBPanel<JBPanel<?>> versionPanel = new JBPanel<>();
         versionPanel.setLayout(new BorderLayout());
@@ -40,49 +48,84 @@ public class MyToolWindow {
         return versionPanel;
     }
 
+    /**
+     * this method sets the client(UI) to get input from user and generate clientclasses.
+     * @return panel
+     */
     public JComponent getInput() {
         JBPanel<JBPanel<?>> mainPanel = new JBPanel<>();
         mainPanel.setLayout(new VerticalLayout(10));
+
+        // Create the TextFieldWithBrowseButton components
         TextFieldWithBrowseButton yamlFilePathField = new TextFieldWithBrowseButton();
         TextFieldWithBrowseButton outputpath = new TextFieldWithBrowseButton();
         TextFieldWithBrowseButton clientClassField = new TextFieldWithBrowseButton();
         TextFieldWithBrowseButton postClientNameField = new TextFieldWithBrowseButton();
-        mainPanel.setLayout(new VerticalLayout(10));
 
-        LabeledComponent<TextFieldWithBrowseButton> labeledField1 = LabeledComponent.create(yamlFilePathField, "Enter the YAML file Path");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField4 = LabeledComponent.create(outputpath, "Enter the output directory");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField2 = LabeledComponent.create(clientClassField, "Enter the name of the client class");
-        LabeledComponent<TextFieldWithBrowseButton> labeledField3 = LabeledComponent.create(postClientNameField, "Enter the name of the postclient to generate");
-        mainPanel.add(labeledField1);
-        mainPanel.add(labeledField4);
-        mainPanel.add(labeledField2);
-        mainPanel.add(labeledField3);
+        // Input labels
+        LabeledComponent<TextFieldWithBrowseButton> yamlFilePath_label = LabeledComponent.create(yamlFilePathField, "Enter the YAML file Path");
+        LabeledComponent<TextFieldWithBrowseButton> outputpath_Label = LabeledComponent.create(outputpath, "Enter the output directory");
+        JLabel languageLabel = new JLabel("Select a Language");
+        LabeledComponent<TextFieldWithBrowseButton> clientclassname_label = LabeledComponent.create(clientClassField, "Enter a name for the client class");
+        LabeledComponent<TextFieldWithBrowseButton> clientclassnameSpace_label = LabeledComponent.create(postClientNameField, "Enter the name of the client class namespace");
 
-        KiotaGenerationLanguage language = KiotaGenerationLanguage.Java;
-        String[] include = new String[0];
-        String[] exclude = new String[0];
+        JComboBox<KiotaGenerationLanguage> languageComboBox = new ComboBox<>(KiotaGenerationLanguage.values());
+        String[] include = new String[0]; //empty string
+        String[] exclude = new String[0]; //empty String
 
-        // Add an action listener to the button to perform an action when clicked
-        JButton executeButton = new JButton("Execute");
-        executeButton.addActionListener(new ActionListener() {
+        // Add an action listener to the  genrate button to perform an action when clicked
+        JButton generateButton = new JButton("Generate");
+        generateButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 String descriptionPath = yamlFilePathField.getText();
                 String output = outputpath.getText();
                 String clientClass = clientClassField.getText();
                 String clientClassNamespace = postClientNameField.getText();
-
-                generateClientHandler.generateclient(descriptionPath, output, language, include, exclude, clientClass, clientClassNamespace);
-
-                System.out.println(descriptionPath);
-                System.out.println(output);
-                System.out.println(language);
-                System.out.println(clientClass);
-                System.out.print(clientClassNamespace);
-
+                KiotaGenerationLanguage selectedLanguage = (KiotaGenerationLanguage) languageComboBox.getSelectedItem();
+                generateClientHandler.generateclient(descriptionPath, output, selectedLanguage, include, exclude, clientClass, clientClassNamespace);
             }
         });
-        mainPanel.add(executeButton);
+
+        // Add the ActionListener to the  (yamlFilePathField) browse icon
+        yamlFilePathField.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JFileChooser fileChooser = new JFileChooser();
+                fileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+                int returnValue = fileChooser.showOpenDialog(null);
+
+                if (returnValue == JFileChooser.APPROVE_OPTION) {
+                    File selectedFile = fileChooser.getSelectedFile();
+                    String selectedPath = selectedFile.getAbsolutePath();
+                    yamlFilePathField.setText(selectedPath);
+                }
+            }
+        });
+        // Add the ActionListener to the  (outputpath) browse icon
+        outputpath.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JFileChooser fileChooser = new JFileChooser();
+                fileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+                int returnValue = fileChooser.showOpenDialog(null);
+
+                if (returnValue == JFileChooser.APPROVE_OPTION) {
+                    File selectedFile = fileChooser.getSelectedFile();
+                    String selectedPath = selectedFile.getAbsolutePath();
+                    outputpath.setText(selectedPath);
+                }
+            }
+        });
+
+        mainPanel.add(yamlFilePath_label);
+        mainPanel.add(outputpath_Label);
+        mainPanel.add(languageLabel);
+        mainPanel.add(languageComboBox);
+        mainPanel.add(clientclassname_label);
+        mainPanel.add(clientclassnameSpace_label);
+        mainPanel.add(generateButton);
         return mainPanel;
     }
 }
+

--- a/intellij/src/main/java/toolWindow/MyToolWindow.java
+++ b/intellij/src/main/java/toolWindow/MyToolWindow.java
@@ -59,21 +59,23 @@ public class MyToolWindow {
         // Create the TextFieldWithBrowseButton components
         TextFieldWithBrowseButton yamlFilePathField = new TextFieldWithBrowseButton();
         TextFieldWithBrowseButton outputpath = new TextFieldWithBrowseButton();
-        TextFieldWithBrowseButton clientClassField = new TextFieldWithBrowseButton();
-        TextFieldWithBrowseButton postClientNameField = new TextFieldWithBrowseButton();
+        JTextField clientClassField = new JTextField();
+        JTextField postClientNameField = new JTextField();
 
         // Input labels
-        LabeledComponent<TextFieldWithBrowseButton> yamlFilePath_label = LabeledComponent.create(yamlFilePathField, "Enter the YAML file Path");
-        LabeledComponent<TextFieldWithBrowseButton> outputpath_Label = LabeledComponent.create(outputpath, "Enter the output directory");
-        JLabel languageLabel = new JLabel("Select a Language");
-        LabeledComponent<TextFieldWithBrowseButton> clientclassname_label = LabeledComponent.create(clientClassField, "Enter a name for the client class");
-        LabeledComponent<TextFieldWithBrowseButton> clientclassnameSpace_label = LabeledComponent.create(postClientNameField, "Enter the name of the client class namespace");
+        LabeledComponent<TextFieldWithBrowseButton> yamlFilePath_label = LabeledComponent.create(yamlFilePathField, "Enter a path to an openAPI description");
+        LabeledComponent<TextFieldWithBrowseButton> outputpath_Label = LabeledComponent.create(outputpath, "Enter an output path ");
+        JLabel languageLabel = new JLabel("Pick a language");
+        LabeledComponent<JTextField> clientclassname_label = LabeledComponent.create(clientClassField, "Enter a name for the client class");
+        LabeledComponent<JTextField> clientclassnameSpace_label = LabeledComponent.create(postClientNameField, "Enter the name of the client class namespace");
+
 
         JComboBox<KiotaGenerationLanguage> languageComboBox = new ComboBox<>(KiotaGenerationLanguage.values());
+        languageComboBox.setSelectedItem(KiotaGenerationLanguage.Java);
         String[] include = new String[0]; //empty string
         String[] exclude = new String[0]; //empty String
 
-        // Add an action listener to the  genrate button to perform an action when clicked
+        // Add an action listener to the  generate button to perform an action when clicked
         JButton generateButton = new JButton("Generate");
         generateButton.addActionListener(new ActionListener() {
             @Override


### PR DESCRIPTION
Updated the code with a functional UI that allows user to enter a YAML file path, output directory path, pick a language for generation (only java is functional at this time) enter clientclassname, and clientclassnamespace and generate client classes. 

Enter the YAML file without quotations. 