### PR TITLE
bugfix/paste api manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug in the vscode extension where the "Paste API Manifest" button would not be able to parse the manifest.
+
 ## [1.9.0] - 2023-12-07
 
 ### Added

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -37,14 +37,14 @@
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.2" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.3" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.3" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.1" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />
     <PackageReference Include="Microsoft.kiota.Serialization.Multipart" Version="1.1.1" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.11" />
-    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.3-preview" />
+    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />

--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -27,31 +27,31 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.3.0"
+          "Version": "1.7.3"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.6"
+          "Version": "1.3.3"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",
-          "Version": "1.0.1"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Json",
-          "Version": "1.0.8"
+          "Version": "1.1.2"
         },
         {
           "Name": "Microsoft.Kiota.Authentication.Azure",
-          "Version": "1.0.3"
+          "Version": "1.1.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Text",
-          "Version": "1.0.3"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Multipart",
-          "Version": "1.0.0"
+          "Version": "1.1.1"
         }
       ],
       "DependencyInstallCommand": "dotnet add package {0} --version {1}"
@@ -61,35 +61,35 @@
       "Dependencies": [
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-abstractions",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-http-okHttp",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-form",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-json",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-authentication-azure",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-text",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "com.microsoft.kiota:microsoft-kiota-serialization-multipart",
-          "Version": "0.5.0"
+          "Version": "0.11.0"
         },
         {
           "Name": "jakarta.annotation:jakarta.annotation-api",
-          "Version": "2.1.1"
+          "Version": "3.0.0-M1"
         }
       ],
       "DependencyInstallCommand": "{0}:{1}"
