### PR TITLE
Add environment variable to disable updates check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Suppress CS1591 when generating CSharp code and documentation is not available
 - Added file name suffix escaping in Go to avoid generating files with reserved suffixes. [#4407](https://github.com/microsoft/kiota/issues/4407)
+- Added `KIOTA_OFFLINE_ENABLED` environment variable to disable checking for updates before each command. [#4556](https://github.com/microsoft/kiota/issues/4556)
 
 ### Changed
 

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -97,6 +97,11 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler, IDisposable
     }
     protected async Task CheckForNewVersionAsync(ILogger logger, CancellationToken cancellationToken)
     {
+        if (Configuration.Update.Disabled)
+        {
+            return;
+        }
+
         var updateService = new UpdateService(httpClient, logger, Configuration.Update);
         var result = await updateService.GetUpdateMessageAsync(Kiota.Generated.KiotaVersion.Current(), cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(result))

--- a/src/kiota/Handlers/Plugin/GenerateHandler.cs
+++ b/src/kiota/Handlers/Plugin/GenerateHandler.cs
@@ -84,6 +84,5 @@ internal class GenerateHandler : BaseKiotaCommandHandler
 #endif
             }
         }
-        throw new NotImplementedException();
     }
 }

--- a/src/kiota/KiotaConfigurationExtensions.cs
+++ b/src/kiota/KiotaConfigurationExtensions.cs
@@ -17,6 +17,7 @@ internal static class KiotaConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(configObject);
         ArgumentNullException.ThrowIfNull(configuration);
+        configObject.Update.Disabled = bool.TryParse(configuration["OFFLINE_ENABLED"], out var disableUpdate) && disableUpdate;
         configObject.Download.CleanOutput = bool.TryParse(configuration[$"{nameof(configObject.Download)}:{nameof(DownloadConfiguration.CleanOutput)}"], out var downloadCleanOutput) && downloadCleanOutput;
         configObject.Download.ClearCache = bool.TryParse(configuration[$"{nameof(configObject.Download)}:{nameof(DownloadConfiguration.ClearCache)}"], out var downloadClearCache) && downloadClearCache;
         configObject.Download.OutputPath = configuration[$"{nameof(configObject.Download)}:{nameof(DownloadConfiguration.OutputPath)}"] is string value && !string.IsNullOrEmpty(value) ? value : configObject.Download.OutputPath;


### PR DESCRIPTION
fixes #4556 

This adds support for the environment variable `KIOTA_OFFLINE_ENABLED`. If set to `true`, checking for updates before each command will be skipped.

Related PR for docs: https://github.com/MicrosoftDocs/openapi-docs/pull/68