### PR TITLE
[FIX] Include the type which a promise resolves to.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Include the type which a promise resolves to in PHPDocs for PHP. [#3542](https://github.com/microsoft/kiota/issues/3542)
 - Aligns header management in Python with other languages. [#3430](https://github.com/microsoft/kiota/issues/3430)
-- Fixed parameters that are in camelcase to snakecase in Python. [#3525](https://github.com/microsoft/kiota/issues/3525
+- Fixed parameters that are in camelcase to snakecase in Python. [#3525](https://github.com/microsoft/kiota/issues/3525)
 - Fixed missing imports for method parameters that are query parameters.
 - Replaces the use of "new" by "override" and "virtual" in CSharp models.
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)

--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -192,7 +192,7 @@ public class PhpRefiner : CommonLanguageRefiner
             "Microsoft\\Kiota\\Abstractions\\Store", "BackingStoreFactory", "BackingStoreFactorySingleton"),
         new (x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.BackingStore),
             "Microsoft\\Kiota\\Abstractions\\Store", "BackingStore", "BackedModel", "BackingStoreFactorySingleton" ),
-        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "Http\\Promise", "Promise", "RejectedPromise"),
+        new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "Http\\Promise", "Promise"),
         new (x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor), "", "Exception"),
         new (x => x is CodeEnum, "Microsoft\\Kiota\\Abstractions\\", "Enum"),
         new(static x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTime", StringComparison.OrdinalIgnoreCase), "", "\\DateTime"),

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -773,8 +773,17 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             ? $", '{returnTypeName}'"
             : returnEnumType;
         var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) ?? throw new InvalidOperationException("Request adapter property not found");
-        writer.WriteLine(
-            $"return {GetPropertyCall(requestAdapterProperty, string.Empty)}->{methodName}({RequestInfoVarName}{finalReturn}, {(hasErrorMappings ? $"{errorMappingsVarName}" : "null")});");
+
+        var methodCall = $"{GetPropertyCall(requestAdapterProperty, string.Empty)}->{methodName}({RequestInfoVarName}{finalReturn}, {(hasErrorMappings ? $"{errorMappingsVarName}" : "null")});";
+        if (methodName.Contains("sendPrimitive", StringComparison.OrdinalIgnoreCase))
+        {
+            writer.WriteLines($"/** @var Promise<{GetDocCommentReturnType(codeElement)}|null> $result",
+                $"$result = {methodCall}",
+                "return $result;"
+                );
+        }
+        else writer.WriteLines(
+            $"return {methodCall}");
     }
 
     private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod codeMethod, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -259,7 +259,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
     private void WriteMethodPhpDocs(CodeMethod codeMethod, LanguageWriter writer)
     {
         var methodDescription = codeMethod.Documentation.Description;
-
+        var methodThrows = codeMethod.IsOfKind(CodeMethodKind.RequestExecutor);
         var hasMethodDescription = !string.IsNullOrEmpty(methodDescription.Trim());
         if (!hasMethodDescription && !codeMethod.Parameters.Any())
         {
@@ -276,13 +276,15 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         {
             var nullableSuffix = (codeMethod.ReturnType.IsNullable ? "|null" : "");
             returnDocString = (codeMethod.Kind == CodeMethodKind.RequestExecutor)
-                ? "@return Promise"
+                ? $"@return Promise<{returnDocString}|null>"
                 : $"@return {returnDocString}{nullableSuffix}";
         }
         else returnDocString = String.Empty;
+
+        var throwsArray = methodThrows ? new[] { "@throws Exception" } : Array.Empty<string>();
         conventions.WriteLongDescription(codeMethod.Documentation,
             writer,
-            parametersWithOrWithoutDescription.Union(new[] { returnDocString })
+            parametersWithOrWithoutDescription.Union(new[] { returnDocString }).Union(throwsArray)
             );
 
     }
@@ -294,6 +296,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             CodeMethodKind.Deserializer => "array<string, callable(ParseNode): void>",
             CodeMethodKind.Getter when codeMethod.AccessedProperty?.IsOfKind(CodePropertyKind.AdditionalData) ?? false => "array<string, mixed>",
             CodeMethodKind.Getter when codeMethod.AccessedProperty?.Type.IsCollection ?? false => $"array<{conventions.TranslateType(codeMethod.AccessedProperty.Type)}>",
+            CodeMethodKind.RequestExecutor when codeMethod.ReturnType.IsCollection => $"array<{conventions.TranslateType(codeMethod.ReturnType)}>",
             _ => conventions.GetTypeString(codeMethod.ReturnType, codeMethod)
         };
     }
