### PR TITLE
Task: default plugin name

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -135,12 +135,14 @@ export async function activate(
         }
 
         let languagesInformation = await getLanguageInformation(context);
+        const pluginName = getPluginName();
         config = await generateSteps(
           {
             clientClassName: openApiTreeProvider.clientClassName,
             clientNamespaceName: openApiTreeProvider.clientNamespaceName,
             language: openApiTreeProvider.language,
             outputPath: openApiTreeProvider.outputPath,
+            pluginName
           },
           languagesInformation
         );
@@ -187,6 +189,12 @@ export async function activate(
           } else {
             await displayGenerationResults(context, openApiTreeProvider, config);
           }
+        }
+        function getPluginName(): string | undefined {
+          if (openApiTreeProvider.apiTitle) {
+            return openApiTreeProvider.apiTitle.replace(/[^a-zA-Z0-9_]+/g, '');
+          }
+          return undefined;
         }
       }
     ),

--- a/vscode/microsoft-kiota/src/openApiTreeProvider.ts
+++ b/vscode/microsoft-kiota/src/openApiTreeProvider.ts
@@ -23,7 +23,7 @@ import { updateTreeViewIcons } from './util';
 export class OpenApiTreeProvider implements vscode.TreeDataProvider<OpenApiTreeNode> {
     private _onDidChangeTreeData: vscode.EventEmitter<OpenApiTreeNode | undefined | null | void> = new vscode.EventEmitter<OpenApiTreeNode | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<OpenApiTreeNode | undefined | null | void> = this._onDidChangeTreeData.event;
-    private apiTitle?: string;
+    public apiTitle?: string;
     private initialStateHash: string = '';
     constructor(
         private readonly context: vscode.ExtensionContext,


### PR DESCRIPTION
Adds a default plugin name from the Open API description

Closes #5110 

## Demo

![image](https://github.com/user-attachments/assets/2680b0c4-5d09-4cff-b88e-d0fdcc89772b)

After generation
![image](https://github.com/user-attachments/assets/997253fe-ad65-4a22-a69a-907ba6d198fc)

Name editable
![image](https://github.com/user-attachments/assets/cae69451-2752-4044-a6c3-491de32551f7)

After generation with new name
![image](https://github.com/user-attachments/assets/f227d361-d153-4f0b-b83f-893f37845d76)



