### PR TITLE
Do not force LogLevel.Debug for DEBUG builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added uri-form encoded serialization for PHP. [#2074](https://github.com/microsoft/kiota/issues/2074)
 - Added information message with base URL in the CLI experience. [#4635](https://github.com/microsoft/kiota/issues/4635)
 - Added optional parameter --disable-ssl-validation for generate, show, and download commands. [#4176](https://github.com/microsoft/kiota/issues/4176)
+- For *Debug* builds of kiota, the `--log-level` / `--ll` option is now observed if specified explicitly on the command line. It still defaults to `Debug` for *Debug* builds and `Warning` for *Release* builds. [#4739](https://github.com/microsoft/kiota/pull/4739)
 
 ### Changed
 

--- a/src/kiota/Handlers/BaseKiotaCommandHandler.cs
+++ b/src/kiota/Handlers/BaseKiotaCommandHandler.cs
@@ -136,9 +136,6 @@ internal abstract class BaseKiotaCommandHandler : ICommandHandler, IDisposable
     protected (ILoggerFactory, ILogger<T>) GetLoggerAndFactory<T>(InvocationContext context, string logFileRootPath = "")
     {
         LogLevel logLevel = context.ParseResult.GetValueForOption(LogLevelOption);
-#if DEBUG
-        logLevel = logLevel > LogLevel.Debug ? LogLevel.Debug : logLevel;
-#endif
         var loggerFactory = LoggerFactory.Create(builder =>
         {
             var logFileAbsoluteRootPath = GetAbsolutePath(logFileRootPath);

--- a/src/kiota/KiotaHost.cs
+++ b/src/kiota/KiotaHost.cs
@@ -541,7 +541,12 @@ public static partial class KiotaHost
     }
     internal static Option<LogLevel> GetLogLevelOption()
     {
-        var logLevelOption = new Option<LogLevel>("--log-level", () => LogLevel.Warning, "The log level to use when logging messages to the main output.");
+#if DEBUG
+        static LogLevel DefaultLogLevel() => LogLevel.Debug;
+#else
+        static LogLevel DefaultLogLevel() => LogLevel.Warning;
+#endif
+        var logLevelOption = new Option<LogLevel>("--log-level", DefaultLogLevel, "The log level to use when logging messages to the main output.");
         logLevelOption.AddAlias("--ll");
         AddEnumValidator(logLevelOption, "log level");
         return logLevelOption;


### PR DESCRIPTION
Never override an explicit `--log-level` option, even in DEBUG builds but default to the `Debug` log level for DEBUG builds and keep the `Warning` default for RELEASE builds.