### PR TITLE
[Java] Move (most of) the name mangling logic to the Refiner

### DIFF
--- a/it/compare-generation.ps1
+++ b/it/compare-generation.ps1
@@ -62,7 +62,7 @@ $tmpFolder1 = New-TemporaryDirectory
 $tmpFolder2 = New-TemporaryDirectory
 
 Start-Process "$kiotaExec" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder1" -Wait -NoNewWindow
-Start-Process "src/kiota/bin/Debug/net7.0/kiota" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder2" -Wait -NoNewWindow
+Start-Process "$kiotaExec" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder2" -Wait -NoNewWindow
 
 # Remove variable output files
 Remove-Item (Join-Path -Path $tmpFolder1 -ChildPath "kiota-lock.json")
@@ -81,10 +81,8 @@ Get-FileHash -InputStream ([IO.MemoryStream]::new([char[]]$HashString1))
 $HashString2 = (Get-ChildItem $tmpFolder2 -Recurse | where { ! $_.PSIsContainer } | Get-FileHash -Algorithm MD5).Hash | Out-String
 Get-FileHash -InputStream ([IO.MemoryStream]::new([char[]]$HashString2))
 
-Write-Output "Folder Old: $tmpFolder1"
-Write-Output "Folder New: $tmpFolder2"
-
-diff --color -r "$tmpFolder1" "$tmpFolder2"
+Write-Output "Folder 1: $tmpFolder1"
+Write-Output "Folder 2: $tmpFolder2"
 
 if ($HashString1 -eq $HashString2) {
     Write-Output "The content of the folders is identical"

--- a/it/compare-generation.ps1
+++ b/it/compare-generation.ps1
@@ -62,7 +62,7 @@ $tmpFolder1 = New-TemporaryDirectory
 $tmpFolder2 = New-TemporaryDirectory
 
 Start-Process "$kiotaExec" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder1" -Wait -NoNewWindow
-Start-Process "$kiotaExec" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder2" -Wait -NoNewWindow
+Start-Process "src/kiota/bin/Debug/net7.0/kiota" -ArgumentList "generate --clean-output --language ${language} --openapi ${targetOpenapiPath} --dvr all --output $tmpFolder2" -Wait -NoNewWindow
 
 # Remove variable output files
 Remove-Item (Join-Path -Path $tmpFolder1 -ChildPath "kiota-lock.json")
@@ -81,8 +81,10 @@ Get-FileHash -InputStream ([IO.MemoryStream]::new([char[]]$HashString1))
 $HashString2 = (Get-ChildItem $tmpFolder2 -Recurse | where { ! $_.PSIsContainer } | Get-FileHash -Algorithm MD5).Hash | Out-String
 Get-FileHash -InputStream ([IO.MemoryStream]::new([char[]]$HashString2))
 
-Write-Output "Folder 1: $tmpFolder1"
-Write-Output "Folder 2: $tmpFolder2"
+Write-Output "Folder Old: $tmpFolder1"
+Write-Output "Folder New: $tmpFolder2"
+
+diff --color -r "$tmpFolder1" "$tmpFolder2"
 
 if ($HashString1 -eq $HashString2) {
     Write-Output "The content of the folders is identical"

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -51,6 +51,7 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore,
+                static s => s,
                 true,
                 AbstractionsNamespaceName,
                 "IComposedTypeWrapper"

--- a/src/Kiota.Builder/Refiners/CliRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CliRefiner.cs
@@ -53,7 +53,8 @@ public class CliRefiner : CSharpRefiner, ILanguageRefiner
             cancellationToken.ThrowIfCancellationRequested();
             MoveClassesWithNamespaceNamesUnderNamespace(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
-                _configuration.UsesBackingStore
+                _configuration.UsesBackingStore,
+                static s => s
             );
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, false);
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -186,7 +186,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 ReturnType = (CodeTypeBase)currentProperty.Type.Clone(),
                 Documentation = new()
                 {
-                    Description = $"Gets the {currentProperty.Name} property value. {currentProperty.Documentation.Description}",
+                    Description = $"Gets the {currentProperty.WireName} property value. {currentProperty.Documentation.Description}",
                 },
                 AccessedProperty = currentProperty,
                 Deprecation = currentProperty.Deprecation,
@@ -200,7 +200,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 Kind = CodeMethodKind.Setter,
                 Documentation = new()
                 {
-                    Description = $"Sets the {currentProperty.Name} property value. {currentProperty.Documentation.Description}",
+                    Description = $"Sets the {currentProperty.WireName} property value. {currentProperty.Documentation.Description}",
                 },
                 AccessedProperty = currentProperty,
                 ReturnType = new CodeType

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -146,7 +146,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             var refinedName = refineAccessorName(currentProperty.Name);
 
             if (!refinedName.Equals(currentProperty.Name, StringComparison.Ordinal) &&
-                !parentClass.Properties.Any(property => !property.Name.Equals(property.Name, StringComparison.Ordinal) && refinedName.Equals(property.Name, StringComparison.Ordinal)))// ensure the refinement won't generate a duplicate
+                !parentClass.Properties.Any(property => !currentProperty.Name.Equals(property.Name, StringComparison.Ordinal) &&
+                    refinedName.Equals(property.Name, StringComparison.OrdinalIgnoreCase)))// ensure the refinement won't generate a duplicate
             {
                 if (string.IsNullOrEmpty(currentProperty.SerializationName))
                     currentProperty.SerializationName = currentProperty.Name;

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -137,9 +137,6 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     {
         ArgumentNullException.ThrowIfNull(refineAccessorName);
         if (!(propertyKindsToReplace?.Any() ?? true)) return;
-        if (current is CodeProperty currentProperty1)
-            Console.WriteLine("-> PROPERTY " + currentProperty1.Name + " " + currentProperty1.Kind + " - " + currentProperty1.ExistsInBaseType + " " + current.Parent);
-
         if (current is CodeProperty currentProperty &&
             !currentProperty.ExistsInBaseType &&
             propertyKindsToReplace!.Contains(currentProperty.Kind) &&

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -442,30 +442,33 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         }
         CrawlTree(currentElement, c => ReplaceBinaryByNativeType(c, symbol, ns, addDeclaration, isNullable));
     }
-    protected static void ConvertUnionTypesToWrapper(CodeElement currentElement, bool usesBackingStore, bool supportInnerClasses = true, string markerInterfaceNamespace = "", string markerInterfaceName = "", string markerMethodName = "")
+    protected static void ConvertUnionTypesToWrapper(CodeElement currentElement, bool usesBackingStore, Func<string, string> refineMethodName, bool supportInnerClasses = true, string markerInterfaceNamespace = "", string markerInterfaceName = "", string markerMethodName = "")
     {
         ArgumentNullException.ThrowIfNull(currentElement);
+        ArgumentNullException.ThrowIfNull(refineMethodName);
         if (currentElement.Parent is CodeClass parentClass)
         {
             if (currentElement is CodeMethod currentMethod)
             {
+                currentMethod.Name = refineMethodName(currentMethod.Name);
+
                 if (currentMethod.ReturnType is CodeComposedTypeBase currentUnionType)
-                    currentMethod.ReturnType = ConvertComposedTypeToWrapper(parentClass, currentUnionType, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
+                    currentMethod.ReturnType = ConvertComposedTypeToWrapper(parentClass, currentUnionType, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
                 if (currentMethod.Parameters.Any(static x => x.Type is CodeComposedTypeBase))
                     foreach (var currentParameter in currentMethod.Parameters.Where(static x => x.Type is CodeComposedTypeBase))
-                        currentParameter.Type = ConvertComposedTypeToWrapper(parentClass, (CodeComposedTypeBase)currentParameter.Type, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
+                        currentParameter.Type = ConvertComposedTypeToWrapper(parentClass, (CodeComposedTypeBase)currentParameter.Type, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
                 if (currentMethod.ErrorMappings.Select(static x => x.Value).OfType<CodeComposedTypeBase>().Any())
                     foreach (var errorUnionType in currentMethod.ErrorMappings.Select(static x => x.Value).OfType<CodeComposedTypeBase>())
-                        currentMethod.ReplaceErrorMapping(errorUnionType, ConvertComposedTypeToWrapper(parentClass, errorUnionType, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName));
+                        currentMethod.ReplaceErrorMapping(errorUnionType, ConvertComposedTypeToWrapper(parentClass, errorUnionType, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName));
             }
             else if (currentElement is CodeIndexer currentIndexer && currentIndexer.ReturnType is CodeComposedTypeBase currentUnionType)
-                currentIndexer.ReturnType = ConvertComposedTypeToWrapper(parentClass, currentUnionType, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
+                currentIndexer.ReturnType = ConvertComposedTypeToWrapper(parentClass, currentUnionType, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
             else if (currentElement is CodeProperty currentProperty && currentProperty.Type is CodeComposedTypeBase currentPropUnionType)
-                currentProperty.Type = ConvertComposedTypeToWrapper(parentClass, currentPropUnionType, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
+                currentProperty.Type = ConvertComposedTypeToWrapper(parentClass, currentPropUnionType, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName);
         }
-        CrawlTree(currentElement, x => ConvertUnionTypesToWrapper(x, usesBackingStore, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName));
+        CrawlTree(currentElement, x => ConvertUnionTypesToWrapper(x, usesBackingStore, refineMethodName, supportInnerClasses, markerInterfaceNamespace, markerInterfaceName, markerMethodName));
     }
-    private static CodeTypeBase ConvertComposedTypeToWrapper(CodeClass codeClass, CodeComposedTypeBase codeComposedType, bool usesBackingStore, bool supportsInnerClasses, string markerInterfaceNamespace, string markerInterfaceName, string markerMethodName)
+    private static CodeTypeBase ConvertComposedTypeToWrapper(CodeClass codeClass, CodeComposedTypeBase codeComposedType, bool usesBackingStore, Func<string, string> refineMethodName, bool supportsInnerClasses, string markerInterfaceNamespace, string markerInterfaceName, string markerMethodName)
     {
         ArgumentNullException.ThrowIfNull(codeClass);
         ArgumentNullException.ThrowIfNull(codeComposedType);
@@ -530,7 +533,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         if (codeComposedType.Types.All(static x => x.TypeDefinition is CodeClass targetClass && targetClass.IsOfKind(CodeClassKind.Model) ||
                                 x.TypeDefinition is CodeEnum || x.TypeDefinition is null))
         {
-            KiotaBuilder.AddSerializationMembers(newClass, false, usesBackingStore);
+            KiotaBuilder.AddSerializationMembers(newClass, false, usesBackingStore, refineMethodName);
             newClass.Kind = CodeClassKind.Model;
         }
         newClass.OriginalComposedType = codeComposedType;
@@ -571,7 +574,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             });
         }
         // Add the discriminator function to the wrapper as it will be referenced. 
-        KiotaBuilder.AddDiscriminatorMethod(newClass, codeComposedType.DiscriminatorInformation.DiscriminatorPropertyName, codeComposedType.DiscriminatorInformation.DiscriminatorMappings);
+        KiotaBuilder.AddDiscriminatorMethod(newClass, codeComposedType.DiscriminatorInformation.DiscriminatorPropertyName, codeComposedType.DiscriminatorInformation.DiscriminatorMappings, refineMethodName);
         return new CodeType
         {
             Name = newClass.Name,

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -146,7 +146,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             var refinedName = refineAccessorName(currentProperty.Name);
 
             if (!refinedName.Equals(currentProperty.Name, StringComparison.Ordinal) &&
-                !parentClass.Properties.Any(property => !property.Name.Equals(property.Name, StringComparison.Ordinal) && refinedName.Equals(property.Name, StringComparison.OrdinalIgnoreCase)))// ensure the refinement won't generate a duplicate
+                !parentClass.Properties.Any(property => !property.Name.Equals(property.Name, StringComparison.Ordinal) && refinedName.Equals(property.Name, StringComparison.Ordinal)))// ensure the refinement won't generate a duplicate
             {
                 if (string.IsNullOrEmpty(currentProperty.SerializationName))
                     currentProperty.SerializationName = currentProperty.Name;

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -53,6 +53,7 @@ public class GoRefiner : CommonLanguageRefiner
             ConvertUnionTypesToWrapper(
                 generatedCode,
                 _configuration.UsesBackingStore,
+                static s => s,
                 true,
                 string.Empty,
                 string.Empty,

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +7,6 @@ using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Configuration;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Java;
-using Microsoft.VisualBasic;
 
 namespace Kiota.Builder.Refiners;
 public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -256,9 +256,10 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
     private const string MultipartBodyClassName = "MultipartBody";
     private static void CorrectCommonNames(CodeElement currentElement)
     {
-        if (currentElement is CodeMethod m)
+        if (currentElement is CodeMethod m &&
+            currentElement.Parent is CodeClass parentClass)
         {
-            m.Name = m.Name.ToFirstCharacterLowerCase();
+            parentClass.RenameChildElement(m.Name, m.Name.ToFirstCharacterLowerCase());
         }
         else if (currentElement is CodeIndexer i)
         {

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -62,6 +62,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore,
+                s => s.ToFirstCharacterLowerCase(),
                 true,
                 SerializationNamespaceName,
                 "ComposedTypeWrapper"
@@ -264,6 +265,20 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
         else if (currentElement is CodeIndexer i)
         {
             i.IndexParameter.Name = i.IndexParameter.Name.ToFirstCharacterLowerCase();
+        }
+        else if (currentElement is CodeEnum e)
+        {
+            foreach (var option in e.Options)
+            {
+                if (!string.IsNullOrEmpty(option.Name) && Char.IsLower(option.Name[0]))
+                {
+                    if (string.IsNullOrEmpty(option.SerializationName))
+                    {
+                        option.SerializationName = option.Name;
+                    }
+                    option.Name = option.Name.ToFirstCharacterUpperCase();
+                }
+            }
         }
 
         CrawlTree(currentElement, element => CorrectCommonNames(element));

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -141,7 +141,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             SplitLongDiscriminatorMethods(generatedCode);
             AddPrimaryErrorMessage(generatedCode,
                 "getMessage",
-                () => new CodeType { Name = "string", IsNullable = false, IsExternal = true }
+                () => new CodeType { Name = "String", IsNullable = false, IsExternal = true }
             );
         }, cancellationToken);
     }

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -43,6 +43,7 @@ public class PhpRefiner : CommonLanguageRefiner
             RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
                 _configuration.UsesBackingStore,
+                static s => s,
                 false);
             ReplaceReservedNames(generatedCode, new PhpReservedNamesProvider(), reservedWord => $"Escaped{reservedWord.ToFirstCharacterUpperCase()}", new HashSet<Type> { typeof(CodeEnumOption) });
             AddQueryParameterFactoryMethod(generatedCode);

--- a/src/Kiota.Builder/Refiners/RubyRefiner.cs
+++ b/src/Kiota.Builder/Refiners/RubyRefiner.cs
@@ -56,7 +56,8 @@ public partial class RubyRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddPropertiesAndMethodTypesImports(generatedCode, false, false, true);
             RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(generatedCode,
-                _configuration.UsesBackingStore
+                _configuration.UsesBackingStore,
+                static s => s
             );
             cancellationToken.ThrowIfCancellationRequested();
             AddParsableImplementsForModelClasses(generatedCode, "MicrosoftKiotaAbstractions::Parsable");

--- a/src/Kiota.Builder/Refiners/SwiftRefiner.cs
+++ b/src/Kiota.Builder/Refiners/SwiftRefiner.cs
@@ -32,7 +32,8 @@ public class SwiftRefiner : CommonLanguageRefiner
             RemoveCancellationParameter(generatedCode);
             ConvertUnionTypesToWrapper(
                 generatedCode,
-                _configuration.UsesBackingStore
+                _configuration.UsesBackingStore,
+                static s => s
             );
             cancellationToken.ThrowIfCancellationRequested();
             AddPropertiesAndMethodTypesImports(

--- a/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeClassDeclarationWriter.cs
@@ -21,8 +21,8 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, Ja
                 .Where(static x => x.Declaration != null)
                 .Where(x => x.Declaration!.IsExternal || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
                 .Select(static x => x.Declaration!.IsExternal ?
-                                    $"import {x.Declaration.Name}.{x.Name.ToFirstCharacterUpperCase()};" :
-                                    $"import {x.Name}.{x.Declaration.Name.ToFirstCharacterUpperCase()};")
+                                    $"import {x.Declaration.Name}.{x.Name};" :
+                                    $"import {x.Name}.{x.Declaration.Name};")
                 .Distinct()
                 .GroupBy(static x => x.Split('.').Last(), StringComparer.OrdinalIgnoreCase)
                 .Select(static x => x.First()) // we don't want to import the same symbol twice
@@ -30,13 +30,13 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, Ja
                 .ToList()
                 .ForEach(x => writer.WriteLine(x));
         }
-        var derivation = (codeElement.Inherits == null ? string.Empty : $" extends {codeElement.Inherits.Name.ToFirstCharacterUpperCase()}") +
+        var derivation = (codeElement.Inherits == null ? string.Empty : $" extends {codeElement.Inherits.Name}") +
                         (!codeElement.Implements.Any() ? string.Empty : $" implements {codeElement.Implements.Select(x => x.Name).Aggregate((x, y) => x + ", " + y)}");
         if (codeElement.Parent is CodeClass parentClass)
             conventions.WriteLongDescription(parentClass, writer);
         var innerClassStatic = codeElement.Parent is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) && currentClass.Parent is CodeClass ? "static " : string.Empty; //https://stackoverflow.com/questions/47541459/no-enclosing-instance-is-accessible-must-qualify-the-allocation-with-an-enclosi
         writer.WriteLine(JavaConventionService.AutoGenerationHeader);
-        writer.WriteLine($"public {innerClassStatic}class {codeElement.Name.ToFirstCharacterUpperCase()}{derivation} {{");
+        writer.WriteLine($"public {innerClassStatic}class {codeElement.Name}{derivation} {{");
         writer.IncreaseIndent();
     }
 }

--- a/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
@@ -14,7 +14,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, JavaConventionService>
         var enumOptions = codeElement.Options.ToArray();
         if (!enumOptions.Any())
             return;
-        var enumName = codeElement.Name.ToFirstCharacterUpperCase();
+        var enumName = codeElement.Name;
         writer.WriteLines($"package {(codeElement.Parent as CodeNamespace)?.Name};",
             string.Empty,
             "import com.microsoft.kiota.serialization.ValuedEnum;",
@@ -29,7 +29,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, JavaConventionService>
         foreach (var enumOption in enumOptions)
         {
             conventions.WriteShortDescription(enumOption.Documentation.Description, writer);
-            writer.WriteLine($"{enumOption.Name.ToFirstCharacterUpperCase()}(\"{enumOption.SerializationName}\"){(enumOption == lastEnumOption ? ";" : ",")}");
+            writer.WriteLine($"{enumOption.Name}(\"{enumOption.SerializationName}\"){(enumOption == lastEnumOption ? ";" : ",")}");
         }
         writer.WriteLines("public final String value;",
             $"{enumName}(final String value) {{");
@@ -46,7 +46,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, JavaConventionService>
                         "switch(searchValue) {");
         writer.IncreaseIndent();
         writer.Write(enumOptions
-                    .Select(x => $"case \"{x.WireName}\": return {x.Name.ToFirstCharacterUpperCase()};")
+                    .Select(x => $"case \"{x.WireName}\": return {x.Name};")
                     .Aggregate((x, y) => $"{x}{LanguageWriter.NewLine}{writer.GetIndent()}{y}") + LanguageWriter.NewLine);
         writer.WriteLine("default: return null;");
         writer.CloseBlock();

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -348,7 +348,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                         .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
                                         .OrderBy(static x => x.Name))
         {
-            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name}";
+            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
             var defaultValue = propWithDefault.DefaultValue;
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {
@@ -375,7 +375,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass)
     {
         if (parentClass.GetBackingStoreProperty() is CodeProperty backingStore)
-            writer.WriteLine($"this.get{backingStore.Name}().set(\"{codeElement.AccessedProperty?.Name}\", value);");
+            writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name}\", value);");
         else
         {
             string value = "PeriodAndDuration".Equals(codeElement.AccessedProperty?.Type?.Name, StringComparison.OrdinalIgnoreCase) ? "PeriodAndDuration.ofPeriodAndDuration(value);" : "value;";
@@ -396,12 +396,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name}\");");
             writer.StartBlock("if(value == null) {");
             writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
