### PR TITLE
fixed defaults for multipart requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed registration of default serialization and deserialization classes in client constructor. [#5478](https://github.com/microsoft/kiota/pull/5478)
 - Fixed incorrect type name generation in aliased scenario in TS due to broad searching of types in root namespaces. [#5404](https://github.com/microsoft/kiota/issues/5404)
 - Fixed incorrect type mapping in request builders with subsequent paths with the same name. [#5462](https://github.com/microsoft/kiota/issues/5462)
+- Fixed multipart generation to default Content-Types are defined for multipart [#5504](https://github.com/microsoft/kiota/issues/5504) 
 
 ## [1.18.0] - 2024-09-05
 

--- a/it/typescript/package.json
+++ b/it/typescript/package.json
@@ -32,13 +32,13 @@
   },
   "dependencies": {
     "@azure/identity": "^4.4.1",
-    "@microsoft/kiota-abstractions": "^1.0.0-preview.66",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.61",
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.65",
-    "@microsoft/kiota-serialization-form": "^1.0.0-preview.54",
-    "@microsoft/kiota-serialization-json": "^1.0.0-preview.66",
-    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.44",
-    "@microsoft/kiota-serialization-text": "^1.0.0-preview.63",
+    "@microsoft/kiota-abstractions": "^1.0.0-preview.68",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.63",
+    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.67",
+    "@microsoft/kiota-serialization-form": "^1.0.0-preview.56",
+    "@microsoft/kiota-serialization-json": "^1.0.0-preview.68",
+    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.46",
+    "@microsoft/kiota-serialization-text": "^1.0.0-preview.65",
     "express": "^5.0.0",
     "node-fetch": "^2.7.0"
   }


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/5504

According to the spec at https://spec.openapis.org/oas/v3.0.3.html#special-considerations-for-multipart-content,

In the event that we do not have encodings present, multipart provides defaults as below, 

- If the property is a primitive, or an array of primitive values, the default Content-Type is text/plain
- If the property is complex, or an array of complex values, the default Content-Type is application/json
- If the property is a type: string with format: binary or format: base64 (aka a file object), the default Content-Type is application/octet-stream

This pr updates the evaluation of the model type to take this into consideration based of the passed configuration in the structured mime types. 

