### PR TITLE
chore: upgrade dependencies feat: removes openai plugin generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed OpenAI plugins generation since the service does not support them anymore.
 - Fixed an issue where models would be missing when they had no properties and a single allOf entry. [#5014](https://github.com/microsoft/kiota/issues/5014)
 - Reverts modification of responses in output openApi file when generating plugins [#4945](https://github.com/microsoft/kiota/issues/4945)
 - Expand properties types with null type for Typescript. [#4993](https://github.com/microsoft/kiota-typescript/issues/1188)

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.17" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.5-preview" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.17" />
-    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.7-preview" />
+    <PackageReference Include="Microsoft.Plugins.Manifest" Version="0.0.19-preview" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/Kiota.Builder/Plugins/AuthComparer.cs
+++ b/src/Kiota.Builder/Plugins/AuthComparer.cs
@@ -16,6 +16,6 @@ internal class AuthComparer : IEqualityComparer<Auth>
     public int GetHashCode([DisallowNull] Auth obj)
     {
         if (obj == null) return 0;
-        return obj.Type is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Type.Value.ToString()) * 3;
+        return obj.Type is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Type) * 3;
     }
 }

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -91,7 +91,8 @@ paths:
 
         Assert.True(File.Exists(Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-apiplugin.json")));
         Assert.True(File.Exists(Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-apimanifest.json")));
-        Assert.True(File.Exists(Path.Combine(outputDirectory, OpenAIPluginFileName)));
+        // v1 plugins are not generated anymore
+        Assert.False(File.Exists(Path.Combine(outputDirectory, OpenAIPluginFileName)));
         Assert.True(File.Exists(Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-openapi.yml")));
         Assert.False(File.Exists(Path.Combine(outputDirectory, "manifest.json")));
         Assert.False(File.Exists(Path.Combine(outputDirectory, "color.png")));
@@ -106,14 +107,6 @@ paths:
         Assert.Equal(2, resultingManifest.Document.Functions.Count);// all functions are generated despite missing operationIds
         Assert.Equal(expectedPluginName, resultingManifest.Document.Namespace);// namespace is cleaned up.
         Assert.Empty(resultingManifest.Problems);// no problems are expected with names
-
-        // Validate the v1 plugin
-        var v1ManifestContent = await File.ReadAllTextAsync(Path.Combine(outputDirectory, OpenAIPluginFileName));
-        using var v1JsonDocument = JsonDocument.Parse(v1ManifestContent);
-        var v1Manifest = PluginManifestDocument.Load(v1JsonDocument.RootElement);
-        Assert.NotNull(resultingManifest.Document);
-        Assert.Equal($"{expectedPluginName.ToLower()}-openapi.yml", v1Manifest.Document.Api.URL);
-        Assert.Empty(v1Manifest.Problems);
     }
     private const string ManifestFileName = "client-apiplugin.json";
     private const string OpenAIPluginFileName = "openai-plugins.json";


### PR DESCRIPTION
this upgrades the plugins dependency.
it also removes the openAI plugin generation since now the service only requires the sliced description.
We might want to review the CLI UX and the extension UX at a later phase since now we could ask one fewer question.
CC @sebastienlevert