-                $"this.set{codeElement.AccessedProperty?.Name}(value);");
+                $"this.set{codeElement.AccessedProperty?.Name.ToFirstCharacterUpperCase()}(value);");
             writer.CloseBlock();
             writer.WriteLine("return value;");
         }
         else
-            writer.WriteLine($"return this.get{backingStore.Name}().get(\"{codeElement.AccessedProperty?.Name}\");");
+            writer.WriteLine($"return this.get{backingStore.Name.ToFirstCharacterUpperCase()}().get(\"{codeElement.AccessedProperty?.Name}\");");
 
     }
     private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType)

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -16,9 +16,6 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         ArgumentNullException.ThrowIfNull(writer);
         if (codeElement.Parent is not CodeClass parentClass) throw new InvalidOperationException("the parent of a method should be a class");
 
-        var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
-        if (codeElement.ReturnType is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
-            returnType = $"EnumSet<{returnType}>";
         var baseReturnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
         var finalReturnType = GetFinalReturnType(codeElement, baseReturnType);
         WriteMethodDocumentation(codeElement, writer, baseReturnType, finalReturnType);
@@ -681,6 +678,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     private string GetFinalReturnType(CodeMethod code, string returnType)
     {
         var voidType = code.IsAsync ? "Void" : "void";
+        if (code.ReturnType is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
+            returnType = $"EnumSet<{returnType}>";
         var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
         var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
         var reType = returnType.Equals("void", StringComparison.OrdinalIgnoreCase) ? voidType : returnType;

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -19,12 +19,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
         if (codeElement.ReturnType is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
             returnType = $"EnumSet<{returnType}>";
-        if (codeElement.IsAsync &&
-            codeElement.IsOfKind(CodeMethodKind.RequestExecutor) &&
-            returnType.Equals("void", StringComparison.OrdinalIgnoreCase))
-            returnType = "Void"; //generic type for the future
-        WriteMethodDocumentation(codeElement, writer, returnType);
-        WriteMethodPrototype(codeElement, writer, returnType);
+        var baseReturnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
+        var finalReturnType = GetFinalReturnType(codeElement, baseReturnType);
+        WriteMethodDocumentation(codeElement, writer, baseReturnType, finalReturnType);
+        WriteMethodPrototype(codeElement, writer, finalReturnType);
         writer.IncreaseIndent();
         var inherits = parentClass.StartBlock.Inherits != null && !parentClass.IsErrorDefinition;
         var requestBodyParam = codeElement.Parameters.OfKind(CodeParameterKind.RequestBody);
@@ -40,7 +38,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                 WriteDeserializerBody(codeElement, parentClass, writer, inherits);
                 break;
             case CodeMethodKind.IndexerBackwardCompatibility:
-                WriteIndexerBody(codeElement, parentClass, writer, returnType);
+                WriteIndexerBody(codeElement, parentClass, writer, finalReturnType);
                 break;
             case CodeMethodKind.RequestGenerator when codeElement.IsOverload:
                 WriteGeneratorOrExecutorMethodCall(codeElement, requestParams, parentClass, writer, "return ", CodeMethodKind.RequestGenerator);
@@ -111,18 +109,18 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     {
         var rawUrlParameter = codeElement.Parameters.OfKind(CodeParameterKind.RawUrl) ?? throw new InvalidOperationException("RawUrlBuilder method should have a RawUrl parameter");
         var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) ?? throw new InvalidOperationException("RawUrlBuilder method should have a RequestAdapter property");
-        writer.WriteLine($"return new {parentClass.Name.ToFirstCharacterUpperCase()}({rawUrlParameter.Name.ToFirstCharacterLowerCase()}, {requestAdapterProperty.Name.ToFirstCharacterLowerCase()});");
+        writer.WriteLine($"return new {parentClass.Name}({rawUrlParameter.Name}, {requestAdapterProperty.Name});");
     }
     private const string ResultVarName = "result";
     private void WriteFactoryMethodBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer)
     {
         var parseNodeParameter = codeElement.Parameters.OfKind(CodeParameterKind.ParseNode) ?? throw new InvalidOperationException("Factory method should have a ParseNode parameter");
         if (parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForUnionType || parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType)
-            writer.WriteLine($"final {parentClass.Name.ToFirstCharacterUpperCase()} {ResultVarName} = new {parentClass.Name.ToFirstCharacterUpperCase()}();");
+            writer.WriteLine($"final {parentClass.Name} {ResultVarName} = new {parentClass.Name}();");
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
         if (writeDiscriminatorValueRead)
         {
-            writer.WriteLine($"final ParseNode mappingValueNode = {parseNodeParameter.Name.ToFirstCharacterLowerCase()}.getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\");");
+            writer.WriteLine($"final ParseNode mappingValueNode = {parseNodeParameter.Name}.getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\");");
             writer.StartBlock("if (mappingValueNode != null) {");
             writer.WriteLine($"final String {DiscriminatorMappingVarName} = mappingValueNode.getStringValue();");
         }
@@ -146,7 +144,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             writer.WriteLine($"return {ResultVarName};");
         }
         else
-            writer.WriteLine($"return new {parentClass.Name.ToFirstCharacterUpperCase()}();");
+            writer.WriteLine($"return new {parentClass.Name}();");
     }
     private static readonly Regex factoryMethodIndexParser = new(@"_(?<idx>\d+)", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
     private static void WriteFactoryOverloadMethod(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer)
@@ -156,7 +154,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         {
             var takeValue = Math.Min(MaxDiscriminatorsPerMethod, parentClass.DiscriminatorInformation.DiscriminatorMappings.Count() - currentDiscriminatorPageIndex * MaxDiscriminatorsPerMethod);
             var currentDiscriminatorPage = parentClass.DiscriminatorInformation.DiscriminatorMappings.Skip(currentDiscriminatorPageIndex * MaxDiscriminatorsPerMethod).Take(takeValue).OrderBy(static x => x.Key, StringComparer.OrdinalIgnoreCase);
-            WriteFactoryMethodBodyForInheritedModel(currentDiscriminatorPage, writer, parameter.Name.ToFirstCharacterLowerCase());
+            WriteFactoryMethodBodyForInheritedModel(currentDiscriminatorPage, writer, parameter.Name);
         }
         writer.WriteLine("return null;");
     }
@@ -168,7 +166,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                                         .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase))
         {
             var varName = $"{otherMethodName}_result";
-            writer.WriteLine($"final {parentClass.Name.ToFirstCharacterUpperCase()} {varName} = {otherMethodName.ToFirstCharacterLowerCase()}({DiscriminatorMappingVarName});");
+            writer.WriteLine($"final {parentClass.Name} {varName} = {otherMethodName}({DiscriminatorMappingVarName});");
             writer.StartBlock($"if ({varName} != null) {{");
             writer.WriteLine($"return {varName};");
             writer.CloseBlock();
@@ -181,7 +179,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         writer.StartBlock($"switch ({varName}) {{");
         foreach (var mappedType in discriminatorMappings)
         {
-            writer.WriteLine($"case \"{mappedType.Key}\": return new {mappedType.Value.AllTypes.First().TypeDefinition?.Name.ToFirstCharacterUpperCase()}();");
+            writer.WriteLine($"case \"{mappedType.Key}\": return new {mappedType.Value.AllTypes.First().TypeDefinition?.Name}();");
         }
         writer.CloseBlock();
     }
