### PR TITLE
Cleanup integration tests

### DIFF
--- a/it/config.json
+++ b/it/config.json
@@ -71,10 +71,22 @@
     ]
   },
   "./tests/Kiota.Builder.IntegrationTests/GeneratesUritemplateHints.yaml": {
-    "MockServerITFolder": "query-params"
+    "MockServerITFolder": "query-params",
+    "Suppressions": [
+      {
+        "Language": "ruby",
+        "Rationale": "https://github.com/microsoft/kiota/issues/4262"
+      }
+    ]
   },
   "apisguru::github.com:api.github.com": {
-    "MockServerITFolder": "gh"
+    "MockServerITFolder": "gh",
+    "Suppressions": [
+      {
+        "Language": "all",
+        "Rationale": "https://github.com/microsoft/kiota/issues/4241"
+      }
+    ]
   },
   "apisguru::notion.com": {
     "ExcludePatterns": [


### PR DESCRIPTION
Suppresses intergration tests for 
- Ruby - GeneratesUritemplateHints.yaml - Tracked via https://github.com/microsoft/kiota/issues/4262
- All languages - apisguru::github.com:api.github.com - Tracked by https://github.com/microsoft/kiota/issues/4241 