### PR TITLE
Fix serialization and deserialization of composed types in TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed Python error when a class inherits from a base class and implements an interface. [5637](https://github.com/microsoft/kiota/issues/5637)
+- Fix anyOf/oneOf generation in TypeScript. [5353](https://github.com/microsoft/kiota/issues/5353)
 
 ## [1.20.0] - 2024-11-07
 

--- a/it/config.json
+++ b/it/config.json
@@ -217,10 +217,6 @@
       {
         "Language": "php",
         "Rationale": "https://github.com/microsoft/kiota/issues/5354"
-      },
-      {
-        "Language": "typescript",
-        "Rationale": "https://github.com/microsoft/kiota/issues/5353"
       }
     ],
     "IdempotencySuppressions": [

--- a/src/Kiota.Builder/CodeDOM/CodeComposedTypeBase.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeComposedTypeBase.cs
@@ -87,5 +87,6 @@ public abstract class CodeComposedTypeBase : CodeTypeBase, IDiscriminatorInforma
         // Count the number of primitives in Types
         return Types.Any(x => checkIfPrimitive(x, this)) && Types.Any(x => !checkIfPrimitive(x, this));
     }
+    public bool IsComposedOfObjects(Func<CodeType, CodeComposedTypeBase, bool> checkIfPrimitive) => Types.All(x => !checkIfPrimitive(x, this));
 
 }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -169,7 +169,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             GroupReusableModelsInSingleFile(modelsNamespace);
             RemoveSelfReferencingUsings(generatedCode);
             AddAliasToCodeFileUsings(generatedCode);
-            CorrectSerializerParameters(generatedCode);
+            //CorrectSerializerParameters(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
         }, cancellationToken);
     }

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -169,29 +169,8 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             GroupReusableModelsInSingleFile(modelsNamespace);
             RemoveSelfReferencingUsings(generatedCode);
             AddAliasToCodeFileUsings(generatedCode);
-            //CorrectSerializerParameters(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
         }, cancellationToken);
-    }
-
-    private static void CorrectSerializerParameters(CodeElement currentElement)
-    {
-        if (currentElement is CodeFunction currentFunction &&
-            currentFunction.OriginalLocalMethod.Kind is CodeMethodKind.Serializer)
-        {
-            foreach (var parameter in currentFunction.OriginalLocalMethod.Parameters
-                         .Where(p => GetOriginalComposedType(p.Type) is CodeComposedTypeBase composedType &&
-                                     composedType.IsComposedOfObjectsAndPrimitives(IsPrimitiveType)))
-            {
-                var composedType = GetOriginalComposedType(parameter.Type)!;
-                var newType = (CodeComposedTypeBase)composedType.Clone();
-                var nonPrimitiveTypes = composedType.Types.Where(x => !IsPrimitiveType(x, composedType)).ToArray();
-                newType.SetTypes(nonPrimitiveTypes);
-                parameter.Type = newType;
-            }
-        }
-
-        CrawlTree(currentElement, CorrectSerializerParameters);
     }
 
     private static void AddAliasToCodeFileUsings(CodeElement currentElement)

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -1461,7 +1461,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
 
             function.AddUsing(new CodeUsing
             {
-                Name = modelDeserializerFunction.Parent.Name,
+                Name = modelDeserializerFunction.Name,
                 Declaration = new CodeType
                 {
                     Name = modelDeserializerFunction.Name,

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFileDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFileDeclarationWriter.cs
@@ -40,7 +40,7 @@ public class CodeFileDeclarationWriter : BaseElementWriter<CodeFileDeclaration, 
                     .Where(static x => x is { IsExternal: false, Declaration.TypeDefinition: not null })
                     .GroupBy(static x =>
                         $"{x.Declaration!.TypeDefinition!.GetImmediateParentOfType<CodeNamespace>().Name}.{x.Declaration?.Name.ToLowerInvariant()}")
-                    .Select(static x => x.OrderByDescending(static x => x.Alias, StringComparer.OrdinalIgnoreCase).First()));
+                .Select(static x => x.OrderByDescending(static x => x.Alias, StringComparer.OrdinalIgnoreCase).ThenBy(static x => x.Parent?.Name, StringComparer.OrdinalIgnoreCase).First()));
 
             _codeUsingWriter.WriteCodeElement(filteredUsing, ns, writer);
         }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFileDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFileDeclarationWriter.cs