@@ -199,9 +197,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         {
             if (property.Type is CodeType propertyType)
             {
-                var deserializationMethodName = $"{parseNodeParameter.Name.ToFirstCharacterLowerCase()}.{GetDeserializationMethodName(propertyType, codeElement)}";
+                var deserializationMethodName = $"{parseNodeParameter.Name}.{GetDeserializationMethodName(propertyType, codeElement)}";
                 writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if ({deserializationMethodName} != null) {{");
-                writer.WriteLine($"{ResultVarName}.{property.Setter!.Name.ToFirstCharacterLowerCase()}({deserializationMethodName});");
+                writer.WriteLine($"{ResultVarName}.{property.Setter!.Name}({deserializationMethodName});");
                 writer.DecreaseIndent();
             }
             if (!includeElse)
@@ -216,7 +214,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             if (includeElse)
                 writer.StartBlock("} else {");
             foreach (var property in complexProperties.Where(static x => x.Item1.Setter != null))
-                writer.WriteLine($"{ResultVarName}.{property.Item1.Setter!.Name.ToFirstCharacterLowerCase()}(new {conventions.GetTypeString(property.Item2, codeElement, false)}());");
+                writer.WriteLine($"{ResultVarName}.{property.Item1.Setter!.Name}(new {conventions.GetTypeString(property.Item2, codeElement, false)}());");
             if (includeElse)
                 writer.CloseBlock();
         }
@@ -244,7 +242,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                 };
             var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(property.Type.Name, StringComparison.OrdinalIgnoreCase));
             writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (\"{mappedType.Key}\".equalsIgnoreCase({DiscriminatorMappingVarName})) {{");
