### PR TITLE
Backing Store is a Protected Property

### DIFF
--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -157,7 +157,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         }
         CrawlTree(current, x => ReplacePropertyNames(x, propertyKindsToReplace!, refineAccessorName));
     }
-    protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, Func<CodeElement, string, string> refineAccessorName, bool removeProperty, bool parameterAsOptional, string getterPrefix, string setterPrefix, string fieldPrefix = "_")
+    protected static void AddGetterAndSetterMethods(CodeElement current, HashSet<CodePropertyKind> propertyKindsToAddAccessors, Func<CodeElement, string, string> refineAccessorName, bool removeProperty, bool parameterAsOptional, string getterPrefix, string setterPrefix, string fieldPrefix = "_", AccessModifier propertyAccessModifier = AccessModifier.Private)
     {
         ArgumentNullException.ThrowIfNull(refineAccessorName);
         if (propertyKindsToAddAccessors is null || propertyKindsToAddAccessors.Count == 0) return;
@@ -171,7 +171,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                 parentClass.RemoveChildElement(currentProperty);
             else
             {
-                currentProperty.Access = AccessModifier.Private;
+                currentProperty.Access = propertyAccessModifier;
                 if (!string.IsNullOrEmpty(fieldPrefix))
                     currentProperty.NamePrefix = fieldPrefix;
             }

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -88,17 +88,6 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "set",
                 string.Empty
             );
-            AddGetterAndSetterMethods(generatedCode,
-                new() {
-                    CodePropertyKind.BackingStore
-                },
-                static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
-                _configuration.UsesBackingStore,
-                false,
-                "get",
-                "set",
-                string.Empty
-            );
             ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped", new HashSet<Type> { typeof(CodeEnumOption) });
             ReplaceReservedExceptionPropertyNames(generatedCode, new JavaExceptionsReservedNamesProvider(), x => $"{x}Escaped");
             LowerCaseNamespaceNames(generatedCode);
@@ -109,7 +98,6 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddEnumSetImport(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
             SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
-            SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.BackingStore));
             AddConstructorsForDefaultValues(generatedCode, true);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
             var defaultConfiguration = new GenerationConfiguration();
@@ -300,9 +288,14 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             currentProperty.Type.IsNullable = true;
         }
         else if (currentProperty.IsOfKind(CodePropertyKind.BackingStore))
+        {
             currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
+            currentProperty.Name = currentProperty.Name.ToFirstCharacterLowerCase();
+        }
         else if (currentProperty.IsOfKind(CodePropertyKind.QueryParameter))
+        {
             currentProperty.DefaultValue = $"new {currentProperty.Type.Name.ToFirstCharacterUpperCase()}()";
+        }
         else if (currentProperty.IsOfKind(CodePropertyKind.AdditionalData))
         {
             currentProperty.Type.Name = "Map<String, Object>";

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -79,7 +79,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddGetterAndSetterMethods(generatedCode,
                 new() {
                     CodePropertyKind.Custom,
-                    CodePropertyKind.AdditionalData,
+                    CodePropertyKind.AdditionalData
                 },
                 static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
                 _configuration.UsesBackingStore,
@@ -87,6 +87,18 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 "get",
                 "set",
                 string.Empty
+            );
+            AddGetterAndSetterMethods(generatedCode,
+                new() {
+                    CodePropertyKind.BackingStore
+                },
+                static (_, s) => s.ToCamelCase(UnderscoreArray).ToFirstCharacterUpperCase(),
+                _configuration.UsesBackingStore,
+                false,
+                "get",
+                "set",
+                string.Empty,
+                AccessModifier.Protected
             );
             ReplaceReservedNames(generatedCode, reservedNamesProvider, x => $"{x}Escaped", new HashSet<Type> { typeof(CodeEnumOption) });
             ReplaceReservedExceptionPropertyNames(generatedCode, new JavaExceptionsReservedNamesProvider(), x => $"{x}Escaped");
@@ -98,6 +110,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             AddEnumSetImport(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
             SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.AdditionalData));
+            SetSetterParametersToNullable(generatedCode, new Tuple<CodeMethodKind, CodePropertyKind>(CodeMethodKind.Setter, CodePropertyKind.BackingStore));
             AddConstructorsForDefaultValues(generatedCode, true);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
             var defaultConfiguration = new GenerationConfiguration();

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -400,7 +400,6 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConventionServ
         }
         else
             writer.WriteLine($"return this.{backingStore.Name}.get(\"{codeElement.AccessedProperty?.Name}\");");
-
     }
     private void WriteIndexerBody(CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer, string returnType)
     {


### PR DESCRIPTION
We want to be able to refer to the BackingStore property in getters and setters as the following: 
```
public Type getSomeType(){
     this.backingStore.get("someType");
}
```
This would be invalid in some cases when a child class extends a parent class that houses the BackingStore property, i.e. any model class which extends the Entity class. 
This is due to the fact that the functionality in the method ```AddGetterAndSetterMethods``` sets the properties accessModifier to Private by default. In an initial attempt to remove this implicit behavior [I removed the getter and setters for the BackingStore property](https://github.com/microsoft/kiota/pull/3737/commits/a97092c21edee99da6493ecd21e5f4b6bc883c4a) and simply made the property public, however the Interface IBackedModel requires that a getBackingStore method is present so I added them back. 
By adding a parameter with which to set the propertyies accessModifier in the ```AddGetterAndSetterMethods``` method we are able to explicitly state what the property accessModifier is set to after adding the getter and setter. In the case of Java I have set the property modifier to Protected. 
This allows child classes to refer to the parent class backingStore property by way of ```this.backingStore``` and while ensuring that users must still use the getBackingStore/setBackingStore methods when making changes to the backingStore itself. This will prevent the use of ```this.backingStore = value``` by a user which is an undesired pattern when getters/setters are available. 
Also, backingStore property needs to be named ```backingStore``` and not ```BackingStore``` per java conventions