### PR TITLE
[Dotnet] Fixes unnecessary indent in request builder properties.

### DIFF
--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -84,14 +84,14 @@ public class CSharpConventionService : CommonLanguageConventionService
         };
     }
 #pragma warning disable CA1822 // Method should be static
-    internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string? urlTemplateVarName = default, string? prefix = default, IEnumerable<CodeParameter>? pathParameters = default)
+    internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string? urlTemplateVarName = default, string? prefix = default, IEnumerable<CodeParameter>? pathParameters = default, bool includeIndent = true)
     {
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProp &&
             parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) is CodeProperty requestAdapterProp)
         {
             var pathParametersSuffix = !(pathParameters?.Any() ?? false) ? string.Empty : $", {string.Join(", ", pathParameters.Select(x => $"{x.Name.ToFirstCharacterLowerCase()}"))}";
             var urlTplRef = string.IsNullOrEmpty(urlTemplateVarName) ? pathParametersProp.Name.ToFirstCharacterUpperCase() : urlTemplateVarName;
-            writer.WriteLine($"{prefix}new {returnType}({urlTplRef}, {requestAdapterProp.Name.ToFirstCharacterUpperCase()}{pathParametersSuffix});");
+            writer.WriteLine($"{prefix}new {returnType}({urlTplRef}, {requestAdapterProp.Name.ToFirstCharacterUpperCase()}{pathParametersSuffix});", includeIndent);
         }
     }
     public override string TempDictionaryVarName => "urlTplParams";

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -44,7 +44,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
                 writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()}");
                 writer.StartBlock();
                 writer.Write("get => ");
-                conventions.AddRequestBuilderBody(parentClass, propertyType, writer);
+                conventions.AddRequestBuilderBody(parentClass, propertyType, writer, includeIndent: false);
                 writer.CloseBlock();
                 break;
             case CodePropertyKind.AdditionalData when backingStoreProperty != null:


### PR DESCRIPTION
Follow up to https://github.com/microsoft/kiota/pull/4348

Request builder properties have unnecessary indentations in declarations. See https://github.com/microsoft/kiota-samples/pull/5331/commits/03fc927ada16cdc8a649cdbd57691abf46ea3d62 for example diff.

This PR enables the writer to skip the indent for better formating. 

Sample generation at https://github.com/microsoft/kiota-samples/pull/5331