### PR TITLE
Fix: "Override" message only displays if there's a change on the tree

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -455,8 +455,8 @@ export async function activate(
     );
     return result;
     });
-    
   void vscode.window.showInformationMessage(`Client ${clientKey} re-generated successfully.`);
+  openApiTreeProvider.setSelectionChanged(false);
   }
   async function regeneratePlugin(clientKey: string, clientObject:any, settings: ExtensionSettings,  selectedPaths?: string[]) {
     const pluginTypes = typeof clientObject.pluginTypes === 'string' ? parsePluginType(clientObject.pluginTypes) : KiotaPluginType.ApiPlugin;
@@ -490,6 +490,7 @@ export async function activate(
       return result;
     });
     void vscode.window.showInformationMessage(`Plugin ${clientKey} re-generated successfully.`);
+    openApiTreeProvider.setSelectionChanged(false);
   }
 
   // create a new status bar item that we can now manage

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -302,6 +302,7 @@ export async function activate(
     {
       await checkForSuccess(result);
       openApiTreeProvider.refreshView();
+      openApiTreeProvider.setSelectionChanged(false);
       await loadLockFile({fsPath: workspaceJsonPath}, openApiTreeProvider, config.pluginName);
       await updateTreeViewIcons(treeViewId, false, true);
       await exportLogsAndShowErrors(result);
@@ -344,6 +345,7 @@ export async function activate(
     {
       await checkForSuccess(result);
       openApiTreeProvider.refreshView();
+      openApiTreeProvider.setSelectionChanged(false);
       await loadLockFile({fsPath: workspaceJsonPath}, openApiTreeProvider, config.pluginName);
       await updateTreeViewIcons(treeViewId, false, true);
       await exportLogsAndShowErrors(result);
@@ -415,6 +417,7 @@ export async function activate(
     {
       await checkForSuccess(result);
       openApiTreeProvider.refreshView();
+      openApiTreeProvider.setSelectionChanged(false);
       await loadLockFile({fsPath: workspaceJsonPath}, openApiTreeProvider, config.clientClassName);
       await updateTreeViewIcons(treeViewId, false, true);
       await exportLogsAndShowErrors(result);

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -171,8 +171,8 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
     public hasSelectionChanged(): boolean {
         return this.selectionChanged;
     }
-    public setSelectionChanged() {
-        this.selectionChanged = true;
+    public setSelectionChanged(state: boolean) {
+        this.selectionChanged = state;
     }
     public async setDescriptionUrl(descriptionUrl: string): Promise<void> {
         this.closeDescription(false);
@@ -196,7 +196,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
     }
     private selectInternal(apiNode: KiotaOpenApiNode, selected: boolean, recursive: boolean) {
         apiNode.selected = selected;
-        this.setSelectionChanged();
+        this.setSelectionChanged(true);
         const isOperationNode = apiNode.isOperation ?? false;
         if (recursive) {
             apiNode.children.forEach(x => this.selectInternal(x, selected, recursive));
@@ -206,7 +206,7 @@ export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeN
             const parent = this.findApiNode(getPathSegments(trimOperation(apiNode.path)), this.rawRootNode);
             if (parent) {
                 parent.selected = selected;
-                this.setSelectionChanged();
+                this.setSelectionChanged(true);
             }
         }
     }


### PR DESCRIPTION
Fixes #4853 

if the Open API tree has changes and a user wishes to open a new description, the override message will appear else, no message appears even after regeneration

Steps to test: 
1. Load extension
2. Open an API Description
3. Select paths and generate a client/plugin/manifest
4. When the tree reloads, try to open an API description file again
5. Observe no message
6. Now select/unselect a node or some nodes, then try to open an API description file 
7. Observe the message appears