### PR TITLE
Casing fix for Java

### DIFF
--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -87,7 +87,7 @@ public class JavaConventionService : CommonLanguageConventionService
             "sbyte" => "Short",
             "decimal" => "BigDecimal",
             "void" or "boolean" when !type.IsNullable => type.Name, //little casing hack
-            "binary" or "base64" or "base64url" => "byte[]",
+            "binary" or "base64" or "base64url" or "Base64url" => "byte[]",
             "Guid" => "UUID",
             _ when type.Name.Contains('.', StringComparison.OrdinalIgnoreCase) => type.Name, // casing
             _ => type.Name is string typeName && !string.IsNullOrEmpty(typeName) ? typeName : "Object",


### PR DESCRIPTION
When the type is 'Base64url' we are not generating the type as byte[] hence we are failing to compile in generation.  https://github.com/microsoftgraph/msgraph-sdk-java/actions/runs/6467940662/job/17558999811?pr=1569