### PR TITLE
Put braces on new line in CSharp generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed Csharp code generation to put braces on new lines (where it makes sense). [#4347](https://github.com/microsoft/kiota/issues/4347)
+
 ## [1.12.0] - 2024-03-06
 
 ### Added

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -37,6 +37,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         var derivation = derivedTypes.Length != 0 ? ": " + derivedTypes.Aggregate(static (x, y) => $"{x}, {y}") + " " : string.Empty;
         conventions.WriteLongDescription(parentClass, writer);
         conventions.WriteDeprecationAttribute(parentClass, writer);
-        writer.StartBlock($"public class {codeElement.Name.ToFirstCharacterUpperCase()} {derivation}{{");
+        writer.WriteLine($"public class {codeElement.Name.ToFirstCharacterUpperCase()} {derivation}");
+        writer.StartBlock();
     }
 }

--- a/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
@@ -33,7 +33,8 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, CSharpConventionServic
         if (codeElement.Flags)
             writer.WriteLine("[Flags]");
         conventions.WriteDeprecationAttribute(codeElement, writer);
-        writer.StartBlock($"public enum {codeElement.Name.ToFirstCharacterUpperCase()} {{");
+        writer.WriteLine($"public enum {codeElement.Name.ToFirstCharacterUpperCase()}");
+        writer.StartBlock();
         var idx = 0;
         foreach (var option in codeElement.Options)
         {

--- a/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeIndexerWriter.cs
@@ -16,10 +16,14 @@ public class CodeIndexerWriter : BaseElementWriter<CodeIndexer, CSharpConvention
         conventions.WriteShortDescription(codeElement.IndexParameter, writer, $"<param name=\"position\">", "</param>");
         conventions.WriteAdditionalDescriptionItem($"<returns>A {conventions.GetTypeStringForDocumentation(codeElement.ReturnType, codeElement)}</returns>", writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
-        writer.StartBlock($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position] {{ get {{");
+        writer.WriteLine($"public {returnType} this[{conventions.GetTypeString(codeElement.IndexParameter.Type, codeElement)} position]");
+        writer.StartBlock();
+        writer.WriteLine("get");
+        writer.StartBlock();
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProp)
             conventions.AddParametersAssignment(writer, pathParametersProp.Type, pathParametersProp.Name.ToFirstCharacterUpperCase(), string.Empty, (codeElement.IndexParameter.Type, codeElement.IndexParameter.SerializationName, "position"));
         conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName, "return ");
-        writer.CloseBlock("} }");
+        writer.CloseBlock();
+        writer.CloseBlock();
     }
 }

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -41,11 +41,11 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
         switch (codeElement.Kind)
         {
             case CodePropertyKind.RequestBuilder:
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get =>");
-                writer.IncreaseIndent();
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()}");
+                writer.StartBlock();
+                writer.Write("get => ");
                 conventions.AddRequestBuilderBody(parentClass, propertyType, writer);
-                writer.DecreaseIndent();
-                writer.WriteLine("}");
+                writer.CloseBlock();
                 break;
             case CodePropertyKind.AdditionalData when backingStoreProperty != null:
             case CodePropertyKind.Custom when backingStoreProperty != null:

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -560,7 +560,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
-        Assert.DoesNotContain("return mappingValue switch {", result);
+        Assert.DoesNotContain("return mappingValue switch", result);
         Assert.Contains("var result = new UnionTypeWrapper()", result);
         Assert.Contains("if(\"#kiota.complexType1\".Equals(mappingValue, StringComparison.OrdinalIgnoreCase))", result);
         Assert.Contains("ComplexType1Value = new ComplexType1()", result);
@@ -600,7 +600,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.DoesNotContain("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
-        Assert.DoesNotContain("return mappingValue switch {", result);
+        Assert.DoesNotContain("return mappingValue switch", result);
         Assert.Contains("var result = new IntersectionTypeWrapper()", result);
         Assert.DoesNotContain("if(\"#kiota.complexType1\".Equals(mappingValue, StringComparison.OrdinalIgnoreCase))", result);
         Assert.Contains("if(parseNode.GetStringValue() is string stringValueValue)", result);
@@ -710,7 +710,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
 
         Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
-        Assert.Contains("return mappingValue switch {", result);
+        Assert.Contains("return mappingValue switch", result);
         Assert.Contains("\"namespaceLevelOne.ConflictingModel\" => new namespaceLevelOne.ConflictingModel(),", result); //Assert the disambiguation happens due to the enum imported
         Assert.Contains("_ => new ConflictingModelBaseClass()", result);
         AssertExtensions.CurlyBracesAreClosed(result);
@@ -765,7 +765,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
-        Assert.Contains("return mappingValue switch {", result);
+        Assert.Contains("return mappingValue switch", result);
         Assert.Contains("\"ns.childmodel\" => new ChildModel()", result);
         Assert.Contains("_ => new ParentModel()", result);
         AssertExtensions.CurlyBracesAreClosed(result);
@@ -859,7 +859,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
         Assert.DoesNotContain("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
         Assert.DoesNotContain("var mappingValue = mappingValueNode?.GetStringValue()", result);
-        Assert.DoesNotContain("return mappingValue switch {", result);
+        Assert.DoesNotContain("return mappingValue switch", result);
         Assert.DoesNotContain("\"ns.childmodel\" => new ChildModel()", result);
         Assert.Contains("return new ParentModel()", result);
         AssertExtensions.CurlyBracesAreClosed(result);
@@ -900,7 +900,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
         Assert.DoesNotContain("var mappingValue = parseNode.GetChildNode(\"@odata.type\")?.GetStringValue()", result);
         Assert.DoesNotContain("var mappingValue = mappingValueNode?.GetStringValue()", result);
-        Assert.DoesNotContain("return mappingValue switch {", result);
+        Assert.DoesNotContain("return mappingValue switch", result);
         Assert.DoesNotContain("\"ns.childmodel\" => new ChildModel()", result);
         Assert.Contains("return new ParentModel()", result);
         AssertExtensions.CurlyBracesAreClosed(result);


### PR DESCRIPTION
Fixes the C# code generation to follow the usual style of putting braces on new lines.
Fixes #4347