### PR TITLE
Fixes indexer cleanup for glob matching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug where models would be duplicated in some allOf scenarios [#4191](https://github.com/microsoft/kiota/issues/4191)
 - Fixes a bug where CLI Generation does not handle path parameters of type "string" and format "date", "date-time", "time", etc. [#4615](https://github.com/microsoft/kiota/issues/4615)
 - Fixes a bug where request executors would be missing Untyped parameters in dotnet [#4692](https://github.com/microsoft/kiota/issues/4692)
+- Fixes a bug where indexers in include/exclude patters were not normalized if the indexer was the last segment without a slash at the end [#4715](https://github.com/microsoft/kiota/issues/4715)
 
 ## [1.14.0] - 2024-05-02
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -331,9 +331,9 @@ public partial class KiotaBuilder
     }
     private readonly WorkspaceManagementService workspaceManagementService;
     private static readonly GlobComparer globComparer = new();
-    [GeneratedRegex(@"([\/\\])\{[\w\d-]+\}([\/\\])", RegexOptions.IgnoreCase | RegexOptions.Singleline, 2000)]
+    [GeneratedRegex(@"([\/\\])\{[\w\d-]+\}([\/\\])?", RegexOptions.IgnoreCase | RegexOptions.Singleline, 2000)]
     private static partial Regex MultiIndexSameLevelCleanupRegex();
-    private static string ReplaceAllIndexesWithWildcard(string path, uint depth = 10) => depth == 0 ? path : ReplaceAllIndexesWithWildcard(MultiIndexSameLevelCleanupRegex().Replace(path, "$1{*}$2"), depth - 1); // the bound needs to be greedy to avoid replacing anything else than single path parameters
+    internal static string ReplaceAllIndexesWithWildcard(string path, uint depth = 10) => depth == 0 ? path : ReplaceAllIndexesWithWildcard(MultiIndexSameLevelCleanupRegex().Replace(path, "$1{*}$2"), depth - 1); // the bound needs to be greedy to avoid replacing anything else than single path parameters
     private static Dictionary<Glob, HashSet<OperationType>> GetFilterPatternsFromConfiguration(HashSet<string> configPatterns)
     {
         return configPatterns.Select(static x =>

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -8647,6 +8647,24 @@ components:
         Assert.Equal("directory_administrativeunits_post", operations[1].Value.OperationId);
     }
 
+    [Theory]
+    [InlineData("repos/{id}/","repos/{*}/")] // normalish case
+    [InlineData("repos/{id}","repos/{*}")]// no trailing slash
+    [InlineData("/repos/{id}","/repos/{*}")]// no trailing slash(slash at begining).
+    [InlineData("repos/{id}/dependencies/{dep-id}","repos/{*}/dependencies/{*}")]// multiple indexers
+    [InlineData("/repos/{id}/dependencies/{dep-id}/","/repos/{*}/dependencies/{*}/")]// multiple indexers(slash at begining and end).
+    [InlineData("/repos/{id}/dependencies/{dep-id}","/repos/{*}/dependencies/{*}")]// multiple indexers(slash at begining).
+    [InlineData("repos/{id}/{dep-id}","repos/{*}/{*}")]// indexers following each other.
+    [InlineData("/repos/{id}/{dep-id}","/repos/{*}/{*}")]// indexers following each other(slash at begining).
+    [InlineData("repos/msft","repos/msft")]// no indexers
+    [InlineData("/repos","/repos")]// no indexers(slash at begining).
+    [InlineData("repos","repos")]// no indexers
+    public void ReplacesAllIndexesWithWildcard(string inputPath, string expectedGlob)
+    {
+        var resultGlob = KiotaBuilder.ReplaceAllIndexesWithWildcard(inputPath);
+        Assert.Equal(expectedGlob,resultGlob);
+    }
+
     [Fact]
     public void CleansUpOperationIdChangesOperationId()
     {

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -8648,21 +8648,21 @@ components:
     }
 
     [Theory]
-    [InlineData("repos/{id}/","repos/{*}/")] // normalish case
-    [InlineData("repos/{id}","repos/{*}")]// no trailing slash
-    [InlineData("/repos/{id}","/repos/{*}")]// no trailing slash(slash at begining).
-    [InlineData("repos/{id}/dependencies/{dep-id}","repos/{*}/dependencies/{*}")]// multiple indexers
-    [InlineData("/repos/{id}/dependencies/{dep-id}/","/repos/{*}/dependencies/{*}/")]// multiple indexers(slash at begining and end).
-    [InlineData("/repos/{id}/dependencies/{dep-id}","/repos/{*}/dependencies/{*}")]// multiple indexers(slash at begining).
-    [InlineData("repos/{id}/{dep-id}","repos/{*}/{*}")]// indexers following each other.
-    [InlineData("/repos/{id}/{dep-id}","/repos/{*}/{*}")]// indexers following each other(slash at begining).
-    [InlineData("repos/msft","repos/msft")]// no indexers
-    [InlineData("/repos","/repos")]// no indexers(slash at begining).
-    [InlineData("repos","repos")]// no indexers
+    [InlineData("repos/{id}/", "repos/{*}/")] // normalish case
+    [InlineData("repos/{id}", "repos/{*}")]// no trailing slash
+    [InlineData("/repos/{id}", "/repos/{*}")]// no trailing slash(slash at begining).
+    [InlineData("repos/{id}/dependencies/{dep-id}", "repos/{*}/dependencies/{*}")]// multiple indexers
+    [InlineData("/repos/{id}/dependencies/{dep-id}/", "/repos/{*}/dependencies/{*}/")]// multiple indexers(slash at begining and end).
+    [InlineData("/repos/{id}/dependencies/{dep-id}", "/repos/{*}/dependencies/{*}")]// multiple indexers(slash at begining).
+    [InlineData("repos/{id}/{dep-id}", "repos/{*}/{*}")]// indexers following each other.
+    [InlineData("/repos/{id}/{dep-id}", "/repos/{*}/{*}")]// indexers following each other(slash at begining).
+    [InlineData("repos/msft", "repos/msft")]// no indexers
+    [InlineData("/repos", "/repos")]// no indexers(slash at begining).
+    [InlineData("repos", "repos")]// no indexers
     public void ReplacesAllIndexesWithWildcard(string inputPath, string expectedGlob)
     {
         var resultGlob = KiotaBuilder.ReplaceAllIndexesWithWildcard(inputPath);
-        Assert.Equal(expectedGlob,resultGlob);
+        Assert.Equal(expectedGlob, resultGlob);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4715

It updates the `ReplaceAllIndexesWithWildcard` to cater for scenarios where the indexer is the end of the path without a trailing slash. 

Normally, this hasn't been seen as an issue as the indexer usually matches the openApi description. However, in some scenarios such as the VS code extension, the paths displayed maybe cleaned up due to the inder deduplication logic and thus the functionality becomes more important.

