### PR TITLE
ci: fixes preview generated code unit test failure introduced by #4907

### DIFF
--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassDeclarationWriterTests.cs
@@ -113,7 +113,6 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
     {
         codeElementWriter.WriteCodeElement(parentClass.StartBlock, writer);
         var result = tw.ToString();
-        var pattern = @"\s+\[global::System\.CodeDom\.Compiler\.GeneratedCode\(""Kiota"", ""[0-9]+\.[0-9]+\.[0-9]+\""\)\]";
-        Assert.Matches(pattern, result);
+        Assert.Matches(CodeEnumWriterTests.GeneratedCodePattern, result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -130,13 +130,13 @@ public sealed class CodeEnumWriterTests : IDisposable
         Assert.Empty(result);
     }
 
+    internal const string GeneratedCodePattern = @"\s+\[global::System\.CodeDom\.Compiler\.GeneratedCode\(""Kiota"", ""[0-9]+\.[0-9]+\.[0-9]+(?:-preview\.\d+)?""\)\]";
     [Fact]
     public void WritesGeneratedCodeAttribute()
     {
         currentEnum.AddOption(new CodeEnumOption { Name = "option2" });
         writer.Write(currentEnum);
         var result = tw.ToString();
-        var pattern = @"\s+\[global::System\.CodeDom\.Compiler\.GeneratedCode\(""Kiota"", ""[0-9]+\.[0-9]+\.[0-9]+\""\)\]";
-        Assert.Matches(pattern, result);
+        Assert.Matches(GeneratedCodePattern, result);
     }
 }


### PR DESCRIPTION
follow up to #4907

More context: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=155225&view=logs&j=7871e8ac-1348-5c5a-3691-0fa1e72e8e2e&t=d966bf08-649a-57f5-fb3f-a56ed96c454c

This is blocking preview releases