### PR TITLE
Fixes integration tests on `https://developers.pipedrive.com/docs/api/v1/openapi.yaml`

### DIFF
--- a/it/config.json
+++ b/it/config.json
@@ -130,6 +130,10 @@
       {
         "Pattern": "/permissionSets/**",
         "Rationale": "error 404 is invalid"
+      },
+      {
+        "Pattern": "/oauth/token/",
+        "Rationale": "Duplicate path exists in the spec without the trailing '/'"
       }
     ],
     "Suppressions": [

--- a/it/generate-code.ps1
+++ b/it/generate-code.ps1
@@ -50,7 +50,16 @@ elseif ($descriptionUrl.StartsWith("http")) {
     Invoke-WebRequest -Uri $descriptionUrl -OutFile $targetOpenapiPath
 }
 else {
-    Start-Process "$kiotaExec" -ArgumentList "download ${descriptionUrl} --clean-output --output $targetOpenapiPath" -Wait -NoNewWindow    
+    $downloadProcess = Start-Process "$kiotaExec" -ArgumentList "download ${descriptionUrl} --clean-output --output $targetOpenapiPath" -Wait -NoNewWindow -PassThru
+    if ($downloadProcess.ExitCode -ne 0) {
+        Write-Error "Failed to download the openapi description"
+        exit 1
+    }
 }
 
-Start-Process "$kiotaExec" -ArgumentList "generate --exclude-backward-compatible --clean-output --language ${language} --openapi ${targetOpenapiPath}${additionalArguments}" -Wait -NoNewWindow
+$generationProcess = Start-Process "$kiotaExec" -ArgumentList "generate --exclude-backward-compatible --clean-output --language ${language} --openapi ${targetOpenapiPath}${additionalArguments}" -Wait -NoNewWindow -PassThru
+
+if ($generationProcess.ExitCode -ne 0) {
+    Write-Error "Failed to generate the code for ${language}"
+    exit 1
+}

--- a/it/get-additional-arguments.ps1
+++ b/it/get-additional-arguments.ps1
@@ -2,7 +2,8 @@
 
 param(
     [Parameter(Mandatory = $true)][string]$descriptionUrl,
-    [Parameter(Mandatory = $true)][string]$language
+    [Parameter(Mandatory = $true)][string]$language,
+    [Parameter(Mandatory = $false)][string]$includeOutputParameter = $true
 )
 
 if ([string]::IsNullOrEmpty($descriptionUrl)) {
@@ -36,6 +37,10 @@ elseif ($language -eq "php") {
 }
 elseif ($language -eq "python") {
     $command = " --output `"./it/$language/integration_test/client`" --namespace-name `"integration_test.client`""
+}
+
+if ($includeOutputParameter -eq $false) {
+    $command = "" # no output parameter to generate
 }
 
 $configPath = Join-Path -Path $PSScriptRoot -ChildPath "config.json"

--- a/it/typescript/src/app/app.ts
+++ b/it/typescript/src/app/app.ts
@@ -3,7 +3,7 @@ import { Logger } from './common/logger';
 import { DeviceCodeCredential } from '@azure/identity';
 import { FetchRequestAdapter } from '@microsoft/kiota-http-fetchlibrary';
 import { AzureIdentityAuthenticationProvider } from '@microsoft/kiota-authentication-azure';
-import { ApiClient } from './client/apiClient';
+import { type ApiClient } from './client/apiClient';
 
 export class App {
   static run(): App {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/kiota/issues/4028

Changes include :
- Ensures the status code of a task is read and validated when executing the integration tests to prevent false positives. 
- Adds exclude pattern for tests on `https://developers.pipedrive.com/docs/api/v1/openapi.yaml`  due to ambiguous paths causing tests failure.
- Ensures exclude pattern parameters used in integration tests are also used in idempotency tests to ensure they build as well.
- Updates typescript `app.ts` imports to prevent build error after changes in https://github.com/microsoft/kiota/pull/3938 changed the client from a class to interface. 