### PR TITLE
Update ToLowerCase so it wouldn't return "image_u_r_l" for "imageURL"

### DIFF
--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -82,7 +82,7 @@ public static partial class StringExtensions
             int count = 0;
             for (var i = 1; i < span.Length; i++)
             {
-                if (char.IsUpper(span[i]) && span[i - 1] is not '_' and not '-')
+                if (char.IsUpper(span[i]) && span[i - 1] is not '_' and not '-' && !char.IsUpper(span[i - 1]))
                 {
                     count++;
                 }
@@ -105,7 +105,10 @@ public static partial class StringExtensions
             }
             else if (char.IsUpper(current))
             {
-                if (nameSpan[i - 1] != '_') span[counter++] = separator;
+                if (nameSpan[i - 1] is not '_' && !char.IsUpper(nameSpan[i - 1]))
+                {
+                    span[counter++] = separator;
+                }
                 span[counter++] = char.ToLowerInvariant(current);
             }
             else

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -75,8 +75,8 @@ public class StringExtensionsTests
         Assert.Equal("microsoft_graph_message_content", "microsoft_Graph_Message_Content".ToSnakeCase());
         Assert.Equal("test_value", "testValue<WithStrippedContent".ToSnakeCase());
         Assert.Equal("test", "test<Value".ToSnakeCase());
-        Assert.Equal("microsoft_website_url", "microsoftWebsiteURL".ToSnakeCase());
-        Assert.Equal("microsoft_website_url", "MICROSOFT_WEBSITE_URL".ToSnakeCase());
+        // Assert.Equal("microsoft_website_url", "microsoftWebsiteURL".ToSnakeCase());
+        // Assert.Equal("microsoft_website_url", "MICROSOFT_WEBSITE_URL".ToSnakeCase());
     }
     [Fact]
     public void NormalizeNameSpaceName()

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -75,6 +75,8 @@ public class StringExtensionsTests
         Assert.Equal("microsoft_graph_message_content", "microsoft_Graph_Message_Content".ToSnakeCase());
         Assert.Equal("test_value", "testValue<WithStrippedContent".ToSnakeCase());
         Assert.Equal("test", "test<Value".ToSnakeCase());
+        Assert.Equal("microsoft_website_url", "microsoftWebsiteURL".ToSnakeCase());
+        Assert.Equal("microsoft_website_url", "MICROSOFT_WEBSITE_URL".ToSnakeCase());
     }
     [Fact]
     public void NormalizeNameSpaceName()


### PR DESCRIPTION
Regarding this issue #4531

Currently any filename and variable name that is converted to lower case get a separator (default "_") before every uppercase letter excluding some edge cases.

So having the filename "NotrixSDK" will become "notrix_s_d_k" and not the desired "notrix_sdk".

This PR is fixing it by checking if the previous letter is upper case and in this case it does not add the separator.