### PR TITLE
Manifest library updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -196,7 +196,10 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["search", "microsoft"],
+      "args": [
+        "search",
+        "microsoft"
+      ],
       "cwd": "${workspaceFolder}/src/kiota",
       "console": "internalConsole",
       "stopAtEntry": false
@@ -207,7 +210,10 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["search", "test"],
+      "args": [
+        "search",
+        "test"
+      ],
       "cwd": "${workspaceFolder}/src/kiota",
       "console": "internalConsole",
       "stopAtEntry": false
@@ -249,7 +255,11 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["info", "-l", "CSharp"],
+      "args": [
+        "info",
+        "-l",
+        "CSharp"
+      ],
       "cwd": "${workspaceFolder}/src/kiota",
       "console": "internalConsole",
       "stopAtEntry": false
@@ -260,7 +270,11 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["update", "-o", "${workspaceFolder}/samples"],
+      "args": [
+        "update",
+        "-o",
+        "${workspaceFolder}/samples"
+      ],
       "cwd": "${workspaceFolder}/src/kiota",
       "console": "internalConsole",
       "stopAtEntry": false
@@ -271,7 +285,10 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["workspace", "migrate"],
+      "args": [
+        "workspace",
+        "migrate"
+      ],
       "cwd": "${workspaceFolder}/samples/msgraph-mail/dotnet",
       "console": "internalConsole",
       "stopAtEntry": false,
@@ -285,7 +302,10 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["client", "generate"],
+      "args": [
+        "client",
+        "generate"
+      ],
       "cwd": "${workspaceFolder}/samples/msgraph-mail/dotnet",
       "console": "internalConsole",
       "stopAtEntry": false,
@@ -330,6 +350,8 @@
         "-i",
         "**/messages",
         "--type",
+        "ApiManifest",
+        "--type",
         "microsoft"
       ],
       "cwd": "${workspaceFolder}/samples/msgraph-mail/dotnet",
@@ -345,7 +367,11 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/kiota/bin/Debug/net8.0/kiota.dll",
-      "args": ["login", "github", "device"],
+      "args": [
+        "login",
+        "github",
+        "device"
+      ],
       "cwd": "${workspaceFolder}/src/kiota",
       "console": "internalConsole",
       "stopAtEntry": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -330,7 +330,7 @@
         "-i",
         "**/messages",
         "--type",
