### PR TITLE
If any response contains octet-stream, make response binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed shorthand for refresh option in workspace experience. [#5240](https://github.com/microsoft/kiota/issues/5240)
 - Fixed missing type options in help for plugin commands. [#5230](https://github.com/microsoft/kiota/issues/5230)
 - Removed OpenAI plugins generation since the service does not support them anymore.
+- Redirect status codes documenting an application/octet-stream content type now generate a stream return type. [#5246](https://github.com/microsoft/kiota/issues/5246)
 - Fixed an issue where models would be missing when they had no properties and a single allOf entry. [#5014](https://github.com/microsoft/kiota/issues/5014)
 - Reverts modification of responses in output openApi file when generating plugins [#4945](https://github.com/microsoft/kiota/issues/4945)
 - Expand properties types with null type for Typescript. [#4993](https://github.com/microsoft/kiota-typescript/issues/1188)

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1159,6 +1159,7 @@ public partial class KiotaBuilder
         };
     }
     private const string RequestBodyPlainTextContentType = "text/plain";
+    private const string RequestBodyOctetStreamContentType = "application/octet-stream";
     private static readonly HashSet<string> noContentStatusCodes = new(StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "301", "302", "303", "304", "307" };
     private static readonly HashSet<string> errorStatusCodes = new(Enumerable.Range(400, 599).Select(static x => x.ToString(CultureInfo.InvariantCulture))
                                                                                  .Concat([CodeMethod.ErrorMappingClientRange, CodeMethod.ErrorMappingServerRange]), StringComparer.OrdinalIgnoreCase);
@@ -1249,7 +1250,9 @@ public partial class KiotaBuilder
             else if (modelType is null)
             {
                 string returnType;
-                if (operation.Responses.Any(static x => noContentStatusCodes.Contains(x.Key)))
+                if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyOctetStreamContentType)))
+                    returnType = "binary";
+                else if (operation.Responses.Any(static x => noContentStatusCodes.Contains(x.Key)))
                     returnType = VoidType;
                 else if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyPlainTextContentType)))
                     returnType = "string";

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1160,7 +1160,8 @@ public partial class KiotaBuilder
     }
     private const string RequestBodyPlainTextContentType = "text/plain";
     private const string RequestBodyOctetStreamContentType = "application/octet-stream";
-    private static readonly HashSet<string> noContentStatusCodes = new(StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "301", "302", "303", "304", "307" };
+    private static readonly HashSet<string> redirectStatusCodes = new(StringComparer.OrdinalIgnoreCase) { "301", "302", "303", "307" };
+    private static readonly HashSet<string> noContentStatusCodes = new(redirectStatusCodes, StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "304" };
     private static readonly HashSet<string> errorStatusCodes = new(Enumerable.Range(400, 599).Select(static x => x.ToString(CultureInfo.InvariantCulture))
                                                                                  .Concat([CodeMethod.ErrorMappingClientRange, CodeMethod.ErrorMappingServerRange]), StringComparer.OrdinalIgnoreCase);
     private void AddErrorMappingsForExecutorMethod(OpenApiUrlTreeNode currentNode, OpenApiOperation operation, CodeMethod executorMethod)
@@ -1249,30 +1250,27 @@ public partial class KiotaBuilder
             }
             else if (modelType is null)
             {
-                string returnType;
-                if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyOctetStreamContentType)))
-                    returnType = "binary";
-                else if (operation.Responses.Any(static x => noContentStatusCodes.Contains(x.Key)))
-                    returnType = VoidType;
-                else if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyPlainTextContentType)))
-                    returnType = "string";
-                else
-                    returnType = "binary";
-                return (new CodeType { Name = returnType, IsExternal = true, }, null);
+                return (GetExecutorMethodDefaultReturnType(operation), null);
             }
             return (modelType, null);
         }
         else
         {
-            string returnType;
-            if (operation.Responses.Any(static x => noContentStatusCodes.Contains(x.Key)))
-                returnType = VoidType;
-            else if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyPlainTextContentType)))
-                returnType = "string";
-            else
-                returnType = "binary";
-            return (new CodeType { Name = returnType, IsExternal = true, }, null);
+            return (GetExecutorMethodDefaultReturnType(operation), null);
         }
+    }
+    private static CodeType GetExecutorMethodDefaultReturnType(OpenApiOperation operation)
+    {
+        string returnType;
+        if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyOctetStreamContentType) && redirectStatusCodes.Contains(x.Key)))
+            returnType = "binary";
+        else if (operation.Responses.Any(static x => noContentStatusCodes.Contains(x.Key)))
+            returnType = VoidType;
+        else if (operation.Responses.Any(static x => x.Value.Content.ContainsKey(RequestBodyPlainTextContentType)))
+            returnType = "string";
+        else
+            returnType = "binary";
+        return new CodeType { Name = returnType, IsExternal = true, };
     }
     private void CreateOperationMethods(OpenApiUrlTreeNode currentNode, OperationType operationType, OpenApiOperation operation, CodeClass parentClass)
     {

--- a/tests/Kiota.Builder.Tests/ContentTypeMappingTests.cs
+++ b/tests/Kiota.Builder.Tests/ContentTypeMappingTests.cs
@@ -57,6 +57,7 @@ public sealed class ContentTypeMappingTests : IDisposable
     [InlineData("application/octet-stream", "204", false, "default", "void")]
     [InlineData("application/octet-stream", "200", true, "default", "binary")]
     [InlineData("application/octet-stream", "200", false, "default", "binary")]
+    [InlineData("application/octet-stream", "302", false, "default", "binary")] // on a redirect to a binary content we generate a binary return type for download
     [InlineData("text/html", "204", true, "default", "void")]
     [InlineData("text/html", "204", false, "default", "void")]
     [InlineData("text/html", "200", true, "default", "binary")]


### PR DESCRIPTION
Fixes #5208. 

If a response contains `application/octet-stream` as a response type, the Kiota-generated response type should be a binary one. 

An concrete example of when this may happen: an API is migrating from hosting their own assets to returning redirects to a blob storage service, and they may return either a 302 Found and redirect to a URL that contains the asset, or the binary asset directly. For a standard consumer with redirects enabled, the end result is the same. For Kiota, generation needs to know to return binary content types. Currently Kiota will not do so and instead return void types. 