### PR TITLE
fix: Unused strconv import in Go request builder

### DIFF
--- a/src/Kiota.Builder/Refiners/GoRefiner.cs
+++ b/src/Kiota.Builder/Refiners/GoRefiner.cs
@@ -148,7 +148,7 @@ public class GoRefiner : CommonLanguageRefiner
             AddConstructorsForDefaultValues(
                 generatedCode,
                 true,
-                true,  //forcing add as constructors are required for by factories 
+                true,  //forcing add as constructors are required for by factories
                 new[] { CodeClassKind.RequestConfiguration });
             cancellationToken.ThrowIfCancellationRequested();
             MakeModelPropertiesNullable(
@@ -744,6 +744,9 @@ public class GoRefiner : CommonLanguageRefiner
         "Duration",
         "TimeOnly",
         "DateOnly",
+        "TimeSpan",
+        "Time",
+        "ISODuration",
         "string",
         "UUID",
         "Guid"


### PR DESCRIPTION
Removes unused `strconv` import added when an [`ISODuration`](https://github.com/microsoftgraph/msgraph-beta-sdk-go/blob/beta/pipelinebuild/174332/security/53a6f3d0c994ce74f28543a3a744def875f53f0ba598927f378769b9738f6200.go#L44) type is parsed and updates types to ignore before importing `strconv`

Unblocks weekly generation build [failure](https://github.com/microsoftgraph/msgraph-beta-sdk-go/actions/runs/12373060629/job/34583008620?pr=488) where `strconv` is imported but not used in [request builder](https://github.com/microsoftgraph/msgraph-beta-sdk-go/blob/beta/pipelinebuild/174332/security/53a6f3d0c994ce74f28543a3a744def875f53f0ba598927f378769b9738f6200.go)