### PR TITLE
Task: create edit paths command

### DIFF
--- a/vscode/microsoft-kiota/src/commands/editPathsCommand.ts
+++ b/vscode/microsoft-kiota/src/commands/editPathsCommand.ts
@@ -1,0 +1,34 @@
+import { extensionId, treeViewId } from "../constants";
+import { ClientOrPluginProperties } from "../kiotaInterop";
+import { OpenApiTreeProvider } from "../openApiTreeProvider";
+import { updateTreeViewIcons } from "../util";
+import { openTreeViewWithProgress } from "../utilities/progress";
+import { Command } from "./Command";
+
+export class EditPathsCommand extends Command {
+
+  private _openApiTreeProvider: OpenApiTreeProvider;
+  private _clientKey: string;
+  private _clientObject: ClientOrPluginProperties;
+
+  public constructor(openApiTreeProvider: OpenApiTreeProvider, clientKey: string, clientObject: ClientOrPluginProperties) {
+    super();
+    this._openApiTreeProvider = openApiTreeProvider;
+    this._clientKey = clientKey;
+    this._clientObject = clientObject;
+  }
+
+  public getName(): string {
+    return `${extensionId}.editPaths`;
+  }
+
+  public async execute(): Promise<void> {
+    await this.loadEditPaths();
+    this._openApiTreeProvider.resetInitialState();
+    await updateTreeViewIcons(treeViewId, false, true);
+  }
+
+  private async loadEditPaths() {
+    await openTreeViewWithProgress(() => this._openApiTreeProvider.loadEditPaths(this._clientKey, this._clientObject));
+  }
+}

