### PR TITLE
Fix Cyclic Dependencies in Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where python constructor parameters are being cast to strings leading to bugs as the types is unknown on graph call. [microsoftgraph/msgraph-sdk-python#165](https://github.com/microsoftgraph/msgraph-sdk-python/issues/165)
 - Fixed a bug where child path segment from single parameter path segment would be incorrectly escaped. [#5433](https://github.com/microsoft/kiota/issues/5433)
 - Fixed inconsistent typing information generated for `ParsableFactory` and stream return types in python [kiota-abstractions-python#533](https://github.com/microsoft/kiota-abstractions-python/issues/333) 
+- Fixed cyclic depencies in generated Go code. [#2834](https://github.com/microsoft/kiota/issues/2834)
 
 ## [1.18.0] - 2024-09-05
 

--- a/it/config.json
+++ b/it/config.json
@@ -149,10 +149,6 @@
     ],
     "Suppressions": [
       {
-        "Language": "go",
-        "Rationale": "https://github.com/microsoft/kiota/issues/3436"
-      },
-      {
         "Language": "ruby",
         "Rationale": "https://github.com/microsoft/kiota/issues/2484"
       },
@@ -238,10 +234,6 @@
         "Rationale": "https://github.com/microsoft/kiota/issues/5256"
       },
       {
-        "Language": "go",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2834"
-      },
-      {
         "Language": "java",
         "Rationale": "https://github.com/microsoft/kiota/issues/2842"
       },
@@ -259,10 +251,6 @@
       }
     ],
     "IdempotencySuppressions": [
-      {
-        "Language": "go",
-        "Rationale": "https://github.com/microsoft/kiota/issues/2834"
-      },
       {
         "Language": "java",
         "Rationale": "https://github.com/microsoft/kiota/issues/2842"

--- a/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeNamespace.cs
@@ -72,11 +72,11 @@ public class CodeNamespace : CodeBlock<BlockDeclaration, BlockEnd>
     public IEnumerable<CodeInterface> Interfaces => InnerChildElements.Values.OfType<CodeInterface>();
     public IEnumerable<CodeConstant> Constants => InnerChildElements.Values.OfType<CodeConstant>();
     public IEnumerable<CodeFile> Files => InnerChildElements.Values.OfType<CodeFile>();
-    public CodeNamespace? FindNamespaceByName(string nsName)
+    public CodeNamespace? FindNamespaceByName(string nsName, bool findInChildElements = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(nsName);
         if (nsName.Equals(Name, StringComparison.OrdinalIgnoreCase)) return this;
-        var result = FindChildByName<CodeNamespace>(nsName, false);
+        var result = FindChildByName<CodeNamespace>(nsName, findInChildElements);
         if (result == null)
             foreach (var childNS in InnerChildElements.Values.OfType<CodeNamespace>())
             {

--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -263,7 +263,7 @@ public class GoRefiner : CommonLanguageRefiner
         return string.Join(string.Empty, classNameList.Count > 1 ? classNameList.Skip(1) : classNameList);
     }
 
-    private void GetUsingsInModelsNameSpace(CodeNamespace modelsNameSpace, CodeNamespace currentNameSpace, Dictionary<string, HashSet<string>> dependencies)
+    private static void GetUsingsInModelsNameSpace(CodeNamespace modelsNameSpace, CodeNamespace currentNameSpace, Dictionary<string, HashSet<string>> dependencies)
     {
         if (!modelsNameSpace.Name.Equals(currentNameSpace.Name, StringComparison.OrdinalIgnoreCase) && !currentNameSpace.IsChildOf(modelsNameSpace))
             return;
@@ -275,7 +275,7 @@ public class GoRefiner : CommonLanguageRefiner
             .OfType<CodeNamespace>()
             .Where(ns => !ns.Name.Equals(currentNameSpace.Name, StringComparison.OrdinalIgnoreCase))
             .Select(static ns => ns.Name)
-            .ToHashSet();
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         foreach (var codeNameSpace in currentNameSpace.Namespaces.Where(codeNameSpace => !dependencies.ContainsKey(codeNameSpace.Name)))
         {
@@ -385,7 +385,7 @@ public class GoRefiner : CommonLanguageRefiner
             MigrateNameSpace(ns, targetNameSpace);
         }
     }
-    private void CorrectReferencesToMigratedModels(CodeElement currentElement, Dictionary<string, string> migratedNamespaces)
+    private static void CorrectReferencesToMigratedModels(CodeElement currentElement, Dictionary<string, string> migratedNamespaces)
     {
         if (currentElement is CodeNamespace cn)
         {

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -852,6 +852,24 @@ components:
             Kind = CodeClassKind.Model,
             Name = "ModelA",
         }).First();
+        subANamespace.AddEnum(new CodeEnum
+        {
+            Name = "ModelAEnum",
+        });
+        subANamespace.AddInterface(new CodeInterface
+        {
+            Name = "ModelAInterface",
+            OriginalClass = modelA,
+        });
+        subANamespace.AddFunction(new CodeFunction(
+            new CodeMethod
+            {
+                Name = "ModelAFunction",
+                IsStatic = true,
+                Parent = modelA,
+                ReturnType = new CodeType()
+            })
+        );
 
         var subBNamespace = modelsNS.AddNamespace($"{modelsNS.Name}.subb");
         var modelB = subBNamespace.AddClass(new CodeClass
@@ -887,6 +905,8 @@ components:
         Assert.Equal("ApiSdk.models", modelA.GetImmediateParentOfType<CodeNamespace>().Name); // migrated to root namespace
         Assert.Equal("SubaModelA", modelA.Name); // renamed to avoid conflict
         Assert.Equal("SubbModelB", modelB.Name); // renamed to avoid conflict
+
+        Assert.Empty(subANamespace.GetChildElements(true));
     }
     #endregion
 

--- a/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/GoLanguageRefinerTests.cs
@@ -841,6 +841,53 @@ components:
         Assert.NotEmpty(model.StartBlock.Usings);
         Assert.Equal("ISODuration", method.ReturnType.Name);
     }
+    [Fact]
+    public async Task CorrectesCircularDependencies()
+    {
+        var modelsNS = root.AddNamespace("ApiSdk.models");
+
+        var subANamespace = modelsNS.AddNamespace($"{modelsNS.Name}.suba");
+        var modelA = subANamespace.AddClass(new CodeClass
+        {
+            Kind = CodeClassKind.Model,
+            Name = "ModelA",
+        }).First();
+
+        var subBNamespace = modelsNS.AddNamespace($"{modelsNS.Name}.subb");
+        var modelB = subBNamespace.AddClass(new CodeClass
+        {
+            Kind = CodeClassKind.Model,
+            Name = "ModelB",
+        }).First();
+
+        modelA.StartBlock.AddUsings(new CodeUsing
+        {
+            Name = subBNamespace.Name,
+            Declaration = new()
+            {
+                Name = modelB.Name,
+                TypeDefinition = modelB,
+                IsExternal = false
+            }
+        });
+
+        modelB.StartBlock.AddUsings(new CodeUsing
+        {
+            Name = subANamespace.Name,
+            Declaration = new()
+            {
+                Name = modelA.Name,
+                TypeDefinition = modelA,
+                IsExternal = false
+            }
+        });
+
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Go }, root);
+        Assert.Equal("ApiSdk.models", modelB.GetImmediateParentOfType<CodeNamespace>().Name); // migrated to root namespace
+        Assert.Equal("ApiSdk.models", modelA.GetImmediateParentOfType<CodeNamespace>().Name); // migrated to root namespace
+        Assert.Equal("SubaModelA", modelA.Name); // renamed to avoid conflict
+        Assert.Equal("SubbModelB", modelB.Name); // renamed to avoid conflict
+    }
     #endregion
 
     #region GoRefinerTests


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota/issues/2834

Fixes cyclic dependencies by flattening models affected by cyclic depndecies i.e when a cyclic depedency is detected the affected packages will be flattened and migrated to the rot models package.

For example 
models -> submodule1 -> submodule2 -> submodule3 -> submodule2
will be flattened by migrating everything under submodule2 to the root models package

Testing:
1. Enabled suppressed integrated tests 
2. Added unit tests