@@ -99,11 +99,11 @@
       "Dependencies": [
         {
           "Name": "github.com/microsoft/kiota-abstractions-go",
-          "Version": "v1.2.0"
+          "Version": "v1.5.3"
         },
         {
           "Name": "github.com/microsoft/kiota-http-go",
-          "Version": "v1.0.1"
+          "Version": "v1.1.1"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-form-go",
@@ -115,7 +115,7 @@
         },
         {
           "Name": "github.com/microsoft/kiota-authentication-azure-go",
-          "Version": "v1.0.0"
+          "Version": "v1.0.1"
         },
         {
           "Name": "github.com/microsoft/kiota-serialization-text-go",
@@ -133,31 +133,31 @@
       "Dependencies": [
         {
           "Name": "@microsoft/kiota-abstractions",
-          "Version": "1.0.0-preview.26"
+          "Version": "1.0.0-preview.35"
         },
         {
           "Name": "@microsoft/kiota-http-fetchlibrary",
-          "Version": "1.0.0-preview.25"
+          "Version": "1.0.0-preview.34"
         },
         {
           "Name": "@microsoft/kiota-serialization-form",
-          "Version": "1.0.0-preview.15"
-        },
-        {
-          "Name": "@microsoft/kiota-serialization-json",
           "Version": "1.0.0-preview.24"
         },
         {
+          "Name": "@microsoft/kiota-serialization-json",
+          "Version": "1.0.0-preview.35"
+        },
+        {
           "Name": "@microsoft/kiota-authentication-azure",
-          "Version": "1.0.0-preview.21"
+          "Version": "1.0.0-preview.30"
         },
         {
           "Name": "@microsoft/kiota-serialization-text",
-          "Version": "1.0.0-preview.23"
+          "Version": "1.0.0-preview.32"
         },
         {
           "Name": "@microsoft/kiota-serialization-multipart",
-          "Version": "1.0.0-preview.3"
+          "Version": "1.0.0-preview.14"
         }
       ],
       "DependencyInstallCommand": "npm install {0}@{1} -S"
@@ -167,23 +167,23 @@
       "Dependencies": [
         {
           "Name": "microsoft/kiota-abstractions",
-          "Version": "0.8.1"
+          "Version": "1.0.2"
         },
         {
           "Name": "microsoft/kiota-http-guzzle",
-          "Version": "0.8.2"
+          "Version": "1.1.0"
         },
         {
           "Name": "microsoft/kiota-serialization-json",
-          "Version": "0.6.0"
+          "Version": "1.0.1"
         },
         {
           "Name": "microsoft/kiota-authentication-phpleague",
-          "Version": "0.8.2"
+          "Version": "1.0.1"
         },
         {
           "Name": "microsoft/kiota-serialization-text",
-          "Version": "0.7.0"
+          "Version": "1.0.1"
         }
       ],
       "DependencyInstallCommand": "composer require {0}:{1}"
@@ -193,23 +193,23 @@
       "Dependencies": [
         {
           "Name": "microsoft-kiota-abstractions",
-          "Version": "0.7.0"
+          "Version": "1.0.0"
         },
         {
           "Name": "microsoft-kiota-http",
-          "Version": "0.4.4"
+          "Version": "1.2.0"
         },
         {
           "Name": "microsoft-kiota-serialization-json",
-          "Version": "0.3.7"
+          "Version": "1.0.0"
         },
         {
           "Name": "microsoft-kiota-authentication-azure",
-          "Version": "0.2.0"
+          "Version": "1.0.0"
         },
         {
           "Name": "microsoft-kiota-serialization-text",
-          "Version": "0.2.1"
+          "Version": "1.0.0"
         }
       ],
       "DependencyInstallCommand": "pip install {0}=={1}"
@@ -219,7 +219,7 @@
       "Dependencies": [
         {
           "Name": "microsoft_kiota_abstractions",
-          "Version": "0.14.0"
+          "Version": "0.14.3"
         },
         {
           "Name": "microsoft_kiota_faraday",
@@ -227,7 +227,7 @@
         },
         {
           "Name": "microsoft_kiota_serialization_json",
-          "Version": "0.9.0"
+          "Version": "0.9.1"
         },
         {
           "Name": "microsoft_kiota_authentication_oauth",
@@ -246,31 +246,31 @@
       "Dependencies": [
         {
           "Name": "Microsoft.Kiota.Abstractions",
-          "Version": "1.3.0"
+          "Version": "1.7.3"
         },
         {
           "Name": "Microsoft.Kiota.Http.HttpClientLibrary",
-          "Version": "1.0.6"
+          "Version": "1.3.3"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Form",
-          "Version": "1.0.1"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Json",
-          "Version": "1.0.8"
+          "Version": "1.1.2"
         },
         {
           "Name": "Microsoft.Kiota.Authentication.Azure",
-          "Version": "1.0.3"
+          "Version": "1.1.2"
         },
         {
           "Name": "Microsoft.Kiota.Serialization.Text",
-          "Version": "1.0.3"
+          "Version": "1.1.1"
         },
         {
           "Name": "Microsoft.Kiota.Cli.Commons",
-          "Version": "0.3.1-preview.1"
+          "Version": "1.0.0"
         }
       ],
       "DependencyInstallCommand": "dotnet add package {0} --version {1}"

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.3-preview" />
+    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageReference Include="StreamJsonRpc" Version="2.17.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
+++ b/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
@@ -18,7 +18,7 @@
     </PackageReference>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="moq" Version="4.20.69" />
+    <PackageReference Include="moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/vscode/microsoft-kiota/package.json
+++ b/vscode/microsoft-kiota/package.json
@@ -3,8 +3,8 @@
   "displayName": "Microsoft Kiota",
   "publisher": "ms-graph",
   "description": "Client generator for HTTP REST APIs described by OpenAPI which helps eliminate the need to take a dependency on a different API client for every API that you need to call, as well as limiting the generation to the exact API surface area you're interested in, thanks to a filtering capability.",
-  "version": "1.7.100000001",
-  "kiotaVersion": "1.7.0",
+  "version": "1.9.100000001",
+  "kiotaVersion": "1.9.0",
   "telemetryInstrumentationKey": "4c6357e0-daf9-42b5-bdfb-67878f8957b5",
   "icon": "images/logo.png",
   "engines": {
@@ -27,37 +27,37 @@
       "title": "Kiota",
       "properties": {
         "kiota.generate.includeAdditionalData.enabled": {
-          "type":"boolean",
+          "type": "boolean",
           "default": true,
           "description": "%kiota.generate.includeAdditionalData.description%"
         },
         "kiota.generate.backingStore.enabled": {
-          "type":"boolean",
+          "type": "boolean",
           "default": false,
           "description": "%kiota.generate.backingStore.description%"
         },
         "kiota.generate.excludeBackwardCompatible.enabled": {
-          "type":"boolean",
+          "type": "boolean",
           "default": false,
           "description": "%kiota.generate.excludeBackwardCompatible.description%"
         },
         "kiota.cleanOutput.enabled": {
-          "type":"boolean",
+          "type": "boolean",
           "default": false,
           "description": "%kiota.cleanOutput.description%"
         },
         "kiota.generate.disabledValidationRules": {
-          "type":"array",
+          "type": "array",
           "default": [],
           "description": "%kiota.generate.disabledValidationRules.description%"
         },
         "kiota.clearCache.enabled": {
-          "type":"boolean",
+          "type": "boolean",
           "default": false,
           "description": "%kiota.clearCache.description%"
         },
         "kiota.generate.serializer.CSharp": {
-          "type":"array",
+          "type": "array",
           "default": [
             "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
             "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
@@ -67,7 +67,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.CSharp": {
-          "type":"array",
+          "type": "array",
           "default": [
             "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
             "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
@@ -76,7 +76,7 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.Go": {
-          "type":"array",
+          "type": "array",
           "default": [
             "github.com/microsoft/kiota-serialization-form-go/FormSerializationWriterFactory",
             "github.com/microsoft/kiota-serialization-json-go/JsonSerializationWriterFactory",
@@ -86,7 +86,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.Go": {
-          "type":"array",
+          "type": "array",
           "default": [
             "github.com/microsoft/kiota-serialization-form-go/FormParseNodeFactory",
             "github.com/microsoft/kiota-serialization-json-go/JsonParseNodeFactory",
@@ -95,7 +95,7 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.Java": {
-          "type":"array",
+          "type": "array",
           "default": [
             "com.microsoft.kiota.serialization.FormSerializationWriterFactory",
             "com.microsoft.kiota.serialization.JsonSerializationWriterFactory",
@@ -105,7 +105,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.Java": {
-          "type":"array",
+          "type": "array",
           "default": [
             "com.microsoft.kiota.serialization.TextParseNodeFactory",
             "com.microsoft.kiota.serialization.JsonParseNodeFactory",
@@ -114,7 +114,7 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.PHP": {
-          "type":"array",
+          "type": "array",
           "default": [
             "Microsoft\\Kiota\\Serialization\\Json\\JsonSerializationWriterFactory",
             "Microsoft\\Kiota\\Serialization\\Text\\TextSerializationWriterFactory"
@@ -122,7 +122,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.PHP": {
-          "type":"array",
+          "type": "array",
           "default": [
             "Microsoft\\Kiota\\Serialization\\Json\\JsonParseNodeFactory",
             "Microsoft\\Kiota\\Serialization\\Text\\TextParseNodeFactory"
@@ -130,7 +130,7 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.Python": {
-          "type":"array",
+          "type": "array",
           "default": [
             "kiota_serialization_json.json_serialization_writer_factory.JsonSerializationWriterFactory",
             "kiota_serialization_text.text_serialization_writer_factory.TextSerializationWriterFactory"
@@ -138,7 +138,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.Python": {
-          "type":"array",
+          "type": "array",
           "default": [
             "kiota_serialization_json.json_parse_node_factory.JsonParseNodeFactory",
             "kiota_serialization_text.text_parse_node_factory.TextParseNodeFactory"
@@ -146,21 +146,21 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.Ruby": {
-          "type":"array",
+          "type": "array",
           "default": [
             "microsoft_kiota_serialization/json_serialization_writer_factory"
           ],
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.Ruby": {
-          "type":"array",
+          "type": "array",
           "default": [
             "microsoft_kiota_serialization/json_parse_node_factory"
           ],
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.serializer.TypeScript": {
-          "type":"array",
+          "type": "array",
           "default": [
             "@microsoft/kiota-serialization-form.FormSerializationWriterFactory",
             "@microsoft/kiota-serialization-json.JsonSerializationWriterFactory",
@@ -170,7 +170,7 @@
           "description": "%kiota.generate.serializer.description%"
         },
         "kiota.generate.deserializer.TypeScript": {
-          "type":"array",
+          "type": "array",
           "default": [
             "@microsoft/kiota-serialization-form.FormParseNodeFactory",
             "@microsoft/kiota-serialization-json.JsonParseNodeFactory",
@@ -179,7 +179,7 @@
           "description": "%kiota.generate.deserializer.description%"
         },
         "kiota.generate.structuredMimeTypes": {
-          "type":"array",
+          "type": "array",
           "default": [
             "application/json;q=1",
             "application/x-www-form-urlencoded;q=0.2",
@@ -450,23 +450,23 @@
   "runtimeDependencies": [
     {
       "platformId": "win-x64",
-      "sha256": "F56C6430DBBD480C33D0BC70FFCABFFA7E3384308B9EC12040D21A6E5B7E99A3"
+      "sha256": "16FE8B6E48A23EE00F89697EB34714C57E996EAFB57476C0F5BFD3D473C17A83"
     },
     {
       "platformId": "win-x86",
-      "sha256": "63AEC3490E0C4DAB4EFC8F06C5BF157A21FB9B613AD13F1F337A2E9D872D0FD5"
+      "sha256": "FF0F55CEA4520C6B8EE8308820847C20CE5C1123B9146E943D29BBAF1BF6E8A9"
     },
     {
       "platformId": "linux-x64",
-      "sha256": "E07A9D438E8CBC30C77F1FEB0943DEA1D28F53C3E31E941A3ED7B19F4013CF77"
+      "sha256": "E9A445B61B9A1B2F733FAC2A47E7D0C530241535137BA98EA8AD5514CA1D5350"
     },
     {
       "platformId": "osx-x64",
-      "sha256": "EAF3BE094DA835BD45B5EA0F4C63E12733D973B5EFA31D25170B3866BEA6B6BD"
+      "sha256": "74DCC6F65D7D9FF9AC2DBA3875EFE4CBE38ADB8888D909AA206E3D67872EB8DB"
     },
     {
       "platformId": "osx-arm64",
-      "sha256": "FC74F2A0E7338CD618F9B98838884BC3E6F8FDD79420D7799A51AD0D0780B87E"
+      "sha256": "FE98BDEB3D606016592C41ED4765D089C30F09DAF24CF1DFAC9F5392FFC57980"
     }
   ]
 }

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -47,11 +47,11 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
         }
         return logs;
     }
-    public async loadManifestFromContent(encodedManifest: string, apiIdentifier?: string): Promise<KiotaLogEntry[]> {
+    public async loadManifestFromContent(jsonManifest: string, apiIdentifier?: string): Promise<KiotaLogEntry[]> {
         this.closeDescription(false);
         const manifestFilePath = path.join(os.tmpdir(), "kiota-vscode-extension", Date.now().toString(), "manifest.json");
         fs.mkdirSync(path.parse(manifestFilePath).dir, { recursive: true });
-        await vscode.workspace.fs.writeFile(vscode.Uri.file(manifestFilePath), Buffer.from(encodedManifest, 'base64'));
+        await vscode.workspace.fs.writeFile(vscode.Uri.file(manifestFilePath), Buffer.from(jsonManifest, 'utf8'));
         return await this.loadManifestFromUri(manifestFilePath, apiIdentifier);
     }
     private setAllSelected(node: KiotaOpenApiNode, selected: boolean) {


### PR DESCRIPTION
- - updates kiota version to 1.9.0 in extension
- - updates dependencies versions
- - updates dependencies
- - fixes a bug where the api manifest could not be parsed from the button