--- a/vscode/microsoft-kiota/src/commands/editPathsCommand.ts
+++ b/vscode/microsoft-kiota/src/commands/editPathsCommand.ts
@@ -8,27 +8,23 @@ import { Command } from "./Command";
 export class EditPathsCommand extends Command {
 
   private _openApiTreeProvider: OpenApiTreeProvider;
-  private _clientKey: string;
-  private _clientObject: ClientOrPluginProperties;
 
-  public constructor(openApiTreeProvider: OpenApiTreeProvider, clientKey: string, clientObject: ClientOrPluginProperties) {
+  public constructor(openApiTreeProvider: OpenApiTreeProvider) {
     super();
     this._openApiTreeProvider = openApiTreeProvider;
-    this._clientKey = clientKey;
-    this._clientObject = clientObject;
   }
 
   public getName(): string {
     return `${extensionId}.editPaths`;
   }
 
-  public async execute(): Promise<void> {
-    await this.loadEditPaths();
+  public async execute({ clientKey, clientObject }: { clientKey: string, clientObject: ClientOrPluginProperties }): Promise<void> {
+    await this.loadEditPaths(clientKey, clientObject);
     this._openApiTreeProvider.resetInitialState();
     await updateTreeViewIcons(treeViewId, false, true);
   }
 
-  private async loadEditPaths() {
-    await openTreeViewWithProgress(() => this._openApiTreeProvider.loadEditPaths(this._clientKey, this._clientObject));
+  private async loadEditPaths(clientKey: string, clientObject: ClientOrPluginProperties) {
+    await openTreeViewWithProgress(() => this._openApiTreeProvider.loadEditPaths(clientKey, clientObject));
   }
 }

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as vscode from "vscode";
 
 import { CodeLensProvider } from "./codelensProvider";
+import { EditPathsCommand } from './commands/editPathsCommand';
 import { MigrateFromLockFileCommand } from './commands/migrateFromLockFileCommand';
 import { AddAllToSelectedEndpointsCommand } from './commands/open-api-tree-view/addAllToSelectedEndpointsCommand';
 import { AddToSelectedEndpointsCommand } from './commands/open-api-tree-view/addToSelectedEndpointsCommand';
@@ -40,9 +41,9 @@ import {
   parseGenerationType, parsePluginType, updateTreeViewIcons
 } from "./util";
 import { IntegrationParams, isDeeplinkEnabled, transformToGenerationConfig, validateDeepLinkQueryParams } from './utilities/deep-linking';
+import { openTreeViewWithProgress } from './utilities/progress';
 import { confirmOverride } from './utilities/regeneration';
 import { loadTreeView } from "./workspaceTreeProvider";
-import { EditPathsCommand } from './commands/editPathsCommand';
 
 let kiotaStatusBarItem: vscode.StatusBarItem;
 let kiotaOutputChannel: vscode.LogOutputChannel;
@@ -670,17 +671,7 @@ export async function activate(
 
   context.subscriptions.push(disposable);
 }
-function openTreeViewWithProgress<T>(callback: () => Promise<T>): Thenable<T> {
-  return vscode.window.withProgress({
-    location: vscode.ProgressLocation.Notification,
-    cancellable: false,
-    title: vscode.l10n.t("Loading...")
-  }, async (progress, _) => {
-    const result = await callback();
-    await vscode.commands.executeCommand(treeViewFocusCommand);
-    return result;
-  });
-}
+
 function registerCommandWithTelemetry(reporter: TelemetryReporter, command: string, callback: (...args: any[]) => any, thisArg?: any): vscode.Disposable {
   return vscode.commands.registerCommand(command, (...args: any[]) => {
     const splatCommand = command.split('/');

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -77,7 +77,7 @@ export async function activate(
   const removeFromSelectedEndpointsCommand = new RemoveFromSelectedEndpointsCommand(openApiTreeProvider);
   const filterDescriptionCommand = new FilterDescriptionCommand(openApiTreeProvider);
   const openDocumentationPageCommand = new OpenDocumentationPageCommand();
-  const editPathsCommand = new EditPathsCommand(openApiTreeProvider, clientOrPluginKey, clientOrPluginObject);
+  const editPathsCommand = new EditPathsCommand(openApiTreeProvider);
 
   await loadTreeView(context);
   await checkForLockFileAndPrompt(context);
@@ -306,7 +306,12 @@ export async function activate(
     }
     ),
     registerCommandWithTelemetry(reporter, filterDescriptionCommand.getName(), async () => await filterDescriptionCommand.execute()),
-    registerCommandWithTelemetry(reporter, editPathsCommand.getName(), async () => await editPathsCommand.execute()),
+    registerCommandWithTelemetry(reporter, editPathsCommand.getName(), async (clientKey: string, clientObject: ClientOrPluginProperties, generationType: string) => {
+      clientOrPluginKey = clientKey;
+      clientOrPluginObject = clientObject;
+      workspaceGenerationType = generationType;
+      await editPathsCommand.execute({ clientKey, clientObject });
+    }),
 
     registerCommandWithTelemetry(reporter, `${treeViewId}.regenerateButton`, async () => {
       const regenerate = await confirmOverride();

--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -42,6 +42,7 @@ import {
 import { IntegrationParams, isDeeplinkEnabled, transformToGenerationConfig, validateDeepLinkQueryParams } from './utilities/deep-linking';
 import { confirmOverride } from './utilities/regeneration';
 import { loadTreeView } from "./workspaceTreeProvider";
+import { EditPathsCommand } from './commands/editPathsCommand';
 
 let kiotaStatusBarItem: vscode.StatusBarItem;
 let kiotaOutputChannel: vscode.LogOutputChannel;
@@ -75,6 +76,7 @@ export async function activate(
   const removeFromSelectedEndpointsCommand = new RemoveFromSelectedEndpointsCommand(openApiTreeProvider);
   const filterDescriptionCommand = new FilterDescriptionCommand(openApiTreeProvider);
   const openDocumentationPageCommand = new OpenDocumentationPageCommand();
+  const editPathsCommand = new EditPathsCommand(openApiTreeProvider, clientOrPluginKey, clientOrPluginObject);
 
   await loadTreeView(context);
   await checkForLockFileAndPrompt(context);
@@ -303,15 +305,8 @@ export async function activate(
     }
     ),
     registerCommandWithTelemetry(reporter, filterDescriptionCommand.getName(), async () => await filterDescriptionCommand.execute()),
+    registerCommandWithTelemetry(reporter, editPathsCommand.getName(), async () => await editPathsCommand.execute()),
 
-    registerCommandWithTelemetry(reporter, `${extensionId}.editPaths`, async (clientKey: string, clientObject: ClientOrPluginProperties, generationType: string) => {
-      clientOrPluginKey = clientKey;
-      clientOrPluginObject = clientObject;
-      workspaceGenerationType = generationType;
-      await loadEditPaths(clientOrPluginKey, clientObject, openApiTreeProvider);
-      openApiTreeProvider.resetInitialState();
-      await updateTreeViewIcons(treeViewId, false, true);
-    }),
     registerCommandWithTelemetry(reporter, `${treeViewId}.regenerateButton`, async () => {
       const regenerate = await confirmOverride();
       if (!regenerate) {

--- a/vscode/microsoft-kiota/src/utilities/progress.ts
+++ b/vscode/microsoft-kiota/src/utilities/progress.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+
+import { treeViewFocusCommand } from "../constants";
+
+function openTreeViewWithProgress<T>(callback: () => Promise<T>): Thenable<T> {
+  return vscode.window.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    cancellable: false,
+    title: vscode.l10n.t("Loading...")
+  }, async (progress, _) => {
+    const result = await callback();
+    await vscode.commands.executeCommand(treeViewFocusCommand);
+    return result;
+  });
+}
+
+export { openTreeViewWithProgress };


### PR DESCRIPTION
### Overview
- Moves the edit Paths command implementation from extensions.ts to it's own file
- Moves the close Description implementation from extensions.ts to its' own file

Closes #5516
