### PR TITLE
fix: pin Microsoft.CodeAnalysis.CSharp to 4.8.0.0 to fix compiler mismatch

### DIFF
--- a/src/Kiota.Generated/KiotaGenerated.csproj
+++ b/src/Kiota.Generated/KiotaGenerated.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*"
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0.0"
       ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"
       ExcludeAssets="runtime" />

--- a/src/Kiota.Generated/KiotaGenerated.csproj
+++ b/src/Kiota.Generated/KiotaGenerated.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- NOTE: This version constraint (4.8.0.0) MUST match the earliest version supported for .NET 8 to prevent compatibility issues with the SDK.
+            Updating this version might cause runtime errors due to unsupported dependencies in older SDK versions.
+            Please avoid upgrading this dependency unless the target framework version is changed or until confirmed compatible with .NET 8.
+            If Dependabot suggests an upgrade, it should be ignored. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0.0"
       ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"


### PR DESCRIPTION
seeing some build failure as:

```
==> dotnet publish src/kiota/kiota.csproj --configuration Release --framework net8.0 --output /opt/homebrew/Cellar/kiota/1.19.0/libexec --runtime osx-arm64 --no-self-contained -p:TargetFramework=net8.0 -p:PublishSingleFile=true -p:Version=1.19.0

Welcome to .NET 8.0!
---------------------
SDK Version: 8.0.108

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate, run 'dotnet dev-certs https --trust'
Learn about HTTPS: https://aka.ms/dotnet-https

----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
MSBuild version 17.8.5+b5265ef37 for .NET
  Determining projects to restore...
  Restored /private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Builder/Kiota.Builder.csproj (in 1.43 sec).
  Restored /private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/kiota/kiota.csproj (in 2.26 sec).
  Restored /private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Generated/KiotaGenerated.csproj (in 2.9 sec).
  KiotaGenerated -> /private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Generated/bin/Release/netstandard2.0/KiotaGenerated.dll
/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/.brew_home/.nuget/packages/microsoft.build.tasks.git/8.0.0/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Unable to locate repository with working directory that contains directory '/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Builder'. [/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Builder/Kiota.Builder.csproj]
/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/.brew_home/.nuget/packages/microsoft.sourcelink.common/8.0.0/build/Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty. [/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Builder/Kiota.Builder.csproj]
CSC : error CS9057: The analyzer assembly '/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Generated/bin/Release/netstandard2.0/KiotaGenerated.dll' references version '4.11.0.0' of the compiler, which is newer than the currently running version '4.8.0.0'. [/private/tmp/kiota-20241007-4190-7glib9/kiota-1.19.0/src/Kiota.Builder/Kiota.Builder.csproj]
```
---

relates to 
- https://github.com/Homebrew/homebrew-core/pull/193091
- https://github.com/microsoft/kiota/issues/4449

cc @baywet 