### PR TITLE
Add imports for method parameters that are query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed missing imports for method parameters that are query parameters.
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)
 - Fixed bug where base64url types would not be generated properly in Java.
 - Fixed bug where symbol name cleanup would not work on forward single quotes characters [#3426](https://github.com/microsoft/kiota/issues/3426).

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -725,7 +725,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                                 .Distinct();
             var methodsParametersTypes = methods
                                 .SelectMany(static x => x.Parameters)
-                                .Where(static x => x.IsOfKind(CodeParameterKind.Custom, CodeParameterKind.RequestBody, CodeParameterKind.RequestConfiguration))
+                                .Where(static x => x.IsOfKind(CodeParameterKind.Custom, CodeParameterKind.RequestBody, CodeParameterKind.RequestConfiguration, CodeParameterKind.QueryParameter))
                                 .Select(static x => x.Type)
                                 .Distinct();
             var indexerTypes = currentClassChildren

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
@@ -160,6 +160,9 @@ public class CodeClassDeclarationWriterTests : IDisposable
     public async void AddsImportsToRequestConfigClasses()
     {
         var queryParamClass = new CodeClass { Name = "TestRequestQueryParameter", Kind = CodeClassKind.QueryParameters };
+        var modelsNamespace = root.AddNamespace("Models");
+        var eventStatus = new CodeEnum { Name = "EventStatus" };
+        modelsNamespace.AddEnum(eventStatus);
         queryParamClass.AddProperty(new[]
         {
             new CodeProperty
@@ -201,6 +204,20 @@ public class CodeClassDeclarationWriterTests : IDisposable
                     Name = "dateonly"
                 },
             },
+            new CodeProperty
+            {
+                Name = "status",
+                Kind = CodePropertyKind.QueryParameter,
+                Documentation = new()
+                {
+                    Description = "Filter by status",
+                },
+                Type = new CodeType
+                {
+                    Name = "EventStatus",
+                    TypeDefinition = eventStatus
+                },
+            }
         });
         root.AddClass(queryParamClass);
         parentClass.Kind = CodeClassKind.RequestConfiguration;
@@ -219,6 +236,7 @@ public class CodeClassDeclarationWriterTests : IDisposable
 
         Assert.Contains("use DateTime;", result);
         Assert.Contains("use Microsoft\\Kiota\\Abstractions\\Types\\Date;", result);
+        Assert.Contains("use Microsoft\\Graph\\Models\\EventStatus;", result);
 
     }
 }


### PR DESCRIPTION
Fixes the failing integration test in https://github.com/microsoft/kiota/pull/3477 since PHP uses a [factory method](https://github.com/microsoft/kiota-samples/blob/main/msgraph-mail/php/src/Users/Item/Messages/MessagesRequestBuilderGetRequestConfiguration.php#L42) in request config classes that initialises the relevant query parameter object to improve the developer experience from importing multiple classes.