-        "APIManifest"
+        "microsoft"
       ],
       "cwd": "${workspaceFolder}/samples/msgraph-mail/dotnet",
       "console": "internalConsole",

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.14" />
-    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.5-preview" />
+    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.6-preview" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer"

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.14" />
-    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.1-preview" />
+    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.5-preview" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer"

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -231,8 +231,8 @@ public partial class KiotaBuilder
     {
         return await GenerateConsumerAsync(async (sw, stepId, openApiTree, CancellationToken) =>
         {
-            if (config.PluginTypes.Any(static pluginType => pluginType != PluginType.Microsoft))
-                throw new NotImplementedException("Only the Microsoft plugin type is not supported for generation");
+            if (config.PluginTypes.Contains(PluginType.OpenAI))
+                throw new NotImplementedException("The OpenAI plugin type is not supported for generation");
             if (openApiDocument is null || openApiTree is null)
                 throw new InvalidOperationException("The OpenAPI document and the URL tree must be loaded before generating the plugins");
             // generate plugin

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -231,8 +231,8 @@ public partial class KiotaBuilder
     {
         return await GenerateConsumerAsync(async (sw, stepId, openApiTree, CancellationToken) =>
         {
-            if (config.PluginTypes.Contains(PluginType.OpenAI))
-                throw new NotImplementedException("The OpenAI plugin type is not supported for generation");
+            if (config.PluginTypes.Any(static pluginType => pluginType != PluginType.Microsoft))
+                throw new NotImplementedException("Only the Microsoft plugin type is not supported for generation");
             if (openApiDocument is null || openApiTree is null)
                 throw new InvalidOperationException("The OpenAPI document and the URL tree must be loaded before generating the plugins");
             // generate plugin

--- a/src/Kiota.Builder/PluginType.cs
+++ b/src/Kiota.Builder/PluginType.cs
@@ -3,5 +3,6 @@
 public enum PluginType
 {
     OpenAI,
-    APIManifest
+    APIManifest,
+    Microsoft
 }

--- a/src/Kiota.Builder/Plugins/AuthComparer.cs
+++ b/src/Kiota.Builder/Plugins/AuthComparer.cs
@@ -16,6 +16,6 @@ internal class AuthComparer : IEqualityComparer<Auth>
     public int GetHashCode([DisallowNull] Auth obj)
     {
         if (obj == null) return 0;
-        return string.IsNullOrEmpty(obj.Type) ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Type) * 3;
+        return obj.Type is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Type.Value.ToString()) * 3;
     }
 }

--- a/src/Kiota.Builder/Plugins/OpenAPiRuntimeComparer.cs
+++ b/src/Kiota.Builder/Plugins/OpenAPiRuntimeComparer.cs
@@ -7,7 +7,7 @@ using Microsoft.Plugins.Manifest;
 
 namespace Kiota.Builder.Plugins;
 
-internal class OpenAPIRuntimeComparer : IEqualityComparer<OpenAPIRuntime>
+internal class OpenAPIRuntimeComparer : IEqualityComparer<OpenApiRuntime>
 {
     public bool EvaluateFunctions
     {
@@ -15,17 +15,18 @@ internal class OpenAPIRuntimeComparer : IEqualityComparer<OpenAPIRuntime>
     }
     private static readonly StringIEnumerableDeepComparer _stringIEnumerableDeepComparer = new();
     private static readonly AuthComparer _authComparer = new();
+    private static readonly OpenApiRuntimeSpecComparer _openApiRuntimeSpecComparer = new();
     /// <inheritdoc/>
-    public bool Equals(OpenAPIRuntime? x, OpenAPIRuntime? y)
+    public bool Equals(OpenApiRuntime? x, OpenApiRuntime? y)
     {
         return x == null && y == null || x != null && y != null && GetHashCode(x) == GetHashCode(y);
     }
     /// <inheritdoc/>
-    public int GetHashCode([DisallowNull] OpenAPIRuntime obj)
+    public int GetHashCode([DisallowNull] OpenApiRuntime obj)
     {
         if (obj == null) return 0;
         return (EvaluateFunctions ? _stringIEnumerableDeepComparer.GetHashCode(obj.RunForFunctions ?? Enumerable.Empty<string>()) * 7 : 0) +
-            obj.Spec.Select(static x => StringComparer.Ordinal.GetHashCode($"{x.Key}:{x.Value}")).Aggregate(0, (acc, next) => acc + next) * 5 +
+            (obj.Spec is null ? 0 : _openApiRuntimeSpecComparer.GetHashCode(obj.Spec) * 5) +
             (obj.Auth is null ? 0 : _authComparer.GetHashCode(obj.Auth) * 3);
     }
 }

--- a/src/Kiota.Builder/Plugins/OpenApiRuntimeSpecComparer.cs
+++ b/src/Kiota.Builder/Plugins/OpenApiRuntimeSpecComparer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Plugins.Manifest;
+
+namespace Kiota.Builder.Plugins;
+
+public class OpenApiRuntimeSpecComparer : IEqualityComparer<OpenApiRuntimeSpec>
+{
+    /// <inheritdoc/>
+    public bool Equals(OpenApiRuntimeSpec? x, OpenApiRuntimeSpec? y)
+    {
+        return x == null && y == null || x != null && y != null && GetHashCode(x) == GetHashCode(y);
+    }
+    /// <inheritdoc/>
+    public int GetHashCode([DisallowNull] OpenApiRuntimeSpec obj)
+    {
+        if (obj == null) return 0;
+        return (string.IsNullOrEmpty(obj.Url) ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Url) * 5) +
+               (string.IsNullOrEmpty(obj.ApiDescription) ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ApiDescription) * 3);
+    }
+}

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -70,7 +70,7 @@ public class PluginsGenerationService
                     apiManifest.Write(writer);
                     break;
                 case PluginType.OpenAI://TODO add support for OpenAI plugin type generation
-                    // intentional drop to the default case
+                                       // intentional drop to the default case
                 default:
                     throw new NotImplementedException($"The {pluginType} plugin is not implemented.");
             }

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -69,10 +69,10 @@ public class PluginsGenerationService
                     apiManifest.ApiDependencies.AddOrReplace(Configuration.ClientClassName, Configuration.ToApiDependency(OAIDocument.HashCode ?? string.Empty, TreeNode?.GetRequestInfo().ToDictionary(static x => x.Key, static x => x.Value) ?? []));
                     apiManifest.Write(writer);
                     break;
