### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
+++ b/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
@@ -39,8 +39,7 @@ public class DocumentCachingProvider
     {
         var hashedUrl = BitConverter.ToString((HashAlgorithm.Value ?? throw new InvalidOperationException("unable to get hash algorithm")).ComputeHash(Encoding.UTF8.GetBytes(documentUri.ToString()))).Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase);
         var target = Path.Combine(Path.GetTempPath(), Constants.TempDirectoryName, "cache", intermediateFolderName, hashedUrl, fileName);
-        var currentLock = _locks.GetOrAdd(target, _ => new AsyncNonKeyedLocker());
-        using (await currentLock.LockAsync(token).ConfigureAwait(false))
+        using (await _locks.LockAsync(target, token).ConfigureAwait(false))
         {// if multiple clients are being updated for the same description, we'll have concurrent download of the file without the lock
             if (!File.Exists(target) || couldNotDelete)
                 return await DownloadDocumentFromSourceAsync(documentUri, target, accept, token).ConfigureAwait(false);

--- a/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
+++ b/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
@@ -67,7 +67,7 @@ public class DocumentCachingProvider
             return await GetDocumentInternalAsync(documentUri, intermediateFolderName, fileName, couldNotDelete, accept, token).ConfigureAwait(false);
         }
     }
-    private static readonly ConcurrentDictionary<string, AsyncNonKeyedLocker> _locks = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly AsyncKeyedLocker<string> _locks = new();
     private async Task<Stream> DownloadDocumentFromSourceAsync(Uri documentUri, string target, string? accept, CancellationToken token)
     {
         Logger.LogDebug("cache file {CacheFile} not found, downloading from {Url}", target, documentUri);

--- a/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
+++ b/src/Kiota.Builder/Caching/DocumentCachingProvider.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using AsyncKeyedLock;
+using Microsoft.Extensions.Logging;
 
 namespace Kiota.Builder.Caching;
 
@@ -66,7 +65,11 @@ public class DocumentCachingProvider
             return await GetDocumentInternalAsync(documentUri, intermediateFolderName, fileName, couldNotDelete, accept, token).ConfigureAwait(false);
         }
     }
-    private static readonly AsyncKeyedLocker<string> _locks = new();
+    private static readonly AsyncKeyedLocker<string> _locks = new(o =>
+    {
+        o.PoolSize = 20;
+        o.PoolInitialFill = 1;
+    });
     private async Task<Stream> DownloadDocumentFromSourceAsync(Uri documentUri, string target, string? accept, CancellationToken token)
     {
         Logger.LogDebug("cache file {CacheFile} not found, downloading from {Url}", target, documentUri);

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -35,6 +35,7 @@
     <NoWarn>$(NoWarn);CS8785;NU5048;NU5104;CA1724;CA1055;CA1848;CA1308;CA1822</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.5" />
@@ -47,7 +48,6 @@
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.12" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
     <PackageReference Include="YamlDotNet" Version="15.1.0" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144