### PR TITLE
refs #4707 bug fix to handle string array querry parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where models would be duplicated in some allOf scenarios [#4191](https://github.com/microsoft/kiota/issues/4191)
 - Fixes a bug where CLI Generation does not handle path parameters of type "string" and format "date", "date-time", "time", etc. [#4615](https://github.com/microsoft/kiota/issues/4615)
 - Fixes a bug where request executors would be missing Untyped parameters in dotnet [#4692](https://github.com/microsoft/kiota/issues/4692)
+- Fixes a bug where CLI generation doesnot handle parameters of type string array. [#4707](https://github.com/microsoft/kiota/issues/4707)
 
 ## [1.14.0] - 2024-05-02
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2402,13 +2402,17 @@ public partial class KiotaBuilder
             Name = "string",
         };
     }
-    private static CodeType GetQueryParameterType(OpenApiSchema schema) =>
-        GetPrimitiveType(schema) ?? new()
+    private static CodeType GetQueryParameterType(OpenApiSchema schema)
+    {
+        var paramType = GetPrimitiveType(schema) ?? new()
         {
             IsExternal = true,
             Name = schema.Items?.Type ?? schema.Type,
-            CollectionKind = schema.IsArray() ? CodeTypeBase.CodeTypeCollectionKind.Array : default,
         };
+
+        paramType.CollectionKind = schema.IsArray() ? CodeTypeBase.CodeTypeCollectionKind.Array : default;
+        return paramType;
+    }
 
     private void CleanUpInternalState()
     {

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -221,6 +221,10 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
                                                 .Select(x => x.Type)
                                                 .Union(new[] { currentMethod.ReturnType })
                                                 .ToArray());
+        CorrectCoreTypes(currentMethod.Parent as CodeClass, DateTypesReplacements, currentMethod.PathQueryAndHeaderParameters
+                                                .Select(x => x.Type)
+                                                .Union(new[] { currentMethod.ReturnType })
+                                                .ToArray());
     }
 
     private static readonly Dictionary<string, (string, CodeUsing?)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
fixes #4707

Working SS:
Build of sample project
<img width="613" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/a3839672-0a8f-4df4-b9ab-dda0fe4de92b">

Option Type - string[]:
`var testStringArrayParameterOption = new Option<string[]>("--test-string-array-parameter", description: "Usage: newParameter=@newParameter") {
                Arity = ArgumentArity.ZeroOrMore
            };`
            
Parameter Type:
`[QueryParameter("testStringArrayParameter")]
public string[]? TestStringArrayParameter { get; set; }`

Tests Passing:
<img width="296" alt="image" src="https://github.com/microsoft/kiota/assets/60655155/72e4b24a-e739-4025-b91c-3b9e0fc6d7af">
