### PR TITLE
Fix SDK version in global.json file

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.402",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
The version number currently used doesn't match with an actual SDK version. It should be `8.0.xxx`. I've updated it to use the latest SDK version.