### PR TITLE
Fixing typo from open-ai-plugins.json to openai-plugins.json

### DIFF
--- a/specs/cli/plugin-add.md
+++ b/specs/cli/plugin-add.md
@@ -16,7 +16,7 @@ Developers can generate `openai` and `apimanifest` type of plugins. By generatin
 
 Once the `workspace.json` file is generated and the OpenAPI document file is saved locally, the generation will be executed and the plugin and the sliced OpenAPI document will become available.
 
-For `openai` plugins, the generated plugin will be named `open-ai-plugins.json` and the mapping should follow [Hidi logic to generate OpenAI Plugin](https://github.com/microsoft/OpenAPI.NET/blob/vnext/src/Microsoft.OpenApi.Hidi/OpenApiService.cs#L748). Requiring fields default as the following:
+For `openai` plugins, the generated plugin will be named `openai-plugins.json` and the mapping should follow [Hidi logic to generate OpenAI Plugin](https://github.com/microsoft/OpenAPI.NET/blob/vnext/src/Microsoft.OpenApi.Hidi/OpenApiService.cs#L748). Requiring fields default as the following:
 
 | OpenAI field | Default value |
 | -- | -- |
@@ -78,7 +78,7 @@ _The resulting `workspace.json` file will look like this:_
 }
 ```
 
-_The resulting OpenAI plugin named `open-ai-plugins.json` will look like this:_
+_The resulting OpenAI plugin named `openai-plugins.json` will look like this:_
 
 ```jsonc
 {
@@ -178,7 +178,7 @@ _The resulting API Manifest named `apimanifest.json` in the `./kiota` folder (co
     └─plugins
       └─github
           └─github-apimanifest.json # Specific API Manifest
-          └─open-ai-plugins.json #OpenAI Plugin
+          └─openai-plugins.json #OpenAI Plugin
           └─sliced-github.json # Sliced and augmented OpenAPI document
 ```
 

--- a/specs/cli/plugin-edit.md
+++ b/specs/cli/plugin-edit.md
@@ -50,7 +50,7 @@ _The resulting `workspace.json` file will look like this:_
 }
 ```
 
-_The resulting OpenAI plugin named `open-ai-plugins.json` will look like this:_
+_The resulting OpenAI plugin named `openai-plugins.json` will look like this:_
 
 ```jsonc
 {
@@ -142,7 +142,7 @@ _The resulting API Manifest named `apimanifest.json` in the `./kiota` folder (co
     └─plugins
       └─github
           └─github-apimanifest.json # Specific API Manifest
-          └─open-ai-plugins.json #OpenAI Plugin
+          └─openai-plugins.json #OpenAI Plugin
           └─sliced-github.json # Sliced and augmented OpenAPI document
 ```
 

--- a/specs/cli/plugin-remove.md
+++ b/specs/cli/plugin-remove.md
@@ -16,7 +16,7 @@ The command also has one optional parameter, the ability to remove the all gener
 ```bash
 kiota plugin remove --plugin-name "GitHub" --clean-output
 ```
-_The resulting `github-apimanifest.json`, `open-ai-plugins.json` and `sliced-github.json` files will be deleted._
+_The resulting `github-apimanifest.json`, `openai-plugins.json` and `sliced-github.json` files will be deleted._
 
 The resulting `workspace.json` file will look like this:
 


### PR DESCRIPTION
Updating the resulting plugin name to openai-plugins.json wheen choosing --type openai