### PR TITLE
Fixes unclosed documentation tags in dotnet 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed return doc comments for Go/Java/CSharp/TypeScript.
 - Fixed type names in doc comments and deprecation noticed across languages.
 - Added thrown exceptions in doc comments for Go/CSharp/Java/TypeScript. [#3811](https://github.com/microsoft/kiota/issues/3811)
+- Fixed `cref` tags not closed in doc comments in CSharp generation.
 - Deduplicates 4XX and 5XX error mappings when they map to the same type to reduce emitted code. [#4025](https://github.com/microsoft/kiota/issues/4025)
 - 📢📢📢 Java generation is now stable! 🚀🚀🚀 special thanks to @andreaTP (Red Hat) for all the help.
 

--- a/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
@@ -14,7 +14,7 @@ public class CodeIndexerWriter : BaseElementWriter<CodeIndexer, CSharpConvention
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
         conventions.WriteShortDescription(codeElement, writer);//TODO make the parameter name dynamic in v2
         conventions.WriteShortDescription(codeElement.IndexParameter, writer, $"<param name=\"position\">", "</param>");
-        conventions.WriteAdditionalDescriptionItem($"<returns>A <see cref=\"{conventions.GetTypeString(codeElement.ReturnType, codeElement)}\"/></returns>", writer);
+        conventions.WriteAdditionalDescriptionItem($"<returns>A {conventions.GetTypeStringForDocumentation(codeElement.ReturnType, codeElement)}</returns>", writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
         writer.StartBlock($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position] {{ get {{");
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProp)

--- a/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
@@ -14,7 +14,7 @@ public class CodeIndexerWriter : BaseElementWriter<CodeIndexer, CSharpConvention
         var returnType = conventions.GetTypeString(codeElement.ReturnType, codeElement);
         conventions.WriteShortDescription(codeElement, writer);//TODO make the parameter name dynamic in v2
         conventions.WriteShortDescription(codeElement.IndexParameter, writer, $"<param name=\"position\">", "</param>");
-        conventions.WriteAdditionalDescriptionItem($"<returns>A <cref=\"{conventions.GetTypeString(codeElement.ReturnType, codeElement)}\"></returns>", writer);
+        conventions.WriteAdditionalDescriptionItem($"<returns>A <see cref=\"{conventions.GetTypeString(codeElement.ReturnType, codeElement)}\"/></returns>", writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
         writer.StartBlock($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position] {{ get {{");
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProp)

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -544,7 +544,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
     {
         conventions.WriteLongDescription(code, writer);
         if (!"void".Equals(code.ReturnType.Name, StringComparison.OrdinalIgnoreCase) && code.Kind is not CodeMethodKind.ClientConstructor or CodeMethodKind.Constructor)
-            conventions.WriteAdditionalDescriptionItem($"<returns>A <see cref=\"{conventions.GetTypeString(code.ReturnType, code)}\"/></returns>", writer);
+            conventions.WriteAdditionalDescriptionItem($"<returns>A {conventions.GetTypeStringForDocumentation(code.ReturnType, code)}</returns>", writer);
         foreach (var paramWithDescription in code.Parameters
                                                 .Where(static x => x.Documentation.DescriptionAvailable)
                                                 .OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase))

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -544,7 +544,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
     {
         conventions.WriteLongDescription(code, writer);
         if (!"void".Equals(code.ReturnType.Name, StringComparison.OrdinalIgnoreCase) && code.Kind is not CodeMethodKind.ClientConstructor or CodeMethodKind.Constructor)
-            conventions.WriteAdditionalDescriptionItem($"<returns>A <cref=\"{conventions.GetTypeString(code.ReturnType, code)}\"></returns>", writer);
+            conventions.WriteAdditionalDescriptionItem($"<returns>A <see cref=\"{conventions.GetTypeString(code.ReturnType, code)}\"/></returns>", writer);
         foreach (var paramWithDescription in code.Parameters
                                                 .Where(static x => x.Documentation.DescriptionAvailable)
                                                 .OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase))


### PR DESCRIPTION
Some cref tags are not closed when doc comments are generated generating warnings in the code. See example logs [here](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=135049&view=logs&j=0c914960-8b50-5299-c9aa-dd3c9595168e&t=3b0ef9b7-0b0d-5874-6c1c-de7c5a8ae365)

In summary this PR centralizes the generation of type string for generation for documentation to 
- remove nullable markers for primitives
- ensure closing tag is present

Samples validated at https://github.com/microsoft/kiota-samples/pull/5049