@@ -40,7 +40,7 @@ public class CodeFileDeclarationWriter : BaseElementWriter<CodeFileDeclaration, 
                     .Where(static x => x is { IsExternal: false, Declaration.TypeDefinition: not null })
                     .GroupBy(static x =>
                         $"{x.Declaration!.TypeDefinition!.GetImmediateParentOfType<CodeNamespace>().Name}.{x.Declaration?.Name.ToLowerInvariant()}")
-                    .Select(static x => x.OrderBy(static x => x.Parent?.Name).First()));
+                    .Select(static x => x.OrderByDescending(static x => x.Alias, StringComparer.OrdinalIgnoreCase).First()));
 
             _codeUsingWriter.WriteCodeElement(filteredUsing, ns, writer);
         }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -54,7 +54,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
         }
     }
 
-    private string GetSerializationMethodsForPrimitiveUnionTypes(CodeComposedTypeBase composedType, string parseNodeParameterName, CodeFunction codeElement, CodeFile codeFile, bool nodeParameterCanBeNull = true)
+    private string GetSerializationMethodsForPrimitiveUnionTypes(CodeComposedTypeBase composedType, string parseNodeParameterName, CodeFile codeFile, bool nodeParameterCanBeNull = true)
     {
         var optionalChainingSymbol = nodeParameterCanBeNull ? "?" : string.Empty;
         return string.Join(" ?? ", composedType.Types.Where(x => IsPrimitiveType(x, composedType)).Select(x => $"{parseNodeParameterName}{optionalChainingSymbol}." + conventions.GetDeserializationMethodName(x, codeFile)));
@@ -240,7 +240,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
         switch (composedType)
         {
             case CodeComposedTypeBase type when type.IsComposedOfPrimitives(IsPrimitiveType):
-                string primitiveValuesUnionString = GetSerializationMethodsForPrimitiveUnionTypes(composedType, parseNodeParameter!.Name.ToFirstCharacterLowerCase(), codeElement, codeFile);
+                string primitiveValuesUnionString = GetSerializationMethodsForPrimitiveUnionTypes(composedType, parseNodeParameter!.Name.ToFirstCharacterLowerCase(), codeFile);
                 writer.WriteLine($"return {primitiveValuesUnionString};");
                 break;
             case CodeUnionType _ when parseNodeParameter != null:

--- a/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeMethodWriter.cs
@@ -16,19 +16,20 @@ public class CodeMethodWriter(TypeScriptConventionService conventionService) : B
         ArgumentNullException.ThrowIfNull(writer);
         if (codeElement.Parent is CodeFunction) return;
 
-        var returnType = GetTypescriptTypeString(codeElement.ReturnType, codeElement, inlineComposedTypeString: true);
+        var codeFile = codeElement.GetImmediateParentOfType<CodeFile>();
+        var returnType = GetTypescriptTypeString(codeElement.ReturnType, codeFile, inlineComposedTypeString: true);
         var isVoid = "void".EqualsIgnoreCase(returnType);
-        WriteMethodDocumentation(codeElement, writer, isVoid);
+        WriteMethodDocumentation(codeFile, codeElement, writer, isVoid);
         WriteMethodPrototype(codeElement, writer, returnType, isVoid);
         if (codeElement.Parent is CodeClass)
             throw new InvalidOperationException("No method implementations are generated in typescript: either functions or constants.");
     }
 
-    private void WriteMethodDocumentation(CodeMethod code, LanguageWriter writer, bool isVoid)
+    private void WriteMethodDocumentation(CodeFile codeFile, CodeMethod code, LanguageWriter writer, bool isVoid)
     {
-        WriteMethodDocumentationInternal(code, writer, isVoid, conventions);
+        WriteMethodDocumentationInternal(codeFile, code, writer, isVoid, conventions);
     }
-    internal static void WriteMethodDocumentationInternal(CodeMethod code, LanguageWriter writer, bool isVoid, TypeScriptConventionService typeScriptConventionService)
+    internal static void WriteMethodDocumentationInternal(CodeFile codeFile, CodeMethod code, LanguageWriter writer, bool isVoid, TypeScriptConventionService typeScriptConventionService)
     {
         var returnRemark = (isVoid, code.IsAsync) switch
         {
@@ -41,7 +42,7 @@ public class CodeMethodWriter(TypeScriptConventionService conventionService) : B
                                         code.Parameters
                                             .Where(static x => x.Documentation.DescriptionAvailable)
                                             .OrderBy(static x => x.Name)
-                                            .Select(x => $"@param {x.Name} {x.Documentation.GetDescription(type => GetTypescriptTypeString(type, code, inlineComposedTypeString: true), ReferenceTypePrefix, ReferenceTypeSuffix, RemoveInvalidDescriptionCharacters)}")
+                                            .Select(x => $"@param {x.Name} {x.Documentation.GetDescription(type => GetTypescriptTypeString(type, codeFile, inlineComposedTypeString: true), ReferenceTypePrefix, ReferenceTypeSuffix, RemoveInvalidDescriptionCharacters)}")
                                             .Union([returnRemark])
                                             .Union(GetThrownExceptionsRemarks(code)));
     }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -81,19 +81,24 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         };
     }
 
