### PR TITLE
fix: uses a version range for analyzer cSharp so kiota is not tied to a specific version of the SDK

### DIFF
--- a/src/Kiota.Generated/KiotaGenerated.csproj
+++ b/src/Kiota.Generated/KiotaGenerated.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework> <!-- important or VS debugging fails https://stackoverflow.com/a/65480017/3808675-->
+    <TargetFramework>netstandard2.0</TargetFramework> <!-- important or VS debugging fails
+    https://stackoverflow.com/a/65480017/3808675-->
     <LangVersion>latest</LangVersion>
     <SonarQubeExclude>true</SonarQubeExclude>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*"
+      ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"
+      ExcludeAssets="runtime" />
   </ItemGroup>
 
   <Target Name="DoSthAfterPublish1" AfterTargets="Publish">


### PR DESCRIPTION
context https://github.com/Homebrew/homebrew-core/pull/183622