### PR TITLE
Display clean output hint when generating CSharp client only when --clean-output is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed cyclic dependencies in generated Go code. [#2834](https://github.com/microsoft/kiota/issues/2834)
 - Fixed a bug where default output folder is created on plugin edit and generate commands. [#5510](https://github.com/microsoft/kiota/issues/5429)
 - Changed GeneratedCode attribute applied when generating CSharp to only include the major version of Kiota. [#5489](https://github.com/microsoft/kiota/issues/5489)
+- Fixed genarating CSharp client displays clean hint regardless of whether --clean-output is already passed [#5576](https://github.com/microsoft/kiota/issues/5576)
 
 ## [1.19.0] - 2024-10-03
 

--- a/src/kiota/Handlers/KiotaGenerateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaGenerateCommandHandler.cs
@@ -141,7 +141,8 @@ internal class KiotaGenerateCommandHandler : BaseKiotaCommandHandler
                 else
                 {
                     DisplaySuccess("Generation skipped as no changes were detected");
-                    DisplayCleanHint("generate");
+                    if (!cleanOutput)
+                        DisplayCleanHint("generate");
                 }
                 var manifestResult = await builder.GetApiManifestDetailsAsync(true, cancellationToken).ConfigureAwait(false);
                 var manifestPath = manifestResult is null ? string.Empty : Configuration.Generation.ApiManifestPath;

--- a/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaUpdateCommandHandler.cs
@@ -69,7 +69,7 @@ internal class KiotaUpdateCommandHandler : BaseKiotaCommandHandler
                 DisplaySuccess($"Update of {locks.Length} clients completed successfully");
                 foreach (var configuration in configurations)
                     DisplayInfoHint(configuration.Language, configuration.OpenAPIFilePath, string.Empty);
-                if (Array.Exists(results, static x => x))
+                if (Array.Exists(results, static x => x) && !cleanOutput)
                     DisplayCleanHint("update");
                 return 0;
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/5576