### PR TITLE
fix: fixes missing mapping for the `int16` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixes mapping of `int16` format to the `integer` type rather than `double` when the type is `integer` or `number` [#5611](https://github.com/microsoft/kiota/issues/5611)
+
 ## [1.19.1] - 2024-10-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed cyclic dependencies in generated Go code. [#2834](https://github.com/microsoft/kiota/issues/2834)
 - Fixed a bug where default output folder is created on plugin edit and generate commands. [#5510](https://github.com/microsoft/kiota/issues/5429)
 - Changed GeneratedCode attribute applied when generating CSharp to only include the major version of Kiota. [#5489](https://github.com/microsoft/kiota/issues/5489)
-- Fixed genarating CSharp client displays clean hint regardless of whether --clean-output is already passed [#5576](https://github.com/microsoft/kiota/issues/5576)
+- Fixed generating CSharp client displays clean hint regardless of whether --clean-output is already passed [#5576](https://github.com/microsoft/kiota/issues/5576)
 
 ## [1.19.0] - 2024-10-03
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1154,6 +1154,7 @@ public partial class KiotaBuilder
                 ("number" or "integer", "int8") => "sbyte",
                 ("number" or "integer", "uint8") => "byte",
                 ("number" or "integer", "int64") => "int64",
+                ("number", "int16") => "integer",
                 ("number", "int32") => "integer",
                 ("number", _) => "double",
                 ("integer", _) => "integer",

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -4491,6 +4491,8 @@ components:
     [InlineData("integer", "int64", "int64")]
     [InlineData("number", "int8", "sbyte")]
     [InlineData("integer", "int8", "sbyte")]
+    [InlineData("number", "int16", "integer")]
+    [InlineData("integer", "int16", "integer")]
     [InlineData("number", "uint8", "byte")]
     [InlineData("integer", "uint8", "byte")]
     [InlineData("number", "", "double")]


### PR DESCRIPTION
Closes https://github.com/microsoft/kiota/issues/5611

Generation run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=167346&view=results

Sample diff at https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/kiota/v1.0/pipelinebuild/167322..kiota/v1.0/pipelinebuild/167346