### PR TITLE
Fixes incorrect type mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated schema link in plugin manifest to the correct url. [#5441](https://github.com/microsoft/kiota/issues/5441)
 - Removed registration of default serialization and deserialization classes in client constructor. [#5478](https://github.com/microsoft/kiota/pull/5478)
 - Fixed incorrect type name generation in aliased scenario in TS due to broad searching of types in root namespaces. [#5404](https://github.com/microsoft/kiota/issues/5404)
+- Fixed incorrect type mapping in request builders with subsequent paths with the same name. [#5462](https://github.com/microsoft/kiota/issues/5462)
 
 ## [1.18.0] - 2024-09-05
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -955,8 +955,11 @@ public partial class KiotaBuilder
 
         Parallel.ForEach(unmappedRequestBuilderTypes, parallelOptions, x =>
         {
+            var parentClass = x.Parent?.Parent as CodeClass;
             var parentNS = x.Parent?.Parent?.Parent as CodeNamespace;
-            x.TypeDefinition = parentNS?.FindChildrenByName<CodeClass>(x.Name).MinBy(shortestNamespaceOrder);
+            x.TypeDefinition = parentNS?.FindChildrenByName<CodeClass>(x.Name)
+                .Except([parentClass]).OfType<CodeClass>() // the property method should not reference itself as a return type. 
+                .MinBy(shortestNamespaceOrder);
             // searching down first because most request builder properties on a request builder are just sub paths on the API
             if (x.TypeDefinition == null)
             {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -955,10 +955,10 @@ public partial class KiotaBuilder
 
         Parallel.ForEach(unmappedRequestBuilderTypes, parallelOptions, x =>
         {
-            var parentClass = x.Parent?.Parent as CodeClass;
             var parentNS = x.Parent?.Parent?.Parent as CodeNamespace;
+            CodeClass[] exceptions = x.Parent?.Parent is CodeClass parentClass ? [parentClass] : [];
             x.TypeDefinition = parentNS?.FindChildrenByName<CodeClass>(x.Name)
-                .Except([parentClass]).OfType<CodeClass>() // the property method should not reference itself as a return type. 
+                .Except(exceptions)// the property method should not reference itself as a return type. 
                 .MinBy(shortestNamespaceOrder);
             // searching down first because most request builder properties on a request builder are just sub paths on the API
             if (x.TypeDefinition == null)


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/5462
Fixes https://github.com/microsoft/kiota/issues/4831

Fixes the mapping of types in request builders with subsequent paths with the same name to not select themselves.