### PR TITLE
Support trailing slash in URL paths

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeConstant.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeConstant.cs
@@ -95,6 +95,7 @@ public class CodeConstant : CodeTerminalWithKind<CodeConstantKind>, IDocumentedE
             Name = $"{codeClass.Name.ToFirstCharacterLowerCase()}{RequestsMetadataSuffix}",
             Kind = CodeConstantKind.RequestsMetadata,
             OriginalCodeElement = codeClass,
+            UriTemplate = $"{codeClass.Name.ToFirstCharacterLowerCase()}{UriTemplateSuffix}",
         };
         result.Documentation.DescriptionTemplate = "Metadata for all the requests in the request builder.";
         if (usingsToAdd is { Length: > 0 } usingsToAddList)

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -266,6 +266,11 @@ public static partial class StringExtensions
             result = result.Replace("+", "_plus_", StringComparison.OrdinalIgnoreCase);
         }
 
+        if (result.Contains('\\', StringComparison.OrdinalIgnoreCase))
+        {
+            result = result.Replace(@"\", "Slash", StringComparison.OrdinalIgnoreCase);
+        }
+
         return result;
     }
     /// <summary>

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -311,10 +311,10 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
     }
     private static void MergeConflictingBuilderCodeFilesForElement(CodeElement currentElement)
     {
-        if (currentElement is CodeNamespace currentNamespace && currentNamespace.Files.Count() > 1)
+        if (currentElement is CodeNamespace currentNamespace && currentNamespace.Files.ToArray() is { Length: > 1 } codeFiles)
         {
-            var targetFile = currentNamespace.Files.First();
-            foreach (var fileToMerge in currentNamespace.Files.Skip(1))
+            var targetFile = codeFiles.First();
+            foreach (var fileToMerge in codeFiles.Skip(1))
             {
                 if (fileToMerge.Classes.Any())
                     targetFile.AddElements(fileToMerge.Classes.ToArray());

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -85,7 +85,7 @@ public class StringExtensionsTests
         Assert.Equal("Toto", "toto".NormalizeNameSpaceName("-"));
         Assert.Equal("Microsoft_Graph_Message_Content", "microsoft.Graph.Message.Content".NormalizeNameSpaceName("_"));
     }
-    [InlineData("\" !#$%&'()*+,./:;<=>?@[]\\^`{}|~-", "plus")]
+    [InlineData("\" !#$%&'()*+,./:;<=>?@[]^`{}|~-", "plus")]
     [InlineData("unchanged", "unchanged")]
     [InlineData("@odata.changed", "OdataChanged")]
     [InlineData("specialLast@", "specialLast")]
@@ -98,6 +98,9 @@ public class StringExtensionsTests
     [InlineData("-1-", "minus_1")]
     [InlineData("-1-1", "minus_11")]
     [InlineData("-", "minus")]
+    [InlineData("\\", "Slash")]
+    [InlineData("Param\\", "ParamSlash")]
+    [InlineData("Param\\RequestBuilder", "ParamSlashRequestBuilder")]
     [Theory]
     public void CleansUpSymbolNames(string input, string expected)
     {

--- a/tests/Kiota.Builder.Tests/OpenApiSampleFiles/TrailingSlashSampleYml.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiSampleFiles/TrailingSlashSampleYml.cs
@@ -1,0 +1,132 @@
+﻿namespace Kiota.Builder.Tests.OpenApiSampleFiles;
+
+public static class TrailingSlashSampleYml
+{
+    /**
+    * An OpenAPI 3.0.0 sample document with trailing slashes on some paths.
+    */
+    public static readonly string OpenApiYaml = @"
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: A sample API that uses trailing slashes.
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /foo:
+    get:
+      summary: Get foo
+      description: Returns foo.
+      responses:
+        '200':
+          description: foo
+          content:
+            text/plain:
+              schema:
+                type: string
+  /foo/:
+    get:
+      summary: Get foo slash
+      description: Returns foo slash.
+      responses:
+        '200':
+          description: foo slash
+          content:
+            text/plain:
+              schema:
+                type: string
+  /message/{id}:
+    get:
+      summary: Get a Message
+      description: Returns a single Message object.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A Message object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+  /message/{id}/:
+    get:
+      summary: Get replies to a Message
+      description: Returns a list of Message object replies for a Message.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of Message objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Message'
+  /bucket/{name}/:
+    get:
+      summary: List items in a bucket
+      description: Returns a list of BucketFiles in a bucket.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of BucketFile objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BucketFile'
+  /bucket/{name}/{id}:
+    get:
+      summary: Get a bucket item
+      description: Returns a single BucketFile object.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A BucketFile object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BucketFile'
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        Guid:
+          type: string
+      required:
+        - Guid
+    BucketFile:
+      type: object
+      properties:
+        Guid:
+          type: string
+      required:
+        - Guid";
+}

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -82,7 +82,7 @@ public sealed class CodeEnumWriterTests : IDisposable
     }
 
     [Theory]
-    [InlineData("\\", "BackSlash")]
+    [InlineData("\\", "Slash")]
     [InlineData("?", "QuestionMark")]
     [InlineData("$", "Dollar")]
     [InlineData("~", "Tilde")]

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
@@ -477,6 +477,33 @@ public sealed class CodeConstantWriterTests : IDisposable
         Assert.Contains("403: createError403FromDiscriminatorValue as ParsableFactory<Parsable>", result);
     }
     [Fact]
+    public void WritesRequestsMetadataWithCorrectUriTemplate()
+    {
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        method.Kind = CodeMethodKind.RequestExecutor;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters();
+        var constant = CodeConstant.FromRequestBuilderToRequestsMetadata(parentClass);
+        var codeFile = root.TryAddCodeFile("foo", constant);
+        codeFile.AddElements(new CodeConstant
+        {
+            Name = "firstAndWrongUriTemplate",
+            Kind = CodeConstantKind.UriTemplate,
+            UriTemplate = "{+baseurl}/foo/"
+        });
+        codeFile.AddElements(new CodeConstant
+        {
+            Name = "parentClassUriTemplate",
+            Kind = CodeConstantKind.UriTemplate,
+            UriTemplate = "{+baseurl}/foo"
+        });
+        writer.Write(constant);
+        var result = tw.ToString();
+        Assert.Contains("uriTemplate: ParentClassUriTemplate", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public void WritesIndexer()
     {
         AddRequestProperties();


### PR DESCRIPTION
Fixes #4291 

Nearly all language-specific writers support *parameterized* paths that have a trailing slash. The TypeScript writer does correctly write the request builder files but because it writes to `index.ts` rather than to a filename based on the request builder like the other writers, there is a conflict when a code namespace has more than one code file.
When the spec has paths like `/{foo}` and `/{foo}/`, kiota writes the first request builder correctly then overwrites it with the second request builder.

The first commit (faec08fbebbfd767b969842995aa1a256cc3d639) addresses this in the TypeScript refiner by detecting when the code namespace has more than one code file and merging them all into one.
However, this creates a new problem because the request metadata generator only selects the first UriTemplate. With the code files merged, there are multiple UriTemplate elements so one of the request metadata constants would have the wrong UriTemplate.

The second commit (514c603c76796dee67ed465bdb0ad940125e07f4) addresses this by taking advantage of how the UriTemplate property is unused in a CodeConstantKind.RequestsMetadata code constant and sets it to match the expected name of the correct UriTemplate. The request metadata generator can then use this now-populated property to find the correct UriTemplate.
Unfortunately, this creates a hidden coupling with how UriTemplates are named but it appears to be unavoidable.


Like the first issue, *non-parameterized* paths that have a trailing slash also result in conflicts. However, the conflict is earlier in the process so it affects all languages.
When the spec has paths like `/foo` and `/foo/`, kiota resolves both nodes (segments `foo` and `foo\\` respectively) to the same name which causes a lot of problems later, resulting in broken generated code.

The third commit (0eaf85452563b8c5e73c9b9278159fde7c022d97) addresses this by changing how slashes are cleaned up so that the `foo` segment still results in `foo` but the `foo\\` segment results in `fooSlash`. This also changes the naming of code elements like `foo\\RequestBuilder` from `fooRequestBuilder` to `fooSlashRequestBuilder`.
I'm not completely happy with this third commit because the trailing slash will now leak into the code element names and files. However, with my shallow understanding of the project, I'm not seeing a better way without messier changes.