### PR TITLE
Revert "- migrates to AAD tokens from PATs for extension publishing due to ADO requirements"

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -567,6 +567,8 @@ extends:
                   baselineFile: $(Build.SourcesDirectory)/guardian/SDL/common/.gdnbaselines
                 suppression:
                   suppressionFile: $(Build.SourcesDirectory)/guardian/SDL/common/.gdnsuppress
+            variables:
+              - group: kiota-vscode-extension-publish
             dependsOn:
               - github_release
             steps:
@@ -584,24 +586,18 @@ extends:
               - pwsh: npm i -g @vscode/vsce
               - pwsh: $(Build.SourcesDirectory)/scripts/get-prerelease-version.ps1 -currentBranch $(Build.SourceBranch) -previewBranch ${{ parameters.previewBranch }}
                 displayName: "Set version suffix"
-              - task: AzureCLI@2
-                inputs:
-                  azureSubscription: "kiota-vscode-marketplace-publish"
-                  scriptType: "pscore"
-                  scriptLocation: 'inlineScript'
-                  inlineScript: |
-                    $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-                    Get-ChildItem -Path $(Pipeline.Workspace) -Filter *.vsix -Recurse | ForEach-Object {
-                      Write-Host "Publishing $_.FullName"
-                      if ($Env:isPrerelease -eq "true") {
-                        Write-Host "Publishing $_.FullName as a pre-release"
-                        vsce publish --pat "$aadToken" --packagePath $_.FullName --pre-release
-                      }
-                      else {
-                        Write-Host "Publishing $_.FullName as a release"
-                        vsce publish --pat "$aadToken" --packagePath $_.FullName
-                      }
+              - pwsh: |
+                  Get-ChildItem -Path $(Pipeline.Workspace) -Filter *.vsix -Recurse | ForEach-Object {
+                    Write-Host "Publishing $_.FullName"
+                    if ($Env:isPrerelease -eq "true") {
+                      Write-Host "Publishing $_.FullName as a pre-release"
+                      vsce publish --pat "$(vs-marketplace-token)" --packagePath $_.FullName --pre-release
                     }
+                    else {
+                      Write-Host "Publishing $_.FullName as a release"
+                      vsce publish --pat "$(vs-marketplace-token)" --packagePath $_.FullName
+                    }
+                  }
                 env:
                   isPrerelease: $(isPrerelease)
           - deployment: github_release


### PR DESCRIPTION
Reverts microsoft/kiota#4510
The marketplace service has a bug where it can't verify service principals for publishing yet. They are working on that while we use a PAT for the time being.