### PR TITLE
Adds support for serialization of csv values for Go enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for external documentation links within descriptions in Python. [#2041](https://github.com/microsoft/kiota/issues/2041)
 - Added support for API manifests. [#3104](https://github.com/microsoft/kiota/issues/3104)
 - Added support for reserved path parameters. [#2320](https://github.com/microsoft/kiota/issues/2320)
+- Added support for csv values in enums using a mask.
 
 ### Changed
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -116,7 +116,7 @@ public class GoRefiner : CommonLanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             MakeModelPropertiesNullable(
                 generatedCode);
-            AddErrorImportForEnums(
+            AddErrorAndStringsImportForEnums(
                 generatedCode);
             var defaultConfiguration = new GenerationConfiguration();
             ReplaceDefaultSerializationModules(
@@ -469,7 +469,7 @@ public class GoRefiner : CommonLanguageRefiner
         }
         CrawlTree(currentElement, ReplaceRequestBuilderPropertiesByMethods);
     }
-    private static void AddErrorImportForEnums(CodeElement currentElement)
+    private static void AddErrorAndStringsImportForEnums(CodeElement currentElement)
     {
         if (currentElement is CodeEnum currentEnum)
         {
@@ -477,8 +477,16 @@ public class GoRefiner : CommonLanguageRefiner
             {
                 Name = "errors",
             });
+
+            if (currentEnum.Flags)
+            {
+                currentEnum.AddUsing(new CodeUsing
+                {
+                    Name = "strings",
+                });
+            }
         }
-        CrawlTree(currentElement, AddErrorImportForEnums);
+        CrawlTree(currentElement, AddErrorAndStringsImportForEnums);
     }
     private static readonly GoConventionService conventions = new();
     private static readonly HashSet<string> typeToSkipStrConv = new(StringComparer.OrdinalIgnoreCase) {

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -16,12 +16,11 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
         if (codeElement.Parent is CodeNamespace ns)
             writer.WriteLine($"package {ns.Name.GetLastNamespaceSegment().Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)}");
 
-        writer.WriteLine("import (");
-        writer.IncreaseIndent();
-        foreach (var cUsing in codeElement.Usings)
+        writer.StartBlock("import (");
+        foreach (var cUsing in codeElement.Usings.OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase))
             writer.WriteLine($"\"{cUsing.Name}\"");
-        writer.DecreaseIndent();
-        writer.WriteLine(")");
+        writer.CloseBlock(")");
+
         var typeName = codeElement.Name.ToFirstCharacterUpperCase();
         conventions.WriteShortDescription(codeElement.Documentation.Description, writer);
         conventions.WriteDeprecation(codeElement, writer);
@@ -40,43 +39,106 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
                 iotaSuffix = string.Empty;
         }
         writer.DecreaseIndent();
-        writer.WriteLines(")",
-                        string.Empty,
-                        $"func (i {typeName}) String() string {{");
-        writer.IncreaseIndent();
-        var literalOptions = enumOptions
-                                        .Select(x => $"\"{x.WireName}\"")
-                                        .Aggregate((x, y) => x + ", " + y);
-        writer.WriteLine($"return []string{{{literalOptions}}}[i]");
-        writer.DecreaseIndent();
-        writer.WriteLines("}",
-                        $"func Parse{typeName}(v string) (any, error) {{");
-        writer.IncreaseIndent();
-        writer.WriteLine($"result := {enumOptions.First().Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
-        writer.WriteLine("switch v {");
-        writer.IncreaseIndent();
-        foreach (var item in enumOptions)
+        writer.WriteLines(")", string.Empty);
+
+        var isMultiValue = codeElement.Flags;
+        WriteStringFunction(codeElement, writer, isMultiValue);
+        WriteParsableEnum(codeElement, writer, isMultiValue);
+        WriteSerializeFunction(codeElement, writer, isMultiValue);
+        WriteMultiValueFunction(codeElement, writer, isMultiValue);
+    }
+
+    private void WriteStringFunction(CodeEnum codeElement, LanguageWriter writer, Boolean isMultiValue)
+    {
+        var typeName = codeElement.Name.ToFirstCharacterUpperCase();
+        var enumOptions = codeElement.Options;
+
+        if (isMultiValue)
         {
-            writer.WriteLine($"case \"{item.WireName}\":");
-            writer.IncreaseIndent();
-            writer.WriteLine($"result = {item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
-            writer.DecreaseIndent();
+            writer.StartBlock($"func (i {typeName}) String() string {{");
+            writer.WriteLine("var values []string");
+            var literalOptions = enumOptions
+                .Select(x => $"\"{x.WireName}\"")
+                .Aggregate((x, y) => x + ", " + y);
+            writer.StartBlock($"for p := {typeName}(1); p <= {enumOptions.Last().Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}; p <<= 1 {{");
+            writer.StartBlock($"if i&p == p {{");
+            writer.WriteLine($"values = append(values, []string{{{literalOptions}}}[p])");
+            writer.CloseBlock();
+            writer.CloseBlock();
+            writer.WriteLine("return strings.Join(values, \",\")");
+            writer.CloseBlock();
         }
-        writer.WriteLine("default:");
-        writer.IncreaseIndent();
+        else
+        {
+            writer.StartBlock($"func (i {typeName}) String() string {{");
+            var literalOptions = enumOptions
+                .Select(x => $"\"{x.WireName}\"")
+                .Aggregate((x, y) => x + ", " + y);
+            writer.WriteLine($"return []string{{{literalOptions}}}[i]");
+            writer.CloseBlock();
+        }
+    }
+
+    private void WriteParsableEnum(CodeEnum codeElement, LanguageWriter writer, Boolean isMultiValue)
+    {
+        var typeName = codeElement.Name.ToFirstCharacterUpperCase();
+        var enumOptions = codeElement.Options;
+
+        writer.StartBlock($"func Parse{typeName}(v string) (any, error) {{");
+
+        if (isMultiValue)
+        {
+            writer.WriteLine($"var result {typeName}");
+            writer.WriteLine("values := strings.Split(v, \",\")");
+            writer.StartBlock("for _, str := range values {");
+            writer.StartBlock("switch str {");
+            foreach (var item in enumOptions)
+            {
+                writer.StartBlock($"case \"{item.WireName}\":");
+                writer.WriteLine($"result |= {item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
+                writer.DecreaseIndent();
+            }
+        }
+        else
+        {
+            writer.WriteLine($"result := {enumOptions.First().Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
+            writer.StartBlock("switch v {");
+            foreach (var item in enumOptions)
+            {
+                writer.StartBlock($"case \"{item.WireName}\":");
+                writer.WriteLine($"result = {item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
+                writer.DecreaseIndent();
+            }
+        }
+
+
+        writer.StartBlock("default:");
         writer.WriteLine($"return 0, errors.New(\"Unknown {typeName} value: \" + v)");
         writer.DecreaseIndent();
         writer.CloseBlock();
+        if (isMultiValue) writer.CloseBlock();
         writer.WriteLine("return &result, nil");
         writer.CloseBlock();
-        writer.WriteLine($"func Serialize{typeName}(values []{typeName}) []string {{");
-        writer.IncreaseIndent();
+    }
+
+    private void WriteSerializeFunction(CodeEnum codeElement, LanguageWriter writer, Boolean isMultiValue)
+    {
+        var typeName = codeElement.Name.ToFirstCharacterUpperCase();
+        writer.StartBlock($"func Serialize{typeName}(values []{typeName}) []string {{");
         writer.WriteLines("result := make([]string, len(values))",
-                            "for i, v := range values {");
+            "for i, v := range values {");
         writer.IncreaseIndent();
         writer.WriteLine("result[i] = v.String()");
         writer.CloseBlock();
         writer.WriteLine("return result");
+        writer.CloseBlock();
+    }
+
+    private void WriteMultiValueFunction(CodeEnum codeElement, LanguageWriter writer, Boolean isMultiValue)
+    {
+        var typeName = codeElement.Name.ToFirstCharacterUpperCase();
+        writer.StartBlock($"func (i {typeName}) isMultiValue() bool {{");
+        writer.WriteLine($"return {isMultiValue.ToString().ToLowerInvariant()}");
         writer.CloseBlock();
     }
 }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -901,9 +901,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                     return $"GetCollectionOfEnumValues({conventions.GetImportedStaticMethodName(propType, parentClass, "Parse")})";
                 else
                     return $"GetCollectionOfObjectValues({GetTypeFactory(propType, parentClass, propertyTypeNameWithoutImportSymbol)})";
-            if (currentType.TypeDefinition is CodeEnum currentEnum)
+            if (currentType.TypeDefinition is CodeEnum)
             {
-                return $"GetEnum{(currentEnum.Flags ? "Set" : string.Empty)}Value({conventions.GetImportedStaticMethodName(propType, parentClass, "Parse")})";
+                return $"GetEnumValue({conventions.GetImportedStaticMethodName(propType, parentClass, "Parse")})";
             }
         }
         return propertyTypeNameWithoutImportSymbol switch

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -817,15 +817,28 @@ public class GoLanguageRefinerTests
         Assert.Single(model.Methods.Where(x => x.IsOfKind(CodeMethodKind.RequestBuilderBackwardCompatibility)));
     }
     [Fact]
-    public async Task AddsErrorImportForEnums()
+    public async Task AddsErrorImportForEnumsForMultiValueEnum()
     {
         var testEnum = root.AddEnum(new CodeEnum
         {
             Name = "TestEnum",
-
+            Flags = true
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
-        Assert.Single(testEnum.Usings.Where(x => x.Name == "errors"));
+        Assert.Single(testEnum.Usings.Where(static x => "errors".Equals(x.Name, StringComparison.Ordinal)));
+        Assert.Single(testEnum.Usings.Where(static x => "strings".Equals(x.Name, StringComparison.Ordinal)));
+    }
+    [Fact]
+    public async Task AddsErrorImportForEnumsForSingleValueEnum()
+    {
+        var testEnum = root.AddEnum(new CodeEnum
+        {
+            Name = "TestEnum",
+            Flags = false
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Single(testEnum.Usings.Where(static x => "errors".Equals(x.Name, StringComparison.Ordinal)));
+        Assert.Empty(testEnum.Usings.Where(static x => "strings".Equals(x.Name, StringComparison.Ordinal)));
     }
     [Fact]
     public async Task CorrectsCoreType()


### PR DESCRIPTION
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/517

Adds support for serialization of csv values for Go enums by adding a value mask that can support multiple Go values 

```go
func (i ConditionalAccessGuestOrExternalUserTypes) String() string {
	var data []string
	for p := ConditionalAccessGuestOrExternalUserTypes(1); p <= UNKNOWNFUTUREVALUE_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES; p <<= 1 {
		if i&p == p {
			data = append(data, []string{"none", "internalGuest", "b2bCollaborationGuest", "b2bCollaborationMember", "b2bDirectConnectUser", "otherExternalUser", "serviceProvider", "unknownFutureValue"}[p])
		}
	}
	return strings.Join(data, ",")
}
func ParseConditionalAccessGuestOrExternalUserTypes(v string) (any, error) {
	// detect a command in the string and return enum as mask
	var result ConditionalAccessGuestOrExternalUserTypes
	values := strings.Split(v, ",")
	for _, str := range values {
		switch str {
		case "none":
			result |= NONE_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "internalGuest":
			result |= INTERNALGUEST_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "b2bCollaborationGuest":
			result |= B2BCOLLABORATIONGUEST_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "b2bCollaborationMember":
			result |= B2BCOLLABORATIONMEMBER_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "b2bDirectConnectUser":
			result |= B2BDIRECTCONNECTUSER_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "otherExternalUser":
			result |= OTHEREXTERNALUSER_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "serviceProvider":
			result |= SERVICEPROVIDER_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		case "unknownFutureValue":
			result |= UNKNOWNFUTUREVALUE_CONDITIONALACCESSGUESTOREXTERNALUSERTYPES
		default:
			return 0, errors.New("Unknown ConditionalAccessGuestOrExternalUserTypes value: " + v)
		}
	}
	return &result, nil
}
```