### PR TITLE
- passes the token to the release step so it doesn't get throttled

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build_extension:
     runs-on: ubuntu-latest
@@ -20,6 +23,7 @@ jobs:
           owner: microsoft
           repo: kiota
           excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: scripts/update-vscode-releases.ps1 -version "${{ steps.last_release.outputs.release }}" -filePath "./vscode/microsoft-kiota/package.json" -online
         shell: pwsh
       - name: Install dependencies


### PR DESCRIPTION
we're seeing more and more of those issues creep up. This is because the workflow is currently  querying the API anonymously which has low throttling limits. https://github.com/microsoft/kiota/actions/runs/8019333735/job/21906993966#step:4:7