### PR TITLE
Fix `ErrorMessageOverride` collision with classname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensures HashSet properties in `KiotaLock` maintain IgnoreCase comparer across runs [#4916](https://github.com/microsoft/kiota/issues/4916)
 - Dropped `client base url set to` message when generating plugins. [#4905](https://github.com/microsoft/kiota/issues/4905)
 - Emit `[GeneratedCode]` attribute for C# types. [#4907](https://github.com/microsoft/kiota/issues/4907)
+- Fixes error property disambiguation when the property has the same name as class [#4893](https://github.com/microsoft/kiota/issues/)
 
 ## [1.15.0] - 2024-06-06
 

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -509,6 +509,32 @@ public class CSharpLanguageRefinerTests
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
         Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed
         Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.Single(exception.Properties);
+        Assert.Equal("message", exception.Properties.First().Name, StringComparer.OrdinalIgnoreCase);
+    }
+    [Fact]
+    public async Task RenamesExceptionClassWithReservedPropertyNameWhenPropertyIsInitiallyAbsent()
+    {
+        var exception = root.AddClass(new CodeClass
+        {
+            Name = "message",
+            Kind = CodeClassKind.Model,
+            IsErrorDefinition = true,
+        }).First();
+        var propToAdd = exception.AddProperty(new CodeProperty
+        {
+            Name = "something",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed
+        Assert.Equal("something", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(2, exception.Properties.Count()); // initial property plus primary message
+        Assert.Equal("Message", exception.Properties.ToArray()[0].Name);
+        Assert.Equal("Something", exception.Properties.ToArray()[1].Name);
     }
     [Fact]
     public async Task DoesNotReplaceNonExceptionPropertiesNames()

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -485,9 +485,9 @@ public class CSharpLanguageRefinerTests
         Assert.False(exception.Properties.First().IsOfKind(CodePropertyKind.ErrorMessageOverride));// property is NOT message override
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
         Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase);// property remains
-        Assert.Single(exception.Properties);
+        Assert.Single(exception.Properties); // no new properties added
         Assert.True(exception.Properties.First().IsOfKind(CodePropertyKind.ErrorMessageOverride));// property is now message override
-        Assert.Equal("Message", exception.Properties.First().Name);
+        Assert.Equal("message", exception.Properties.First().Name, StringComparer.OrdinalIgnoreCase); // name is expected.
     }
     [Fact]
     public async Task RenamesExceptionClassWithReservedPropertyName()
@@ -507,9 +507,9 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed
-        Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
-        Assert.Single(exception.Properties);
+        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed to avoid removing special overidden property
+        Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase); // property is unchanged
+        Assert.Single(exception.Properties); // no new properties added
         Assert.Equal("message", exception.Properties.First().Name, StringComparer.OrdinalIgnoreCase);
     }
     [Fact]
@@ -530,11 +530,11 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed
-        Assert.Equal("something", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed to avoid removing special overidden property
+        Assert.Equal("something", propToAdd.Name, StringComparer.OrdinalIgnoreCase); // existing property remains
         Assert.Equal(2, exception.Properties.Count()); // initial property plus primary message
-        Assert.Equal("Message", exception.Properties.ToArray()[0].Name);
-        Assert.Equal("Something", exception.Properties.ToArray()[1].Name);
+        Assert.Equal("message", exception.Properties.ToArray()[0].Name, StringComparer.OrdinalIgnoreCase); // primary error message is present
+        Assert.Equal("something", exception.Properties.ToArray()[1].Name, StringComparer.OrdinalIgnoreCase);// existing property remains
     }
     [Fact]
     public async Task DoesNotReplaceNonExceptionPropertiesNames()

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -455,6 +455,51 @@ public class CSharpLanguageRefinerTests
         }).First();
         var propToAdd = exception.AddProperty(new CodeProperty
         {
+            Name = "stacktrace",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+        Assert.Equal("stacktraceEscaped", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("stacktrace", propToAdd.SerializationName, StringComparer.OrdinalIgnoreCase);
+    }
+    [Fact]
+    public async Task DoesNotRenamePrimaryErrorMessageIfMatchAlreadyExists()
+    {
+        var exception = root.AddClass(new CodeClass
+        {
+            Name = "error403",
+            Kind = CodeClassKind.Model,
+            IsErrorDefinition = true,
+        }).First();
+        var propToAdd = exception.AddProperty(new CodeProperty
+        {
+            Name = "message",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        Assert.False(exception.Properties.First().IsOfKind(CodePropertyKind.ErrorMessageOverride));// property is NOT message override
+        await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
+        Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase);// property remains
+        Assert.Single(exception.Properties);
+        Assert.True(exception.Properties.First().IsOfKind(CodePropertyKind.ErrorMessageOverride));// property is now message override
+        Assert.Equal("Message", exception.Properties.First().Name);
+    }
+    [Fact]
+    public async Task RenamesExceptionClassWithReservedPropertyName()
+    {
+        var exception = root.AddClass(new CodeClass
+        {
+            Name = "message",
+            Kind = CodeClassKind.Model,
+            IsErrorDefinition = true,
+        }).First();
+        var propToAdd = exception.AddProperty(new CodeProperty
+        {
             Name = "message",
             Type = new CodeType
             {
@@ -462,8 +507,8 @@ public class CSharpLanguageRefinerTests
             }
         }).First();
         await ILanguageRefiner.Refine(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root);
-        Assert.Equal("messageEscaped", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
-        Assert.Equal("message", propToAdd.SerializationName, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("messageEscaped", exception.Name, StringComparer.OrdinalIgnoreCase);// class is renamed
+        Assert.Equal("message", propToAdd.Name, StringComparer.OrdinalIgnoreCase);
     }
     [Fact]
     public async Task DoesNotReplaceNonExceptionPropertiesNames()


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4893

In summary, this PR

- Updates the `ReplaceReservedExceptionPropertyNames` method to also rename the error class if it is the same name as a reserved class to avoid collision with class name and property name.
- Updates the `AddPrimaryErrorMessage` to rename existing matching properties if they already exist in the error model to avoid information/property loss (otherwise we will fail to add the override and lead to invalid generation)
- Add tests to validate the scenarios.

Essentially, in a scenario where a `ErrorMessageOverride` property kind named `message` is added,
- if the error model class is also called `message`, the model class will be renamed to avoid class and property name collision.
- if a property with the same name already exists in the model, the pre-existing property is renamed to ensure the suitable override is added (if the type does not match).
- otherwise, normal behavior of adding the override property will be used.