### PR TITLE
Fixes generation of scalar collection primitives in Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for AnyOf arrays. [#3786](https://github.com/microsoft/kiota/pull/3792)
 - Fixed a bug where property names that matched reserved type would be replaced in dotnet.
 - Fixed pass by value for `contentType` param in Go `requestInfo.SetStreamContentAndContentType`[#3830](https://github.com/microsoft/kiota/issues/3830)
+- Fixed parsing of `DateOnly` values generated in request executors [#3679](https://github.com/microsoft/kiota/issues/3679)
 
 ## [1.8.2] - 2023-11-08
 

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -742,7 +742,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         var constructorFunction = returnType switch
         {
             _ when isVoid => string.Empty,
-            _ when isPrimitive => $"\"{returnType.TrimCollectionAndPointerSymbols()}\", ",
+            _ when isPrimitive => $"\"{returnType.TrimCollectionAndPointerSymbols().TrimPackageReference().ToLowerInvariant()}\", ",
             _ when isBinary => $"\"{returnType}\", ",
             _ when isEnum => $"{conventions.GetImportedStaticMethodName(codeElement.ReturnType, parentClass, "Parse", string.Empty, string.Empty)}, ",
             _ => $"{conventions.GetImportedStaticMethodName(codeElement.ReturnType, parentClass, "Create", "FromDiscriminatorValue", "able")}, ",

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -114,7 +114,7 @@ public class GoConventionService : CommonLanguageConventionService
     }
     public bool IsPrimitiveType(string typeName)
     {
-        return typeName.TrimCollectionAndPointerSymbols() switch
+        return typeName.TrimCollectionAndPointerSymbols().TrimPackageReference() switch
         {
             "void" or "string" or "float" or "integer" or "long" or "double" or "boolean" or "Guid" or "DateTimeOffset"
             or "bool" or "int32" or "int64" or "float32" or "float64" or "UUID" or "Time" or "decimal" or "TimeOnly"

--- a/src/Kiota.Builder/Writers/Go/StringExtensions.cs
+++ b/src/Kiota.Builder/Writers/Go/StringExtensions.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Linq;
 
 namespace Kiota.Builder.Writers.Go;
 public static class StringExtensions
 {
     public static string TrimCollectionAndPointerSymbols(this string s) =>
-    string.IsNullOrEmpty(s) ? s : s.TrimStart('[').TrimStart(']').TrimStart('*');
+        string.IsNullOrEmpty(s) ? s : s.TrimStart('[').TrimStart(']').TrimStart('*');
+
+    public static string TrimPackageReference(this string s) =>
+        !string.IsNullOrEmpty(s) && s.Contains('.', StringComparison.InvariantCultureIgnoreCase) ? s.Split('.').Last() : s;
 
     public static string TrimSuffix(this string s, string suffix) =>
         !string.IsNullOrEmpty(s) && suffix != null && s.EndsWith(suffix, StringComparison.Ordinal) ? s[..^suffix.Length] : s;


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/3679

Resolves a bug affecting genration of collection primitives in Go request executors. ReturnTypes were passed as a combination of the PointerSymbols, collection and package reference e.g `[]i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.DateOnly`, the fix resolves extraction of the data type by only considering the collection symbol and the actual data type