-    private static bool ShouldIncludeCollectionInformationForParameter(CodeParameter parameter)
-    {
-        return !(GetOriginalComposedType(parameter) is not null
-            && parameter.Parent is CodeMethod codeMethod
-            && (codeMethod.IsOfKind(CodeMethodKind.Serializer) || codeMethod.IsOfKind(CodeMethodKind.Deserializer)));
-    }
-
     public override string GetParameterSignature(CodeParameter parameter, CodeElement targetElement, LanguageWriter? writer = null)
     {
         ArgumentNullException.ThrowIfNull(parameter);
-        var includeCollectionInformation = ShouldIncludeCollectionInformationForParameter(parameter);
-        var paramType = GetTypescriptTypeString(parameter.Type, targetElement, includeCollectionInformation: includeCollectionInformation, inlineComposedTypeString: true);
-        var isComposedOfPrimitives = GetOriginalComposedType(parameter.Type) is CodeComposedTypeBase composedType && composedType.IsComposedOfPrimitives(IsPrimitiveType);
+        var paramType = GetTypescriptTypeString(parameter.Type, targetElement, includeCollectionInformation: true, inlineComposedTypeString: true);
+        var composedType = GetOriginalComposedType(parameter.Type);
+        var isComposedOfPrimitives = composedType != null && composedType.IsComposedOfPrimitives(IsPrimitiveType);
+
+        // add a 'Parsable' suffix to composed parameters of primitives only if they are not deserialization targets
+        var parsableTypes = (
+            composedType != null && composedType.IsComposedOfPrimitives(IsPrimitiveTypeOrPrimitiveCollection),
+            parameter.Parent is CodeMethod method && method.IsOfKind(CodeMethodKind.Deserializer)
+            ) switch
+        {
+            (true, false) => string.Empty,
+            (true, true) => "Parsable | ",
+            _ => string.Empty,
+        };
+
         var defaultValueSuffix = (string.IsNullOrEmpty(parameter.DefaultValue), parameter.Kind, isComposedOfPrimitives) switch
         {
             (false, CodeParameterKind.DeserializationTarget, false) when parameter.Parent is CodeMethod codeMethod && codeMethod.Kind is CodeMethodKind.Serializer
@@ -107,7 +112,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
             (false, CodeParameterKind.DeserializationTarget) => ("Partial<", ">"),
             _ => (string.Empty, string.Empty),
         };
-        return $"{parameter.Name.ToFirstCharacterLowerCase()}{(parameter.Optional && parameter.Type.IsNullable ? "?" : string.Empty)}: {partialPrefix}{paramType}{partialSuffix}{(parameter.Type.IsNullable ? " | undefined" : string.Empty)}{defaultValueSuffix}";
+        return $"{parameter.Name.ToFirstCharacterLowerCase()}{(parameter.Optional && parameter.Type.IsNullable ? "?" : string.Empty)}: {partialPrefix}{parsableTypes}{paramType}{partialSuffix}{(parameter.Type.IsNullable ? " | undefined" : string.Empty)}{defaultValueSuffix}";
     }
 
     public override string GetTypeString(CodeTypeBase code, CodeElement targetElement, bool includeCollectionInformation = true, LanguageWriter? writer = null)