@@ -735,8 +738,6 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
 
         var returnTypeName = conventions.GetTypeString(codeElement.ReturnType, codeElement, false);
         writer.WriteLine($"$requestInfo = $this->{generatorMethodName}({joinedParams});");
-        writer.WriteLine("try {");
-        writer.IncreaseIndent();
         var errorMappings = codeElement.ErrorMappings;
         var hasErrorMappings = false;
         var errorMappingsVarName = "$errorMappings";
@@ -774,13 +775,6 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         var requestAdapterProperty = parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) ?? throw new InvalidOperationException("Request adapter property not found");
         writer.WriteLine(
             $"return {GetPropertyCall(requestAdapterProperty, string.Empty)}->{methodName}({RequestInfoVarName}{finalReturn}, {(hasErrorMappings ? $"{errorMappingsVarName}" : "null")});");
-
-        writer.DecreaseIndent();
-        writer.WriteLine("} catch(Exception $ex) {");
-        writer.IncreaseIndent();
-        writer.WriteLine("return new RejectedPromise($ex);");
-        writer.DecreaseIndent();
-        writer.WriteLine("}");
     }
 
     private static void WriteApiConstructorBody(CodeClass parentClass, CodeMethod codeMethod, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -777,7 +777,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         var methodCall = $"{GetPropertyCall(requestAdapterProperty, string.Empty)}->{methodName}({RequestInfoVarName}{finalReturn}, {(hasErrorMappings ? $"{errorMappingsVarName}" : "null")});";
         if (methodName.Contains("sendPrimitive", StringComparison.OrdinalIgnoreCase))
         {
-            writer.WriteLines($"/** @var Promise<{GetDocCommentReturnType(codeElement)}|null> $result",
+            writer.WriteLines($"/** @var Promise<{GetDocCommentReturnType(codeElement)}|null> $result */",
                 $"$result = {methodCall}",
                 "return $result;"
                 );

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeClassDeclarationWriterTests.cs
@@ -134,8 +134,7 @@ public class CodeClassDeclarationWriterTests : IDisposable
         codeElementWriter.WriteCodeElement(dec, writer);
         var result = tw.ToString();
 
-        Assert.Contains("use Http\\Promise\\Promise;", result);
-        Assert.Contains("use Http\\Promise\\RejectedPromise;", result);
+        Assert.Contains(@"use Http\Promise\Promise;", result);
         Assert.Contains("use Exception;", result);
     }
 

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -287,9 +287,7 @@ public class CodeMethodWriterTests : IDisposable
 
         Assert.Contains("public function post(): Promise", result);
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
-        Assert.Contains("RejectedPromise", result);
         Assert.Contains("@link https://learn.microsoft.com/ Learning", result);
-        Assert.Contains("catch(Exception $ex)", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
         Assert.Contains("return $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $errorMappings);", result);
     }
@@ -380,11 +378,10 @@ public class CodeMethodWriterTests : IDisposable
         _codeMethodWriter.WriteCodeElement(codeMethod, languageWriter);
         var result = stringWriter.ToString();
 
+        Assert.Contains("@throws Exception", result);
         Assert.Contains("public function post(): Promise", result);
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
-        Assert.Contains("RejectedPromise", result);
         Assert.Contains("@link https://learn.microsoft.com/ Learning", result);
-        Assert.Contains("catch(Exception $ex)", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
         Assert.Contains("return $this->requestAdapter->sendPrimitiveAsync($requestInfo, PhoneNumberPrefix::class, $errorMappings);", result);
     }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -289,7 +289,8 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
         Assert.Contains("@link https://learn.microsoft.com/ Learning", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
-        Assert.Contains("return $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $errorMappings);", result);
+        Assert.Contains("$result = $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $errorMappings);", result);
+        Assert.Contains("return $result;", result);
     }
 
     [Fact]
@@ -383,7 +384,9 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
         Assert.Contains("@link https://learn.microsoft.com/ Learning", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
-        Assert.Contains("return $this->requestAdapter->sendPrimitiveAsync($requestInfo, PhoneNumberPrefix::class, $errorMappings);", result);
+        Assert.Contains("/** @var Promise<PhoneNumberPrefix|null> $result", result);
+        Assert.Contains("$result = $this->requestAdapter->sendPrimitiveAsync($requestInfo, PhoneNumberPrefix::class, $errorMappings);", result);
+        Assert.Contains("return $result;", result);
     }
 
     public static IEnumerable<object[]> SerializerProperties => new List<object[]>


### PR DESCRIPTION
This commit also includes:
 - Removing the try catch in the request executor and instead just allow
   the exception to be thrown.
 - Refactor the type resolution logic in the PHPConventionService.
