### PR TITLE
Source generated models should not scream on CS0618

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expand properties types with null type for Typescript. [#4993](https://github.com/microsoft/kiota-typescript/issues/1188)
 - Added Collection, HashMap, Map, Objects, InputStream, BigDecimal to the list of reserved names for Java generation. [#5135](https://github.com/microsoft/kiota/issues/5135)
 - C# refiner now fixes data types for indexers. [#5201](https://github.com/microsoft/kiota/issues/5201)
+- C# do not report CS0618 in the generated code. [#5229](https://github.com/microsoft/kiota/issues/5229)
 
 ## [1.17.0] - 2024-08-09
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -21,6 +21,9 @@ public class CSharpConventionService : CommonLanguageConventionService
     public const string NullableEnableDirective = "#nullable enable";
     public const string NullableRestoreDirective = "#nullable restore";
 
+    public const string CS0618 = "CS0618";
+    public const string CS1591 = "CS1591";
+
     public static void WriteNullableOpening(LanguageWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
@@ -37,6 +40,16 @@ public class CSharpConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(writer);
         writer.WriteLine("#endif", false);
+    }
+    public void WritePragmaDisable(LanguageWriter writer, string code)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        writer.WriteLine($"#pragma warning disable {code}");
+    }
+    public void WritePragmaRestore(LanguageWriter writer, string code)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        writer.WriteLine($"#pragma warning restore {code}");
     }
     private const string ReferenceTypePrefix = "<see cref=\"";
     private const string ReferenceTypeSuffix = "\"/>";

--- a/src/Kiota.Builder/Writers/CSharp/CodeBlockEndWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeBlockEndWriter.cs
@@ -12,6 +12,7 @@ public class CodeBlockEndWriter : BaseElementWriter<BlockEnd, CSharpConventionSe
         if (codeElement?.Parent is CodeClass codeClass && codeClass.Parent is CodeNamespace)
         {
             writer.CloseBlock();
+            conventions.WritePragmaRestore(writer, CSharpConventionService.CS0618);
         }
     }
 }

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -18,7 +18,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         if (codeElement.Parent?.Parent is CodeNamespace)
         {
             writer.WriteLine(AutoGenerationHeader);
-            writer.WriteLine("#pragma warning disable CS0618");
+            conventions.WritePragmaDisable(writer, CSharpConventionService.CS0618);
             codeElement.Usings
                     .Where(x => (x.Declaration?.IsExternal ?? true) || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
                     .Select(static x => x.Declaration?.IsExternal ?? false ?
@@ -40,9 +40,9 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         bool hasDescription = conventions.WriteLongDescription(parentClass, writer);
         conventions.WriteDeprecationAttribute(parentClass, writer);
         writer.WriteLine(GeneratedCodeAttribute);
-        if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
+        if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
         writer.WriteLine($"public partial class {codeElement.Name.ToFirstCharacterUpperCase()} {derivation}");
-        if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
+        if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
         writer.StartBlock();
     }
 }

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -18,6 +18,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         if (codeElement.Parent?.Parent is CodeNamespace)
         {
             writer.WriteLine(AutoGenerationHeader);
+            writer.WriteLine("#pragma warning disable CS0618");
             codeElement.Usings
                     .Where(x => (x.Declaration?.IsExternal ?? true) || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
                     .Select(static x => x.Declaration?.IsExternal ?? false ?

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassDeclarationWriterTests.cs
@@ -55,6 +55,14 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
     }
 
     [Fact]
+    public void WritesWarningDisableCs0618()
+    {
+        codeElementWriter.WriteCodeElement(parentClass.StartBlock, writer);
+        var result = tw.ToString();
+        Assert.Contains("#pragma warning disable CS0618", result);
+    }
+
+    [Fact]
     public void WritesImplementation()
     {
         var declaration = parentClass.StartBlock;

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassEndWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeClassEndWriterTests.cs
@@ -45,6 +45,14 @@ public sealed class CodeClassEndWriterTests : IDisposable
         codeElementWriter.WriteCodeElement(child.EndBlock, writer);
         var result = tw.ToString();
         Assert.Equal(1, result.Count(x => x == '}'));
+        Assert.DoesNotContain("#pragma warning restore CS0618", result);
+    }
+    [Fact]
+    public void WritesWarningRestoreCs0618()
+    {
+        codeElementWriter.WriteCodeElement(parentClass.EndBlock, writer);
+        var result = tw.ToString();
+        Assert.Contains("#pragma warning restore CS0618", result);
     }
     [Fact]
     public void ClosesNonNestedClasses()


### PR DESCRIPTION
Hi,
when the source document contains a model that is not deprecated but contains a deprecated property, the compiler is unhappy with CS0618. This PR simply disables CS0618 in generated code