@@ -234,6 +239,8 @@ public class TypeScriptConventionService : CommonLanguageConventionService
     }
 
     public static bool IsPrimitiveType(CodeType codeType, CodeComposedTypeBase codeComposedTypeBase) => IsPrimitiveType(codeType, codeComposedTypeBase, true);
+
+    public static bool IsPrimitiveTypeOrPrimitiveCollection(CodeType codeType, CodeComposedTypeBase codeComposedTypeBase) => IsPrimitiveType(codeType, codeComposedTypeBase, false);
 
     public static bool IsPrimitiveType(CodeType codeType, CodeComposedTypeBase codeComposedTypeBase, bool includeCollectionInformation) => IsPrimitiveType(GetTypescriptTypeString(codeType, codeComposedTypeBase, includeCollectionInformation));
 

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -93,7 +93,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
             var newType = (CodeComposedTypeBase)composedType.Clone();
             var nonPrimitiveTypes = composedType.Types.Where(x => !IsPrimitiveTypeOrPrimitiveCollection(x, composedType)).ToArray();
             newType.SetTypes(nonPrimitiveTypes);
-            paramType = GetTypescriptTypeString(newType, targetElement, includeCollectionInformation: true, inlineComposedTypeString: true);
+            paramType = GetTypescriptTypeString(newType, targetElement, includeCollectionInformation: false, inlineComposedTypeString: true);
         }
         var isComposedOfPrimitives = composedType != null && composedType.IsComposedOfPrimitives(IsPrimitiveType);
 

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -323,12 +323,12 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         return definitionClass.GetImmediateParentOfType<CodeFile>(definitionClass)?.FindChildByName<CodeFunction>(factoryMethodName);
     }
 
-    public string GetDeserializationMethodName(CodeTypeBase codeType, CodeMethod method, bool? IsCollection = null)
+    public string GetDeserializationMethodName(CodeTypeBase codeType, CodeElement targetElement, bool? IsCollection = null)
     {
         ArgumentNullException.ThrowIfNull(codeType);
-        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(targetElement);
         var isCollection = IsCollection == true || codeType.IsCollection;
-        var propertyType = GetTypescriptTypeString(codeType, method, false);
+        var propertyType = GetTypescriptTypeString(codeType, targetElement, false);
 
         CodeTypeBase _codeType = GetOriginalComposedType(codeType) is CodeComposedTypeBase composedType ? new CodeType() { Name = composedType.Name, TypeDefinition = composedType } : codeType;
 
@@ -339,19 +339,19 @@ public class TypeScriptConventionService : CommonLanguageConventionService
                 (CodeEnum currentEnum, _, _) when currentEnum.CodeEnumObject is not null => $"{(currentEnum.Flags || isCollection ? "getCollectionOfEnumValues" : "getEnumValue")}<{currentEnum.Name.ToFirstCharacterUpperCase()}>({currentEnum.CodeEnumObject.Name.ToFirstCharacterUpperCase()})",
                 (_, _, _) when StreamTypeName.Equals(propertyType, StringComparison.OrdinalIgnoreCase) => "getByteArrayValue",
                 (_, true, _) when currentType.TypeDefinition is null => $"getCollectionOfPrimitiveValues<{propertyType}>()",
-                (_, true, _) => $"getCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>({GetFactoryMethodName(_codeType, method)})",
-                _ => GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, method)
+                (_, true, _) => $"getCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>({GetFactoryMethodName(_codeType, targetElement)})",
+                _ => GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, targetElement)
             };
         }
-        return GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, method);
+        return GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, targetElement);
     }
 
