### PR TITLE
Fixes missing functions when operationIds aren't present in the input openApi doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes constructor generation for nullable properties that are initialized as null in C#,Java and PHP
 - Fixed a bug where the hash alias in typescript wasn't being generated uniformly for similar interfaces [microsoftgraph/msgraph-beta-sdk-typescript#84](https://github.com/microsoftgraph/msgraph-beta-sdk-typescript/issues/84)
 - Fixes a bug where name collisions would occur in the Typescript refiner if model name also exists with the `Interface` suffix [#4382](https://github.com/microsoft/kiota/issues/4382)
-
+- Fixes a bug where paths without operationIds would not be included in the generated plugins and ensured operationIds are cleaned up [#4642](https://github.com/microsoft/kiota/issues/4642)
 
 ## [1.14.0] - 2024-05-02
 

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -163,7 +163,7 @@ public static partial class OpenApiUrlTreeNodeExtensions
     public static bool DoesNodeBelongToItemSubnamespace(this OpenApiUrlTreeNode currentNode) => currentNode.IsPathSegmentWithSingleSimpleParameter();
     public static bool IsPathSegmentWithSingleSimpleParameter(this OpenApiUrlTreeNode currentNode) =>
         currentNode?.DeduplicatedSegment().IsPathSegmentWithSingleSimpleParameter() ?? false;
-    private static bool IsPathSegmentWithSingleSimpleParameter(this string currentSegment)
+    internal static bool IsPathSegmentWithSingleSimpleParameter(this string currentSegment)
     {
         if (string.IsNullOrEmpty(currentSegment)) return false;
         var segmentWithoutExtension = stripExtensionForIndexersRegex().Replace(currentSegment, string.Empty);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -358,12 +358,12 @@ public partial class KiotaBuilder
     internal static void CleanupOperationIdForPlugins(OpenApiDocument document)
     {
         if (document.Paths is null) return;
-        foreach (var (pathItem, operation) in document.Paths.SelectMany(path => path.Value.Operations.Select(value => new Tuple<string, KeyValuePair<OperationType, OpenApiOperation>>(path.Key, value))))
+        foreach (var (pathItem, operation) in document.Paths.SelectMany(static path => path.Value.Operations.Select(value => new Tuple<string, KeyValuePair<OperationType, OpenApiOperation>>(path.Key, value))))
         {
             if (string.IsNullOrEmpty(operation.Value.OperationId))
             {
                 var stringBuilder = new StringBuilder();
-                foreach (var segment in pathItem.Split('/'))
+                foreach (var segment in pathItem.TrimStart('/').Split('/',StringSplitOptions.RemoveEmptyEntries))
                 {
                     if (segment.IsPathSegmentWithSingleSimpleParameter())
                         stringBuilder.Append("item");

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -17,7 +17,7 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
     public void Defensive()
     {
         Assert.False(OpenApiUrlTreeNodeExtensions.IsComplexPathMultipleParameters(null));
-        Assert.False(OpenApiUrlTreeNodeExtensions.IsPathSegmentWithSingleSimpleParameter(null));
+        Assert.False(OpenApiUrlTreeNodeExtensions.IsPathSegmentWithSingleSimpleParameter((OpenApiUrlTreeNode)null));
         Assert.False(OpenApiUrlTreeNodeExtensions.DoesNodeBelongToItemSubnamespace(null));
         Assert.Empty(OpenApiUrlTreeNodeExtensions.GetPathItemDescription(null, null));
         Assert.Empty(OpenApiUrlTreeNodeExtensions.GetPathItemDescription(null, Label));

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -44,14 +44,13 @@ paths:
   /test:
     get:
       description: description for test path
-      operationId: test
       responses:
         '200':
           description: test
   /test/{id}:
     get:
       description: description for test path with id
-      operationId: test_WithId
+      operationId: test.WithId
       parameters:
       - name: id
         in: path
@@ -79,6 +78,7 @@ paths:
         };
         var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath, generationConfiguration, null, false);
         var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory);
@@ -95,7 +95,8 @@ paths:
         var resultingManifest = PluginManifestDocument.Load(jsonDocument.RootElement);
         Assert.NotNull(resultingManifest.Document);
         Assert.Equal(OpenApiFileName, resultingManifest.Document.Runtimes.OfType<OpenApiRuntime>().First().Spec.Url);
-        Assert.Empty(resultingManifest.Problems);
+        Assert.Equal(2, resultingManifest.Document.Functions.Count);// all functions are generated despite missing operationIds
+        Assert.Empty(resultingManifest.Problems);// no problems are expected with names
 
         // Validate the v1 plugin
         var v1ManifestContent = await File.ReadAllTextAsync(Path.Combine(outputDirectory, OpenAIPluginFileName));


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4642

In the event a generation is a plugin generation, the builder will run through the trimmed document to insert placeholder operationIds as well as clean them up to prevent validation issues and ensure functions are generated downsteam.