-            writer.WriteLine($"{ResultVarName}.{property.Setter!.Name.ToFirstCharacterLowerCase()}(new {conventions.GetTypeString(property.Type, codeElement, false)}());");
+            writer.WriteLine($"{ResultVarName}.{property.Setter!.Name}(new {conventions.GetTypeString(property.Type, codeElement, false)}());");
             writer.DecreaseIndent();
             if (!includeElse)
                 includeElse = true;
@@ -264,9 +262,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         {
             if (property.Type is CodeType propertyType)
             {
-                var serializationMethodName = $"{parseNodeParameter.Name.ToFirstCharacterLowerCase()}.{GetDeserializationMethodName(propertyType, currentElement)}";
+                var serializationMethodName = $"{parseNodeParameter.Name}.{GetDeserializationMethodName(propertyType, currentElement)}";
                 writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if ({serializationMethodName} != null) {{");
-                writer.WriteLine($"{ResultVarName}.{property.Setter!.Name.ToFirstCharacterLowerCase()}({serializationMethodName});");
+                writer.WriteLine($"{ResultVarName}.{property.Setter!.Name}({serializationMethodName});");
                 writer.DecreaseIndent();
                 if (!includeElse)
                     includeElse = true;
@@ -284,7 +282,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     {
         if (!codeElement.IsOverload)
             foreach (var parameter in codeElement.Parameters.Where(static x => !x.Optional && !x.IsOfKind(CodeParameterKind.RequestAdapter, CodeParameterKind.PathParameters)).OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase))
-                writer.WriteLine($"Objects.requireNonNull({parameter.Name.ToFirstCharacterLowerCase()});");
+                writer.WriteLine($"Objects.requireNonNull({parameter.Name});");
     }
     private static void WriteRequestBuilderConstructorCall(CodeMethod codeElement, LanguageWriter writer)
     {
@@ -299,7 +297,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
         var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
         var backingStoreParameter = method.Parameters.FirstOrDefault(static x => x.IsOfKind(CodeParameterKind.BackingStore));
-        var requestAdapterPropertyName = requestAdapterProperty?.Name.ToFirstCharacterLowerCase() ?? string.Empty;
+        var requestAdapterPropertyName = requestAdapterProperty?.Name ?? string.Empty;
         WriteSerializationRegistration(method.SerializerModules, writer, "registerDefaultSerializer");
         WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
         if (!string.IsNullOrEmpty(method.BaseUrl))
@@ -308,7 +306,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
             writer.CloseBlock();
             if (pathParametersProperty != null)
-                writer.WriteLine($"{pathParametersProperty.Name.ToFirstCharacterLowerCase()}.put(\"baseurl\", {requestAdapterPropertyName}.getBaseUrl());");
+                writer.WriteLine($"{pathParametersProperty.Name}.put(\"baseurl\", {requestAdapterPropertyName}.getBaseUrl());");
         }
         if (backingStoreParameter != null)
             writer.WriteLine($"this.{requestAdapterPropertyName}.enableBackingStore({backingStoreParameter.Name});");
@@ -332,7 +330,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                     thirdParameterName = $", {pathParametersParameter.Name}";
                 else if (currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl) is CodeParameter rawUrlParameter)
                     thirdParameterName = $", {rawUrlParameter.Name}";
-                writer.WriteLine($"super({requestAdapterParameter.Name.ToFirstCharacterLowerCase()}, {urlTemplateProperty.DefaultValue}{thirdParameterName});");
+                writer.WriteLine($"super({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue}{thirdParameterName});");
             }
             else
                 writer.WriteLine("super();");
@@ -342,7 +340,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
+            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name} = {propWithDefault.DefaultValue};");
         }
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData, CodePropertyKind.Custom) //additional data and custom properties rely on accessors
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
@@ -350,11 +348,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                         .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
                                         .OrderBy(static x => x.Name))
         {
-            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name.ToFirstCharacterLowerCase() is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
+            var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name}";
             var defaultValue = propWithDefault.DefaultValue;
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {
-                defaultValue = $"{enumDefinition.Name.ToFirstCharacterUpperCase()}.forValue({defaultValue})";
+                defaultValue = $"{enumDefinition.Name}.forValue({defaultValue})";
             }
             writer.WriteLine($"this.{setterName}({defaultValue});");
         }
@@ -367,21 +365,21 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             if (pathParameters.Any())
                 conventions.AddParametersAssignment(writer,
                                                     pathParametersParam.Type,
-                                                    pathParametersParam.Name.ToFirstCharacterLowerCase(),
-                                                    $"this.{pathParametersProp.Name.ToFirstCharacterLowerCase()}",
+                                                    pathParametersParam.Name,
+                                                    $"this.{pathParametersProp.Name}",
                                                     pathParameters
-                                                                .Select(static x => (x.Type, string.IsNullOrEmpty(x.SerializationName) ? x.Name : x.SerializationName, x.Name.ToFirstCharacterLowerCase()))
+                                                                .Select(static x => (x.Type, string.IsNullOrEmpty(x.SerializationName) ? x.Name : x.SerializationName, x.Name))
                                                                 .ToArray());
         }
     }
     private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass)
     {
         if (parentClass.GetBackingStoreProperty() is CodeProperty backingStore)
-            writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\", value);");
+            writer.WriteLine($"this.get{backingStore.Name}().set(\"{codeElement.AccessedProperty?.Name}\", value);");
         else
         {
             string value = "PeriodAndDuration".Equals(codeElement.AccessedProperty?.Type?.Name, StringComparison.OrdinalIgnoreCase) ? "PeriodAndDuration.ofPeriodAndDuration(value);" : "value;";
-            writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()} = {value}");
+            writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name} = {value}");
 
         }
     }
@@ -389,28 +387,28 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     {
         var backingStore = parentClass.GetBackingStoreProperty();
         if (backingStore == null || (codeElement.AccessedProperty?.IsOfKind(CodePropertyKind.BackingStore) ?? false))
-            writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()};");
+            writer.WriteLine($"return this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name};");
         else
             if (!(codeElement.AccessedProperty?.Type?.IsNullable ?? true) &&
                 !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
                 !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue))
         {
-            writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.get(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\");");
+            writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name}\");");
             writer.StartBlock("if(value == null) {");
             writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
-                $"this.set{codeElement.AccessedProperty?.Name?.ToFirstCharacterUpperCase()}(value);");
+                $"this.set{codeElement.AccessedProperty?.Name}(value);");
             writer.CloseBlock();
             writer.WriteLine("return value;");
         }
         else
