### PR TITLE
Extension/task5285/fix command step back

### DIFF
--- a/vscode/microsoft-kiota/src/steps.ts
+++ b/vscode/microsoft-kiota/src/steps.ts
@@ -157,6 +157,14 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         return state;
     }
 
+    const isDeepLinkPluginNameProvided = isDeeplinkEnabled && state.pluginName;
+    const isDeepLinkGenerationTypeProvided = isDeeplinkEnabled && state.generationType;
+    const isDeepLinkPluginTypeProvided = isDeeplinkEnabled && state.pluginTypes;
+    const isDeepLinkLanguageProvided = isDeeplinkEnabled && state.language;
+    const isDeepLinkOutputPathProvided = isDeeplinkEnabled && state.outputPath;
+    const isDeepLinkClientClassNameProvided = isDeeplinkEnabled && state.clientClassName;
+
+
     if (typeof state.outputPath === 'string' && !isTemporaryDirectory(state.outputPath)) {
         state.outputPath = workspace.asRelativePath(state.outputPath);
     }
@@ -169,8 +177,6 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
     }
 
     let step = 1;
-    let totalSteps = 4;
-
     const folderSelectionOption = l10n.t('Browse your output directory');
     let inputOptions = [
         { label: l10n.t('Default folder'), description: workspaceFolder },
@@ -199,12 +205,12 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         }
     }
     async function inputGenerationType(input: MultiStepInput, state: Partial<GenerateState>) {
-        if (!state.generationType) {
+        if (!isDeepLinkGenerationTypeProvided) {
             const items = [l10n.t('Generate an API client'), l10n.t('Generate a plugin'), l10n.t('Generate an API manifest')];
             const option = await input.showQuickPick({
                 title: l10n.t('What do you want to generate?'),
-                step: 1,
-                totalSteps: 1,
+                step: step++,
+                totalSteps: 3,
                 placeholder: l10n.t('Select an option'),
                 items: items.map(x => ({ label: x })),
                 validate: validateIsNotEmpty,
@@ -224,11 +230,11 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         return (input: MultiStepInput) => nextStep(input, state);
     }
     async function inputClientClassName(input: MultiStepInput, state: Partial<GenerateState>) {
-        if (!state.clientClassName) {
+        if (!isDeepLinkClientClassNameProvided) {
             state.clientClassName = await input.showInputBox({
                 title: `${l10n.t('Create a new API client')} - ${l10n.t('class')}`,
                 step: step++,
-                totalSteps: totalSteps,
+                totalSteps: 5,
                 value: state.clientClassName ?? '',
                 placeholder: 'ApiClient',
                 prompt: l10n.t('Choose a name for the client class'),
@@ -243,7 +249,7 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         state.clientNamespaceName = await input.showInputBox({
             title: `${l10n.t('Create a new API client')} - ${l10n.t('namespace')}`,
             step: step++,
-            totalSteps: totalSteps,
+            totalSteps: 5,
             value: typeof state.clientNamespaceName === 'string' ? state.clientNamespaceName : '',
             placeholder: 'ApiSDK',
             prompt: l10n.t('Choose a name for the client class namespace'),
@@ -256,8 +262,8 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         while (true) {
             const selectedOption = await input.showQuickPick({
                 title: `${l10n.t('Create a new API client')} - ${l10n.t('output directory')}`,
-                step: 4,
-                totalSteps: totalSteps,
+                step: step++,
+                totalSteps: 5,
                 placeholder: l10n.t('Enter an output path relative to the root of the project'),
                 items: inputOptions,
                 shouldResume: shouldResume
@@ -291,7 +297,7 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
 
     }
     async function pickLanguage(input: MultiStepInput, state: Partial<GenerateState>) {
-        if (!state.language) {
+        if (!isDeepLinkLanguageProvided) {
             const items = allGenerationLanguages.map(x => {
                 const lngName = generationLanguageToString(x);
                 const lngInfo = languagesInformation ? languagesInformation[lngName] : undefined;
@@ -304,7 +310,7 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
             const pick = await input.showQuickPick({
                 title: `${l10n.t('Create a new API client')} - ${l10n.t('language')}`,
                 step: step++,
-                totalSteps: totalSteps,
+                totalSteps: 5,
                 placeholder: l10n.t('Pick a language'),
                 items,
                 activeItem: typeof state.language === 'string' ? items.find(x => x.languageName === state.language) : undefined,
@@ -314,12 +320,11 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         }
     }
     async function inputPluginName(input: MultiStepInput, state: Partial<GenerateState>) {
-        const isDeepLinkPluginNameProvided = isDeeplinkEnabled && state.pluginName;
         if (!isDeepLinkPluginNameProvided) {
             state.pluginName = await input.showInputBox({
                 title: `${l10n.t('Create a new plugin')} - ${l10n.t('plugin name')}`,
                 step: step++,
-                totalSteps: 3,
+                totalSteps: 4,
                 value: state.pluginName ?? '',
                 placeholder: 'MyPlugin',
                 prompt: l10n.t('Choose a name for the plugin'),
@@ -331,12 +336,12 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         return (input: MultiStepInput) => inputPluginType(input, state);
     }
     async function inputPluginType(input: MultiStepInput, state: Partial<GenerateState>) {
-        if (!state.pluginTypes) {
+        if (!isDeepLinkPluginTypeProvided) {
             const items = ['API Plugin', 'Open AI'].map(x => ({ label: x }) as QuickPickItem);
             const pluginTypes = await input.showQuickPick({
                 title: l10n.t('Choose a plugin type'),
                 step: step++,
-                totalSteps: 3,
+                totalSteps: 4,
                 placeholder: l10n.t('Select an option'),
                 items: items,
                 validate: validateIsNotEmpty,
@@ -347,11 +352,11 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         return (input: MultiStepInput) => inputPluginOutputPath(input, state);
     }
     async function inputPluginOutputPath(input: MultiStepInput, state: Partial<GenerateState>) {
-        while (!state.outputPath) {
+        while (!isDeepLinkOutputPathProvided) {
             const selectedOption = await input.showQuickPick({
                 title: `${l10n.t('Create a new plugin')} - ${l10n.t('output directory')}`,
-                step: 3,
-                totalSteps: 3,
+                step: step++,
+                totalSteps: 4,
                 placeholder: l10n.t('Enter an output path relative to the root of the project'),
                 items: inputOptions,
                 shouldResume: shouldResume
@@ -383,9 +388,8 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
             break;
         }
     }
-
     async function inputManifestName(input: MultiStepInput, state: Partial<GenerateState>) {
-        if (!state.pluginName)  {
+        if (!isDeepLinkPluginNameProvided)  {
             state.pluginName = await input.showInputBox({
                 title: `${l10n.t('Create a new manifest')} - ${l10n.t('manifest name')}`,
                 step: step++,
@@ -404,7 +408,7 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         while (true) {
             const selectedOption = await input.showQuickPick({
                 title: `${l10n.t('Create a new manifest')} - ${l10n.t('output directory')}`,
-                step: 2,
+                step: step++,
                 totalSteps: 3,
                 placeholder: l10n.t('Enter an output path relative to the root of the project'),
                 items: inputOptions,

--- a/vscode/microsoft-kiota/src/steps.ts
+++ b/vscode/microsoft-kiota/src/steps.ts
@@ -576,8 +576,8 @@ class MultiStepInput {
                 step = await step(this);
             } catch (err) {
                 if (err === InputFlowAction.back) {
-                    if (onNavBack) {
-                        onNavBack();
+                    if (onNavBack) { 
+                        onNavBack();  //Currently, step -= 2 passed as onNavBack because of using postfix increment in steps in the input functions
                     }
                     this.steps.pop();
                     step = this.steps.pop();

--- a/vscode/microsoft-kiota/src/steps.ts
+++ b/vscode/microsoft-kiota/src/steps.ts
@@ -2,9 +2,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { Disposable, l10n, OpenDialogOptions, QuickInput, QuickInputButton, QuickInputButtons, QuickPickItem, Uri, window, workspace } from 'vscode';
 import { allGenerationLanguages, generationLanguageToString, KiotaSearchResultItem, LanguagesInformation, maturityLevelToString } from './kiotaInterop';
-import { findAppPackageDirectory, getWorkspaceJsonDirectory, IntegrationParams } from './util';
+import { findAppPackageDirectory, getWorkspaceJsonDirectory } from './util';
 import { createTemporaryFolder, isTemporaryDirectory } from './utilities/temporary-folder';
-import { isDeeplinkEnabled } from './utilities/deep-linking';
 
 export async function filterSteps(existingFilter: string, filterCallback: (searchQuery: string) => void) {
     const state = {} as Partial<BaseStepsState>;


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/5285
- Fixed the total steps for each path including the step to decide what you want to generate because we would like to step back into this quickpick as well and it will be part of the multistep stack anyway, so it would be off to omit it from total steps count
- Fixed the check for state.<given-config> e.g state.GenerationType to not just check if the state exists but also if deeplinking is enabled. This unblocks the step back too since if you have already gone forward in a multistep, you have a value of the previous state already set but you do not want to not show the quickpick.

To test:
![image](https://github.com/user-attachments/assets/5967c747-033f-445e-a54f-66b1dbc02041)

Confirm the step back icon is working as in video below
https://microsoft.sharepoint-df.com/:v:/t/GraphTooling/ERDwVErYQ9FKoB9Th2EJJKIB5lsy3VqWkhjPRiaQ6iKEmQ?e=N2VZkj&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D