### PR TITLE
Fixes incosistent typing information in python generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the description special characters are encoded. [5286](https://github.com/microsoft/kiota/issues/5286)
 - Fixed a bug where python constructor parameters are being cast to strings leading to bugs as the types is unknown on graph call. [microsoftgraph/msgraph-sdk-python#165](https://github.com/microsoftgraph/msgraph-sdk-python/issues/165)
 - Fixed a bug where child path segment from single parameter path segment would be incorrectly escaped. [#5433](https://github.com/microsoft/kiota/issues/5433)
+- Fixed inconsistent typing information generated for `ParsableFactory` and stream return types in python [kiota-abstractions-python#533](https://github.com/microsoft/kiota-abstractions-python/issues/333) 
 
 ## [1.18.0] - 2024-09-05
 

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -585,7 +585,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         {
             _codeUsingWriter.WriteInternalErrorMappingImports(parentClass, writer);
             errorMappingVarName = "error_mapping";
-            writer.StartBlock($"{errorMappingVarName}: Dict[str, ParsableFactory] = {{");
+            writer.StartBlock($"{errorMappingVarName}: Dict[str, type[ParsableFactory]] = {{");
             foreach (var errorMapping in codeElement.ErrorMappings)
             {
                 writer.WriteLine($"\"{errorMapping.Key.ToUpperInvariant()}\": {errorMapping.Value.Name},");
@@ -736,8 +736,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                                         .Select(p => new PythonConventionService() // requires a writer instance because method parameters use inline type definitions
                                                         .GetParameterSignature(p, code, writer))
                                                         .ToList());
-        var nullablePrefix = code.ReturnType.IsNullable && !isVoid ? "Optional[" : string.Empty;
-        var nullableSuffix = code.ReturnType.IsNullable && !isVoid ? "]" : string.Empty;
+        var isStreamType = conventions.StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
+        var nullablePrefix = (code.ReturnType.IsNullable || isStreamType) && !isVoid ? "Optional[" : string.Empty;
+        var nullableSuffix = (code.ReturnType.IsNullable || isStreamType) && !isVoid ? "]" : string.Empty;
         var propertyDecorator = code.Kind switch
         {
             CodeMethodKind.Getter => "@property",

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -623,7 +623,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("from .error401 import Error401", result);
         Assert.Contains("from .error4_x_x import Error4XX", result);
         Assert.Contains("from .error5_x_x import Error5XX", result);
-        Assert.Contains("error_mapping: Dict[str, ParsableFactory] =", result);
+        Assert.Contains("error_mapping: Dict[str, type[ParsableFactory]] =", result);
         Assert.Contains("\"4XX\": Error4XX", result);
         Assert.Contains("\"5XX\": Error5XX", result);
         Assert.Contains("\"401\": Error401", result);


### PR DESCRIPTION
Partial of https://github.com/microsoft/kiota-abstractions-python/issues/333