### PR TITLE
Fix unsigned kiota.exe file when installed as dotnet tool.

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -163,7 +163,7 @@ extends:
               - pwsh: $(Build.SourcesDirectory)/scripts/get-prerelease-version.ps1 -currentBranch $(Build.SourceBranch) -previewBranch ${{ parameters.previewBranch }} -excludeHeadingDash
                 displayName: "Set version suffix"
 
-              - pwsh: $(Build.SourcesDirectory)/scripts/enable-shims-for-packaging.ps1"
+              - pwsh: $(Build.SourcesDirectory)/scripts/enable-shims-for-packaging.ps1
                 displayName: "Add PackAsToolShimRuntimeIdentifiers attributes for tool packaging"
 
               - pwsh: $(Build.SourcesDirectory)/scripts/update-version-suffix-for-source-generator.ps1 -versionSuffix "$(versionSuffix)"

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -163,6 +163,9 @@ extends:
               - pwsh: $(Build.SourcesDirectory)/scripts/get-prerelease-version.ps1 -currentBranch $(Build.SourceBranch) -previewBranch ${{ parameters.previewBranch }} -excludeHeadingDash
                 displayName: "Set version suffix"
 
+              - pwsh: $(Build.SourcesDirectory)/scripts/enable-shims-for-packaging.ps1"
+                displayName: "Add PackAsToolShimRuntimeIdentifiers attributes for tool packaging"
+
               - pwsh: $(Build.SourcesDirectory)/scripts/update-version-suffix-for-source-generator.ps1 -versionSuffix "$(versionSuffix)"
                 displayName: "Set version suffix in csproj for generators"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fixed python generation client serailization failure str being quoted as "str"
 - Fixed Issue with primitive values being stringified in python python. [#5417](https://github.com/microsoft/kiota/issues/5417)
-
 - Fixed an issue where multipart request content would be ignored if other unstructured content was present in the description. [#5638](https://github.com/microsoft/kiota/issues/5638)
 - Fixed an issue where when generating Go code the deserializer for unions was using `CodeClass` as a filter and not `CodeInterface`. [#4844](https://github.com/microsoft/kiota/issues/4844)
 - Fixes mapping of `int16` format to the `integer` type rather than `double` when the type is `integer` or `number` [#5611](https://github.com/microsoft/kiota/issues/5611)
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the type name for inherited inline models would be incorrect. [#5610](https://github.com/microsoft/kiota/issues/5610)
 - Fixes typing inconsistencies in generated code and libraries in Python [kiota-python#333](https://github.com/microsoft/kiota-python/issues/333)
 - Fixes generation of superfluous fields for Models with discriminator due to refiners adding the same properties to the same model [#4178](https://github.com/microsoft/kiota/issues/4178).
+- Fixes unsigned shim binary when installed as dotnet tool [#5650](https://github.com/microsoft/kiota/issues/5650).
 
 ## [1.19.1] - 2024-10-11
 

--- a/scripts/enable-shims-for-packaging.ps1
+++ b/scripts/enable-shims-for-packaging.ps1
@@ -1,0 +1,13 @@
+# This script enables the shims for packaging the project as a tool
+$csprojPath = Join-Path $PSScriptRoot "../src/kiota/kiota.csproj"
+
+$xml = [Xml] (Get-Content $csprojPath)
+
+$shimIdentifiers = $xml.CreateElement("PackAsToolShimRuntimeIdentifiers")
+$shimIdentifiers.InnerText = "win-x64;win-x86;osx-x64"
+
+$rootPropertyGroup = $xml.Project.PropertyGroup[0]
+$rootPropertyGroup.AppendChild($shimIdentifiers)
+
+#save xml to csproj
+$xml.Save($csprojPath)


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/5650

According to the docs at https://github.com/dotnet/sdk/blob/main/documentation/general/signing-global-tool-packages.md,
a shim is created in target machine by dotnet in scenarios where the `PackAsToolShimRuntimeIdentifiers` tag is not defined in the csproj. This ends up showing as an unsigned binary as it is created at the time of installation.

This PR adds as script to dynamically add the attribute so that the shim is created during `dotnet build` in the release pipeline so that it signed together with the artifacts. 

This has been validated by installing the tool locally as well as inspecting the artifacts in this pipeline run. 

https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=169565&view=results

<img width="806" alt="image" src="https://github.com/user-attachments/assets/219f67ff-b75a-492c-b09f-4acc5efe0a2f">

**Notes**
We could have added this directly to the csproj. However, this causes build errors for the project when we attempt to build/publish the project as an **executable** with a runtime idenfier and not a **dotnet tool**. So this script is intended to run only for scenarios where we want to publish the dotnet tool. 