-            writer.WriteLine($"return this.get{backingStore.Name.ToFirstCharacterUpperCase()}().get(\"{codeElement.AccessedProperty?.Name?.ToFirstCharacterLowerCase()}\");");
+            writer.WriteLine($"return this.get{backingStore.Name}().get(\"{codeElement.AccessedProperty?.Name}\");");
 
     }
     private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType)
     {
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty && codeElement.OriginalIndexer != null)
             conventions.AddParametersAssignment(writer, pathParametersProperty.Type, $"this.{pathParametersProperty.Name}",
-                parameters: (codeElement.OriginalIndexer.IndexParameter.Type, codeElement.OriginalIndexer.IndexParameter.SerializationName, codeElement.OriginalIndexer.IndexParameter.Name.ToFirstCharacterLowerCase()));
+                parameters: (codeElement.OriginalIndexer.IndexParameter.Type, codeElement.OriginalIndexer.IndexParameter.SerializationName, codeElement.OriginalIndexer.IndexParameter.Name));
         conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName);
     }
     private void WriteDeserializerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, bool inherits)
@@ -432,12 +430,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                 .Where(static x => x.Getter != null && x.Type is CodeType propertyType && !propertyType.IsCollection && propertyType.TypeDefinition is CodeClass)
                                 .OrderBy(static x => x, CodePropertyTypeForwardComparer)
                                 .ThenBy(static x => x.Name)
