### PR TITLE
remove async suffix for request adapter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- BREAKING - Removed the async suffix from request adapter methods in TypeScript. [microsoft/kiota-typescript#992](https://github.com/microsoft/kiota-typescript/issues/992)
 - Fixed mantis for bitwise enums in Go. [#3936](https://github.com/microsoft/kiota/issues/3936)
 - Keyword in enum names for go should not be escaped. [#2877](https://github.com/microsoft/kiota/issues/2877)
 - Generator method code reduction in Python. [#3695](https://github.com/microsoft/kiota/issues/3695)

--- a/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
@@ -188,15 +188,15 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
     }
     private string GetSendRequestMethodName(bool isVoid, bool isStream, bool isCollection, string returnType)
     {
-        if (isVoid) return "sendNoResponseContentAsync";
+        if (isVoid) return "sendNoResponseContent";
         if (isCollection)
         {
-            if (conventions.IsPrimitiveType(returnType)) return $"sendCollectionOfPrimitiveAsync";
-            return $"sendCollectionAsync";
+            if (conventions.IsPrimitiveType(returnType)) return $"sendCollectionOfPrimitive";
+            return $"sendCollection";
         }
 
-        if (isStream || conventions.IsPrimitiveType(returnType)) return $"sendPrimitiveAsync";
-        return $"sendAsync";
+        if (isStream || conventions.IsPrimitiveType(returnType)) return $"sendPrimitive";
+        return $"send";
     }
 
     private void WriteUriTemplateConstant(CodeConstant codeElement, LanguageWriter writer)

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
@@ -183,7 +183,7 @@ public sealed class CodeConstantWriterTests : IDisposable
         });
         writer.Write(constant);
         var result = tw.ToString();
-        Assert.Contains("sendCollectionAsync", result);
+        Assert.Contains("sendCollection", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Fixes:https://github.com/microsoft/kiota-typescript/issues/992