### PR TITLE
java paths/properties/setters/getters maintain '_'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed bug in java where underscores were removed from property names, setters and getters, but not paths in java. Underscores are now maintained throughout to preserve consistency with dotnet. 
 - Fixed missing imports for method parameters that are query parameters.
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)
 - Fixed bug where base64url and decimal types would not be generated properly in Java.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed bug in java where underscores were removed from property names, setters and getters, but not paths in java. Underscores are now maintained throughout to preserve consistency with dotnet. 
+- Fixed bug in java where underscores were removed from property names, setters and getters, but not paths. Underscores are now maintained throughout to preserve consistency with dotnet. 
 - Fixed missing imports for method parameters that are query parameters.
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)
 - Fixed bug where base64url and decimal types would not be generated properly in Java.

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -42,7 +42,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             CorrectNames(generatedCode, s =>
             {
                 if (s.Contains('_', StringComparison.OrdinalIgnoreCase) &&
-                     s.ToPascalCase(UnderscoreArray) is string refinedName &&
+                     s.ToPascalCase() is string refinedName &&
                     !reservedNamesProvider.ReservedNames.Contains(s) &&
                     !reservedNamesProvider.ReservedNames.Contains(refinedName))
                     return refinedName;
@@ -75,14 +75,14 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                     CodePropertyKind.QueryParameter,
                     CodePropertyKind.RequestBuilder,
                 },
-                static s => s.ToCamelCase(UnderscoreArray).ToFirstCharacterLowerCase());
+                static s => s.ToCamelCase().ToFirstCharacterLowerCase());
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
                     CodePropertyKind.BackingStore,
                 },
-                static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
+                static (_, s) => s.ToCamelCase().ToFirstCharacterUpperCase(),
                 _configuration.UsesBackingStore,
                 true,
                 "get",


### PR DESCRIPTION
Underscores were removed from property names, setters and getters, but not paths in java. Underscores are now maintained throughout to preserve consistency with dotnet.