### PR TITLE
Fixes invalid code in Php caused by `/*/*`` in property description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
 - Fixed Python error when a class inherits from a base class and implements an interface. [5637](https://github.com/microsoft/kiota/issues/5637)
 - Fix anyOf/oneOf generation in TypeScript. [5353](https://github.com/microsoft/kiota/issues/5353)
+- Fixed invalid code in Php caused by "*/*/" in property description. [5635](https://github.com/microsoft/kiota/issues/5635)
 
 ## [1.20.0] - 2024-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fixed Python error when a class inherits from a base class and implements an interface. [5637](https://github.com/microsoft/kiota/issues/5637)
 - Fix anyOf/oneOf generation in TypeScript. [5353](https://github.com/microsoft/kiota/issues/5353)
 - Fixed invalid code in Php caused by "*/*/" in property description. [5635](https://github.com/microsoft/kiota/issues/5635)

--- a/it/config.json
+++ b/it/config.json
@@ -34,10 +34,6 @@
         "Rationale": "https://github.com/microsoft/kiota/issues/5634"
       },
       {
-        "Language": "php",
-        "Rationale": "https://github.com/microsoft/kiota/issues/5635"
-      },
-      {
         "Language": "ruby",
         "Rationale": "https://github.com/microsoft/kiota/issues/1816"
       },

--- a/it/config.json
+++ b/it/config.json
@@ -36,6 +36,10 @@
       {
         "Language": "ruby",
         "Rationale": "https://github.com/microsoft/kiota/issues/1816"
+      },
+      {
+        "Language": "php",
+        "Rationale": "https://github.com/microsoft/kiota/issues/5779"
       }
     ],
     "ExcludePatterns": [

--- a/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
@@ -47,7 +47,7 @@ public partial class CodeEnumWriter : BaseElementWriter<CodeEnum, PhpConventionS
         writer.IncreaseIndent();
         foreach (var enumProperty in enumProperties)
         {
-            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = '{enumProperty.WireName}';");
+            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = \"{enumProperty.WireName}\";");
         }
     }
     [GeneratedRegex(@"([A-Z]{1})", RegexOptions.Singleline, 500)]

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -135,7 +135,7 @@ public class PhpConventionService : CommonLanguageConventionService
         return codeParameter.Optional ? $"{doc}|null" : doc;
     }
 
-    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase);
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).Replace("*/", "", StringComparison.OrdinalIgnoreCase);
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
         ArgumentNullException.ThrowIfNull(writer);

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -135,7 +135,7 @@ public class PhpConventionService : CommonLanguageConventionService
         return codeParameter.Optional ? $"{doc}|null" : doc;
     }
 
-    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).Replace("*/", "", StringComparison.OrdinalIgnoreCase);
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).Replace("*/", string.Empty, StringComparison.OrdinalIgnoreCase);
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
         ArgumentNullException.ThrowIfNull(writer);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
@@ -52,7 +52,7 @@ public sealed class CodeEnumWriterTests : IDisposable
         Assert.Contains("use Microsoft\\Kiota\\Abstractions\\Enum", result);
         Assert.Contains("class", result);
         Assert.Contains("extends Enum", result);
-        Assert.Contains($"public const {optionName.ToUpperInvariant()} = '{optionName}'", result);
+        Assert.Contains($"public const {optionName.ToUpperInvariant()} = \"{optionName}\"", result);
         AssertExtensions.CurlyBracesAreClosed(result, 1);
         Assert.Contains(optionName, result);
     }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
@@ -246,4 +246,26 @@ public class CodePropertyWriterTests
         Assert.Contains("@var array<RequestOption>|null $options", result);
         Assert.Contains("public ?array $options = null;", result);
     }
+
+    [Fact]
+    public void WritePropertyWithDescription()
+    {
+        CodeProperty property = new CodeProperty
+        {
+            Name = "name",
+            Documentation = new()
+            {
+                DescriptionTemplate = "The name pattern that branches must match in order to deploy to the environment.Wildcard characters will not match `/`. For example, to match branches that begin with `release/` and contain an additional single slash, use `release/*/*`.For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).",
+            },
+            Type = new CodeType
+            {
+                Name = "string"
+            },
+            Access = AccessModifier.Private
+        };
+        parentClass.AddProperty(property);
+        propertyWriter.WriteCodeElement(property, languageWriter);
+        var result = stringWriter.ToString();
+        Assert.DoesNotContain("/*/*", result);
+    }
 }


### PR DESCRIPTION
Fixes #5635
Property descriptions containing ``/*/*`` causes malformed document in generated Php classes with properties and descriptions.