### PR TITLE
fix/error message missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed shorthand for refresh option in workspace experience. [#5240](https://github.com/microsoft/kiota/issues/5240)
 - Fixed missing type options in help for plugin commands. [#5230](https://github.com/microsoft/kiota/issues/5230)
 - Removed OpenAI plugins generation since the service does not support them anymore.
+- Fixed a bug where the error message would not be deserialized if the property name matched a reserved property. [#5311](https://github.com/microsoft/kiota/issues/5311)
 - Fixed an issue where TypeScript clients would be missing path parameters. [#5247](https://github.com/microsoft/kiota/issues/5247)
 - Fixed a bug where names normalization could lead to collisions in Ruby and other languages. [#5310](https://github.com/microsoft/kiota/issues/5310)
 - Redirect status codes documenting an application/octet-stream content type now generate a stream return type. [#5246](https://github.com/microsoft/kiota/issues/5246)

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1522,6 +1522,8 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                         // set this as the primary error message as it matches the type so that the deserialization logic can map this correctly. 
                         sameNameProperty.IsPrimaryErrorMessage = true;
                     }
+                    if (string.IsNullOrEmpty(sameNameProperty.SerializationName))
+                        sameNameProperty.SerializationName = sameNameProperty.Name;
                     currentClass.RenameChildElement(name, $"{name}Escaped"); // rename to prevent collisions and keep the original
                 }
 

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1512,10 +1512,14 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         {
             if (asProperty)
             {
-                if (currentClass.Properties.FirstOrDefault(property => property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) is { } sameNameProperty)
+                var serializationName = string.Empty;
+                if (currentClass.FindChildByName<CodeProperty>(name, false) is { } sameNameProperty)
                 {
                     if (sameNameProperty.Type.Name.Equals(type().Name, StringComparison.OrdinalIgnoreCase))
+                    {
                         currentClass.RemoveChildElementByName(name); // type matches so just remove it for replacement
+                        serializationName = sameNameProperty.WireName;
+                    }
                     else
                         currentClass.RenameChildElement(name, $"{name}Escaped"); // type mismatch so just rename it
                 }
@@ -1526,6 +1530,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
                     Access = AccessModifier.Public,
                     Kind = CodePropertyKind.ErrorMessageOverride,
                     Type = type(),
+                    SerializationName = serializationName,
                     Documentation = new()
                     {
                         DescriptionTemplate = "The primary error message.",

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -334,7 +334,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         writer.WriteLine($"return {DefaultDeserializerValue}{parentSerializationInfo}");
         writer.StartBlock();
         foreach (var otherProp in parentClass
-                                        .GetPropertiesOfKind(CodePropertyKind.Custom, CodePropertyKind.ErrorMessageOverride)
+                                        .GetPropertiesOfKind(CodePropertyKind.Custom)
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name, StringComparer.Ordinal))
         {
@@ -463,7 +463,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         if (shouldHide)
             writer.WriteLine("base.Serialize(writer);");
         foreach (var otherProp in parentClass
-                                        .GetPropertiesOfKind(CodePropertyKind.Custom, CodePropertyKind.ErrorMessageOverride)
+                                        .GetPropertiesOfKind(CodePropertyKind.Custom)
                                         .Where(static x => !x.ExistsInBaseType && !x.ReadOnly)
                                         .OrderBy(static x => x.Name))
         {

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -334,7 +334,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         writer.WriteLine($"return {DefaultDeserializerValue}{parentSerializationInfo}");
         writer.StartBlock();
         foreach (var otherProp in parentClass
-                                        .GetPropertiesOfKind(CodePropertyKind.Custom)
+                                        .GetPropertiesOfKind(CodePropertyKind.Custom, CodePropertyKind.ErrorMessageOverride)
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name, StringComparer.Ordinal))
         {
@@ -463,7 +463,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         if (shouldHide)
             writer.WriteLine("base.Serialize(writer);");
         foreach (var otherProp in parentClass
-                                        .GetPropertiesOfKind(CodePropertyKind.Custom)
+                                        .GetPropertiesOfKind(CodePropertyKind.Custom, CodePropertyKind.ErrorMessageOverride)
                                         .Where(static x => !x.ExistsInBaseType && !x.ReadOnly)
                                         .OrderBy(static x => x.Name))
         {

--- a/src/Kiota.Builder/Writers/CodeClassExtensions.cs
+++ b/src/Kiota.Builder/Writers/CodeClassExtensions.cs
@@ -11,7 +11,7 @@ public static class CodeClassExtensions
     public static IEnumerable<CodeProperty> GetPropertiesOfKind(this CodeClass parentClass, params CodePropertyKind[] kinds)
     {
         if (parentClass == null)
-            return Enumerable.Empty<CodeProperty>();
+            return [];
         if (kinds == null || kinds.Length == 0)
             throw new ArgumentOutOfRangeException(nameof(kinds));
         return parentClass.Properties
@@ -25,7 +25,7 @@ public static class CodeClassExtensions
     public static IEnumerable<CodeMethod> GetMethodsOffKind(this CodeClass parentClass, params CodeMethodKind[] kinds)
     {
         if (parentClass == null)
-            return Enumerable.Empty<CodeMethod>();
+            return [];
         if (kinds == null || kinds.Length == 0)
             throw new ArgumentOutOfRangeException(nameof(kinds));
         return parentClass.Methods


### PR DESCRIPTION
fixes #5311

This a PR is a follow up to https://github.com/microsoft/kiota/pull/4930. 

Rather than removing the conflicting errorMessage property, we should rename it and keep the primary message property. The renamed property should then set as `IsPrimaryErrorMessage` so that the derialized information may be propagated up to the Exception/error info. 