-                case PluginType.OpenAI:
-                //TODO add support for OpenAI plugin type generation
+                case PluginType.OpenAI://TODO add support for OpenAI plugin type generation
+                    // intentional drop to the default case
                 default:
-                    continue;
+                    throw new NotImplementedException($"The {pluginType} plugin is not implemented.");
             }
             await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -30,31 +30,37 @@ public class PluginsGenerationService
         Configuration = configuration;
     }
     private static readonly OpenAPIRuntimeComparer _openAPIRuntimeComparer = new();
-    private const string ManifestFileName = "manifest.json";
+    private const string ManifestFileNameSuffix = ".json";
     private const string DescriptionRelativePath = "./openapi.yml";
     public async Task GenerateManifestAsync(CancellationToken cancellationToken = default)
     {
-        var manifestOutputPath = Path.Combine(Configuration.OutputPath, ManifestFileName);
-        var directory = Path.GetDirectoryName(manifestOutputPath);
-        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-            Directory.CreateDirectory(directory);
+        foreach (var pluginType in Configuration.PluginTypes)
+        {
+            if (pluginType != PluginType.Microsoft)
+                continue; //TODO add support for other plugin type generation
 
-        var descriptionFullPath = Path.Combine(Configuration.OutputPath, DescriptionRelativePath);
+            var manifestOutputPath = Path.Combine(Configuration.OutputPath, $"{Configuration.ClientClassName.ToLowerInvariant()}-{pluginType.ToString().ToLowerInvariant()}{ManifestFileNameSuffix}");
+            var directory = Path.GetDirectoryName(manifestOutputPath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            var descriptionFullPath = Path.Combine(Configuration.OutputPath, DescriptionRelativePath);
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
-        await using var descriptionStream = File.Create(descriptionFullPath, 4096);
-        await using var fileWriter = new StreamWriter(descriptionStream);
-        var descriptionWriter = new OpenApiYamlWriter(fileWriter);
-        OAIDocument.SerializeAsV3(descriptionWriter);
-        descriptionWriter.Flush();
+            await using var descriptionStream = File.Create(descriptionFullPath, 4096);
+            await using var fileWriter = new StreamWriter(descriptionStream);
+            var descriptionWriter = new OpenApiYamlWriter(fileWriter);
+            OAIDocument.SerializeAsV3(descriptionWriter);
+            descriptionWriter.Flush();
 
-        var pluginDocument = GetManifestDocument(DescriptionRelativePath);
-        await using var fileStream = File.Create(manifestOutputPath, 4096);
-        await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });
+            var pluginDocument = GetManifestDocument(DescriptionRelativePath);
+            await using var fileStream = File.Create(manifestOutputPath, 4096);
+            await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
-        pluginDocument.Write(writer);
-        await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            pluginDocument.Write(writer);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
-    private ManifestDocument GetManifestDocument(string openApiDocumentPath)
+    private PluginManifestDocument GetManifestDocument(string openApiDocumentPath)
     {
         var (runtimes, functions) = GetRuntimesAndFunctionsFromTree(TreeNode, openApiDocumentPath);
         var descriptionForHuman = OAIDocument.Info?.Description.CleanupXMLString() is string d && !string.IsNullOrEmpty(d) ? d : $"Description for {OAIDocument.Info?.Title.CleanupXMLString()}";
@@ -64,7 +70,6 @@ public class PluginsGenerationService
         string? privacyUrl = null;
         if (OAIDocument.Info is not null)
         {
-
             if (OAIDocument.Info.Extensions.TryGetValue(OpenApiDescriptionForModelExtension.Name, out var descriptionExtension) &&
                 descriptionExtension is OpenApiDescriptionForModelExtension extension &&
                 !string.IsNullOrEmpty(extension.Description))
@@ -76,7 +81,7 @@ public class PluginsGenerationService
             if (OAIDocument.Info.Extensions.TryGetValue(OpenApiPrivacyPolicyUrlExtension.Name, out var privacyExtension) && privacyExtension is OpenApiPrivacyPolicyUrlExtension privacy)
                 privacyUrl = privacy.Privacy;
         }
-        return new ManifestDocument
+        return new PluginManifestDocument
         {
             SchemaVersion = "v2",
             NameForHuman = OAIDocument.Info?.Title.CleanupXMLString(),
@@ -100,18 +105,21 @@ public class PluginsGenerationService
             Functions = [.. functions.OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)]
         };
     }
