### PR TITLE
Feat: Ext/task5206/command based ttk integration in vs code extension

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -63,7 +63,7 @@ export async function activate(
   await loadTreeView(context);
   await checkForLockFileAndPrompt(context);
   let codeLensProvider = new CodeLensProvider();
-  let deepLinkParams: Record<string, string|undefined> = {};
+  let deepLinkParams: Partial<IntegrationParams> = {};
   context.subscriptions.push(
     vscode.window.registerUriHandler({
       handleUri: async (uri: vscode.Uri) => {
@@ -79,8 +79,8 @@ export async function activate(
             "validationErrors": errorsArray.join(", ")
           }); 
 
-          if (deepLinkParams.descriptionUrl) {
-            await openTreeViewWithProgress(() => openApiTreeProvider.setDescriptionUrl(deepLinkParams.descriptionUrl!));
+          if (deepLinkParams.descriptionurl) {
+            await openTreeViewWithProgress(() => openApiTreeProvider.setDescriptionUrl(deepLinkParams.descriptionurl!));
             return;
           }
         }

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -229,11 +229,9 @@ export async function activate(
       reporter,
       `${treeViewId}.searchOrOpenApiDescription`,
       async (
-        kind?: string, type?: string, name?: string, source?: string
+        searchParams: Partial<IntegrationParams> = {}
       ) => {
         // set deeplink params if exists
-        let searchParams = {kind,type,name,source } as Partial<IntegrationParams>;
-        console.log("searchParams", searchParams);
         if (Object.keys(searchParams).length > 0) {
           let errorsArray: string [];
           [deepLinkParams, errorsArray] = validateDeepLinkQueryParams(searchParams);

--- a/vscode/microsoft-kiota/src/test/suite/extension.test.ts
+++ b/vscode/microsoft-kiota/src/test/suite/extension.test.ts
@@ -12,17 +12,4 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
-
-    test('Extension Test Suite', () => {
-        vscode.commands.executeCommand(
-            'kiota.openApiExplorer.searchOrOpenApiDescription',
-            [
-                'https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Frest-api-description%2Fmain%2Fdescriptions%2Fghes-3.0%2Fghes-3.0.json',
-                "Plugin",
-                "ApiPlugin",
-                "GitHubClientPlugin",
-                "ttk"
-            ]   
-        ).then((result) => {});
-    });
 });

--- a/vscode/microsoft-kiota/src/test/suite/extension.test.ts
+++ b/vscode/microsoft-kiota/src/test/suite/extension.test.ts
@@ -12,4 +12,17 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
+
+    test('Extension Test Suite', () => {
+        vscode.commands.executeCommand(
+            'kiota.openApiExplorer.searchOrOpenApiDescription',
+            [
+                'https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Frest-api-description%2Fmain%2Fdescriptions%2Fghes-3.0%2Fghes-3.0.json',
+                "Plugin",
+                "ApiPlugin",
+                "GitHubClientPlugin",
+                "ttk"
+            ]   
+        ).then((result) => {});
+    });
 });

--- a/vscode/microsoft-kiota/src/util.ts
+++ b/vscode/microsoft-kiota/src/util.ts
@@ -172,11 +172,11 @@ export interface IntegrationParams {
 };
 
 export function validateDeepLinkQueryParams(queryParameters: Partial<IntegrationParams>):
- [Record<string, string|undefined>, string[]]
+ [Partial<IntegrationParams>, string[]]
 {
   let errormsg: string [] = [];
-  let validQueryParams: Record<string, string|undefined> = {};
-  const descriptionUrl = queryParameters["descriptionurl"];
+  let validQueryParams: Partial<IntegrationParams> = {};
+  const descriptionurl = queryParameters["descriptionurl"];
   const name = getSanitizedString(queryParameters["name"]);
   const source = getSanitizedString(queryParameters["source"]);
   let lowercasedKind: string = queryParameters["kind"]?.toLowerCase() ?? "";
@@ -224,7 +224,7 @@ export function validateDeepLinkQueryParams(queryParameters: Partial<Integration
   }
 
   validQueryParams = {
-    descriptionUrl: descriptionUrl,
+    descriptionurl: descriptionurl,
     name: name,
     kind: validKind,
     type: providedType,

--- a/vscode/microsoft-kiota/src/util.ts
+++ b/vscode/microsoft-kiota/src/util.ts
@@ -162,7 +162,16 @@ export function allGenerationLanguagesToString(): string[] {
   return allSupportedLanguages;
 }
 
-export function validateDeepLinkQueryParams(queryParameters: Record<string, string>):
+export interface IntegrationParams {
+  descriptionurl: string;
+  name: string;
+  kind: string;
+  type: string;
+  language: string;
+  source: string;
+};
+
+export function validateDeepLinkQueryParams(queryParameters: Partial<IntegrationParams>):
  [Record<string, string|undefined>, string[]]
 {
   let errormsg: string [] = [];
@@ -170,7 +179,7 @@ export function validateDeepLinkQueryParams(queryParameters: Record<string, stri
   const descriptionUrl = queryParameters["descriptionurl"];
   const name = getSanitizedString(queryParameters["name"]);
   const source = getSanitizedString(queryParameters["source"]);
-  let lowercasedKind: string = queryParameters["kind"]?.toLowerCase();
+  let lowercasedKind: string = queryParameters["kind"]?.toLowerCase() ?? "";
   let validKind: string | undefined = ["plugin", "client"].indexOf(lowercasedKind) > -1 ? lowercasedKind : undefined ;
   if (!validKind){
     errormsg.push(


### PR DESCRIPTION
Partial fix for #5206

To test:
1. Follow steps specified in [debugging.md](https://github.com/microsoft/kiota/blob/main/vscode/microsoft-kiota/debugging.md#running-in-debug-mode)
2. On pressing F5 to open a new vscode debug window, run these next commands in that debug window
3. Create|open an md file e.g "test.md" in/from your preferred location and create a commandUri that enables you to pass requisite parameters. See sample attached. 
[test.md](https://github.com/user-attachments/files/16787882/test.md)

4. ctrl + click on the command uri to execute the command which is similar to doing 
```
vscode.commands.executeCommand(
            'kiota.openApiExplorer.searchOrOpenApiDescription',
            [
                {
                    "kind":"Plugin|Client",
                    "type":"ApiPlugin|ApiManifest|OpenAI", //Only useful when kind is plugin
                    "language": "csharp|python|go|typescript|java|php|ruby|swift|cli" //currently supported kiota languages. Only important when kind=Client
                    "name":"GithubRestPlugin", // or any other suitable name
                    "source":"ttk|<any other source name as string>"
                }
            ]   
        );
```
i.e. passing params as an array of a single object with given keys and value pairs
5. The command should skip predefined questions e.g what to generate, name and language as applicable but still generate client|plugin after you provide output folder
6. Next step of work may include auto populating folder path with temp folder when source=ttk for seamless integration. Intentionally puting the temp folder generation on hold until integration team agrees on way forward as agreed.