### PR TITLE
- directly downloads descriptions from github instead of apis.guru

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed an issue where domain expiration for apis.guru would lead to search failures.
+
 ## [1.10.0] - 2024-01-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.10.1] - 2024-01-12
+
+### Added
+
+### Changed
+
 - Fixed an issue where domain expiration for apis.guru would lead to search failures.
 
 ## [1.10.0] - 2024-01-11
@@ -1214,4 +1220,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
+
 

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.10.0</VersionPrefix>
+    <VersionPrefix>1.10.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.11.0</VersionPrefix>
+    <VersionPrefix>1.10.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -25,6 +25,7 @@ using Kiota.Builder.Logging;
 using Kiota.Builder.Manifest;
 using Kiota.Builder.OpenApiExtensions;
 using Kiota.Builder.Refiners;
+using Kiota.Builder.SearchProviders.APIsGuru;
 using Kiota.Builder.Validation;
 using Kiota.Builder.Writers;
 using Microsoft.Extensions.Logging;
@@ -411,7 +412,7 @@ public partial class KiotaBuilder
                 {
                     ClearCache = config.ClearCache,
                 };
-                var targetUri = new Uri(inputPath);
+                var targetUri = APIsGuruSearchProvider.ChangeSourceUrlToGitHub(new Uri(inputPath)); // so updating existing clients doesn't break
                 var fileName = targetUri.GetFileName() is string name && !string.IsNullOrEmpty(name) ? name : "description.yml";
                 input = await cachingProvider.GetDocumentAsync(targetUri, "generation", fileName, cancellationToken: cancellationToken).ConfigureAwait(false);
             }

--- a/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
+++ b/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
@@ -57,8 +57,10 @@ public class APIsGuruSearchProvider : ISearchProvider
                                             StringComparer.OrdinalIgnoreCase);
         return results;
     }
-    private static Uri ChangeSourceUrlToGitHub(Uri original) =>
-        new(original.ToString().Replace("https://api.apis.guru", "https://raw.githubusercontent.com/APIs-guru/openapi-directory/gh-pages", StringComparison.OrdinalIgnoreCase), UriKind.Absolute);
+    internal static Uri ChangeSourceUrlToGitHub(Uri original) =>
+        original.Host.StartsWith("api.apis.guru", StringComparison.OrdinalIgnoreCase) ?
+            new(original.ToString().Replace("https://api.apis.guru", "https://raw.githubusercontent.com/APIs-guru/openapi-directory/gh-pages", StringComparison.OrdinalIgnoreCase), UriKind.Absolute) :
+            original;
     private static string GetVersionKey(bool singleCandidate, string? version, KeyValuePair<string, ApiEntry> x) => singleCandidate && !string.IsNullOrEmpty(version) ? version : x.Value.preferred;
 }
 

--- a/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
+++ b/src/Kiota.Builder/SearchProviders/APIsGuru/APIsGuruSearchProvider.cs
@@ -30,7 +30,7 @@ public class APIsGuruSearchProvider : ISearchProvider
     public HashSet<string> KeysToExclude
     {
         get; init;
-    } = new() {
+    } = new(StringComparer.OrdinalIgnoreCase) {
         "microsoft.com:graph"
     };
     public async Task<IDictionary<string, SearchResult>> SearchAsync(string term, string? version, CancellationToken cancellationToken)
@@ -53,10 +53,12 @@ public class APIsGuruSearchProvider : ISearchProvider
                                 .Where(static x => x.versionInfo is not null)
                                 .DistinctBy(static x => x.Key, StringComparer.OrdinalIgnoreCase)
                                 .ToDictionary(static x => x.Key,
-                                            static x => new SearchResult(x.versionInfo!.info?.title ?? string.Empty, x.versionInfo.info?.description ?? string.Empty, x.versionInfo.info?.contact?.url, x.versionInfo.swaggerUrl, x.Item3 ?? Enumerable.Empty<string>().ToList()),
+                                            static x => new SearchResult(x.versionInfo!.info?.title ?? string.Empty, x.versionInfo.info?.description ?? string.Empty, x.versionInfo.info?.contact?.url, ChangeSourceUrlToGitHub(x.versionInfo.swaggerUrl), x.Item3 ?? Enumerable.Empty<string>().ToList()),
                                             StringComparer.OrdinalIgnoreCase);
         return results;
     }
+    private static Uri ChangeSourceUrlToGitHub(Uri original) =>
+        new(original.ToString().Replace("https://api.apis.guru", "https://raw.githubusercontent.com/APIs-guru/openapi-directory/gh-pages", StringComparison.OrdinalIgnoreCase), UriKind.Absolute);
     private static string GetVersionKey(bool singleCandidate, string? version, KeyValuePair<string, ApiEntry> x) => singleCandidate && !string.IsNullOrEmpty(version) ? version : x.Value.preferred;
 }
 

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.10.0</VersionPrefix>
+    <VersionPrefix>1.10.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.11.0</VersionPrefix>
+    <VersionPrefix>1.10.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/tests/Kiota.Builder.Tests/KiotaSearcherTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaSearcherTests.cs
@@ -78,6 +78,10 @@ public sealed class KiotaSearcherTests : IDisposable
         var searcher = new KiotaSearcher(new Mock<ILogger<KiotaSearcher>>().Object, searchConfiguration, httpClient, null, null);
         var results = await searcher.SearchAsync("apisguru::github.com:api.github.com.2022-11-28", string.Empty, new CancellationToken());
         Assert.Single(results);
+        var result = results.First();
+        var resultUrl = result.Value.DescriptionUrl;
+        var bytes = await httpClient.GetByteArrayAsync(resultUrl);
+        Assert.NotEmpty(bytes);
     }
     public void Dispose()
     {


### PR DESCRIPTION
patch to avoid relying on the apis.guru domain name because of its expiration https://github.com/APIs-guru/openapi-directory/issues/1219