-                                .Select(static x => x.Getter!.Name.ToFirstCharacterLowerCase())
+                                .Select(static x => x.Getter!.Name)
                                 .ToArray();
         foreach (var otherPropGetter in otherPropGetters)
         {
             writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (this.{otherPropGetter}() != null) {{");
-            writer.WriteLine($"return this.{otherPropGetter}().{method.Name.ToFirstCharacterLowerCase()}();");
+            writer.WriteLine($"return this.{otherPropGetter}().{method.Name}();");
             writer.DecreaseIndent();
             if (!includeElse)
                 includeElse = true;
@@ -455,7 +453,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         {
             var propertiesNames = complexProperties
                                 .Where(static x => x.Getter != null)
-                                .Select(static x => x.Getter!.Name.ToFirstCharacterLowerCase())
+                                .Select(static x => x.Getter!.Name)
                                 .OrderBy(static x => x)
                                 .ToArray();
             var propertiesNamesAsConditions = propertiesNames
@@ -475,14 +473,14 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     {
         var fieldToSerialize = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).ToArray();
         writer.WriteLines(
-            $"final {DeserializerReturnType} {DeserializerVarName} = new {DeserializerReturnType}({(inherits ? "super." + method.Name.ToFirstCharacterLowerCase() + "()" : fieldToSerialize.Length)});");
+            $"final {DeserializerReturnType} {DeserializerVarName} = new {DeserializerReturnType}({(inherits ? "super." + method.Name + "()" : fieldToSerialize.Length)});");
         if (fieldToSerialize.Any())
         {
             fieldToSerialize
                     .Where(static x => !x.ExistsInBaseType && x.Setter != null)
                     .OrderBy(static x => x.Name)
                     .Select(x =>
-                        $"{DeserializerVarName}.put(\"{x.WireName}\", (n) -> {{ this.{x.Setter!.Name.ToFirstCharacterLowerCase()}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
+                        $"{DeserializerVarName}.put(\"{x.WireName}\", (n) -> {{ this.{x.Setter!.Name}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
         }
@@ -502,7 +500,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             writer.WriteLine($"final HashMap<String, ParsableFactory<? extends Parsable>> {errorMappingVarName} = new HashMap<String, ParsableFactory<? extends Parsable>>();");
             foreach (var errorMapping in codeElement.ErrorMappings)
             {
-                writer.WriteLine($"{errorMappingVarName}.put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name.ToFirstCharacterUpperCase()}::{FactoryMethodName});");
+                writer.WriteLine($"{errorMappingVarName}.put(\"{errorMapping.Key.ToUpperInvariant()}\", {errorMapping.Value.Name}::{FactoryMethodName});");
             }
         }
         var factoryParameter = codeElement.ReturnType is CodeType returnCodeType && returnCodeType.TypeDefinition is CodeClass ? $"{returnType}::{FactoryMethodName}" : $"{returnType}.class";
@@ -557,26 +555,26 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         if (requestParams.requestBody != null &&
             currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) is CodeProperty requestAdapterProperty)
         {
-            var toArrayPostfix = requestParams.requestBody.Type.IsCollection ? $".toArray(new {requestParams.requestBody.Type.Name.ToFirstCharacterUpperCase()}[0])" : string.Empty;
+            var toArrayPostfix = requestParams.requestBody.Type.IsCollection ? $".toArray(new {requestParams.requestBody.Type.Name}[0])" : string.Empty;
             var collectionPostfix = requestParams.requestBody.Type.IsCollection ? "Collection" : string.Empty;
             if (requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
                 writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name});");
             else if (requestParams.requestBody.Type is CodeType bodyType && (bodyType.TypeDefinition is CodeClass || bodyType.Name.Equals("MultipartBody", StringComparison.OrdinalIgnoreCase)))
-                writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable({requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {requestParams.requestBody.Name}{toArrayPostfix});");
+                writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable({requestAdapterProperty.Name}, \"{codeElement.RequestBodyContentType}\", {requestParams.requestBody.Name}{toArrayPostfix});");
             else
-                writer.WriteLine($"{RequestInfoVarName}.setContentFromScalar{collectionPostfix}({requestAdapterProperty.Name.ToFirstCharacterLowerCase()}, \"{codeElement.RequestBodyContentType}\", {requestParams.requestBody.Name}{toArrayPostfix});");
+                writer.WriteLine($"{RequestInfoVarName}.setContentFromScalar{collectionPostfix}({requestAdapterProperty.Name}, \"{codeElement.RequestBodyContentType}\", {requestParams.requestBody.Name}{toArrayPostfix});");
         }
         if (requestParams.requestConfiguration != null)
         {
             writer.WriteLine($"if ({requestParams.requestConfiguration.Name} != null) {{");
             writer.IncreaseIndent();
-            var requestConfigTypeName = requestParams.requestConfiguration.Type.Name.ToFirstCharacterUpperCase();
+            var requestConfigTypeName = requestParams.requestConfiguration.Type.Name;
             writer.WriteLines($"final {requestConfigTypeName} {RequestConfigVarName} = new {requestConfigTypeName}();",
                         $"{requestParams.requestConfiguration.Name}.accept({RequestConfigVarName});");
             var queryString = requestParams.QueryParameters;
             if (queryString != null)
             {
-                var queryStringName = $"{RequestConfigVarName}.{queryString.Name.ToFirstCharacterLowerCase()}";
+                var queryStringName = $"{RequestConfigVarName}.{queryString.Name}";
                 writer.WriteLine($"{RequestInfoVarName}.addQueryParameters({queryStringName});");
             }
             writer.WriteLines($"{RequestInfoVarName}.headers.putAll({RequestConfigVarName}.headers);",
@@ -587,7 +585,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
 
         writer.WriteLine($"return {RequestInfoVarName};");
     }
-    private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"{property.Name.ToFirstCharacterLowerCase()}";
+    private static string GetPropertyCall(CodeProperty property, string defaultValue) => property == null ? defaultValue : $"{property.Name}";
     private void WriteSerializerBody(CodeClass parentClass, CodeMethod method, LanguageWriter writer, bool inherits)
     {
         if (parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForUnionType)
@@ -613,7 +611,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                 .ToArray();
         foreach (var otherProp in otherProps)
         {
-            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (this.{otherProp.Getter!.Name.ToFirstCharacterLowerCase()}() != null) {{");
+            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (this.{otherProp.Getter!.Name}() != null) {{");
             WriteSerializationMethodCall(otherProp, method, writer, "null");
             writer.DecreaseIndent();
             if (!includeElse)
@@ -634,7 +632,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                                 .ToArray();
         foreach (var otherProp in otherProps)
         {
-            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (this.{otherProp.Getter!.Name.ToFirstCharacterLowerCase()}() != null) {{");
+            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (this.{otherProp.Getter!.Name}() != null) {{");
             WriteSerializationMethodCall(otherProp, method, writer, "null");
             writer.DecreaseIndent();
             if (!includeElse)
@@ -652,7 +650,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
             }
             var propertiesNames = complexProperties
                                 .Where(static x => x.Getter != null)
-                                .Select(static x => $"this.{x.Getter!.Name.ToFirstCharacterLowerCase()}()")
+                                .Select(static x => $"this.{x.Getter!.Name}()")
                                 .OrderBy(static x => x)
                                 .Aggregate(static (x, y) => $"{x}, {y}");
             WriteSerializationMethodCall(complexProperties.First(), method, writer, "null", propertiesNames);
@@ -676,42 +674,55 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     private void WriteSerializationMethodCall(CodeProperty otherProp, CodeMethod method, LanguageWriter writer, string serializationKey, string? dataToSerialize = default)
     {
         if (string.IsNullOrEmpty(dataToSerialize))
-            dataToSerialize = $"this.{(otherProp.Getter?.Name?.ToFirstCharacterLowerCase() is string gName && !string.IsNullOrEmpty(gName) ? gName : "get" + otherProp.Name.ToFirstCharacterUpperCase())}()";
+            dataToSerialize = $"this.{(otherProp.Getter?.Name is string gName && !string.IsNullOrEmpty(gName) ? gName : "get" + otherProp.Name)}()";
         writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type, method)}({serializationKey}, {dataToSerialize});");
     }
     private static readonly BaseCodeParameterOrderComparer parameterOrderComparer = new();
+    private string GetFinalReturnType(CodeMethod code, string returnType)
+    {
+        var voidType = code.IsAsync ? "Void" : "void";
+        var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
+        var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
+        var reType = returnType.Equals("void", StringComparison.OrdinalIgnoreCase) ? voidType : returnType;
+        var collectionCorrectedReturnType = code.ReturnType.IsArray && code.IsOfKind(CodeMethodKind.RequestExecutor) ?
+                                            $"Iterable<{returnType.StripArraySuffix()}>" :
+                                            reType;
+        var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
+        var finalReturnType = isConstructor ? string.Empty : $"{returnTypeAsyncPrefix}{collectionCorrectedReturnType}{returnTypeAsyncSuffix}";
+        return finalReturnType.Trim();
+    }
     private void WriteMethodPrototype(CodeMethod code, LanguageWriter writer, string returnType)
     {
         var accessModifier = conventions.GetAccessModifier(code.Access);
-        var returnTypeAsyncPrefix = code.IsAsync ? "java.util.concurrent.CompletableFuture<" : string.Empty;
-        var returnTypeAsyncSuffix = code.IsAsync ? ">" : string.Empty;
         var isConstructor = code.IsOfKind(CodeMethodKind.Constructor, CodeMethodKind.ClientConstructor, CodeMethodKind.RawUrlConstructor);
         var methodName = code.Kind switch
         {
-            _ when isConstructor && code.Parent != null => code.Parent.Name.ToFirstCharacterUpperCase(),
-            _ => code.Name.ToFirstCharacterLowerCase()
+            _ when isConstructor && code.Parent != null => code.Parent.Name,
+            _ => code.Name
         };
         var parameters = string.Join(", ", code.Parameters.OrderBy(static x => x, parameterOrderComparer).Select(p => conventions.GetParameterSignature(p, code)));
+        var reType = returnType.Equals("void", StringComparison.OrdinalIgnoreCase) ? "void" : returnType;
         var collectionCorrectedReturnType = code.ReturnType.IsArray && code.IsOfKind(CodeMethodKind.RequestExecutor) ?
                                             $"Iterable<{returnType.StripArraySuffix()}>" :
-                                            returnType;
-        var finalReturnType = isConstructor ? string.Empty : $" {returnTypeAsyncPrefix}{collectionCorrectedReturnType}{returnTypeAsyncSuffix}";
+                                            reType;
         var staticModifier = code.IsStatic ? " static" : string.Empty;
         conventions.WriteDeprecatedAnnotation(code, writer);
         if (code.Kind is CodeMethodKind.ErrorMessageOverride)
         {
             writer.WriteLine($"@Override");
         }
-        writer.WriteLine($"{accessModifier}{staticModifier}{finalReturnType} {methodName}({parameters}) {{");
+        if (returnType.Length > 0)
+            returnType = $" {returnType}";
+        writer.WriteLine($"{accessModifier}{staticModifier}{returnType} {methodName}({parameters}) {{");
     }
-    private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer, string returnType)
+    private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer, string baseReturnType, string finalReturnType)
     {
-        var returnVoid = returnType.Equals("void", StringComparison.OrdinalIgnoreCase);
+        var returnVoid = baseReturnType.Equals("void", StringComparison.OrdinalIgnoreCase);
         // Void returns, this includes constructors, should not have a return statement in the JavaDocs.
         var returnRemark = returnVoid ? string.Empty : (code.IsAsync switch
         {
-            true => $"@return a CompletableFuture of {code.ReturnType.Name}",
-            false => $"@return a {code.ReturnType.Name}",
+            true => $"@return a CompletableFuture of {baseReturnType}",
+            false => $"@return a {finalReturnType}",
         });
         conventions.WriteLongDescription(code,
                                         writer,
@@ -733,7 +744,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                 if (currentType.TypeDefinition == null)
                     return $"getCollectionOfPrimitiveValues({propertyType.ToFirstCharacterUpperCase()}.class)";
                 else if (currentType.TypeDefinition is CodeEnum enumType)
-                    return $"getCollectionOfEnumValues({enumType.Name.ToFirstCharacterUpperCase()}.class)";
+                    return $"getCollectionOfEnumValues({enumType.Name}.class)";
                 else
                     return $"getCollectionOfObjectValues({propertyType.ToFirstCharacterUpperCase()}::{FactoryMethodName})";
             if (currentType.TypeDefinition is CodeEnum currentEnum)

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -23,7 +23,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, JavaConvention
                 throw new InvalidOperationException("Error message overrides are implemented with methods in Java.");
             case CodePropertyKind.RequestBuilder:
                 writer.WriteLine("@jakarta.annotation.Nonnull");
-                writer.StartBlock($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.Name.ToFirstCharacterLowerCase()}() {{");
+                writer.StartBlock($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.Name}() {{");
                 conventions.AddRequestBuilderBody(parentClass, returnType, writer);
                 writer.CloseBlock();
                 break;
@@ -41,7 +41,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, JavaConvention
                     returnType = $"EnumSet<{returnType}>";
                 if (codeElement.Access != AccessModifier.Private)
                     writer.WriteLine(codeElement.Type.IsNullable ? "@jakarta.annotation.Nullable" : "@jakarta.annotation.Nonnull");
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.NamePrefix}{codeElement.Name.ToFirstCharacterLowerCase()}{defaultValue};");
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {returnType} {codeElement.NamePrefix}{codeElement.Name}{defaultValue};");
                 break;
         }
 

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -39,7 +39,7 @@ public class JavaConventionService : CommonLanguageConventionService
         var parameterType = GetTypeString(parameter.Type, targetElement);
         if (parameter.Type is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
             parameterType = $"EnumSet<{parameterType}>";
-        return $"{nullAnnotation}final {parameterType} {parameter.Name.ToFirstCharacterLowerCase()}";
+        return $"{nullAnnotation}final {parameterType} {parameter.Name}";
     }
 
     public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true, LanguageWriter? writer = null)
@@ -83,14 +83,14 @@ public class JavaConventionService : CommonLanguageConventionService
         ArgumentNullException.ThrowIfNull(type);
         return type.Name switch
         {
-            "int64" => "Long",
+            "Int64" => "Long",
             "sbyte" => "Short",
             "decimal" => "BigDecimal",
             "void" or "boolean" when !type.IsNullable => type.Name, //little casing hack
             "binary" or "base64" or "base64url" => "byte[]",
             "Guid" => "UUID",
             _ when type.Name.Contains('.', StringComparison.OrdinalIgnoreCase) => type.Name, // casing
-            _ => type.Name.ToFirstCharacterUpperCase() is string typeName && !string.IsNullOrEmpty(typeName) ? typeName : "Object",
+            _ => type.Name is string typeName && !string.IsNullOrEmpty(typeName) ? typeName : "Object",
         };
     }
     public override void WriteShortDescription(string description, LanguageWriter writer)
@@ -133,7 +133,7 @@ public class JavaConventionService : CommonLanguageConventionService
         var pathParametersProperty = parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters);
         var requestAdapterProp = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter);
         var urlTemplateParams = string.IsNullOrEmpty(urlTemplateVarName) ? pathParametersProperty?.Name : urlTemplateVarName;
-        var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
+        var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name}"))}";
         writer.WriteLines($"return new {returnType}({urlTemplateParams}, {requestAdapterProp?.Name}{pathParametersSuffix});");
     }
     public override string TempDictionaryVarName => "urlTplParams";

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -183,7 +183,7 @@ public class CSharpLanguageRefinerTests
         // Assert
         Assert.Equal("break", model.Name);
         Assert.DoesNotContain("@", model.Name); // classname will be capitalized
-        Assert.Equal("alias", property.Name);
+        Assert.Equal("Alias", property.Name);
         Assert.DoesNotContain("@", property.Name); // classname will be capitalized
     }
 

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -122,7 +122,7 @@ public class CSharpLanguageRefinerTests
         };
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
 
-        Assert.Contains(model.Properties, x => x.Name.Equals("otherProp"));
+        Assert.Contains(model.Properties, x => x.Name.Equals("OtherProp"));
         Assert.Contains(model.Methods, x => x.Name.Equals("otherMethod"));
         Assert.Contains(model.Usings, x => x.Name.Equals("otherNs"));
     }
@@ -230,10 +230,10 @@ public class CSharpLanguageRefinerTests
         // Assert
         Assert.Equal("fileObject1", reservedModel.Name);// classes/models will be renamed if reserved without conflicts
         Assert.Equal("fileObject", reservedObjectModel.Name);// original stays the same
-        Assert.Equal("alias", property.Name);// property names don't bring issue in dotnet
-        Assert.Equal("file", secondProperty.Name);// property names don't bring issue in dotnet
+        Assert.Equal("Alias", property.Name);// property names don't bring issue in dotnet
+        Assert.Equal("File", secondProperty.Name);// property names don't bring issue in dotnet
         Assert.Equal("fileObject1", secondProperty.Type.Name);// property type was renamed 
-        Assert.Equal("fileObject", thirdProperty.Name);// property names don't bring issue in dotnet
+        Assert.Equal("FileObject", thirdProperty.Name);// property names don't bring issue in dotnet
         Assert.Equal("fileObject", thirdProperty.Type.Name);// property type was renamed 
 
     }
@@ -494,7 +494,7 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("modelProp", propToAdd.Name);
+        Assert.Equal("ModelProp", propToAdd.Name);
         Assert.Equal("model", propToAdd.SerializationName);
     }
     [Fact]
@@ -530,7 +530,7 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("summary", firstProperty.Name);// remains as is. No refinement needed
+        Assert.Equal("Summary", firstProperty.Name);// remains as is. No refinement needed
         Assert.Equal("_summary", secondProperty.Name);// No refinement as it will create a duplicate with firstProperty
         Assert.Equal("Replaced", thirdProperty.Name);// Base case. Proper refinements
     }

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -21,11 +21,11 @@ public class JavaLanguageRefinerTests
         }).First();
         var option = new CodeEnumOption
         {
-            Name = "break", // this a keyword
+            Name = "Void", // this a keyword
         };
         model.AddOption(option);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-        Assert.Equal("break", option.Name);
