### PR TITLE
Fix: Update plugin type on to accept multiple values

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -309,7 +309,7 @@ export async function activate(
     }
   }
   async function generatePluginAndRefreshUI(config: Partial<GenerateState>, settings: ExtensionSettings, outputPath: string, selectedPaths: string[]):Promise<void> {
-    const pluginTypes = typeof config.pluginTypes === 'string' ? parsePluginType(config.pluginTypes) : KiotaPluginType.ApiPlugin;
+    const pluginTypes = Array.isArray(config.pluginTypes) ? parsePluginType(config.pluginTypes) : [KiotaPluginType.ApiPlugin];
     const result = await vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
       cancellable: false,
@@ -320,7 +320,7 @@ export async function activate(
         context,
         openApiTreeProvider.descriptionUrl,
         outputPath,
-        [pluginTypes],
+        pluginTypes,
         selectedPaths,
         [],
         typeof config.pluginName === "string"
@@ -459,7 +459,7 @@ export async function activate(
   openApiTreeProvider.setSelectionChanged(false);
   }
   async function regeneratePlugin(clientKey: string, clientObject:any, settings: ExtensionSettings,  selectedPaths?: string[]) {
-    const pluginTypes = typeof clientObject.pluginTypes === 'string' ? parsePluginType(clientObject.pluginTypes) : KiotaPluginType.ApiPlugin;
+    const pluginTypes =  Array.isArray(clientObject.types) ? parsePluginType(clientObject.types) : [KiotaPluginType.ApiPlugin];
     await vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
       cancellable: false,
@@ -470,7 +470,7 @@ export async function activate(
         context,
         clientObject.descriptionLocation,
         clientObject.outputPath,
-        [pluginTypes],
+        pluginTypes,
         selectedPaths ? selectedPaths : clientObject.includePatterns,
         [],
         clientKey,

--- a/vscode/microsoft-kiota/src/kiotaInterop.ts
+++ b/vscode/microsoft-kiota/src/kiotaInterop.ts
@@ -125,18 +125,21 @@ export enum ConsumerOperation {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     Generate
 }
-export function parsePluginType(value: string): KiotaPluginType {
-    switch (value) {
-        case "OpenAI":
-            return KiotaPluginType.OpenAI;
-        case "ApiManifest":
-            return KiotaPluginType.ApiManifest;
-        case "ApiPlugin":
-            return KiotaPluginType.ApiPlugin;
-        default:
-            throw new Error("unknown plugin type");
-    }
+export function parsePluginType(values: string[]): KiotaPluginType[] {
+    return values.map(value => {
+        switch (value.toLowerCase()) {
+            case "openai":
+                return KiotaPluginType.OpenAI;
+            case "apimanifest":
+                return KiotaPluginType.ApiManifest;
+            case "apiplugin":
+                return KiotaPluginType.ApiPlugin;
+            default:
+                throw new Error(`unknown plugin type: ${value}`);
+        }
+    });
 }
+
 export function generationLanguageToString(language: KiotaGenerationLanguage): string {
     switch (language) {
         case KiotaGenerationLanguage.CSharp:


### PR DESCRIPTION
Fixes #4870 

This PR updates the generation and re-generation functions to accept an array of plugin types.

**Steps to test**
1. Load extension
2. Open an API description and select endpoints
3. Generate a plugin
4. Open workspace.json and edit the plugin type, save, then click re-generate on the file.
5. Observe fix