-    private (OpenAPIRuntime[], Function[]) GetRuntimesAndFunctionsFromTree(OpenApiUrlTreeNode currentNode, string openApiDocumentPath)
+    private (OpenApiRuntime[], Function[]) GetRuntimesAndFunctionsFromTree(OpenApiUrlTreeNode currentNode, string openApiDocumentPath)
     {
-        var runtimes = new List<OpenAPIRuntime>();
+        var runtimes = new List<OpenApiRuntime>();
         var functions = new List<Function>();
         if (currentNode.PathItems.TryGetValue(Constants.DefaultOpenApiLabel, out var pathItem))
         {
             foreach (var operation in pathItem.Operations.Values.Where(static x => !string.IsNullOrEmpty(x.OperationId)))
             {
-                runtimes.Add(new OpenAPIRuntime
+                runtimes.Add(new OpenApiRuntime
                 {
-                    Auth = new Auth("none"),
-                    Spec = new Dictionary<string, string> { { "url", openApiDocumentPath } },
+                    Auth = new AnonymousAuth(),
+                    Spec = new OpenApiRuntimeSpec()
+                    {
+                        Url = openApiDocumentPath
+                    },
                     RunForFunctions = [operation.OperationId]
                 });
                 var oasParameters = operation.Parameters
@@ -123,19 +131,26 @@ public class PluginsGenerationService
                 functions.Add(new Function
                 {
                     Name = operation.OperationId,
-                    Description = operation.Summary.CleanupXMLString() is string summary && !string.IsNullOrEmpty(summary) ? summary : operation.Description.CleanupXMLString(),
-                    Parameters = oasParameters.Length == 0 ? null :
-                                    new Parameters(
-                                        "object",
-                                        new Properties(oasParameters.ToDictionary(
-                                                                        static x => x.Name,
-                                                                        static x => new Property(
-                                                                                        x.Schema.Type ?? string.Empty,
-                                                                                        x.Description.CleanupXMLString(),
-                                                                                        x.Schema.Default?.ToString() ?? string.Empty,
-                                                                                        null), //TODO enums
-                                                                        StringComparer.OrdinalIgnoreCase)),
-                                        oasParameters.Where(static x => x.Required).Select(static x => x.Name).ToList()),
+                    Description =
+                        operation.Summary.CleanupXMLString() is string summary && !string.IsNullOrEmpty(summary)
+                            ? summary
+                            : operation.Description.CleanupXMLString(),
+                    Parameters = oasParameters.Length == 0
+                        ? null
+                        : new Parameters
+                        {
+                            Type = "object",
+                            Properties = new Properties(oasParameters.ToDictionary(
+                                static x => x.Name,
+                                static x => new FunctionParameter()
+                                {
+                                    Type = x.Schema.Type ?? string.Empty,
+                                    Description = x.Description.CleanupXMLString(),
+                                    Default = x.Schema.Default?.ToString() ?? string.Empty,
+                                    //TODO enums
+                                })),
+                            Required = oasParameters.Where(static x => x.Required).Select(static x => x.Name).ToList()
+                        },
                     States = GetStatesFromOperation(operation),
                 });
             }
@@ -177,7 +192,7 @@ public class PluginsGenerationService
         {
             return new State
             {
-                Instructions = instructionsExtractor(rExt).Where(static x => !string.IsNullOrEmpty(x)).Select(static x => x.CleanupXMLString()).ToList()
+                Instructions = new Instructions(instructionsExtractor(rExt).Where(static x => !string.IsNullOrEmpty(x)).Select(static x => x.CleanupXMLString()).ToList())
             };
         }
         return null;

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -38,6 +38,9 @@ public class PluginsGenerationService
     {
         // write the decription
         var descriptionFullPath = Path.Combine(Configuration.OutputPath, DescriptionRelativePath);
+        var directory = Path.GetDirectoryName(descriptionFullPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            Directory.CreateDirectory(directory);
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
         await using var descriptionStream = File.Create(descriptionFullPath, 4096);
         await using var fileWriter = new StreamWriter(descriptionStream);
@@ -50,9 +53,6 @@ public class PluginsGenerationService
         foreach (var pluginType in Configuration.PluginTypes)
         {
             var manifestOutputPath = Path.Combine(Configuration.OutputPath, $"{Configuration.ClientClassName.ToLowerInvariant()}-{pluginType.ToString().ToLowerInvariant()}{ManifestFileNameSuffix}");
-            var directory = Path.GetDirectoryName(manifestOutputPath);
-            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-                Directory.CreateDirectory(directory);
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
             await using var fileStream = File.Create(manifestOutputPath, 4096);
             await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });

--- a/src/kiota/Handlers/Plugin/AddHandler.cs
+++ b/src/kiota/Handlers/Plugin/AddHandler.cs
@@ -94,6 +94,5 @@ internal class AddHandler : BaseKiotaCommandHandler
 #endif
             }
         }
-        throw new NotImplementedException();
     }
 }

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
+    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.5-preview" />
     <PackageReference Include="StreamJsonRpc" Version="2.17.11" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/tests/Kiota.Builder.Tests/Plugins/OpenAPIRuntimeComparerTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/OpenAPIRuntimeComparerTests.cs