+        Assert.Equal("Void", option.Name);
         Assert.Empty(option.SerializationName);
     }
     [Fact]
@@ -436,7 +436,7 @@ public class JavaLanguageRefinerTests
         method.AddParameter(nonNormalizedParam);
         method.AddParameter(normalizedParam);
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.Java }, root);
-        Assert.Equal("foo_bar", method.Parameters.First().Type.Name);
+        Assert.Equal("Foo_bar", method.Parameters.First().Type.Name);
         Assert.Equal("FooBaz", method.Parameters.Last().Type.Name);
     }
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
@@ -89,6 +89,6 @@ public class CodeEnumWriterTests : IDisposable
         currentEnum.AddOption(option);
         writer.Write(currentEnum);
         var result = tw.ToString();
-        Assert.Contains($"Plus_1(\"+1\")", result);
+        Assert.Contains($"plus_1(\"+1\")", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -2074,7 +2074,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.ErrorMessageOverride,
             ReturnType = new CodeType
             {
-                Name = "string",
+                Name = "String",
                 IsNullable = false,
             },
             IsAsync = false,

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -43,27 +43,27 @@ public class CodeMethodWriterTests : IDisposable
         {
             baseClass = root.AddClass(new CodeClass
             {
-                Name = "someParentClass",
+                Name = "SomeParentClass",
             }).First();
             baseClass.AddProperty(new CodeProperty
             {
                 Name = "definedInParent",
                 Type = new CodeType
                 {
-                    Name = "string"
+                    Name = "String"
                 },
                 Kind = CodePropertyKind.Custom,
             });
         }
         parentClass = new CodeClass
         {
-            Name = "parentClass"
+            Name = "ParentClass"
         };
         if (withInheritance)
         {
             parentClass.StartBlock.Inherits = new CodeType
             {
-                Name = "someParentClass",
+                Name = "SomeParentClass",
                 TypeDefinition = baseClass
             };
         }
@@ -105,7 +105,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.PathParameters,
             Type = new CodeType
             {
-                Name = "string",
+                Name = "String",
             }
         });
         parentClass.AddProperty(new CodeProperty
@@ -114,7 +114,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.UrlTemplate,
             Type = new CodeType
             {
-                Name = "string",
+                Name = "String",
             }
         });
     }
@@ -126,22 +126,22 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.AdditionalData,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             },
             Getter = new CodeMethod
             {
-                Name = "GetAdditionalData",
+                Name = "getAdditionalData",
                 ReturnType = new CodeType
                 {
-                    Name = "string"
+                    Name = "String"
                 }
             },
             Setter = new CodeMethod
             {
-                Name = "SetAdditionalData",
+                Name = "setAdditionalData",
                 ReturnType = new CodeType
                 {
-                    Name = "string"
+                    Name = "String"
                 }
             }
         });
@@ -150,19 +150,19 @@ public class CodeMethodWriterTests : IDisposable
             Name = "dummyProp",
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             },
             Getter = new CodeMethod
             {
-                Name = "GetDummyProp",
+                Name = "getDummyProp",
                 ReturnType = new CodeType
                 {
-                    Name = "string"
+                    Name = "String"
                 },
             },
             Setter = new CodeMethod
             {
-                Name = "SetDummyProp",
+                Name = "setDummyProp",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -175,7 +175,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         });
         parentClass.AddProperty(new CodeProperty
@@ -183,21 +183,21 @@ public class CodeMethodWriterTests : IDisposable
             Name = "dummyColl",
             Type = new CodeType
             {
-                Name = "string",
+                Name = "String",
                 CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
             },
             Getter = new CodeMethod
             {
-                Name = "GetDummyColl",
+                Name = "getDummyColl",
                 ReturnType = new CodeType
                 {
-                    Name = "string",
+                    Name = "String",
                     CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
                 },
             },
             Setter = new CodeMethod
             {
-                Name = "SetDummyColl",
+                Name = "setDummyColl",
                 ReturnType = new CodeType
                 {
                     Name = "void",
@@ -218,16 +218,16 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetDummyComplexColl",
+                Name = "getDummyComplexColl",
                 ReturnType = new CodeType
                 {
-                    Name = "string",
+                    Name = "String",
                     CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
                 },
             },
             Setter = new CodeMethod
             {
-                Name = "SetDummyComplexColl",
+                Name = "setDummyComplexColl",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -247,15 +247,15 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetDummyEnumCollection",
+                Name = "getDummyEnumCollection",
                 ReturnType = new CodeType
                 {
-                    Name = "string"
+                    Name = "String"
                 },
             },
             Setter = new CodeMethod
             {
-                Name = "SetDummyEnumCollection",
+                Name = "setDummyEnumCollection",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -301,7 +301,7 @@ public class CodeMethodWriterTests : IDisposable
         };
         var sType = new CodeType
         {
-            Name = "string",
+            Name = "String",
         };
         unionTypeWrapper.DiscriminatorInformation.AddDiscriminatorMapping("#kiota.complexType1", new CodeType
         {
@@ -323,7 +323,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetComplexType1Value",
+                Name = "setComplexType1Value",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -332,7 +332,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetComplexType1Value",
+                Name = "getComplexType1Value",
                 ReturnType = cType1,
                 Kind = CodeMethodKind.Getter,
             }
@@ -344,7 +344,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetComplexType2Value",
+                Name = "setComplexType2Value",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -353,7 +353,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetComplexType2Value",
+                Name = "getComplexType2Value",
                 ReturnType = cType2,
                 Kind = CodeMethodKind.Getter,
             }
@@ -365,7 +365,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetStringValue",
+                Name = "setStringValue",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -374,7 +374,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetStringValue",
+                Name = "getStringValue",
                 ReturnType = sType,
                 Kind = CodeMethodKind.Getter,
             }
@@ -444,7 +444,7 @@ public class CodeMethodWriterTests : IDisposable
         });
         var sType = new CodeType
         {
-            Name = "string",
+            Name = "String",
         };
         intersectionTypeWrapper.OriginalComposedType.AddType(cType1);
         intersectionTypeWrapper.OriginalComposedType.AddType(cType2);
@@ -457,7 +457,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetComplexType1Value",
+                Name = "setComplexType1Value",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -466,7 +466,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetComplexType1Value",
+                Name = "getComplexType1Value",
                 ReturnType = cType1,
                 Kind = CodeMethodKind.Getter,
             }
@@ -478,7 +478,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetComplexType2Value",
+                Name = "setComplexType2Value",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -487,7 +487,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetComplexType2Value",
+                Name = "getComplexType2Value",
                 ReturnType = cType2,
                 Kind = CodeMethodKind.Getter,
             }
@@ -499,7 +499,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetComplexType3Value",
+                Name = "setComplexType3Value",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -508,7 +508,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetComplexType3Value",
+                Name = "getComplexType3Value",
                 ReturnType = cType3,
                 Kind = CodeMethodKind.Getter,
             }
