### PR TITLE
Fix Wrong mantis for bitwise/flaggable enums in G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fixed mantis for bitwise enums in Go. [#3936](https://github.com/microsoft/kiota/issues/3936)
 
 ## [1.11.1] - 2024-02-05
 

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -594,6 +594,7 @@ public class GoRefiner : CommonLanguageRefiner
             "github.com/microsoft/kiota-abstractions-go/store", "BackingStoreFactory"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator) && method.Parameters.Any(static y => y.IsOfKind(CodeParameterKind.RequestBody) && y.Type.Name.Equals(MultipartBodyClassName, StringComparison.OrdinalIgnoreCase)),
             AbstractionsNamespaceName, MultipartBodyClassName),
+        new (static x => x is CodeEnum @enum && @enum.Flags,"", "math"),
     };
     private const string MultipartBodyClassName = "MultipartBody";
     private const string AbstractionsNamespaceName = "github.com/microsoft/kiota-abstractions-go";

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -29,7 +29,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
                         "const (");
         writer.IncreaseIndent();
         var isMultiValue = codeElement.Flags;
-        
+
         var enumOptions = codeElement.Options;
         int power = 0;
         foreach (var item in enumOptions)

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -29,8 +29,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
                         "const (");
         writer.IncreaseIndent();
         var isMultiValue = codeElement.Flags;
-
-        var iotaSuffix = $" {typeName} = iota";
+        
         var enumOptions = codeElement.Options;
         int power = 0;
         foreach (var item in enumOptions)
@@ -41,10 +40,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
             if (isMultiValue)
                 writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()} = {(int)Math.Pow(2, power)}");
             else
-                writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}{iotaSuffix}");
-
-            if (!string.IsNullOrEmpty(iotaSuffix))
-                iotaSuffix = string.Empty;
+                writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}{(power == 0 ? $" {typeName} = iota" : string.Empty)}");
 
             power++;
         }

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -29,7 +29,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
                         "const (");
         writer.IncreaseIndent();
         var isMultiValue = codeElement.Flags;
-        
+
         var iotaSuffix = $" {typeName} = iota";
         var enumOptions = codeElement.Options;
         int power = 0;
@@ -37,12 +37,12 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
         {
             if (!string.IsNullOrEmpty(item.Documentation.Description))
                 writer.WriteLine($"// {item.Documentation.Description}");
-            
+
             if (isMultiValue)
                 writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()} = {(int)Math.Pow(2, power)}");
-            else 
+            else
                 writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}{iotaSuffix}");
-            
+
             if (!string.IsNullOrEmpty(iotaSuffix))
                 iotaSuffix = string.Empty;
 
@@ -70,7 +70,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
                 .Select(x => $"\"{x.WireName}\"")
                 .Aggregate((x, y) => x + ", " + y);
             writer.WriteLine($"options := []string{{{literalOptions}}}");
-            writer.StartBlock($"for p := 0; p < { enumOptions.Count }; p++ {{");
+            writer.StartBlock($"for p := 0; p < {enumOptions.Count}; p++ {{");
             writer.WriteLine($"mantis := {typeName}(int(math.Pow(2, float64(p))))");
             writer.StartBlock($"if i&mantis == mantis {{");
             writer.WriteLine($"values = append(values, options[p])");

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -70,18 +70,22 @@ public sealed class CodeEnumWriterTests : IDisposable
             Flags = true
         }).First();
         const string optionName = "option1";
-        myEnum.AddOption(new CodeEnumOption { Name = optionName });
+        myEnum.AddOption(new CodeEnumOption { Name = optionName }, new CodeEnumOption { Name = "option2" }, new CodeEnumOption { Name = "option3" });
         writer.Write(myEnum);
 
         var result = tw.ToString();
         Assert.Contains($"type MultiValueEnum int", result);
         Assert.Contains("const (", result);
-        Assert.Contains("OPTION1_MULTIVALUEENUM MultiValueEnum = iota", result);
+        Assert.Contains("OPTION1_MULTIVALUEENUM = 1", result);
+        Assert.Contains("OPTION2_MULTIVALUEENUM = 2", result);
+        Assert.Contains("OPTION3_MULTIVALUEENUM = 4", result);
         Assert.Contains("func (i", result);
         Assert.Contains("String() string {", result);
-        Assert.Contains("for p := MultiValueEnum(1); p <= OPTION1_MULTIVALUEENUM; p <<= 1 {", result);
-        Assert.Contains("if i&p == p {", result);
-        Assert.Contains("values = append(values, []string{\"option1\"}[p])", result);
+        Assert.Contains("options := []string{\"option1\", \"option2\", \"option3\"}", result);
+        Assert.Contains("for p := 0; p < 3; p++ {", result);
+        Assert.Contains("mantis := MultiValueEnum(int(math.Pow(2, float64(p))))", result);
+        Assert.Contains("if i&mantis == mantis {", result);
+        Assert.Contains("values = append(values, options[p])", result);
         Assert.Contains("for _, str := range values {", result);
         Assert.Contains("strings.Join(values", result);
         Assert.Contains("result |= OPTION1_MULTIVALUEENUM", result);


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/3936
Fixes https://github.com/microsoftgraph/msgraph-beta-sdk-go/issues/366

Resolves issue with left shift algorithm used in String() operation to assign a value to a multi value enum

Example output

```go
// Supported platform types.
type DeviceManagementConfigurationPlatforms int

// enum values for multi values are base 2
const (
	// Default. No platform type specified.
	NONE_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 1
	// Settings for Android platform.
	ANDROID_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 2
	// Settings for iOS platform.
	IOS_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 4
	// Settings for MacOS platform.
	MACOS_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 8
	// Windows 10 X.
	WINDOWS10X_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 16
	// Settings for Windows 10 platform.
	WINDOWS10_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 32
	// Settings for Linux platform.
	LINUX_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 64
	// Evolvable enumeration sentinel value. Do not use.
	UNKNOWNFUTUREVALUE_DEVICEMANAGEMENTCONFIGURATIONPLATFORMS = 128
)


func (i DeviceManagementConfigurationPlatforms) String() string {
	var values []string
	options := []string{"none", "android", "iOS", "macOS", "windows10X", "windows10", "linux", "unknownFutureValue"}
	for p := 0; p < 8; p++ {
		mantis := DeviceManagementConfigurationPlatforms(int(math.Pow(2, float64(p))))
		if i&mantis == mantis {
			values = append(values, options[p])
		}
	}
	return strings.Join(values, ",")
}

```