### PR TITLE
Fix: regenerate button after immediate generation

### DIFF
--- a/vscode/microsoft-kiota/src/extension.ts
+++ b/vscode/microsoft-kiota/src/extension.ts
@@ -196,11 +196,13 @@ export async function activate(
         return;
       }
       const workspaceGenerationType = getWorkspaceGenerationType();
+      const configObject = clientOrPluginObject || configuration;
+
       if (isClientType(workspaceGenerationType)) {
-        await regenerateClient(clientOrPluginKey, clientOrPluginObject, settings, selectedPaths);
+        await regenerateClient(clientOrPluginKey, configObject, settings, selectedPaths);
       }
       if (isPluginType(workspaceGenerationType)) {
-        await regeneratePlugin(clientOrPluginKey, clientOrPluginObject, settings, selectedPaths);
+        await regeneratePlugin(clientOrPluginKey, configObject, settings, selectedPaths);
       }
     }),
     registerCommandWithTelemetry(reporter, `${extensionId}.regenerate`, async (clientKey: string, clientObject: ClientOrPluginProperties, generationType: string) => {


### PR DESCRIPTION
### Overview
A follow up to #5541 
Closes #5527

When a user generates a client and the openapi tree view is still on the description that's been used to generate the client, hitting the regenerate button after adding / removing a path fails.

### Notes
the `clientOrPluginObject` is populated by `editPaths`. So in this scenario where the user doesn't open the workspace to trigger an edit and merely just continues editing after generation, the `clientOrPluginObject` is empty but the configuration object is populated.