### PR TITLE
Fixes duplicated models in single allOf scenarios 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the hash alias in typescript wasn't being generated uniformly for similar interfaces [microsoftgraph/msgraph-beta-sdk-typescript#84](https://github.com/microsoftgraph/msgraph-beta-sdk-typescript/issues/84)
 - Fixes a bug where name collisions would occur in the Typescript refiner if model name also exists with the `Interface` suffix [#4382](https://github.com/microsoft/kiota/issues/4382)
 - Fixes a bug where paths without operationIds would not be included in the generated plugins and ensured operationIds are cleaned up [#4642](https://github.com/microsoft/kiota/issues/4642)
+- Fixes a bug where models would be duplicated in some allOf scenarios [#4191](https://github.com/microsoft/kiota/issues/4191)
 
 ## [1.14.0] - 2024-05-02
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1595,12 +1595,6 @@ public partial class KiotaBuilder
     {
         var flattenedAllOfs = schema.AllOf.FlattenSchemaIfRequired(static x => x.AllOf).ToArray();
         var referenceId = schema.Reference?.Id;
-        var className = (schema.GetSchemaName(true) is string cName && !string.IsNullOrEmpty(cName) ?
-                            cName :
-                            (!string.IsNullOrEmpty(typeNameForInlineSchema) ?
-                                typeNameForInlineSchema :
-                                currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, schema: schema, requestBody: isRequestBody)))
-                        .CleanupSymbolName();
         var shortestNamespaceName = GetModelsNamespaceNameFromReferenceId(referenceId);
         var codeNamespaceFromParent = GetShortestNamespace(codeNamespace, schema);
         if (rootNamespace is null)
@@ -1609,6 +1603,12 @@ public partial class KiotaBuilder
         var inlineSchema = Array.Find(flattenedAllOfs, static x => !x.IsReferencedSchema());
         var referencedSchema = Array.Find(flattenedAllOfs, static x => x.IsReferencedSchema());
         var rootSchemaHasProperties = schema.HasAnyProperty();
+        var className = (schema.GetSchemaName(schema.IsSemanticallyMeaningful()) is string cName && !string.IsNullOrEmpty(cName) ?
+                cName :
+                (!string.IsNullOrEmpty(typeNameForInlineSchema) ?
+                    typeNameForInlineSchema :
+                    currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, schema: schema, requestBody: isRequestBody)))
+            .CleanupSymbolName();
         var codeDeclaration = (rootSchemaHasProperties, inlineSchema, referencedSchema) switch
         {
             // greatest parent type

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -7476,7 +7476,7 @@ components:
         Assert.Null(inlinedClassThatIsDuplicate);//no duplicate
         var modelsNamespace = codeModel.FindChildByName<CodeNamespace>("ApiSdk.models.microsoft.graph");
         Assert.NotNull(modelsNamespace);
-        Assert.Equal(4,modelsNamespace.Classes.Count());// only 4 classes for user, member, group and directoryObject
+        Assert.Equal(4, modelsNamespace.Classes.Count());// only 4 classes for user, member, group and directoryObject
     }
     [Fact]
     public async Task InheritanceWithAllOfWith3Parts3SchemaChildClass()


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4191

Update the parameter for `GetSchemaName` to be calculated based on whether the schema is meaningful (if it isn't let's try to find the name as it could be flattened schema that's referenced) so that we avoid duplicate models in the same namespace. 

Validated with graph V1 at https://github.com/microsoftgraph/msgraph-sdk-dotnet/commit/3a7dcfdff19c15aa788241fbe1949a6f6439a654 (essentially no diff present)