### PR TITLE
Fixed a bug with reserved property names in dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where a property named constructor would make generation fail. [#3756](https://github.com/microsoft/kiota/issues/3756)
 - Removed reflection for Java enum deserialization. [microsoft/kiota-java#843](https://github.com/microsoft/kiota-java/pull/843)
 - Added support for AnyOf arrays. [#3786](https://github.com/microsoft/kiota/pull/3792)
+- Fixed a bug where property names that matched reserved type would be replaced in dotnet.
 
 ## [1.8.2] - 2023-11-08
 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -264,8 +264,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             codeElementExceptions: new HashSet<Type> { typeof(CodeNamespace) },
             shouldReplaceCallback: codeElement => codeElement is CodeClass
                                                 || codeElement is CodeMethod
-                                                || codeElement is CodeEnum codeEnum && provider.ReservedNames.Contains(codeEnum.Name) // only replace enum type names not enum member names
-                                                || (codeElement is CodeProperty currentProperty && currentProperty.Type is CodeType propertyType && !propertyType.IsExternal && provider.ReservedNames.Contains(propertyType.Name)));// only replace property type names not property names
+                                                || codeElement is CodeEnum codeEnum && provider.ReservedNames.Contains(codeEnum.Name)); // only replace enum type names not enum member names
 
     protected static void ReplaceReservedNamespaceTypeNames(CodeElement current, IReservedNamesProvider provider, Func<string, string> replacement) =>
         ReplaceReservedNames(current, provider, replacement, shouldReplaceCallback: codeElement => codeElement is CodeNamespace || codeElement is CodeClass);

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -170,9 +170,17 @@ public class CSharpLanguageRefinerTests
             Name = "break", // this a keyword
             Kind = CodeClassKind.Model,
         }).First();
-        var property = model.AddProperty(new CodeProperty
+        var propertyWithCsharpReservedName = model.AddProperty(new CodeProperty
         {
             Name = "alias",// this a keyword
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        var propertyWithReservedTypeName = model.AddProperty(new CodeProperty
+        {
+            Name = "task",// this a type name reserved in C#
             Type = new CodeType
             {
                 Name = "string"
@@ -183,8 +191,11 @@ public class CSharpLanguageRefinerTests
         // Assert
         Assert.Equal("break", model.Name);
         Assert.DoesNotContain("@", model.Name); // classname will be capitalized
-        Assert.Equal("Alias", property.Name);
-        Assert.DoesNotContain("@", property.Name); // classname will be capitalized
+        Assert.Equal("Alias", propertyWithCsharpReservedName.Name);
+        Assert.DoesNotContain("@", propertyWithCsharpReservedName.Name); // classname will be capitalized
+        Assert.Equal("Task", propertyWithReservedTypeName.Name);
+        Assert.DoesNotContain("@", propertyWithReservedTypeName.Name); // classname will be capitalized
+        Assert.DoesNotContain("Escaped", propertyWithReservedTypeName.Name); // classname will be capitalized
     }
 
     [Fact]


### PR DESCRIPTION
This PR is a follow up to https://github.com/microsoft/kiota/pull/3798/files and fixes failing CI at https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/766

If fixes a bug after the refactor of the `ReplaceReservedNames` function to not replace reserved property type names which was still catered into the `ReplaceReservedModelTypes` function.

Tests added to validate. 