### PR TITLE
fix: Guid is an alias to primitive type string

### DIFF
--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -193,7 +193,6 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         {
             TYPE_INTEGER or TYPE_INT or TYPE_INT64 or TYPE_FLOAT or TYPE_DOUBLE or TYPE_BYTE or TYPE_SBYTE or TYPE_DECIMAL => TYPE_NUMBER,
             TYPE_BINARY or TYPE_BASE64 or TYPE_BASE64URL => TYPE_STRING,
-            TYPE_GUID => TYPE_GUID,
             TYPE_STRING or TYPE_OBJECT or TYPE_BOOLEAN or TYPE_VOID or TYPE_LOWERCASE_STRING or TYPE_LOWERCASE_OBJECT or TYPE_LOWERCASE_BOOLEAN or TYPE_LOWERCASE_VOID => type.Name.ToFirstCharacterLowerCase(),
             null => TYPE_OBJECT,
             _ when type is CodeComposedTypeBase composedType => composedType.Name.ToFirstCharacterUpperCase(),
@@ -222,6 +221,15 @@ public class TypeScriptConventionService : CommonLanguageConventionService
             TYPE_LOWERCASE_BOOLEAN or
             TYPE_LOWERCASE_VOID => true,
             _ => false,
+        };
+    }
+
+    public static string? GetPrimitiveAlias(string typeName)
+    {
+        return typeName switch
+        {
+            TYPE_GUID => TYPE_LOWERCASE_STRING,
+            _ => null
         };
     }
 


### PR DESCRIPTION
Hello!
After my PR [microsoft/kiota#5734](https://github.com/microsoft/kiota/pull/5734) I realized that there is no need for the createGuidFromDiscriminatorValue function (which causes an error in the generated client), since Guid is now an alias to string. So I made it so that Guid is parsed as its alias primitive.