### PR TITLE
BackingStore fixes for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixes bug where import statements for additionalDataHolder and enumSet are missing when BackingStore is enabled in java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
+- Fixes bug where getBackingStore method body was malformed for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
+- Fixes bug where serialize method will not write additional data when backingStore is enabled for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
+
 ## [1.8.1] - 2023-11-02
 
 ### Added
@@ -18,9 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where query parameter enum reusable types would be trimmed. [#3637](https://github.com/microsoft/kiota/issues/3637)
-- Fixes bug where import statements for additionalDataHolder and enumSet are missing when BackingStore is enabled in java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
-- Fixes bug where getBackingStore method body was malformed for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
-- Fixes bug where serialize method will not write additional data when backingStore is enabled for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
 
 ## [1.8.0] - 2023-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where query parameter enum reusable types would be trimmed. [#3637](https://github.com/microsoft/kiota/issues/3637)
+- Fixes bug where import statements for additionalDataHolder and enumSet are missing when BackingStore is enabled in java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
+- Fixes bug where getBackingStore method body was malformed for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
 
 ## [1.8.0] - 2023-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing imports for method parameters that are query parameters.
 - Replaces the use of "new" by "override" and "virtual" in CSharp models.
 - Fixed a bug in validation rules where form data would wrongfully warn for arrays. [#3569](https://github.com/microsoft/kiota/issues/3569)
+- Fixed a bug where content type parameter would be missing for TypeScript, Java, PHP, Python, Ruby and Go. [#3610](https://github.com/microsoft/kiota/issues/3610)
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)
 - The lock file now contains the relative path to the description in case of local path. [#3151](https://github.com/microsoft/kiota/issues/3151)
 - Fixes a bug where query parameters would be missing in CSharp for ebc clients. [#3583](https://github.com/microsoft/kiota/issues/3583)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [1.8.1] - 2023-11-02
+
+### Added
+
+### Changed
+
+- Fixed a bug where query parameter enum reusable types would be trimmed. [#3637](https://github.com/microsoft/kiota/issues/3637)
+
+## [1.8.0] - 2023-11-02
+
+### Added
+
+- 📢📢📢 Python generation is now stable! 🚀🚀🚀
+- 📢📢📢 PHP generation is now stable! 🚀🚀🚀
 - Added support for enum query parameter types. [#2490](https://github.com/microsoft/kiota/issues/2490)
 - Added settings in the vscode extension for: backingStore, additionalData, excludeBackwardCompatible, cleanOutput, clearCache, serializers, deserializers, disabledValidationRules, structuredMimeTypes. [#3355](https://github.com/microsoft/kiota/issues/3355)
 - Support for primary error message in PHP [#3276](https://github.com/microsoft/kiota/issues/3276)
@@ -19,12 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Set serialization name for path parameters for use with url templating in Python. [#3612](https://github.com/microsoft/kiota/issues/3612)
 - Include the type which a promise resolves to in PHPDocs for PHP. [#3542](https://github.com/microsoft/kiota/issues/3542)
 - Added null check for null content type instances when getting deprecation information [#3588](https://github.com/microsoft/kiota/issues/3588)
 - Aligns header management in Python with other languages. [#3430](https://github.com/microsoft/kiota/issues/3430)
 - Fixed parameters that are in camelcase to snakecase in Python. [#3525](https://github.com/microsoft/kiota/issues/3525)
 - Fixed missing imports for method parameters that are query parameters.
 - Replaces the use of "new" by "override" and "virtual" in CSharp models.
+- Fixed a bug where namespaces segment names might contain special characters. [#3599](https://github.com/microsoft/kiota/issues/3599)
 - Fixed a bug in validation rules where form data would wrongfully warn for arrays. [#3569](https://github.com/microsoft/kiota/issues/3569)
 - Fixed a bug where content type parameter would be missing for TypeScript, Java, PHP, Python, Ruby and Go. [#3610](https://github.com/microsoft/kiota/issues/3610)
 - Fixed query parameters type mapping for arrays. [#3354](https://github.com/microsoft/kiota/issues/3354)
@@ -39,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The structured content type generation parameter now supports prioritization with `q=value` syntax. [#3377](https://github.com/microsoft/kiota/issues/3377)
 - Fixed bug where `Tilde` char convert to Enum member name properly in C#. [#3500](https://github.com/microsoft/kiota/issues/3500)
 - Restore backing store feature for typescript. [#2613](https://github.com/microsoft/kiota/issues/2613)
+- Fixed default code documentation for RequestBodyContentType method parameter.
 
 ## [1.7.0] - 2023-10-05
 
@@ -1123,3 +1142,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where query parameter enum reusable types would be trimmed. [#3637](https://github.com/microsoft/kiota/issues/3637)
 - Fixes bug where import statements for additionalDataHolder and enumSet are missing when BackingStore is enabled in java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
 - Fixes bug where getBackingStore method body was malformed for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
+- Fixes bug where serialize method will not write additional data when backingStore is enabled for java. [#3643](https://github.com/microsoft/kiota/pull/3643)  
 
 ## [1.8.0] - 2023-11-02
 

--- a/it/csharp/dotnet.csproj
+++ b/it/csharp/dotnet.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.3" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.6.0" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.0" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.2.0" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.0" />

--- a/it/python/requirements-dev.txt
+++ b/it/python/requirements-dev.txt
@@ -4,7 +4,7 @@ astroid==3.0.1 ; python_full_version >= '3.7.2'
 
 certifi==2023.7.22 ; python_version >= '3.6'
 
-charset-normalizer==3.3.1 ; python_full_version >= '3.7.0'
+charset-normalizer==3.3.2 ; python_full_version >= '3.7.0'
 
 colorama==0.4.6 ; sys_platform == 'win32'
 
@@ -98,15 +98,15 @@ httpx[http2]==0.25.0
 
 hyperframe==6.0.1 ; python_full_version >= '3.6.1'
 
-microsoft-kiota-abstractions==0.9.1
+microsoft-kiota-abstractions==1.0.0
 
-microsoft-kiota-authentication-azure==0.3.2
+microsoft-kiota-authentication-azure==1.0.0
 
-microsoft-kiota-http==0.6.3
+microsoft-kiota-http==1.0.0
 
-microsoft-kiota-serialization-json==0.4.2
+microsoft-kiota-serialization-json==1.0.0
 
-microsoft-kiota-serialization-text==0.3.0
+microsoft-kiota-serialization-text==1.0.0
 
 msal==1.24.1
 

--- a/it/typescript/package-lock.json
+++ b/it/typescript/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@azure/identity": "^3.3.2",
         "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
-        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.24",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.28",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.18",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.29",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.8",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.26",
+        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.25",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.29",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.19",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.30",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.9",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.27",
         "express": "^4.18.2",
         "node-fetch": "^2.7.0"
       },
@@ -664,9 +664,9 @@
       "dev": true
     },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.29.tgz",
-      "integrity": "sha512-R9/Yh+mD6EFD+46iIpQjMiA7BgfrQF7AI4kuZYQteiPWFwQY30dW92BGWFHv0ODYyrJeMDjdXt5VxVaE83diEw==",
+      "version": "1.0.0-preview.30",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.30.tgz",
+      "integrity": "sha512-dw7fwNVJB9RJ8cWIJIsh2TVe83wdfdMSlkUaHiOyLeYxjepiGVzwgWRVOSfv31R5yF0DvKE+Q5r0n6iXSI2huA==",
       "dependencies": {
         "@opentelemetry/api": "^1.2.0",
         "@std-uritemplate/std-uritemplate": "^0.0.46",
@@ -685,22 +685,22 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.24.tgz",
-      "integrity": "sha512-qZApJBpTFU3P+ki6XKH4M1h5oZgaD1n4MojJcYu3Ici1gpu+BcDLZhByXHLOeDBpG+m2IwebkzYr7FFVqFNagA==",
+      "version": "1.0.0-preview.25",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.25.tgz",
+      "integrity": "sha512-U/uceGq1uTWr7K5uWiS0tS1B4I0u3QR++smKLhxLR8Fp1+VYjSrNbF4gZqa5uz8ZemjFK6H1nTjCoXAD6z68xA==",
       "dependencies": {
         "@azure/core-auth": "^1.3.2",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "@opentelemetry/api": "^1.2.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.28",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.28.tgz",
-      "integrity": "sha512-+QsvKa3K3NgHjhJ6tN3Xs/hdq4fKYTpylXDV4oPk0ayYMuvn389nLRvyfm26jTao4pTVPrA/2fRy5EFekTedHQ==",
+      "version": "1.0.0-preview.29",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.29.tgz",
+      "integrity": "sha512-fj+OWO0ImRd/qzuuDO2unh16t0L1ah+aa5FDGXj0sFEpl8jCRsMI/pXbHITsE0sTCxdEqkezD6cIRUvz8Zfhtg==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "@opentelemetry/api": "^1.2.0",
         "guid-typescript": "^1.0.9",
         "node-fetch": "^2.6.5",
@@ -708,41 +708,41 @@
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.18",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.18.tgz",
-      "integrity": "sha512-GrNqZXEI+kIrowH5z1OvvhJmp40RnUC20Jo2BSmBAJz8pYWfPz+vhmkq9otMJG6gS4Ru1f7aqqAtszfXPuJ0EA==",
+      "version": "1.0.0-preview.19",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.19.tgz",
+      "integrity": "sha512-HtogIkIi3afbUD/aeVg8Stj9dtkrEGX4Zob1nUexxRSw5jOGwkxSIhwvYICD+nxDrDzXrJfzvCDKkeFlKPPYFg==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "guid-typescript": "^1.0.9",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.29.tgz",
-      "integrity": "sha512-ipV9Lgf/RIKEOTOGBgxR36/L92GNVj55HFiWmO6ZabjUXGay+0iqFWeMLGHbvgGnbU8BNa8ZE4Fs/XMR/4g/hg==",
+      "version": "1.0.0-preview.30",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.30.tgz",
+      "integrity": "sha512-aSosH4iOt1bqj9JVyQYQlXzSO/B1A/oqEsMT+IoIS/Hoa7Z/qnftp6CVtg15/bpCIMZA19G+UQ4IBx685JyrAg==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "guid-typescript": "^1.0.9",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.8.tgz",
-      "integrity": "sha512-yyyTXCS0exoWREYLLKoXC942Pt91okSUogO8eEOPfL9EOcrqHG+H5WgayWiJEpZKkUF1BLxoDd/VedVWDwBDaA==",
+      "version": "1.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.9.tgz",
+      "integrity": "sha512-jDAFg0aiYAkYm14O+iTUT37eLhvL2zLavTeEIhBcEVvepeAkXYjVqco2c4itroF8r2RYIbNN0LHm9k68jnNzuQ==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "guid-typescript": "^1.0.9",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.26",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.26.tgz",
-      "integrity": "sha512-XUBCHXfaEoiROKF8PiT/XSd2vGlIwLOpjUgyUiDKI61eUnE4Vx+/cf6TlA3bzM4wXJXmBO7TrV0fY1WlObuEGw==",
+      "version": "1.0.0-preview.27",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.27.tgz",
+      "integrity": "sha512-AE3yZ+MCQKyzFVEU36rV/Cx4JTWJtKOulEKJKKJO8oIFLUJ0BYFpCUGYnN4srgbrvrvq8w57betTFG21WDLk5A==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.30",
         "guid-typescript": "^1.0.9",
         "tslib": "^2.3.1"
       }

--- a/it/typescript/package.json
+++ b/it/typescript/package.json
@@ -32,12 +32,12 @@
   "dependencies": {
     "@azure/identity": "^3.3.2",
     "@microsoft/kiota-abstractions": "^1.0.0-preview.29",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.24",
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.28",
-    "@microsoft/kiota-serialization-form": "^1.0.0-preview.18",
-    "@microsoft/kiota-serialization-json": "^1.0.0-preview.29",
-    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.8",
-    "@microsoft/kiota-serialization-text": "^1.0.0-preview.26",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.25",
+    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.29",
+    "@microsoft/kiota-serialization-form": "^1.0.0-preview.19",
+    "@microsoft/kiota-serialization-json": "^1.0.0-preview.30",
+    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.9",
+    "@microsoft/kiota-serialization-text": "^1.0.0-preview.27",
     "express": "^4.18.2",
     "node-fetch": "^2.7.0"
   }

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -1,3 +1,8 @@
+param(
+    [ValidateSet("minor", "major", "patch")]
+    [string]$kind = "minor"
+)
+
 $indentContentScriptPath = Join-Path -Path $PSScriptRoot -ChildPath "indent-xml-content.ps1"
 . $indentContentScriptPath
 
@@ -5,8 +10,18 @@ $mainCSProjpath = Join-Path -Path $PSScriptRoot -ChildPath "../src/kiota/kiota.c
 $mainCsprojContent = [xml](Get-Content -Path $mainCSProjpath)
 $version = $mainCsprojContent.Project.PropertyGroup[0].VersionPrefix
 $versionParts = $version.Split(".")
-$versionParts[1] = [int]$versionParts[1] + 1
-$versionParts[2] = 0
+if ($kind -eq "major") {
+    $versionParts[0] = [int]$versionParts[0] + 1
+    $versionParts[1] = 0
+    $versionParts[2] = 0
+}
+elseif ($kind -eq "minor") {
+    $versionParts[1] = [int]$versionParts[1] + 1
+    $versionParts[2] = 0
+}
+elseif ($kind -eq "patch") {
+    $versionParts[2] = [int]$versionParts[2] + 1
+}
 $version = $versionParts -join "."
 $mainCsprojContent.Project.PropertyGroup[0].VersionPrefix = $version
 Format-XMLIndent -Content $mainCsprojContent | Set-Content -Path $mainCSProjpath -Encoding utf8

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.6.0" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.2.0" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.0" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.1" />
@@ -53,8 +53,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
-    <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer"
-      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="*.g.cs" />

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -220,7 +220,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             "java.util", "Collection", "Map"),
         new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model),
             SerializationNamespaceName, "Parsable"),
-        new (static x => x is CodeClass @class && @class.IsOfKind(CodeClassKind.Model) && @class.Properties.Any(x => x.IsOfKind(CodePropertyKind.AdditionalData)),
+        new (static x => x is CodeMethod @method && @method.IsOfKind(CodeMethodKind.Getter, CodeMethodKind.Setter) && (@method.AccessedProperty?.IsOfKind(CodePropertyKind.AdditionalData) ?? false),
             SerializationNamespaceName, "AdditionalDataHolder"),
         new (static x => x is CodeMethod method && method.Parameters.Any(x => !x.Optional),
                 "java.util", "Objects"),

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -194,7 +194,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
     private static void AddEnumSetImport(CodeElement currentElement)
     {
         if (currentElement is CodeClass currentClass && currentClass.IsOfKind(CodeClassKind.Model) &&
-            currentClass.Properties.Any(x => x.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags))
+            currentClass.Methods.Any(x => x.AccessedProperty?.Type is CodeType xType && xType.TypeDefinition is CodeEnum xEnumType && xEnumType.Flags))
         {
             var nUsing = new CodeUsing
             {

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -80,11 +80,21 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 new() {
                     CodePropertyKind.Custom,
                     CodePropertyKind.AdditionalData,
-                    CodePropertyKind.BackingStore,
                 },
                 static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
                 _configuration.UsesBackingStore,
                 true,
+                "get",
+                "set",
+                string.Empty
+            );
+            AddGetterAndSetterMethods(generatedCode,
+                new() {
+                    CodePropertyKind.BackingStore
+                },
+                static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
+                _configuration.UsesBackingStore,
+                false,
                 "get",
                 "set",
                 string.Empty
@@ -99,6 +109,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddEnumSetImport(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
             SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
+            SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.BackingStore));
             AddConstructorsForDefaultValues(generatedCode, true);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
             var defaultConfiguration = new GenerationConfiguration();

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -180,6 +180,8 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
 
             foreach (var param in m.Parameters)
             {
+                if (param.SerializationName != null)
+                    param.SerializationName = param.Name;
                 param.Name = param.Name.ToFirstCharacterLowerCase().ToSnakeCase();
             }
             if (parentClassM.IsOfKind(CodeClassKind.Model))

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -793,10 +793,12 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                                             ?.Name
                                             ?.ToFirstCharacterUpperCase();
         var paramsList = new List<CodeParameter?> { codeElement.Parameters.OfKind(CodeParameterKind.Cancellation), requestParams.requestBody, requestParams.requestConfiguration };
+        if (requestParams.requestContentType is not null)
+            paramsList.Insert(2, requestParams.requestContentType);
         if (parametersPad > 0)
-            paramsList.AddRange(Enumerable.Range(0, parametersPad).Select<int, CodeParameter?>(x => null));
-        var requestInfoParameters = paramsList.Where(static x => x != null)
-                                            .Select(static x => x!.Name)
+            paramsList.AddRange(Enumerable.Range(0, parametersPad).Select<int, CodeParameter?>(static x => null));
+        var requestInfoParameters = paramsList.OfType<CodeParameter>()
+                                            .Select(static x => x.Name)
                                             .ToList();
         var skipIndex = requestParams.requestBody == null ? 1 : 0;
         requestInfoParameters.AddRange(paramsList.Where(static x => x == null).Skip(skipIndex).Select(static x => "nil"));

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -392,7 +392,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
                 !(codeElement.AccessedProperty?.ReadOnly ?? true) &&
                 !string.IsNullOrEmpty(codeElement.AccessedProperty?.DefaultValue))
         {
-            writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.NamePrefix}{backingStore.Name}\");");
+            writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.Name}.get(\"{codeElement.AccessedProperty.Name}\");");
             writer.StartBlock("if(value == null) {");
             writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
                 $"this.set{codeElement.AccessedProperty?.Name.ToFirstCharacterUpperCase()}(value);");

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -602,7 +602,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         else
             WriteSerializerBodyForInheritedModel(method, inherits, parentClass, writer);
 
-        if (parentClass.Methods.Any(x => x.AccessedProperty?.IsOfKind(CodePropertyKind.AdditionalData) ?? false))
+        if (parentClass.Methods.Any(x => x.AccessedProperty?.IsOfKind(CodePropertyKind.AdditionalData) ?? false) ||
+        parentClass.Properties.Any(x => x?.IsOfKind(CodePropertyKind.AdditionalData) ?? false))
             writer.WriteLine($"writer.writeAdditionalData(this.get{CodePropertyKind.AdditionalData.ToString().ToFirstCharacterUpperCase()}());");
     }
     private void WriteSerializerBodyForUnionModel(CodeClass parentClass, CodeMethod method, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -602,10 +602,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         else
             WriteSerializerBodyForInheritedModel(method, inherits, parentClass, writer);
 
-        var additionalDataProperty = parentClass.GetPropertyOfKind(CodePropertyKind.AdditionalData);
-
-        if (additionalDataProperty != null)
-            writer.WriteLine($"writer.writeAdditionalData(this.get{additionalDataProperty.Name.ToFirstCharacterUpperCase()}());");
+        if (parentClass.Methods.Any(x => x.AccessedProperty?.IsOfKind(CodePropertyKind.AdditionalData) ?? false))
+            writer.WriteLine($"writer.writeAdditionalData(this.get{CodePropertyKind.AdditionalData.ToString().ToFirstCharacterUpperCase()}());");
     }
     private void WriteSerializerBodyForUnionModel(CodeClass parentClass, CodeMethod method, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -373,14 +373,13 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
     }
     private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass)
     {
-        if (parentClass.GetBackingStoreProperty() is CodeProperty backingStore)
-            writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name}\", value);");
-        else
+        if (parentClass.GetBackingStoreProperty() is not CodeProperty backingStore || (codeElement.AccessedProperty?.IsOfKind(CodePropertyKind.BackingStore) ?? false))
         {
             string value = "PeriodAndDuration".Equals(codeElement.AccessedProperty?.Type?.Name, StringComparison.OrdinalIgnoreCase) ? "PeriodAndDuration.ofPeriodAndDuration(value);" : "value;";
             writer.WriteLine($"this.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name} = {value}");
-
         }
+        else
+            writer.WriteLine($"this.get{backingStore.Name.ToFirstCharacterUpperCase()}().set(\"{codeElement.AccessedProperty?.Name}\", value);");
     }
     private void WriteGetterBody(CodeMethod codeElement, LanguageWriter writer, CodeClass parentClass)
     {

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -35,7 +35,7 @@ public class JavaConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var nullKeyword = parameter.Optional ? "Nullable" : "Nonnull";
-        var nullAnnotation = parameter.Type.IsNullable ? $"@jakarta.annotation.{nullKeyword} " : string.Empty;
+        var nullAnnotation = parameter.Type.IsNullable || parameter.IsOfKind(CodeParameterKind.RequestBodyContentType) ? $"@jakarta.annotation.{nullKeyword} " : string.Empty;
         var parameterType = GetTypeString(parameter.Type, targetElement);
         if (parameter.Type is CodeType { TypeDefinition: CodeEnum { Flags: true }, IsCollection: false })
             parameterType = $"EnumSet<{parameterType}>";

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -726,14 +726,14 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             .FirstOrDefault(x =>
                 x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod);
         var generatorMethodName = generatorMethod?.Name.ToFirstCharacterLowerCase();
-        var requestInfoParameters = new[] { requestParams.requestBody, requestParams.requestConfiguration }
-            .Where(static x => x?.Name != null)
-            .Select(static x => x!);
-        var callParams = requestInfoParameters.Select(conventions.GetParameterName);
+        var requestInfoParameters = new CodeParameter?[] { requestParams.requestBody, requestParams.requestContentType, requestParams.requestConfiguration }
+            .OfType<CodeParameter>()
+            .Select(conventions.GetParameterName)
+            .ToArray();
         var joinedParams = string.Empty;
         if (requestInfoParameters.Any())
         {
-            joinedParams = string.Join(", ", callParams);
+            joinedParams = string.Join(", ", requestInfoParameters);
         }
 
         var returnTypeName = conventions.GetTypeString(codeElement.ReturnType, codeElement, false);

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -562,14 +562,14 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                             .FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestGenerator) && x.HttpMethod == codeElement.HttpMethod)
                                             ?.Name;
         writer.WriteLine($"request_info = self.{generatorMethodName}(");
-        var requestInfoParameters = new[] { requestParams.requestBody, requestParams.requestConfiguration }
-                                        .Where(static x => x != null)
-                                        .Select(static x => x!.Name)
+        var requestInfoParameters = new CodeParameter?[] { requestParams.requestBody, requestParams.requestContentType, requestParams.requestConfiguration }
+                                        .OfType<CodeParameter>()
+                                        .Select(static x => x.Name)
                                         .ToArray();
-        if (requestInfoParameters.Any() && requestInfoParameters.Aggregate(static (x, y) => $"{x}, {y}") is string parameters)
+        if (requestInfoParameters.Any())
         {
             writer.IncreaseIndent();
-            writer.WriteLine(parameters);
+            writer.WriteLine(requestInfoParameters.Aggregate(static (x, y) => $"{x}, {y}"));
             writer.DecreaseIndent();
         }
         writer.WriteLine(")");

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -251,9 +251,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                             ?.Name
                                             ?.ToSnakeCase();
         writer.WriteLine($"request_info = self.{generatorMethodName}(");
-        var requestInfoParameters = new[] { requestParams.requestBody, requestParams.requestConfiguration }
-            .Where(static x => x != null)
-            .Select(static x => x!.Name.ToSnakeCase())
+        var requestInfoParameters = new CodeParameter?[] { requestParams.requestBody, requestParams.requestContentType, requestParams.requestConfiguration }
+            .OfType<CodeParameter>()
+            .Select(static x => x.Name.ToSnakeCase())
             .ToArray();
         if (requestInfoParameters.Any())
         {

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -297,13 +297,14 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, TypeScriptConventi
                                             ?.Name
                                             ?.ToFirstCharacterLowerCase();
         writer.WriteLine($"const requestInfo = this.{generatorMethodName}(");
-        var requestInfoParameters = new[] { requestParams.requestBody, requestParams.requestConfiguration }
-                                        .Select(x => x?.Name).Where(x => x != null)
+        var requestInfoParameters = new CodeParameter?[] { requestParams.requestBody, requestParams.requestContentType, requestParams.requestConfiguration }
+                                        .OfType<CodeParameter>()
+                                        .Select(static x => x.Name)
                                         .ToArray();
-        if (requestInfoParameters.Any() && requestInfoParameters.Aggregate((x, y) => $"{x}, {y}") is string requestInfoParametersString)
+        if (requestInfoParameters.Any())
         {
             writer.IncreaseIndent();
-            writer.WriteLine(requestInfoParametersString);
+            writer.WriteLine(requestInfoParameters.Aggregate(static (x, y) => $"{x}, {y}"));
             writer.DecreaseIndent();
         }
         writer.WriteLine(");");

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -163,7 +163,7 @@
       "DependencyInstallCommand": "npm install {0}@{1} -S"
     },
     "PHP": {
-      "MaturityLevel": "Preview",
+      "MaturityLevel": "Stable",
       "Dependencies": [
         {
           "Name": "microsoft/kiota-abstractions",
@@ -189,7 +189,7 @@
       "DependencyInstallCommand": "composer require {0}:{1}"
     },
     "Python": {
-      "MaturityLevel": "Preview",
+      "MaturityLevel": "Stable",
       "Dependencies": [
         {
           "Name": "microsoft-kiota-abstractions",

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="17.7.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Kiota.Builder.Tests/Caching/DocumentCachingProviderTests.cs
+++ b/tests/Kiota.Builder.Tests/Caching/DocumentCachingProviderTests.cs
@@ -24,9 +24,9 @@ public class DocumentCachingProviderTests
         Assert.Throws<ArgumentNullException>(() => new DocumentCachingProvider(null, mockLogger));
 
         var provider = new DocumentCachingProvider(client, mockLogger);
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await provider.GetDocumentAsync(null, null, null));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await provider.GetDocumentAsync(new Uri("https://localhost"), null, null));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await provider.GetDocumentAsync(new Uri("https://localhost"), "foo", null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => provider.GetDocumentAsync(null, null, null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => provider.GetDocumentAsync(new Uri("https://localhost"), null, null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => provider.GetDocumentAsync(new Uri("https://localhost"), "foo", null));
     }
     private const string ResponsePayload = @"{
   ""headers"": {

--- a/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
+++ b/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1503,6 +1503,7 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("writeCollectionOfObjectValues", result);
         Assert.Contains("writeEnumValue", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("writeAdditionalData(this.getAdditionalData());", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1502,7 +1502,6 @@ public class CodeMethodWriterTests : IDisposable
         Assert.Contains("writeCollectionOfPrimitiveValues", result);
         Assert.Contains("writeCollectionOfObjectValues", result);
         Assert.Contains("writeEnumValue", result);
-        Assert.Contains("writeAdditionalData(this.getAdditionalData());", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
     }

--- a/tests/Kiota.Tests/Kiota.Tests.csproj
+++ b/tests/Kiota.Tests/Kiota.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/vscode/microsoft-kiota/package-lock.json
+++ b/vscode/microsoft-kiota/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kiota",
       "version": "1.7.100000001",
       "dependencies": {
-        "@vscode/extension-telemetry": "^0.8.5",
+        "@vscode/extension-telemetry": "^0.9.0",
         "@vscode/l10n": "^0.0.16",
         "adm-zip": "^0.5.10",
         "is-online": "^10.0.0",
@@ -19,7 +19,7 @@
         "@types/adm-zip": "^0.5.3",
         "@types/mocha": "^10.0.3",
         "@types/node": "20.x",
-        "@types/vscode": "^1.83.1",
+        "@types/vscode": "^1.83.2",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "@vscode/test-electron": "^2.3.6",
@@ -42,121 +42,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
-      "integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
-        "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-      "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.4.0.tgz",
-      "integrity": "sha512-eGAyJpm3skVQoLiRqm/xPa+SXi/NPDdSHMxbRAz2lSprd+Zs+qrpQGQQ2VQ3Nttu+nSZR4XoYQC71LbEI7jsig==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
-      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
-      "dependencies": {
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/logger": "^1.0.0",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.15.2",
-        "@opentelemetry/instrumentation": "^0.41.2",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -365,164 +250,74 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.13.tgz",
-      "integrity": "sha512-CluYTRWcEk0ObG5EWFNWhs87e2qchJUn0p2D21ZUa3PWojPZfPSBs4//WIE0MYV8Qg1Hdif2ZTwlM7TbYUjfAg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.4.tgz",
+      "integrity": "sha512-QOCE0fTDOMNptB791chnVlfnRvb7faDQTaUIO3DfPBkvjF3PUAJJCsqJKWitw7nwVn8L82TFx+K22UifIr0zkg==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.15",
-        "@microsoft/applicationinsights-shims": "^2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.13.tgz",
-      "integrity": "sha512-HgS574fdD19Bo2vPguyznL4eDw7Pcm1cVNpvbvBLWiW3x4e1FCQ3VMXChWnAxCae8Hb0XqlA2sz332ZobBavTA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.4.tgz",
+      "integrity": "sha512-jlPNL16iRXzmXfriGXv0INzrAl3AeDx+eCORjq8ZjRhIvohB6Q88m5E28nL6Drf5hJWE2ehoW4q8Vh612VoEHw==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "3.2.13",
-        "@microsoft/applicationinsights-shims": "^2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/1ds-core-js": "4.0.4",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.2.tgz",
-      "integrity": "sha512-jDBNKbCHsJgmpv0CKNhJ/uN9ZphvfGdb93Svk+R4LjO8L3apNNMbDDPxBvXXi0uigRmA1TBcmyBG4IRKjabGhw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.5.tgz",
+      "integrity": "sha512-KfTYY0uZmrQgrz8ErBh1q08eiYfzjUIVzJZHETgEkqv3l2RTndQgpmywDbVNf9wVTB7Mp89ZrFeCciVJFf5geg==",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "3.0.2",
-        "@microsoft/applicationinsights-core-js": "3.0.2",
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-async": ">= 0.2.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.2.tgz",
-      "integrity": "sha512-WQhVhzlRlLDrQzn3OShCW/pL3BW5WC57t0oywSknX3q7lMzI3jDg7Ihh0iuIcNTzGCTbDkuqr4d6IjEDWIMtJQ==",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-async": ">= 0.2.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-shims": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
-      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
-      "dependencies": {
-        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/dynamicproto-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
-      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
-      "dependencies": {
-        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.2.tgz",
-      "integrity": "sha512-y+WXWop+OVim954Cu1uyYMnNx6PWO8okHpZIQi/1YSqtqaYdtJVPv4P0AVzwJdohxzVfgzKvqj9nec/VWqE2Zg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.5.tgz",
+      "integrity": "sha512-ahph1fMqyLcZ1twzDKMzpHRgR9zEIyqNhMQxDgQ45ieVD641bZiYVwSlbntSXhGCtr5G5HE02zlEzwSxbx95ng==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.0.2",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.2.tgz",
-      "integrity": "sha512-WQhVhzlRlLDrQzn3OShCW/pL3BW5WC57t0oywSknX3q7lMzI3jDg7Ihh0iuIcNTzGCTbDkuqr4d6IjEDWIMtJQ==",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-async": ">= 0.2.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-shims": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
-      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
-      "dependencies": {
-        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/dynamicproto-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
-      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
-      "dependencies": {
-        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.15.tgz",
-      "integrity": "sha512-yYAs9MyjGr2YijQdUSN9mVgT1ijI1FPMgcffpaPmYbHAVbQmF7bXudrBWHxmLzJlwl5rfep+Zgjli2e67lwUqQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.5.tgz",
+      "integrity": "sha512-/x+tkxsVALNWSvwGMyaLwFPdD3p156Pef9WHftXrzrKkJ+685nhrwm9MqHIyEHHpSW09ElOdpJ3rfFVqpKRQyQ==",
       "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.9"
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
-      "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.2.tgz",
-      "integrity": "sha512-6Lq0DE/pZp9RvSV+weGbcxN1NDmfczj6gNPhvZKV2YSQ3RK0LZE3+wjTWLXfuStq8a+nCBdsRpWk8tOKgsoxcg==",
-      "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.0.2",
-        "@microsoft/applicationinsights-common": "3.0.2",
-        "@microsoft/applicationinsights-core-js": "3.0.2",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-async": ">= 0.2.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.2.tgz",
-      "integrity": "sha512-WQhVhzlRlLDrQzn3OShCW/pL3BW5WC57t0oywSknX3q7lMzI3jDg7Ihh0iuIcNTzGCTbDkuqr4d6IjEDWIMtJQ==",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.2",
-        "@nevware21/ts-async": ">= 0.2.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-shims": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
       "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
@@ -530,7 +325,24 @@
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
-    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/dynamicproto-js": {
+    "node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.5.tgz",
+      "integrity": "sha512-ps4wjmF9X80hakYxywlzBdSlDjfToZrz/cHKA/9yarrW3mbZGqjjksNoaFxtyU5BK4lhOvrgu+2+QcDHeEEnOA==",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "3.0.5",
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
       "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
@@ -538,34 +350,18 @@
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
-    "node_modules/@microsoft/applicationinsights-web-snippet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
-      "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
-    },
-    "node_modules/@microsoft/dynamicproto-js": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
-      "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
-    },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.2.6.tgz",
-      "integrity": "sha512-NCUqEZSbsy7LVtKlUScd/eTst6djkWauLlzoIPVKCOxalEBdO8lrgNRIm4Xy68JNudNN5faqa2WA12X8m0BVhA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.3.0.tgz",
+      "integrity": "sha512-ZUcgUH12LN/F6nzN0cYd0F/rJaMLmXr0EHVTyYfaYmK55bdwE4338uue4UiVoRqHVqNW4KDUrJc49iGogHKeWA==",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.9.7 < 2.x"
-      },
-      "peerDependencies": {
-        "typescript": ">=1"
+        "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.9.8.tgz",
-      "integrity": "sha512-kZ8s8hcn9jPVX/M7kSsBYrOGlHjqLahmxrG7QeKTk5paeVwfgKdvVCjj5Acb4UGb/ukU1G34U1Z3eb7bbVanyA==",
-      "peerDependencies": {
-        "typescript": ">=1"
-      }
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.1.tgz",
+      "integrity": "sha512-pMny25NnF2/MJwdqC3Iyjm2pGIXNxni4AROpcqDeWa+td9JMUY4bUS9uU9XW+BoBRqTLUL+WURF9SOd/6OQzRg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -600,85 +396,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
-      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.15.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
-      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
-      "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.4.2",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.1",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
-      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
-      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
-      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -789,15 +506,10 @@
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
       "dev": true
     },
-    "node_modules/@types/shimmer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
-      "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
-    },
     "node_modules/@types/vscode": {
-      "version": "1.83.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.1.tgz",
-      "integrity": "sha512-BHu51NaNKOtDf3BOonY3sKFFmZKEpRkzqkZVpSYxowLbs5JqjOQemYFob7Gs5rpxE5tiGhfpnMpcdF/oKrLg4w==",
+      "version": "1.83.2",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.2.tgz",
+      "integrity": "sha512-qIN48iXkJi2eVyd9HB+TSYBssz7/EgSYw4IeoMNL9sJCao6qOVSXJR4z0HohV+Mvoiib1/rpK5hqoJ2Ua0N/+w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -996,14 +708,13 @@
       "dev": true
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.8.5.tgz",
-      "integrity": "sha512-YFKANBT2F3qdWQstjcr40XX8BLsdKlKM7a7YPi/jNuMjuiPhb1Jn7YsDR3WZaVEzAqeqGy4gzXsFCBbuZ+L1Tg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.0.tgz",
+      "integrity": "sha512-37RxGHXrs3GoXPgCUKQhghEu0gxs8j27RLjQwwtSf4WhPdJKz8UrqMYzpsXlliQ05zURYmtdGZst9C6+hfWXaQ==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^3.2.13",
-        "@microsoft/1ds-post-js": "^3.2.13",
-        "@microsoft/applicationinsights-web-basic": "^3.0.2",
-        "applicationinsights": "^2.7.1"
+        "@microsoft/1ds-core-js": "^4.0.3",
+        "@microsoft/1ds-post-js": "^4.0.3",
+        "@microsoft/applicationinsights-web-basic": "^3.0.4"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -1235,6 +946,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1246,6 +958,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "dev": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -1271,6 +984,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1364,36 +1078,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/applicationinsights": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.2.tgz",
-      "integrity": "sha512-sdkIhSqWntX01EAF5H/YcGgrqDIHNBARzhkQAuCav76KNpo/2enjJ1pTxFB7WgV+S3aTiGR+M7UvKijGlBy5tQ==",
-      "dependencies": {
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-rest-pipeline": "1.10.1",
-        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
-        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.15.2",
-        "@opentelemetry/sdk-trace-base": "^1.15.2",
-        "@opentelemetry/semantic-conventions": "^1.15.2",
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.1.1",
-        "diagnostic-channel-publishers": "1.0.7"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "applicationinsights-native-metrics": "*"
-      },
-      "peerDependenciesMeta": {
-        "applicationinsights-native-metrics": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1408,42 +1092,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
-    },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1656,11 +1304,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
-    },
     "node_modules/clean-stack": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
@@ -1748,27 +1391,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1793,17 +1415,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1815,15 +1426,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -1849,6 +1451,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1910,30 +1513,6 @@
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diagnostic-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
-      "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
-      "dependencies": {
-        "semver": "^7.5.3"
-      }
-    },
-    "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
-      "integrity": "sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==",
-      "peerDependencies": {
-        "diagnostic-channel": "*"
       }
     },
     "node_modules/diff": {
@@ -2002,14 +1581,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.455.tgz",
       "integrity": "sha512-8tgdX0Odl24LtmLwxotpJCVjIndN559AvaOtd67u+2mo+IDsgsTF580NB+uuDCqsHw8yFg53l5+imFV9Fw3cbA==",
       "dev": true
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2408,19 +1979,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -2452,7 +2010,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2613,6 +2172,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2673,6 +2233,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -2710,17 +2271,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/import-local": {
@@ -2811,6 +2361,7 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
       "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -3179,6 +2730,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3187,6 +2739,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3340,15 +2893,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -3567,7 +3116,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
@@ -3804,23 +3354,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -3978,6 +3516,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3992,6 +3531,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4047,11 +3587,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
     "node_modules/signal-exit": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
@@ -4091,11 +3626,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -4224,6 +3754,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4361,9 +3892,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4393,6 +3925,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4451,14 +3984,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -4743,7 +4268,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/vscode/microsoft-kiota/package.json
+++ b/vscode/microsoft-kiota/package.json
@@ -8,7 +8,7 @@
   "telemetryInstrumentationKey": "4c6357e0-daf9-42b5-bdfb-67878f8957b5",
   "icon": "images/logo.png",
   "engines": {
-    "vscode": "^1.83.1"
+    "vscode": "^1.83.2"
   },
   "categories": [
     "Other"
@@ -426,7 +426,7 @@
     "@types/adm-zip": "^0.5.3",
     "@types/mocha": "^10.0.3",
     "@types/node": "20.x",
-    "@types/vscode": "^1.83.1",
+    "@types/vscode": "^1.83.2",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "@vscode/test-electron": "^2.3.6",
@@ -439,7 +439,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@vscode/extension-telemetry": "^0.8.5",
+    "@vscode/extension-telemetry": "^0.9.0",
     "@vscode/l10n": "^0.0.16",
     "adm-zip": "^0.5.10",
     "is-online": "^10.0.0",


### PR DESCRIPTION
- getAdditionalData method body when backingStore is enabled is fixed 
```Java
 //Current
    public Map<String, Object> getAdditionalData() {
        Map<String, Object> value = this.BackingStore");
 //Fix
    public Map<String, Object> getAdditionalData() {
        Map<String, Object> value = this.BackingStore.get("additionalData");
```
- SetBackingStore method body is fixed.
- Annotations for setBackingStore parameter is added. 
```Java
 //Current
    public void setBackingStore(final BackingStore value) {
        this.getBackingStore().set("BackingStore", value);
    }
 //Fix
    public void setBackingStore(@jakarta.annotation.Nonnull final BackingStore value) {
        Objects.requireNonNull(value);
        this.BackingStore = value;
    }
```
- serialize method would not write additional data when backing store was enabled due to it's reliance on the additional data property which is not present when backing store is enabled. Now it will write based on whether there is a method with an AccessedProperty of kind additionalData. 
```Java
 //Current
    public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
        Objects.requireNonNull(writer);
        writer.writeStringValue("x", this.getX());
    }
 //Fix
    public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
        Objects.requireNonNull(writer);
        writer.writeStringValue("x", this.getX());
        writer.writeAdditionalData(this.getAdditionalData());
    }
```

-Import statements for additionalDataHolder and enumSet were previously based on class properties, when backing store is enabled these properties are not generated so the import statements are missing. 
Instead, the import statements are now based on the AccessedProperty of the methods present in the class. 


