### PR TITLE
Fix: Workspace file display

### DIFF
--- a/vscode/microsoft-kiota/package.json
+++ b/vscode/microsoft-kiota/package.json
@@ -409,6 +409,10 @@
       {
         "command": "kiota.regenerate",
         "title": "%kiota.openApiExplorer.regenerateButton.title%"
+      },
+      {
+        "command": "kiota.workspace.refresh",
+        "title": "%kiota.openApiExplorer.refresh.title%"
       }
     ],
     "languages": [

--- a/vscode/microsoft-kiota/package.nls.json
+++ b/vscode/microsoft-kiota/package.nls.json
@@ -29,5 +29,6 @@
   "kiota.openApiExplorer.openFile.title": "Open file",
   "kiota.workspace.name": "My Workspace",
   "kiota.openApiExplorer.regenerateButton.title": "Re-generate",
-  "kiota.openApiExplorer.editPaths.title": "Edit paths"
+  "kiota.openApiExplorer.editPaths.title": "Edit paths",
+  "kiota.openApiExplorer.refresh.title": "Refresh"
 }

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -444,6 +444,7 @@ export async function activate(
     openApiTreeProvider.setSelectionChanged(false);
     const workspaceJsonPath = getWorkspaceJsonPath();
     await loadLockFile({fsPath: workspaceJsonPath}, openApiTreeProvider, clientNameOrPluginName );
+    await vscode.commands.executeCommand('kiota.workspace.refresh');
     await updateTreeViewIcons(treeViewId, false, true);
   }
   async function regenerateClient(clientKey: string, clientObject:any, settings: ExtensionSettings,  selectedPaths?: string[]): Promise<void> {

--- a/vscode/microsoft-kiota/src/util.ts
+++ b/vscode/microsoft-kiota/src/util.ts
@@ -42,6 +42,7 @@ export function getWorkspaceJsonDirectory(clientNameOrPluginName?: string): stri
   return workspaceFolder;
 }
 
+//used to store output in the App Package directory in the case where the workspace is a Teams Toolkit Project
 export function findAppPackageDirectory(directory: string): string | null {
   if (!fs.existsSync(directory)) {
     return null;


### PR DESCRIPTION
Fixes #4855 

Please note that VSCode does not provide direct APIs to programmatically collapse or expand the entire tree view