### PR TITLE
Fix kiota vscode settings dependency for task build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,16 +22,7 @@
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
-      "problemMatcher": "$msCompile",
-    },
-    {
-      "label": "checkout:sample:locks",
-      "type": "process",
-      "command": "git",
-      "args": ["checkout", "**/kiota-lock.json"],
-      "options": {
-        "cwd": "${workspaceFolder}/samples"
-      }
+      "problemMatcher": "$msCompile"
     },
     {
       "label": "test",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,6 @@
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile",
-      "dependsOn": ["checkout:sample:locks"]
     },
     {
       "label": "checkout:sample:locks",


### PR DESCRIPTION
When you launch the debugger in vscode, following error is thrown
```bash
Executing task: C:\Program Files\Git\cmd\git.exe checkout **/kiota-lock.json 

error: pathspec '**/kiota-lock.json' did not match any file(s) known to git

*  The terminal process "C:\Program Files\Git\cmd\git.exe 'checkout', '**/kiota-lock.json'" terminated with exit code: 1.
```

The proposed changes fixes this by removing the dependency for the build task on the task ["checkout:sample:locks"] in the .vscode/tasks.json file. 