### PR TITLE
Update the replacement of reserved names in GoRefiner

### DIFF
--- a/src/Kiota.Builder/Refiners/GoNamespaceReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/GoNamespaceReservedNamesProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kiota.Builder.Refiners;
+public class GoNamespaceReservedNamesProvider : IReservedNamesProvider
+{
+    private readonly Lazy<HashSet<string>> _reservedNames = new(() => new(StringComparer.OrdinalIgnoreCase) {
+        "break",
+        "case",
+        "chan",
+        "const",
+        "continue",
+        "default",
+        "defer",
+        "else",
+        "fallthrough",
+        "for",
+        "func",
+        "goto",
+        "if",
+        "import",
+        "interface",
+        "map",
+        "package",
+        "range",
+        "return",
+        "select",
+        "struct",
+        "switch",
+        "type",
+        "var",
+        "vendor", // cannot be used as a package name
+        "BaseRequestBuilder",
+        "MultipartBody",
+    });
+    public HashSet<string> ReservedNames => _reservedNames.Value;
+}

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -93,9 +93,16 @@ public class GoRefiner : CommonLanguageRefiner
             FixConstructorClashes(generatedCode, x => $"{x}Escaped");
             ReplaceReservedNames(
                 generatedCode,
+                new GoNamespaceReservedNamesProvider(),
+                x => $"{x}Escaped",
+                shouldReplaceCallback: x => x is CodeNamespace
+            );
+            ReplaceReservedNames(
+                generatedCode,
                 new GoReservedNamesProvider(),
                 x => $"{x}Escaped",
-                shouldReplaceCallback: x => (x is not CodeEnumOption && x is not CodeEnum) && // enums and enum options start with uppercase
+                shouldReplaceCallback: x => (x is not CodeNamespace) &&
+                                            (x is not CodeEnumOption && x is not CodeEnum) && // enums and enum options start with uppercase
                                             (x is not CodeProperty currentProp ||
                                             !(currentProp.Parent is CodeClass parentClass &&
                                             parentClass.IsOfKind(CodeClassKind.QueryParameters, CodeClassKind.ParameterSet) &&

--- a/src/Kiota.Builder/Refiners/GoReservedNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/GoReservedNamesProvider.cs
@@ -1,38 +1,16 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Kiota.Builder.Refiners;
+
 public class GoReservedNamesProvider : IReservedNamesProvider
 {
-    private readonly Lazy<HashSet<string>> _reservedNames = new(() => new(StringComparer.OrdinalIgnoreCase) {
-        "break",
-        "case",
-        "chan",
-        "const",
-        "continue",
-        "default",
-        "defer",
-        "else",
-        "fallthrough",
-        "for",
-        "func",
-        "go",
-        "goto",
-        "if",
-        "import",
-        "interface",
-        "map",
-        "package",
-        "range",
-        "return",
-        "select",
-        "struct",
-        "switch",
-        "type",
-        "var",
-        "vendor", // cannot be used as a package name
-        "BaseRequestBuilder",
-        "MultipartBody",
+    private readonly Lazy<HashSet<string>> _reservedNames = new(() =>
+    {
+        var reservedNames = new GoNamespaceReservedNamesProvider().ReservedNames;
+        reservedNames.Add("go");
+        return reservedNames;
     });
+
     public HashSet<string> ReservedNames => _reservedNames.Value;
 }


### PR DESCRIPTION
Add handling for Go-specific namespace reserved names in GoRefiner.