### PR TITLE
Feat: hand over generated plugin manifest

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -4,6 +4,7 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from "vscode";
+
 import { CodeLensProvider } from "./codelensProvider";
 import { KIOTA_WORKSPACE_FILE, dependenciesInfo, extensionId, statusBarCommandId, treeViewFocusCommand, treeViewId } from "./constants";
 import { DependenciesViewProvider } from "./dependenciesViewProvider";
@@ -200,9 +201,9 @@ export async function activate(
             clientClassName: config.clientClassName || config.pluginName
           };
           void context.workspaceState.update('generatedOutput', outputState as GeneratedOutputState);
-          const pathOfSpec = outputPath + `\\${outputState.clientClassName?.toLowerCase()}-openapi.yaml`;
-          const pathPluginManifest = outputPath + `\\${outputState.clientClassName?.toLowerCase()}-apiplugin.json`;
-          if (deepLinkParams.source && deepLinkParams.source === 'ttk') {
+          
+          const pathOfSpec = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-openapi.yaml`);
+          const pathPluginManifest = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-apiplugin.json`);          if (deepLinkParams.source && deepLinkParams.source === 'ttk') {
             await vscode.commands.executeCommand(
               'fx-extension.createprojectfromkiota',
               [

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -40,7 +40,6 @@ let clientOrPluginKey: string;
 let clientOrPluginObject: ClientOrPluginProperties;
 let workspaceGenerationType: string;
 let config: Partial<GenerateState>;
-let deepLinkParams: Record<string, string | undefined> = {};
 interface GeneratedOutputState {
   outputPath: string;
   clientClassName: string;
@@ -54,6 +53,7 @@ export async function activate(
   kiotaOutputChannel = vscode.window.createOutputChannel("Kiota", {
     log: true,
   });
+  let deepLinkParams: Record<string, string | undefined> = {};
   const openApiTreeProvider = new OpenApiTreeProvider(context, () => getExtensionSettings(extensionId));
   const dependenciesInfoProvider = new DependenciesViewProvider(
     context.extensionUri
@@ -204,7 +204,7 @@ export async function activate(
 
           const pathOfSpec = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-openapi.yml`);
           const pathPluginManifest = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-apiplugin.json`);
-          if (deepLinkParams.source && deepLinkParams.source === 'ttk') {
+          if (deepLinkParams.source && deepLinkParams.source.toLowerCase() === 'ttk') {
             try {
               await vscode.commands.executeCommand(
                 'fx-extension.createprojectfromkiota',

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -214,7 +214,11 @@ export async function activate(
                   true
                 ]
               );
-            } catch (error) {}
+            } catch (error) {
+              reporter.sendTelemetryEvent("DeepLinked fx-extension.createprojectfromkiota", {
+                "error": JSON.stringify(error)
+              });
+            }
           } else {
             if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
               await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(config.workingDirectory ?? getWorkspaceJsonDirectory()), true);

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -201,17 +201,20 @@ export async function activate(
             clientClassName: config.clientClassName || config.pluginName
           };
           void context.workspaceState.update('generatedOutput', outputState as GeneratedOutputState);
-          
-          const pathOfSpec = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-openapi.yaml`);
-          const pathPluginManifest = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-apiplugin.json`);          if (deepLinkParams.source && deepLinkParams.source === 'ttk') {
-            await vscode.commands.executeCommand(
-              'fx-extension.createprojectfromkiota',
-              [
-                pathOfSpec,
-                pathPluginManifest,
-                true
-              ]
-            );
+
+          const pathOfSpec = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-openapi.yml`);
+          const pathPluginManifest = path.join(outputPath, `${outputState.clientClassName?.toLowerCase()}-apiplugin.json`);
+          if (deepLinkParams.source && deepLinkParams.source === 'ttk') {
+            try {
+              await vscode.commands.executeCommand(
+                'fx-extension.createprojectfromkiota',
+                [
+                  pathOfSpec,
+                  pathPluginManifest,
+                  true
+                ]
+              );
+            } catch (error) {}
           } else {
             if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
               await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(config.workingDirectory ?? getWorkspaceJsonDirectory()), true);


### PR DESCRIPTION
Sends the plugin manifest to TTK if source of generation is TTK.

## How to test

- Follow steps specified in https://github.com/microsoft/kiota/blob/main/vscode/microsoft-kiota/debugging.md#running-in-debug-mode
- On pressing F5 to open a new vscode debug window, press the key combination ctrl + shift + p to open the command pallete.
- Select the Debug: Open Link command which will provide an input box to paste your url. e.g. "vscode://ms-graph.kiota/OpenDescription?descriptionUrl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Frest-api-description%2Fmain%2Fdescriptions%2Fghes-3.0%2Fghes-3.0.json&kind=Plugin&type=ApiPlugin&name=GitHubClientPlugin&source=ttk"
- Follow the prompts to open the link in vscode debug window.
- When tree loads in the side panel, select the nodes you want to include in your plugin, and select the "generate" button at the top of the tree structure.
- The generate process should skip the questions with provided answers in the deeplink params.
- Once generation is done, a new set of prompts appear powered by ttk and you will generate a teams app 