### PR TITLE
CLI Generation to handle  parameter of type 'string' but different format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the hash alias in typescript wasn't being generated uniformly for similar interfaces [microsoftgraph/msgraph-beta-sdk-typescript#84](https://github.com/microsoftgraph/msgraph-beta-sdk-typescript/issues/84)
 - Fixes a bug where name collisions would occur in the Typescript refiner if model name also exists with the `Interface` suffix [#4382](https://github.com/microsoft/kiota/issues/4382)
 - Fixes a bug where paths without operationIds would not be included in the generated plugins and ensured operationIds are cleaned up [#4642](https://github.com/microsoft/kiota/issues/4642)
+- Fixes a bug where CLI Generation does not handle path parameters of type "string" and format "date", "date-time", "time", etc. [#4615](https://github.com/microsoft/kiota/issues/4615)
 
 ## [1.14.0] - 2024-05-02
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2403,7 +2403,7 @@ public partial class KiotaBuilder
         };
     }
     private static CodeType GetQueryParameterType(OpenApiSchema schema) =>
-        new()
+        GetPrimitiveType(schema) ?? new()
         {
             IsExternal = true,
             Name = schema.Items?.Type ?? schema.Type,


### PR DESCRIPTION
fixes #4615

CLI Generator is unable to handle parameters such as `DateTime`, `Date`, etc.  More precisely, the parameters having `type="string"` and `format="datetime"`, `"date"` etc.
<img width="317" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/6561f2c8-cb59-449b-a335-235601464828">

Screenshots: 

Tests:
<img width="352" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/6a8933a3-255b-409c-8f60-14c594b66a9d">

Kiota Update:
<img width="452" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/93737a17-e734-48a2-afdd-108edc246c76">

Build of Sample project:
<img width="413" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/174c5db0-934a-460c-8251-e0c3dddae25b">

Change in the builder Class:
<img width="505" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/136c86f5-b5f7-4f27-a5ac-b3ebfaa13db2">

