### PR TITLE
remove falsy check for nulls in method parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds generation of default 'color.png`and`outline.png` files when generating plugins. [#4993](https://github.com/microsoft/kiota/issues/4993)
+- Adds generation of default `color.png` and `outline.png` files when generating plugins. [#4993](https://github.com/microsoft/kiota/issues/4993)
 
 ### Changed
 
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exclude the `x-openai-isConsequential` extension from cleanup. [#4962](https://github.com/microsoft/kiota/issues/4962)
 - Fixed file name and namespace sanitization when generating plugins. [#5019](https://github.com/microsoft/kiota/issues/5019)
 - Added TypeScript typecheck suppression to generated method prototype, where anused arguments can cause build fail in projects which use `noUnusedLocals: true` compiler option. [#5095](https://github.com/microsoft/kiota/issues/5095)
+- Fixed a bug where defensive programming would consider some default values as invalid in Python.
 
 ## [1.16.0] - 2024-07-05
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -43,7 +43,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
             foreach (var parameter in codeElement.Parameters.Where(static x => !x.Optional).OrderBy(static x => x.Name))
             {
                 var parameterName = parameter.Name;
-                writer.StartBlock($"if not {parameterName}:");
+                writer.StartBlock($"if {parameterName} is None:");
                 writer.WriteLine($"raise TypeError(\"{parameterName} cannot be null.\")");
                 writer.DecreaseIndent();
             }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -2086,7 +2086,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains("if not original_name:", result);
+        Assert.Contains("if original_name is None:", result);
         Assert.Contains("if original_name == \"select\":", result);
         Assert.Contains("return \"%24select\"", result);
         Assert.Contains("if original_name == \"expand\":", result);
@@ -2124,7 +2124,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains("if not original_name:", result);
+        Assert.Contains("if original_name is None:", result);
         Assert.Contains("if original_name == \"start_date_time\":", result);
         Assert.Contains("return \"startDateTime\"", result);
         Assert.Contains("return original_name", result);


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-python/issues/795


Note that

`if not column` is falsy even if colum exists and is zero, using i`f column is None` will check that column is null in a better way in this case:


The generated code behavior is now adjusted from
```python
if not body:
    raise TypeError("body cannot be null.")
request_info = self.to_patch_request_information(
        body, request_configuration
    )

```

To
```python

if body is None:
    raise TypeError("body cannot be null.")
request_info = self.to_patch_request_information(
        body, request_configuration
    )
```


And the same applies in all areas including drive items