### PR TITLE
Task: regenerate without overwrite

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -527,7 +527,7 @@ export async function activate(
         [],
         clientKey,
         settings.clearCache,
-        settings.cleanOutput,
+        false,
         settings.disableValidationRules,
         ConsumerOperation.Edit
       );


### PR DESCRIPTION
Closes #5094 

# Notes

- Sets the regeneration behavior of `cleanOutput` to false to allow the plugin to be regerated in the same folder without overwriting
