### PR TITLE
Ensure response description is not empty in response for openApi file generated during plugin generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TypeScript imports are now using ES6 imports with the .js extension.
 - Remove LINQ usage in generated code.
+- Ensures descriptions are not empty in sliced OpenApi file when generating a plugin. 
 
 ## [1.15.0] - 2024-06-06
 

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -108,11 +108,14 @@ public class PluginsGenerationService
         //empty out all the responses with a single empty 2XX
         foreach (var operation in doc.Paths.SelectMany(static item => item.Value.Operations.Values))
         {
+            var responseDescription = operation.Responses.Values.Select(static response => response.Description)
+                                                                      .FirstOrDefault(static desc => !string.IsNullOrEmpty(desc)) ?? "Api Response";
             operation.Responses = new OpenApiResponses()
             {
                 {
                     "2XX",new OpenApiResponse
                     {
+                        Description = responseDescription,
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
                             {

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -218,6 +218,8 @@ components:
         Assert.Empty(resultDocument.Extensions); // no extension at root (unsupported extension is removed)
         Assert.Equal(2, resultDocument.Paths.Count); // document has only two paths
         Assert.Single(resultDocument.Paths["/test"].Operations[OperationType.Get].Responses); // other responses are removed from the document
+        Assert.NotEmpty(resultDocument.Paths["/test"].Operations[OperationType.Get].Responses["2XX"].Description); // response description string is not empty
         Assert.Single(resultDocument.Paths["/test/{id}"].Operations[OperationType.Get].Responses); // 2 responses originally
+        Assert.NotEmpty(resultDocument.Paths["/test/{id}"].Operations[OperationType.Get].Responses["2XX"].Description);// response description string is not empty
     }
 }


### PR DESCRIPTION
Updates the slicing of the openApi file to ensure the response description is not empty to prevent validation from TTK as it doesn't accept empty description properties.