### PR TITLE
Fix a Java Mock Server test result

### DIFF
--- a/it/java/query-params/src/test/java/BasicAPITest.java
+++ b/it/java/query-params/src/test/java/BasicAPITest.java
@@ -46,7 +46,7 @@ public class BasicAPITest {
         });
         reqInf.pathParameters.put("baseurl", "http://test");
 
-        assertEquals("http://test/api/something/v1?startDateTime=START&EndDateTime=END", reqInf.getUri().toString());
+        assertEquals("http://test/api/something/v1?EndDateTime=END&startDateTime=START", reqInf.getUri().toString());
     }
 
 }


### PR DESCRIPTION
I noticed the failure in #4197 and could reproduce it locally, it doesn't seem like a regression, just a different encoding leading to a different result.