### PR TITLE
fixes incompatibility with new odata primitive format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed incompatibility with detecting odata primitives after conversion library updates at [OpenAPI.NET.OData#581](https://github.com/microsoft/OpenAPI.NET.OData/issues/581);
 - Fixed cyclic dependencies in generated Go code. [#2834](https://github.com/microsoft/kiota/issues/2834)
 - Fixed a bug where default output folder is created on plugin edit and generate commands. [#5510](https://github.com/microsoft/kiota/issues/5429)
 

--- a/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiSchemaExtensions.cs
@@ -132,7 +132,7 @@ public static class OpenApiSchemaExtensions
         "number",
         "integer",
     };
-    public static bool IsODataPrimitiveType(this OpenApiSchema schema)
+    private static bool IsODataPrimitiveTypeBackwardCompatible(this OpenApiSchema schema)
     {
         return schema.IsExclusiveUnion() &&
                 schema.OneOf.Count == 3 &&
@@ -145,6 +145,22 @@ public static class OpenApiSchemaExtensions
                 schema.AnyOf.Count(static x => x.Enum?.Any() ?? false) == 1 &&
                 schema.AnyOf.Count(static x => oDataTypes.Contains(x.Type)) == 1 &&
                 schema.AnyOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase)) == 1;
+    }
+    public static bool IsODataPrimitiveType(this OpenApiSchema schema)
+    {
+        return schema.IsExclusiveUnion() &&
+               schema.OneOf.Count == 3 &&
+               schema.OneOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase) && (x.Enum?.Any() ?? false)) == 1 &&
+               schema.OneOf.Count(static x => oDataTypes.Contains(x.Type)) == 1 &&
+               schema.OneOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase)) == 2
+               ||
+               schema.IsInclusiveUnion() &&
+               schema.AnyOf.Count == 3 &&
+               schema.AnyOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase) && (x.Enum?.Any() ?? false)) == 1 &&
+               schema.AnyOf.Count(static x => oDataTypes.Contains(x.Type)) == 1 &&
+               schema.AnyOf.Count(static x => "string".Equals(x.Type, StringComparison.OrdinalIgnoreCase)) == 2
+               ||
+               schema.IsODataPrimitiveTypeBackwardCompatible();
     }
     public static bool IsEnum(this OpenApiSchema schema)
     {

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -785,4 +785,66 @@ public class OpenApiSchemaExtensionsTests
         };
         Assert.False(schema.IsEnum());
     }
+    [Fact]
+    public void IsOdataPrimitive()
+    {
+        var schema = new OpenApiSchema
+        {
+            OneOf = new List<OpenApiSchema>
+            {
+                new ()
+                {
+                    Type = "number",
+                    Format = "double",
+                    Nullable = true
+                },
+                new ()
+                {
+                    Type = "string",
+                    Nullable = true
+                },
+                new ()
+                {
+                    Enum = new List<IOpenApiAny>()
+                    {
+                        new OpenApiString("INF"),
+                        new OpenApiString("INF"),
+                        new OpenApiString("NaN"),
+                    },
+                    Type = "string",
+                    Nullable = true
+                }
+            }
+        };
+        Assert.True(schema.IsODataPrimitiveType());
+    }
+    [Fact]
+    public void IsOdataPrimitiveBackwardCompatible()
+    {
+        var schema = new OpenApiSchema
+        {
+            OneOf = new List<OpenApiSchema>
+            {
+                new ()
+                {
+                    Type = "number",
+                    Format = "double",
+                },
+                new ()
+                {
+                    Type = "string",
+                },
+                new ()
+                {
+                    Enum = new List<IOpenApiAny>()
+                    {
+                        new OpenApiString("INF"),
+                        new OpenApiString("INF"),
+                        new OpenApiString("NaN"),
+                    }
+                }
+            }
+        };
+        Assert.True(schema.IsODataPrimitiveType());
+    }
 }


### PR DESCRIPTION
Related to https://github.com/microsoft/OpenAPI.NET.OData/pull/589

Latest changes in the conversion library add the `type` property to the schema of the `ReferenceNumeric` type used in odata primitives.

This causes incompatibility with the `IsODataPrimitiveType` which only expects one schema to have the type of `string`.

This PR updates the implementation so that the new scenario is captured and older documents with the older format are not broken by this change.