-    private static string GetDeserializationMethodNameForPrimitiveOrObject(CodeTypeBase propType, string propertyTypeName, CodeMethod method)
+    private static string GetDeserializationMethodNameForPrimitiveOrObject(CodeTypeBase propType, string propertyTypeName, CodeElement targetElement)
     {
         return propertyTypeName switch
         {
             TYPE_LOWERCASE_STRING or TYPE_STRING or TYPE_LOWERCASE_BOOLEAN or TYPE_BOOLEAN or TYPE_NUMBER or TYPE_GUID or TYPE_DATE or TYPE_DATE_ONLY or TYPE_TIME_ONLY or TYPE_DURATION => $"get{propertyTypeName.ToFirstCharacterUpperCase()}Value()",
-            _ => $"getObjectValue<{propertyTypeName.ToFirstCharacterUpperCase()}>({GetFactoryMethodName(propType, method)})"
+            _ => $"getObjectValue<{propertyTypeName.ToFirstCharacterUpperCase()}>({GetFactoryMethodName(propType, targetElement)})"
         };
     }
 }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -99,7 +99,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
 
         // add a 'Parsable' type to the parameter if it is composed of non-Parsable types
         var parsableTypes = (
-            composedType != null,
+            composedType != null && !composedType.IsComposedOfObjects(IsPrimitiveType),
             parameter.Parent is CodeMethod method && (method.IsOfKind(CodeMethodKind.Deserializer, CodeMethodKind.Serializer))
             ) switch
         {

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -1252,10 +1252,8 @@ public sealed class CodeFunctionWriterTests : IDisposable
         writer.Write(serializerFunction);
         var serializerFunctionStr = tw.ToString();
         Assert.Contains("return", serializerFunctionStr);
-        Assert.Contains("switch", serializerFunctionStr);
-        Assert.Contains("case \"number\":", serializerFunctionStr);
-        Assert.Contains("case \"string\":", serializerFunctionStr);
-        Assert.Contains("break", serializerFunctionStr);
+        Assert.Contains("typeof primitives === \"number\"", serializerFunctionStr);
+        Assert.Contains("typeof primitives === \"string\"", serializerFunctionStr);
         AssertExtensions.CurlyBracesAreClosed(serializerFunctionStr, 1);
     }
 
@@ -1454,9 +1452,9 @@ public sealed class CodeFunctionWriterTests : IDisposable
         writer.Write(serializeFunction);
         var result = tw.ToString();
 
-        Assert.Contains("case typeof parentClass.property === \"string\"", result);
+        Assert.Contains("typeof parentClass.property === \"string\"", result);
         Assert.Contains("writer.writeStringValue(\"property\", parentClass.property as string);", result);
-        Assert.Contains("case typeof parentClass.property === \"number\"", result);
+        Assert.Contains("typeof parentClass.property === \"number\"", result);
         Assert.Contains("writer.writeNumberValue(\"property\", parentClass.property as number);", result);
         Assert.Contains(
             "writer.writeCollectionOfObjectValues<ArrayOfObjects>(\"property\", parentClass.property as ArrayOfObjects[] | undefined | null",


### PR DESCRIPTION
Fix serialization and deserialization of composed types in TS 
fixes https://github.com/microsoft/kiota/issues/5353

Changes made to fix the serializer will include writing an undefined value for the string and and the collection of string

```ts
export function serializeSuccess(writer: SerializationWriter, success: Partial<string[] | string> | undefined | null = {}) : void {
    if(success){
        switch (true) {
            case typeof success === "string":
                writer.writeStringValue(undefined, success as string);
            break;
            case Array.isArray(success) && (success).every(item => typeof item === 'string') :
                writer.writeCollectionOfObjectValues<string>(undefined, success as string []);
            break;
        }
    }
}
```

changes made to fix thd deserializer. since `undefined` is not an acceptable key in a record, the serializers will have to invoke the method with an empty key i.e "" to as the assign the value of success to the node

```ts
export function deserializeIntoSuccess(success: Partial<Parsable | string[] | string> | undefined = {}) : Record<string, (node: ParseNode) => void> {
    return {
        "" : n => { success = n.getStringValue() ?? n.getCollectionOfPrimitiveValues<string>(); },
    }
}
```
