### PR TITLE
Fixes EnumSet generation in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aggregate typescript import statements by source [#3232](https://github.com/microsoft/kiota/issues/3232)
 - Fixes a bug in dotnet where enums types would not be fully disambiguated when initialized in constructor with default values and existing conflicting property exists [#3233]
 - Fixes a bug in generation of flagged enum properties and their serializer/deserializer functions in typescript [https://github.com/microsoft/kiota/issues/3260]
+- Fixes missing EnumSet types in method parameter and return types in Java [https://github.com/microsoft/kiota/issues/3272]
 
 ## [1.5.1] - 2023-08-08
 

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -17,6 +17,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         if (codeElement.Parent is not CodeClass parentClass) throw new InvalidOperationException("the parent of a method should be a class");
 
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
+        if (codeElement.ReturnType is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
+            returnType = $"EnumSet<{returnType}>";
         if (codeElement.IsAsync &&
             codeElement.IsOfKind(CodeMethodKind.RequestExecutor) &&
             returnType.Equals("void", StringComparison.OrdinalIgnoreCase))

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -35,7 +35,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, JavaConvention
                 defaultValue = $" = new {returnType}()";
                 goto default;
             default:
-                if (codeElement.Type is CodeType currentType && currentType.TypeDefinition is CodeEnum enumType && enumType.Flags)
+                if (codeElement.Type is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
                     returnType = $"EnumSet<{returnType}>";
                 if (codeElement.Access != AccessModifier.Private)
                     writer.WriteLine(codeElement.Type.IsNullable ? "@jakarta.annotation.Nullable" : "@jakarta.annotation.Nonnull");

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -36,7 +36,10 @@ public class JavaConventionService : CommonLanguageConventionService
         ArgumentNullException.ThrowIfNull(parameter);
         var nullKeyword = parameter.Optional ? "Nullable" : "Nonnull";
         var nullAnnotation = parameter.Type.IsNullable ? $"@jakarta.annotation.{nullKeyword} " : string.Empty;
-        return $"{nullAnnotation}final {GetTypeString(parameter.Type, targetElement)} {parameter.Name.ToFirstCharacterLowerCase()}";
+        var parameterType = GetTypeString(parameter.Type, targetElement);
+        if (parameter.Type is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
+            parameterType = $"EnumSet<{parameterType}>";
+        return $"{nullAnnotation}final {parameterType} {parameter.Name.ToFirstCharacterLowerCase()}";
     }
 
     public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true, LanguageWriter? writer = null)

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1723,10 +1723,10 @@ public class CodeMethodWriterTests : IDisposable
         setup();
         var codeEnumType = new CodeType
         {
-            Name = "customEnum", 
+            Name = "customEnum",
             TypeDefinition = new CodeEnum
             {
-                Name = "customEnumType", 
+                Name = "customEnumType",
                 Flags = true
             }
         };

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1718,6 +1718,32 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("this.someProperty = value", result);
     }
     [Fact]
+    public void WritesGetterToFieldWithEnumSetParameter()
+    {
+        setup();
+        var codeEnumType = new CodeType
+        {
+            Name = "customEnum", 
+            TypeDefinition = new CodeEnum
+            {
+                Name = "customEnumType", 
+                Flags = true
+            }
+        };
+        method.AccessedProperty = new CodeProperty
+        {
+            Name = "someProperty",
+            Type = codeEnumType
+        };
+        (method.Parent as CodeClass)?.AddProperty(method.AccessedProperty);
+        method.Kind = CodeMethodKind.Getter;
+        method.ReturnType = codeEnumType;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("this.someProperty", result);
+        Assert.Contains("EnumSet<", result);
+    }
+    [Fact]
     public void WritePeriodAndDurationSetterToField()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodePropertyWriterTests.cs
@@ -113,4 +113,23 @@ public class CodePropertyWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("@QueryParameter(name = \"someserializationname\")", result);
     }
+    [Fact]
+    public void WritesCollectionFlagEnumsAsOneDimensionalArray()
+    {
+        property.Kind = CodePropertyKind.Custom;
+        property.Type = new CodeType
+        {
+            Name = "customEnum",
+            CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex
+        };
+        (property.Type as CodeType).TypeDefinition = new CodeEnum
+        {
+            Name = "customEnumType",
+            Flags = true,//this is not expected for a collection. So treat as enum collection
+        };
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains("List<", result);
+        Assert.DoesNotContain("EnumSet", result);
+    }
 }


### PR DESCRIPTION
Closes #3272

Getters and Setters in Java fail to add the `EnumSet` parameter and return types in java causing generation build to fail. 

Sample generation of this PR at https://github.com/microsoftgraph/msgraph-sdk-java/pull/1553