### PR TITLE
Fix: create new plugin same oad

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -163,7 +163,7 @@ export async function activate(
         config = await generateSteps(
           availableStateInfo,
           languagesInformation,
-          isDeeplinkEnabled(deepLinkParams)
+          deepLinkParams
         );
         const generationType = parseGenerationType(config.generationType);
         const outputPath = typeof config.outputPath === "string"

--- a/vscode/microsoft-kiota/src/steps.ts
+++ b/vscode/microsoft-kiota/src/steps.ts
@@ -127,7 +127,7 @@ export async function generateSteps(existingConfiguration: Partial<GenerateState
         return state;
     }
 
-    const deeplinkEnabled = !!deepLinkParams && isDeeplinkEnabled(deepLinkParams);
+    const deeplinkEnabled = deepLinkParams && isDeeplinkEnabled(deepLinkParams);
     const isDeepLinkPluginNameProvided = deeplinkEnabled && state.pluginName;
     const isDeepLinkGenerationTypeProvided = deeplinkEnabled && state.generationType;
     const isDeepLinkPluginTypeProvided = deeplinkEnabled && state.pluginTypes;


### PR DESCRIPTION
### Overview

Closes #5385 

### Notes

When in deep link and with ttk, the kiota working directory changes to the temp folder ensuring that generation of new plugins is not blocked