### PR TITLE
Fixes bitwise enum serialization in typescript.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work around a System.ComandLine bug where adjacent matching command names would crash the CLI parser (CLI). [microsoftgraph/msgraph-cli#316](https://github.com/microsoftgraph/msgraph-cli/issues/316) [microsoftgraph/msgraph-cli#320](https://github.com/microsoftgraph/msgraph-cli/issues/320), [dotnet/command-line-api#2260](https://github.com/dotnet/command-line-api/issues/2260)
 - Aggregate typescript import statements by source [#3232](https://github.com/microsoft/kiota/issues/3232)
 - Fixes a bug in dotnet where enums types would not be fully disambiguated when initialized in constructor with default values and existing conflicting property exists [#3233]
+- Fixes a bug in generation of flagged enum properties and their serializer/deserializer functions in typescript [https://github.com/microsoft/kiota/issues/3260]
 
 ## [1.5.1] - 2023-08-08
 

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -163,7 +163,7 @@ public class CodeFunctionWriter : BaseElementWriter<CodeFunction, TypeScriptConv
     private string? GetSerializationMethodNameForCodeType(CodeType propType, string propertyType)
     {
         if (propType.TypeDefinition is CodeEnum currentEnum)
-            return $"writeEnumValue<{currentEnum.Name.ToFirstCharacterUpperCase()}>";
+            return $"writeEnumValue<{currentEnum.Name.ToFirstCharacterUpperCase()}{(currentEnum.Flags && !propType.IsCollection ? "[]" : string.Empty)}>";
         else if (conventions.StreamTypeName.Equals(propertyType, StringComparison.OrdinalIgnoreCase))
             return "writeByteArrayValue";
         else if (propType.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None)

--- a/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodePropertyWriter.cs
@@ -13,7 +13,8 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, TypeScriptConv
         if (codeElement.ExistsInExternalBaseType)
             return;
         var returnType = conventions.GetTypeString(codeElement.Type, codeElement);
-        var isFlagEnum = codeElement.Type is CodeType currentType && currentType.TypeDefinition is CodeEnum currentEnum && currentEnum.Flags;
+        var isFlagEnum = codeElement.Type is CodeType { TypeDefinition: CodeEnum { Flags: true } }
+                         && !codeElement.Type.IsCollection;//collection of flagged enums are not supported/don't make sense
 
         conventions.WriteLongDescription(codeElement, writer);
         switch (codeElement.Parent)

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
@@ -94,4 +94,23 @@ public class CodePropertyWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("[]", result);
     }
+    [Fact]
+    public void WritesCollectionFlagEnumsAsOneDimensionalArray()
+    {
+        property.Kind = CodePropertyKind.Custom;
+        property.Type = new CodeType
+        {
+            Name = "customEnum",
+            CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array
+        };
+        (property.Type as CodeType).TypeDefinition = new CodeEnum
+        {
+            Name = "customEnumType",
+            Flags = true,//this is not expected for a collection. So treat as enum collection
+        };
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains("[]", result);
+        Assert.DoesNotContain("[] []", result);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/3260

Typescript writers are creating multidimensional collections for flagged enums that are collections. This fixes the issues by handling them as collections of enums. 

Sample generation of PR at https://github.com/microsoftgraph/msgraph-sdk-typescript/pull/361