@@ -520,7 +520,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Setter = new CodeMethod
             {
-                Name = "SetStringValue",
+                Name = "setStringValue",
                 ReturnType = new CodeType
                 {
                     Name = "void"
@@ -529,7 +529,7 @@ public class CodeMethodWriterTests : IDisposable
             },
             Getter = new CodeMethod
             {
-                Name = "GetStringValue",
+                Name = "getStringValue",
                 ReturnType = sType,
                 Kind = CodeMethodKind.Getter,
             }
@@ -540,7 +540,7 @@ public class CodeMethodWriterTests : IDisposable
     {
         var stringType = new CodeType
         {
-            Name = "string",
+            Name = "String",
         };
         var requestConfigClass = parentClass.AddInnerClass(new CodeClass
         {
@@ -790,17 +790,17 @@ public class CodeMethodWriterTests : IDisposable
         setup();
         var parentModel = root.AddClass(new CodeClass
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             Kind = CodeClassKind.Model,
         }).First();
         var childModel = root.AddClass(new CodeClass
         {
-            Name = "childModel",
+            Name = "ChildModel",
             Kind = CodeClassKind.Model,
         }).First();
         childModel.StartBlock.Inherits = new CodeType
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             TypeDefinition = parentModel,
         };
         var factoryMethod = parentModel.AddMethod(new CodeMethod
@@ -809,7 +809,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.Factory,
             ReturnType = new CodeType
             {
-                Name = "parentModel",
+                Name = "ParentModel",
                 TypeDefinition = parentModel,
             },
             IsStatic = true,
@@ -851,17 +851,17 @@ public class CodeMethodWriterTests : IDisposable
         setup();
         var parentModel = root.AddClass(new CodeClass
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             Kind = CodeClassKind.Model,
         }).First();
         var childModel = root.AddClass(new CodeClass
         {
-            Name = "childModel",
+            Name = "ChildModel",
             Kind = CodeClassKind.Model,
         }).First();
         childModel.StartBlock.Inherits = new CodeType
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             TypeDefinition = parentModel,
         };
         var factoryMethod = parentModel.AddMethod(new CodeMethod
@@ -870,7 +870,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.Factory,
             ReturnType = new CodeType
             {
-                Name = "parentModel",
+                Name = "ParentModel",
                 TypeDefinition = parentModel,
             },
             IsStatic = true,
@@ -999,7 +999,7 @@ public class CodeMethodWriterTests : IDisposable
         Assert.DoesNotContain("if (mappingValueNode != null) {", result);
         Assert.DoesNotContain("final String mappingValue = mappingValueNode.getStringValue()", result);
         Assert.Contains("switch (value) {", result);
-        Assert.Contains("case \"#microsoft.graph.Foo535\": return new ChildModel();", result);
+        Assert.Contains("case \"#microsoft.graph.Foo535\": return new childModel();", result);
         Assert.DoesNotContain("final ParentModel factory_1_result = factory_1(mappingValue);", result);
         Assert.DoesNotContain("if (factory_1_result != null) {", result);
         Assert.DoesNotContain("return new ParentModel()", result);
@@ -1049,12 +1049,12 @@ public class CodeMethodWriterTests : IDisposable
         setup();
         var parentModel = root.AddClass(new CodeClass
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             Kind = CodeClassKind.Model,
         }).First();
         var childModel = root.AddClass(new CodeClass
         {
-            Name = "childModel",
+            Name = "ChildModel",
             Kind = CodeClassKind.Model,
         }).First();
         childModel.StartBlock.Inherits = new CodeType
@@ -1068,14 +1068,14 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.Factory,
             ReturnType = new CodeType
             {
-                Name = "parentModel",
+                Name = "ParentModel",
                 TypeDefinition = parentModel,
             },
             IsStatic = true,
         }).First();
         parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.childmodel", new CodeType
         {
-            Name = "childModel",
+            Name = "ChildModel",
             TypeDefinition = childModel,
         });
         parentModel.DiscriminatorInformation.DiscriminatorPropertyName = string.Empty;
@@ -1110,7 +1110,7 @@ public class CodeMethodWriterTests : IDisposable
         setup();
         var parentModel = root.AddClass(new CodeClass
         {
-            Name = "parentModel",
+            Name = "ParentModel",
             Kind = CodeClassKind.Model,
         }).First();
         var factoryMethod = parentModel.AddMethod(new CodeMethod
@@ -1119,7 +1119,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.Factory,
             ReturnType = new CodeType
             {
-                Name = "parentModel",
+                Name = "ParentModel",
                 TypeDefinition = parentModel,
             },
             IsStatic = true,
@@ -1286,7 +1286,7 @@ public class CodeMethodWriterTests : IDisposable
         var wrapper = AddUnionTypeWrapper();
         var deserializationMethod = wrapper.AddMethod(new CodeMethod
         {
-            Name = "GetFieldDeserializers",
+            Name = "getFieldDeserializers",
             Kind = CodeMethodKind.Deserializer,
             IsAsync = false,
             ReturnType = new CodeType
@@ -1470,7 +1470,7 @@ public class CodeMethodWriterTests : IDisposable
             Name = ParamName,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         };
         method.AddParameter(parameter);
@@ -1500,7 +1500,7 @@ public class CodeMethodWriterTests : IDisposable
             Name = ParamName,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         };
         method.AddParameter(parameter);
@@ -1526,7 +1526,7 @@ public class CodeMethodWriterTests : IDisposable
             Name = ParamName,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         };
         method.AddParameter(parameter);
@@ -1614,7 +1614,7 @@ public class CodeMethodWriterTests : IDisposable
             Name = "idx",
             ReturnType = new CodeType
             {
-                Name = "string"
+                Name = "String"
             },
             IndexParameter = new()
             {
@@ -1646,7 +1646,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeParameterKind.Path,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         });
         writer.Write(method);
@@ -1675,7 +1675,7 @@ public class CodeMethodWriterTests : IDisposable
         parentClass.GetGreatestGrandparent().AddBackingStoreProperty();
         method.AccessedProperty.Type = new CodeType
         {
-            Name = "string",
+            Name = "String",
             IsNullable = false,
         };
         var defaultValue = "someDefaultValue";
@@ -1776,7 +1776,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         });
         AddRequestProperties();
@@ -1791,7 +1791,7 @@ public class CodeMethodWriterTests : IDisposable
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains(parentClass.Name.ToFirstCharacterUpperCase(), result);
+        Assert.Contains(parentClass.Name, result);
         Assert.Contains($"this.set{propName.ToFirstCharacterUpperCase()}({defaultValue})", result);
         Assert.Contains("super", result);
     }
@@ -1807,14 +1807,14 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeParameterKind.RawUrl,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             },
         });
         Assert.Throws<InvalidOperationException>(() => writer.Write(method));
         AddRequestProperties();
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains($"return new {parentClass.Name.ToFirstCharacterUpperCase()}", result);
+        Assert.Contains($"return new {parentClass.Name}", result);
     }
     [Fact]
     public void DoesNotWriteConstructorWithDefaultFromComposedType()
@@ -1845,7 +1845,7 @@ public class CodeMethodWriterTests : IDisposable
         });
         var sType = new CodeType
         {
-            Name = "string",
+            Name = "String",
         };
         var arrayType = new CodeType
         {
@@ -1856,7 +1856,7 @@ public class CodeMethodWriterTests : IDisposable
 
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains(parentClass.Name.ToFirstCharacterUpperCase(), result);
+        Assert.Contains(parentClass.Name, result);
         Assert.DoesNotContain(defaultValue, result);//ensure the composed type is not referenced
     }
     [Fact]
@@ -1874,7 +1874,7 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodePropertyKind.Custom,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         });
         AddRequestProperties();
@@ -1884,12 +1884,12 @@ public class CodeMethodWriterTests : IDisposable
             Kind = CodeParameterKind.RawUrl,
             Type = new CodeType
             {
-                Name = "string"
+                Name = "String"
             }
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains(parentClass.Name.ToFirstCharacterUpperCase(), result);
+        Assert.Contains(parentClass.Name, result);
         Assert.Contains($"this.set{propName.ToFirstCharacterUpperCase()}({defaultValue})", result);
         Assert.Contains("super", result);
     }
@@ -1929,7 +1929,7 @@ public class CodeMethodWriterTests : IDisposable
         method.SerializerModules = new() { "com.microsoft.kiota.serialization.Serializer" };
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains(parentClass.Name.ToFirstCharacterUpperCase(), result);
+        Assert.Contains(parentClass.Name, result);
         Assert.Contains("registerDefaultSerializer", result);
         Assert.Contains("registerDefaultDeserializer", result);
         Assert.Contains($"put(\"baseurl\", core.getBaseUrl())", result);
@@ -1985,7 +1985,7 @@ public class CodeMethodWriterTests : IDisposable
         model.AddProperty(new CodeProperty
         {
             Name = "short",
-            Type = new CodeType { Name = "string" },
+            Type = new CodeType { Name = "String" },
             Access = AccessModifier.Public,
             Kind = CodePropertyKind.Custom,
         });
@@ -2014,16 +2014,16 @@ public class CodeMethodWriterTests : IDisposable
         AddSerializationProperties();
         parentClass.AddProperty(new CodeProperty
         {
-            Name = "ReadOnlyProperty",
+            Name = "readOnlyProperty",
             ReadOnly = true,
             Type = new CodeType
             {
-                Name = "string",
+                Name = "String",
             },
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.DoesNotContain("ReadOnlyProperty", result);
+        Assert.DoesNotContain("readOnlyProperty", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Sharing to receive early feedback on the direction (cc. @baywet).

I started with Java(instead of Python where we experienced more issues) as I felt more comfortable with it, but I believe that this effort should be extended to all of the languages.

You can check the results by running:
- on the `main` branch: `dotnet publish ./src/kiota/kiota.csproj -c Release -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./publish`
- on this PR branch I'm testing with commands like: `(cd src/kiota && dotnet build) && ./it/compare-generation.ps1 -descriptionUrl "oas::petstore" -language java`
- use more complex specs by testing against the rest ...