### PR TITLE
Fix uuid for indexer params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RequestExecuters call overload methods reducing code generation size for Java. [#3150](https://github.com/microsoft/kiota/issues/3150)  
 - Remove URISyntaxException from Java generated RequestExecutors and RequestGenerators. [#3149](https://github.com/microsoft/kiota/issues/3149)
 - Adds 'Generated' annotation to generated Enums and Classes for Java. [#3106](https://github.com/microsoft/kiota/issues/3106)
+- Fixes uuid conversion to string value in PathParameters in Go. [#3106](https://github.com/microsoft/kiota/issues/3176)
 
 ## [1.5.1] - 2023-08-08
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -489,7 +489,9 @@ public class GoRefiner : CommonLanguageRefiner
         "Duration",
         "TimeOnly",
         "DateOnly",
-        "string"
+        "string",
+        "UUID",
+        "Guid"
     };
     private static readonly AdditionalUsingEvaluator[] defaultUsingEvaluators = {
         new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.RequestAdapter),
@@ -501,7 +503,8 @@ public class GoRefiner : CommonLanguageRefiner
                                             !typeToSkipStrConv.Contains(x.Type.Name)),
             "strconv", "FormatBool"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility) &&
-                    method.OriginalIndexer is CodeIndexer indexer && !indexer.IndexParameter.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase),
+                    method.OriginalIndexer is CodeIndexer indexer && !indexer.IndexParameter.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase) 
+                    && !typeToSkipStrConv.Contains(indexer.IndexParameter.Type.Name),
             "strconv", "FormatInt"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),
             "github.com/microsoft/kiota-abstractions-go/serialization", "SerializationWriter"),

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -503,7 +503,7 @@ public class GoRefiner : CommonLanguageRefiner
                                             !typeToSkipStrConv.Contains(x.Type.Name)),
             "strconv", "FormatBool"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.IndexerBackwardCompatibility) &&
-                    method.OriginalIndexer is CodeIndexer indexer && !indexer.IndexParameter.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase) 
+                    method.OriginalIndexer is CodeIndexer indexer && !indexer.IndexParameter.Type.Name.Equals("string", StringComparison.OrdinalIgnoreCase)
                     && !typeToSkipStrConv.Contains(indexer.IndexParameter.Type.Name),
             "strconv", "FormatInt"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.Serializer),

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -238,6 +238,7 @@ public class GoConventionService : CommonLanguageConventionService
             "float" or "double" or "decimal" or "float64" or "float32" => $"{StrConvHash}.FormatFloat({reference}, 'E', -1, 64)",
             "DateTimeOffset" or "Time" => $"({reference}).Format({TimeFormatHash}.RFC3339)", // default to using ISO 8601
             "ISODuration" or "TimeSpan" or "TimeOnly" or "DateOnly" => $"({reference}).String()",
+            "Guid" or "UUID" => $"{reference}.String()",
             _ => reference,
         };
     }


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota/issues/3176

1. Converts UUID indexers to string when adding it to parameters dictionary. Resolves go compilation error.
2. Avoid unnecessary importation of strconv in import statements when using uuid params for indexer methods
