### PR TITLE
Fixes intermittent issues in model renaming. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove URISyntaxException from Java generated RequestExecutors and RequestGenerators. [#3149](https://github.com/microsoft/kiota/issues/3149)
 - Adds 'Generated' annotation to generated Enums and Classes for Java. [#3106](https://github.com/microsoft/kiota/issues/3106)
 - Fixes uuid conversion to string value in PathParameters in Go. [#3106](https://github.com/microsoft/kiota/issues/3176)
+- Fixes a bug with incorrect reserved models renaming that occurs sometimes depending on the order of type processing [microsoftgraph/msgraph-sdk-dotnet/issues/2084](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2084)
 
 ## [1.5.1] - 2023-08-08
 

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -145,8 +145,8 @@ public class JavaLanguageRefinerTests
         };
         nUsing.Declaration = new CodeType
         {
-            Name = "break",
             IsExternal = false,
+            TypeDefinition = model
         };
         model.AddUsing(nUsing);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2084

After changes made in https://github.com/microsoft/kiota/pull/3107 involved the `CodeType` sharing the name with the `TypeDefinition` property to limit unnecessary string copies. This however led to indeterministic renaming of model types as renaming a `TypeDefinition` instance through the parameter type or discriminator mapping would lead to indeterministic results depending on which was processed first and sometimes fail to check for conflicts after renaming.
An example include renaming `microsoft.graph.directory` to `microsoft.graph.directoryObject` (which already exists rather than resolving the renaming conflict) when the `TypeDefinition` when encountered through the discriminator mapping of the base rather than as child element of the `microsoft.graph` namespace.

This PR therefore eliminates other points of `TypeDefinition/CodeType` renaming(as multiple string copies are no longer held) by dropping functions that looked up the `TypeDefinition/CodeType` name indirectly through the 
- Discriminator mappings
- Code using declarations
- Parameter types