### PR TITLE
fix: getting rid of unnecessary guid-typescript dependency

### DIFF
--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -692,7 +692,6 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
         }
         CrawlTree(currentElement, AliasUsingsWithSameSymbol);
     }
-    private const string GuidPackageName = "guid-typescript";
     private const string AbstractionsPackageName = "@microsoft/kiota-abstractions";
     // A helper method to check if a parameter is a multipart body
     private static bool IsMultipartBody(CodeParameter p) =>
@@ -840,7 +839,7 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
     {"Guid", (string.Empty, new CodeUsing {
                             Name = "Guid",
                             Declaration = new CodeType {
-                                Name = GuidPackageName,
+                                Name = AbstractionsPackageName,
                                 IsExternal = true,
                             },
                             IsErasable = true, // the import is used only for the type, not for the value


### PR DESCRIPTION
Supplement to MR: [microsoft/kiota-typescript#1475](https://github.com/microsoft/kiota-typescript/pull/1475)

Fixes [microsoft/kiota#4508](https://github.com/microsoft/kiota/issues/4508)
Using a custom Guid type to get rid of unnecessary package (and partly broken) guid-typescript.