### PR TITLE
Fixes the union deserializer code generation in Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed an issue where when generating Go code the deserializer for unions was using `CodeClass` as a filter and not `CodeInterface`. [#4844](https://github.com/microsoft/kiota/issues/4844)
+
+
 ## [1.19.1] - 2024-10-11
 
 ### Added

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -632,7 +632,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         var otherPropGetters = parentClass
                                 .GetPropertiesOfKind(CodePropertyKind.Custom)
                                 .Where(static x => !x.ExistsInBaseType && x.Getter != null)
-                                .Where(static x => x.Type is CodeType propertyType && !propertyType.IsCollection && propertyType.TypeDefinition is CodeClass)
+                                .Where(static x => x.Type is CodeType propertyType && !propertyType.IsCollection && propertyType.TypeDefinition is CodeInterface)
                                 .OrderBy(static x => x, CodePropertyTypeForwardComparer)
                                 .ThenBy(static x => x.Name)
                                 .Select(static x => x.Getter!.Name.ToFirstCharacterUpperCase())

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -291,16 +291,20 @@ public sealed class CodeMethodWriterTests : IDisposable
     }
     private CodeClass AddUnionTypeWrapper()
     {
-        var complexType1 = root.AddClass(new CodeClass
+        var complexType1 = root.AddInterface(new CodeInterface
         {
             Name = "ComplexType1",
-            Kind = CodeClassKind.Model,
+            Kind = CodeInterfaceKind.Model,
+            OriginalClass = new CodeClass { Name = "ComplexType1", Kind = CodeClassKind.Model }
         }).First();
-        var complexType2 = root.AddClass(new CodeClass
+
+        var complexType2 = root.AddInterface(new CodeInterface
         {
             Name = "ComplexType2",
-            Kind = CodeClassKind.Model,
+            Kind = CodeInterfaceKind.Model,
+            OriginalClass = new CodeClass { Name = "ComplexType2", Kind = CodeClassKind.Model }
         }).First();
+
         var unionTypeWrapper = root.AddClass(new CodeClass
         {
             Name = "UnionTypeWrapper",


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota/issues/4844

### What
When generating Go based SDKs from GitHub's OpenAPI [definitions](https://github.com/github/rest-api-description/tree/main/descriptions/api.github.com) we noticed that the `GetFieldDeserializers` function was empty for any operations using discriminators and `OneOf`

### Why
It turns out that the issue is in WriteDeserializerBodyForUnionModel or at least why the method body is not getting generated.
So the LINQ statement for Go is:

```
var otherPropGetters = parentClass
 .GetPropertiesOfKind(CodePropertyKind.Custom)
 .Where(static x => !x.ExistsInBaseType && x.Getter != null)
 .Where(static x => x.Type is CodeType propertyType && !propertyType.IsCollection && propertyType.TypeDefinition is CodeClass)
 .OrderBy(static x => x, CodePropertyTypeForwardComparer)
 .ThenBy(static x => x.Name)
 .Select(static x => x.Getter!.Name.ToFirstCharacterUpperCase())
 .ToArray();
```
The problem is that for these discriminators the TypeDefinition is not of type CodeClass but of type CodeInterface
When the LINQ is rewritten like this, it works:
```
var otherPropGetters = parentClass
 .GetPropertiesOfKind(CodePropertyKind.Custom)
 .Where(static x => !x.ExistsInBaseType && x.Getter != null)
 .Where(static x => x.Type is CodeType propertyType && !propertyType.IsCollection && propertyType.TypeDefinition is CodeInterface)
 .OrderBy(static x => x, CodePropertyTypeForwardComparer)
 .ThenBy(static x => x.Name)
 .Select(static x => x.Getter!.Name.ToFirstCharacterUpperCase())
 .ToArray();
```

- [x] Tests have been updated
- [x] Change log has been updated
- [x] Verified to be working using GitHub's OpenAPI [definitions](https://github.com/github/rest-api-description/tree/main/descriptions/api.github.com) 