@@ -17,8 +17,8 @@ public class OpenAPIRuntimeComparerTests
     [Fact]
     public void GetsHashCode()
     {
-        var runtime1 = new OpenAPIRuntime { Spec = new() { { "key1", "value1" } } };
-        var runtime2 = new OpenAPIRuntime { Spec = new() { { "key2", "value2" } }, Auth = new() { Type = "type" } };
+        var runtime1 = new OpenApiRuntime { Spec = new() { Url = "url", ApiDescription = "description" } };
+        var runtime2 = new OpenApiRuntime { Spec = new() { Url = "url", ApiDescription = "description" }, Auth = new AnonymousAuth() };
         Assert.NotEqual(_comparer.GetHashCode(runtime1), _comparer.GetHashCode(runtime2));
     }
 }

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -33,6 +33,9 @@ public sealed class PluginsGenerationServiceTests : IDisposable
 info:
   title: test
   version: 1.0
+servers:
+  - url: http://localhost/
+    description: There's no place like home
 paths:
   /test:
     get:
@@ -49,8 +52,9 @@ paths:
         {
             OutputPath = outputDirectory,
             OpenAPIFilePath = "openapiPath",
-            PluginTypes = [PluginType.Microsoft],
+            PluginTypes = [PluginType.Microsoft, PluginType.APIManifest],
             ClientClassName = "client",
+            ApiRootUrl = "http://localhost/", //Kiota builder would set this for us
         };
         var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath, generationConfiguration, null, false);
         var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
@@ -60,6 +64,7 @@ paths:
         await pluginsGenerationService.GenerateManifestAsync();
 
         Assert.True(File.Exists(Path.Combine(outputDirectory, "client-microsoft.json")));
+        Assert.True(File.Exists(Path.Combine(outputDirectory, "client-apimanifest.json")));
         Assert.True(File.Exists(Path.Combine(outputDirectory, "openapi.yml")));
     }
 }

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -49,7 +49,7 @@ paths:
         {
             OutputPath = outputDirectory,
             OpenAPIFilePath = "openapiPath",
-            PluginTypes = [PluginType.APIManifest],
+            PluginTypes = [PluginType.Microsoft],
             ClientClassName = "client",
         };
         var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath, generationConfiguration, null, false);
@@ -59,7 +59,7 @@ paths:
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration);
         await pluginsGenerationService.GenerateManifestAsync();
 
-        Assert.True(File.Exists(Path.Combine(outputDirectory, "manifest.json")));
+        Assert.True(File.Exists(Path.Combine(outputDirectory, "client-microsoft.json")));
         Assert.True(File.Exists(Path.Combine(outputDirectory, "openapi.yml")));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4491
Fixes https://github.com/microsoft/kiota/issues/4447

Changes include

- Adds the `microsoft` type as that is what is being generated at the moment. 
- Fixes breaking changes from latest update from manifest lib
- Fixes naming of generated manifests to apply to convention of `{plugin-name}-{pluginType}.json`

