### PR TITLE
Chore/python headers add all

### DIFF
--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -824,7 +824,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         {
             writer.StartBlock($"if {requestParams.requestConfiguration.Name}:");
             var headers = requestParams.Headers?.Name ?? "headers";
-            writer.WriteLine($"{RequestInfoVarName}.headers.add({requestParams.requestConfiguration.Name}.{headers})");
+            writer.WriteLine($"{RequestInfoVarName}.headers.add_all({requestParams.requestConfiguration.Name}.{headers})");
             var queryString = requestParams.QueryParameters;
             if (queryString != null)
                 writer.WriteLines($"{RequestInfoVarName}.set_query_string_parameters_from_raw_object({requestParams.requestConfiguration.Name}.{queryString.Name})");

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -6,7 +6,6 @@ using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers;
 using Kiota.Builder.Writers.Python;
-
 using Xunit;
 
 namespace Kiota.Builder.Tests.Writers.Python;
@@ -695,6 +694,8 @@ public class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("request_info = RequestInformation()", result);
         Assert.Contains("request_info.http_method = Method", result);
+        Assert.Contains("if c:", result);
+        Assert.Contains("request_info.headers.add_all(c.h)", result);
         Assert.Contains("request_info.url_template = ", result);
         Assert.Contains("request_info.path_parameters = ", result);
         Assert.Contains("request_info.headers.try_add(\"Accept\", \"application/json, text/plain\")", result);


### PR DESCRIPTION
Aligns RequestBuilders with https://github.com/microsoft/kiota-abstractions-python/pull/170

Uses `try_add` method as headers is a `HeadersCollection` instance