### PR TITLE
VS Code extension: show children nodes when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched to proxy generation for TypeScript, leading to about ~44% bundle sizes reduction. [#3642](https://github.com/microsoft/kiota/issues/3642)
 - Fixed a bug where TypeScript models factory methods would be missing return types.
 - Fixed a bug where generated paths would possibly get too long. [#3854](https://github.com/microsoft/kiota/issues/3854)
+- The vscode extension now also displays the children nodes when filtering. [#3998](https://github.com/microsoft/kiota/issues/3998)
 
 ## [1.10.1] - 2024-01-12
 

--- a/vscode/microsoft-kiota/package-lock.json
+++ b/vscode/microsoft-kiota/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiota",
-  "version": "1.9.100000001",
+  "version": "1.10.100000002",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiota",
-      "version": "1.9.100000001",
+      "version": "1.10.100000002",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.2",
         "@vscode/l10n": "^0.0.18",

--- a/vscode/microsoft-kiota/package.json
+++ b/vscode/microsoft-kiota/package.json
@@ -3,8 +3,8 @@
   "displayName": "Microsoft Kiota",
   "publisher": "ms-graph",
   "description": "Client generator for HTTP REST APIs described by OpenAPI which helps eliminate the need to take a dependency on a different API client for every API that you need to call, as well as limiting the generation to the exact API surface area you're interested in, thanks to a filtering capability.",
-  "version": "1.9.100000001",
-  "kiotaVersion": "1.9.0",
+  "version": "1.10.100000002",
+  "kiotaVersion": "1.10.1",
   "telemetryInstrumentationKey": "4c6357e0-daf9-42b5-bdfb-67878f8957b5",
   "icon": "images/logo.png",
   "engines": {
@@ -450,23 +450,23 @@
   "runtimeDependencies": [
     {
       "platformId": "win-x64",
-      "sha256": "16FE8B6E48A23EE00F89697EB34714C57E996EAFB57476C0F5BFD3D473C17A83"
+      "sha256": "F14DA204DBB513B12995C006DD4A356C8498EFF087BA77EE84E06C18AE92A947"
     },
     {
       "platformId": "win-x86",
-      "sha256": "FF0F55CEA4520C6B8EE8308820847C20CE5C1123B9146E943D29BBAF1BF6E8A9"
+      "sha256": "1E55DDEBC4EC8AC8B527C7681FD342A2CFB74150914DD1E9669B84DAF26E18D5"
     },
     {
       "platformId": "linux-x64",
-      "sha256": "E9A445B61B9A1B2F733FAC2A47E7D0C530241535137BA98EA8AD5514CA1D5350"
+      "sha256": "311F765AEC73477501B1C6EA97C0EAF108144318CB1C7C39D20B3CEE4C5DF848"
     },
     {
       "platformId": "osx-x64",
-      "sha256": "74DCC6F65D7D9FF9AC2DBA3875EFE4CBE38ADB8888D909AA206E3D67872EB8DB"
+      "sha256": "82843F91BEC078C9344BAFFE7D8B7FB87BDAD7160329AF221BCEBA2C10DD0B50"
     },
     {
       "platformId": "osx-arm64",
-      "sha256": "FE98BDEB3D606016592C41ED4765D089C30F09DAF24CF1DFAC9F5392FFC57980"
+      "sha256": "FD8EE5E60432E2885B4DE0E650D92829EE5EA4D20C50E7CB7D3E7B2FCDCDCB9B"
     }
   ]
 }

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -215,18 +215,11 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
         }
     }
     getCollapsedState(node: KiotaOpenApiNode): vscode.TreeItemCollapsibleState {
-        const hasChildren = node.children.length > 0;
-        if (!hasChildren) {
-            return vscode.TreeItemCollapsibleState.None;
-        }
-        if (this.tokenizedFilter.length === 0) {
-            return vscode.TreeItemCollapsibleState.Expanded;
-        }
-
-        if (this.tokenizedFilter.some(x => node.children.some(c => c.segment.includes(x) || this.getCollapsedState(c) === vscode.TreeItemCollapsibleState.Expanded))) {
-            return vscode.TreeItemCollapsibleState.Expanded;
-        }
-        return vscode.TreeItemCollapsibleState.Collapsed;
+        return node.children.length === 0 ?
+                vscode.TreeItemCollapsibleState.None :
+                (this.tokenizedFilter.length === 0 ?
+                    vscode.TreeItemCollapsibleState.Collapsed : 
+                    vscode.TreeItemCollapsibleState.Expanded);
     }
     getTreeNodeFromKiotaNode(node: KiotaOpenApiNode, collapsibleStateOverride: vscode.TreeItemCollapsibleState | undefined = undefined): OpenApiTreeNode {
         return new OpenApiTreeNode(

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -278,20 +278,15 @@ export class OpenApiTreeNode extends vscode.TreeItem {
         const lowerCaseSegment = this.label.toLowerCase();
         const splatPath = trimOperation(this.path);
         if (tokenizedFilter.some(x => lowerCaseSegment.includes(x.toLowerCase()))) {
-            if (this.isOperation &&tokenizedFilter.some(x => operationsNames.has(x)) && !tokenizedFilter.some(x => splatPath.includes(x))) {
+            if (this.isOperation && tokenizedFilter.some(x => operationsNames.has(x)) && !tokenizedFilter.some(x => splatPath.includes(x))) {
                 return false;
             }
             return true;
         }
-        
-        if (this.isOperation) {
-            const segments = getPathSegments(splatPath);
-            if (segments.length === 0) {
-                return false;
-            }
-            const parentSegment = segments[segments.length - 1].toLowerCase();
-            return tokenizedFilter.some(x => parentSegment.includes(x));
-        }
-        return this.children.some(x => x.isNodeVisible(tokenizedFilter));
+
+        const segments = getPathSegments(splatPath);
+
+        return tokenizedFilter.some(x => segments.some(s => s.includes(x)))
+            || this.children.some(x => x.isNodeVisible(tokenizedFilter));
     }
 }

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -228,12 +228,12 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
         }
         return vscode.TreeItemCollapsibleState.Collapsed;
     }
-    getTreeNodeFromKiotaNode(node: KiotaOpenApiNode): OpenApiTreeNode {
+    getTreeNodeFromKiotaNode(node: KiotaOpenApiNode, collapsibleStateOverride: vscode.TreeItemCollapsibleState | undefined = undefined): OpenApiTreeNode {
         return new OpenApiTreeNode(
-            node.path, 
+            node.path,
             node.segment === pathSeparator && this.apiTitle ? pathSeparator + " (" + this.apiTitle + ")" : node.segment,
             node.selected ?? false,
-            this.getCollapsedState(node),
+            collapsibleStateOverride ?? this.getCollapsedState(node),
             node.isOperation ?? false,
             node.children.map(x => this.getTreeNodeFromKiotaNode(x)),
             node.documentationUrl
@@ -246,8 +246,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
         if (element) {
             return element.children.filter(x => x.isNodeVisible(this.tokenizedFilter));
         } else {
-            const result = this.getTreeNodeFromKiotaNode(this.rawRootNode);
-            result.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+            const result = this.getTreeNodeFromKiotaNode(this.rawRootNode, vscode.TreeItemCollapsibleState.Expanded);
             return [result];
         }
     }
@@ -269,7 +268,7 @@ export class OpenApiTreeNode extends vscode.TreeItem {
         public readonly path: string,
         public readonly label: string,
         selected: boolean,
-        public collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         private readonly isOperation: boolean,
         public readonly children: OpenApiTreeNode[] = [],
         public readonly documentationUrl?: string,

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -170,7 +170,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
         if (!this.rawRootNode) {
             return;
         }
-        this.tokenizedFilter = filterText.length === 0 ? [] : filterText.split(' ').filter(x => x !== '').map(x => x.trim().toLowerCase());
+        this.tokenizedFilter = filterText.length === 0 ? [] : filterText.split(' ').filter(x => x !== '').map(x => x.trim().toLowerCase()).sort();
         this.refreshView();
     }
     public get filter(): string {
@@ -228,6 +228,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
             node.selected ?? false,
             collapsibleStateOverride ?? this.getCollapsedState(node),
             node.isOperation ?? false,
+            this.tokenizedFilter,
             node.children.map(x => this.getTreeNodeFromKiotaNode(x)),
             node.documentationUrl
         );
@@ -263,10 +264,12 @@ export class OpenApiTreeNode extends vscode.TreeItem {
         selected: boolean,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         private readonly isOperation: boolean,
+        filterTokens: string[],
         public readonly children: OpenApiTreeNode[] = [],
         public readonly documentationUrl?: string,
     ) {
         super(label, collapsibleState);
+        this.id = `${path}_${filterTokens.join('_')}`; // so the collapsed state is NOT persisted between filter changes
         this.contextValue = documentationUrl;
         this.iconPath = selected ? OpenApiTreeNode.selectedSet : OpenApiTreeNode.unselectedSet;
     }

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -239,7 +239,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
             node.documentationUrl
         );
     }
-    getChildren(element?: OpenApiTreeNode): OpenApiTreeNode[] {
+    getChildren(element?: OpenApiTreeNode): vscode.ProviderResult<OpenApiTreeNode[]> {
         if (!this.rawRootNode) {
             return [];
         }


### PR DESCRIPTION
Fixes #3998.

When filtering, it shows all children nodes, but the filtering target is collapsed.

Visibility works really well IMO, but there is some problem with collapsing nodes - it works overall, but not straight away. 🤷 I'm confused. :(

![kiota-vscode-filtering-v1](https://github.com/microsoft/kiota/assets/26791344/16a0f6b9-a5e9-4ad6-9d71-9e8ee2c77d11)
