### PR TITLE
Suggest save-exact for npm dependencies

### DIFF
--- a/src/kiota/appsettings.json
+++ b/src/kiota/appsettings.json
@@ -160,7 +160,7 @@
           "Version": "1.0.0-preview.14"
         }
       ],
-      "DependencyInstallCommand": "npm install {0}@{1} -S"
+      "DependencyInstallCommand": "npm install {0}@{1} -SE"
     },
     "PHP": {
       "MaturityLevel": "Stable",


### PR DESCRIPTION
Added the `exact` switch when suggesting dependency installs for npm under the TypeScript mode.

PR as suggested in: https://github.com/microsoft/kiota-typescript/issues/1075