### PR TITLE
fix: anyOf/oneOf missing properties for intersection/inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug in generation when a referenced schema in an allOf was a primitive [#5701](https://github.com/microsoft/kiota/issues/5701).
 - Fixed a bug where inherited error models would be missing interface declarations. [#5888](https://github.com/microsoft/kiota/issues/5888)
+- Fixed a bug where oneOf/anyOf schemas with single references to inheritance or intersections would be missing properties. [#5921](https://github.com/microsoft/kiota/issues/5921)
 
 ## [1.21.0] - 2024-12-05
 

--- a/src/Kiota.Builder/Extensions/IListExtensions.cs
+++ b/src/Kiota.Builder/Extensions/IListExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace Kiota.Builder.Extensions;
+
+public static class IListExtensions
+{
+    /// <summary>
+    /// Returns the only element of this list when it has count of exactly <c>1</c>
+    /// </summary>
+    /// <typeparam name="T">The contained item type.</typeparam>
+    /// <param name="items">The items.</param>
+    /// <returns>The only element or null.</returns>
+    internal static T? OnlyOneOrDefault<T>(this IList<T> items) =>
+        items.Count == 1 ? items[0] : default;
+
+    /// <summary>
+    /// Adds the provided <paramref name="values"/> to this list.
+    /// </summary>
+    /// <typeparam name="T">The contained item type.</typeparam>
+    /// <param name="items">The items.</param>
+    /// <param name="values">The values to add.</param>
+    internal static void AddRange<T>(this IList<T> items, IEnumerable<T> values)
+    {
+        foreach (var item in values)
+        {
+            items.Add(item);
+        }
+    }
+}

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -958,7 +958,7 @@ public partial class KiotaBuilder
             var parentNS = x.Parent?.Parent?.Parent as CodeNamespace;
             CodeClass[] exceptions = x.Parent?.Parent is CodeClass parentClass ? [parentClass] : [];
             x.TypeDefinition = parentNS?.FindChildrenByName<CodeClass>(x.Name)
-                .Except(exceptions)// the property method should not reference itself as a return type. 
+                .Except(exceptions)// the property method should not reference itself as a return type.
                 .MinBy(shortestNamespaceOrder);
             // searching down first because most request builder properties on a request builder are just sub paths on the API
             if (x.TypeDefinition == null)
@@ -1833,6 +1833,18 @@ public partial class KiotaBuilder
             return CreateComposedModelDeclaration(currentNode, schema, operation, suffix, codeNamespace, isRequestBody, typeNameForInlineSchema);
         }
 
+        // type: object with single oneOf referring to inheritance or intersection
+        if (schema.IsObjectType() && schema.MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries() is OpenApiSchema mergedExclusiveUnionSchema)
+        {
+            return CreateModelDeclarations(currentNode, mergedExclusiveUnionSchema, operation, parentElement, suffixForInlineSchema, response, typeNameForInlineSchema, isRequestBody);
+        }
+
+        // type: object with single anyOf referring to inheritance or intersection
+        if (schema.IsObjectType() && schema.MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries() is OpenApiSchema mergedInclusiveUnionSchema)
+        {
+            return CreateModelDeclarations(currentNode, mergedInclusiveUnionSchema, operation, parentElement, suffixForInlineSchema, response, typeNameForInlineSchema, isRequestBody);
+        }
+
         if (schema.IsObjectType() || schema.HasAnyProperty() || schema.IsEnum() || !string.IsNullOrEmpty(schema.AdditionalProperties?.Type))
         {
             // no inheritance or union type, often empty definitions with only additional properties are used as property bags.
@@ -1840,7 +1852,7 @@ public partial class KiotaBuilder
         }
 
         if (schema.IsArray() &&
-            !schema.Items.IsArray()) // Only handle collections of primitives and complex types. Otherwise, multi-dimensional arrays would be recursively unwrapped undesirably to lead to incorrect serialization types. 
+            !schema.Items.IsArray()) // Only handle collections of primitives and complex types. Otherwise, multi-dimensional arrays would be recursively unwrapped undesirably to lead to incorrect serialization types.
         {
             // collections at root
             return CreateCollectionModelDeclaration(currentNode, schema, operation, codeNamespace, typeNameForInlineSchema, isRequestBody);
@@ -2230,7 +2242,7 @@ public partial class KiotaBuilder
             logger.LogWarning("Discriminator {ComponentKey} not found in the OpenAPI document.", componentKey);
             return null;
         }
-        // Call CreateModelDeclarations with isViaDiscriminator=true. This is for a special case where we always generate a base class when types are referenced via a oneOf discriminator. 
+        // Call CreateModelDeclarations with isViaDiscriminator=true. This is for a special case where we always generate a base class when types are referenced via a oneOf discriminator.
         if (CreateModelDeclarations(currentNode, discriminatorSchema, currentOperation, GetShortestNamespace(currentNamespace, discriminatorSchema), string.Empty, null, string.Empty, false, true) is not CodeType result)
         {
             logger.LogWarning("Discriminator {ComponentKey} is not a valid model and points to a union type.", componentKey);
@@ -2238,7 +2250,7 @@ public partial class KiotaBuilder
         }
         if (baseClass is not null && (result.TypeDefinition is not CodeClass codeClass || codeClass.StartBlock.Inherits is null))
         {
-            if (!baseClass.Equals(result.TypeDefinition))// don't log warning if the discriminator points to the base type itself as this is implicitly the default case. 
+            if (!baseClass.Equals(result.TypeDefinition))// don't log warning if the discriminator points to the base type itself as this is implicitly the default case.
                 logger.LogWarning("Discriminator {ComponentKey} is not inherited from {ClassName}.", componentKey, baseClass.Name);
             return null;
         }

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -673,6 +673,289 @@ public class OpenApiSchemaExtensionsTests
         Assert.Equal("description", result.Description);
         Assert.True(result.Deprecated);
     }
+
+    public class MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries
+    {
+        [Fact]
+        public void DoesMergeWithInheritance()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                AnyOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Reference = new() {
+                                    Id = "BaseClass"
+                                },
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.True(schema.AnyOf[0].IsInherited());
+            Assert.NotNull(result);
+            Assert.True(result.IsInherited());
+            Assert.Contains("one", result.Properties.Keys);
+            Assert.Empty(result.AnyOf);
+            Assert.Equal(2, result.AllOf.Count);
+        }
+        [Fact]
+        public void DoesMergeWithIntersection()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                AnyOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["first"] = new OpenApiSchema(),
+                                }
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["second"] = new OpenApiSchema(),
+                                }
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["third"] = new OpenApiSchema(),
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.NotNull(result);
+            Assert.True(schema.AnyOf[0].IsIntersection());
+            Assert.True(result.IsIntersection());
+            Assert.Contains("one", result.Properties.Keys);
+            Assert.Empty(result.AnyOf);
+            Assert.Equal(3, result.AllOf.Count);
+        }
+        [Fact]
+        public void DoesNotMergeWithMoreThanOneInclusiveEntry()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                AnyOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Reference = new() {
+                                    Id = "BaseClass"
+                                },
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                    new() { Type = "object" },
+                ],
+            };
+
+            var result = schema.MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.Null(result);
+        }
+        [Fact]
+        public void DoesNotMergeWithoutInheritanceOrIntersection()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                AnyOf = [
+                    new() {
+                        AllOf = [
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleInclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.Null(result);
+        }
+    }
+
+    public class MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries
+    {
+        [Fact]
+        public void DoesMergeWithInheritance()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                OneOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Reference = new() {
+                                    Id = "BaseClass"
+                                },
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.True(schema.OneOf[0].IsInherited());
+            Assert.NotNull(result);
+            Assert.True(result.IsInherited());
+            Assert.Contains("one", result.Properties.Keys);
+            Assert.Empty(result.OneOf);
+            Assert.Equal(2, result.AllOf.Count);
+        }
+        [Fact]
+        public void DoesMergeWithIntersection()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                OneOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["first"] = new OpenApiSchema(),
+                                }
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["second"] = new OpenApiSchema(),
+                                }
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["third"] = new OpenApiSchema(),
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.NotNull(result);
+            Assert.True(schema.OneOf[0].IsIntersection());
+            Assert.True(result.IsIntersection());
+            Assert.Contains("one", result.Properties.Keys);
+            Assert.Empty(result.OneOf);
+            Assert.Equal(3, result.AllOf.Count);
+        }
+        [Fact]
+        public void DoesNotMergeWithMoreThanOneExclusiveEntry()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                OneOf = [
+                    new() {
+                        Properties = new Dictionary<string, OpenApiSchema>() {
+                            ["one"] = new OpenApiSchema(),
+                        },
+                        AllOf = [
+                            new() {
+                                Reference = new() {
+                                    Id = "BaseClass"
+                                },
+                            },
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                    new() { Type = "object" },
+                ],
+            };
+
+            var result = schema.MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.Null(result);
+        }
+        [Fact]
+        public void DoesNotMergeWithoutInheritanceOrIntersection()
+        {
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                OneOf = [
+                    new() {
+                        AllOf = [
+                            new() {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                    ["firstName"] = new OpenApiSchema(),
+                                    ["lastName"] = new OpenApiSchema()
+                                }
+                            },
+                        ]
+                    },
+                ],
+            };
+
+            var result = schema.MergeSingleExclusiveUnionInheritanceOrIntersectionSchemaEntries();
+            Assert.Null(result);
+        }
+    }
+
     [Fact]
     public void IsArrayFalseOnEmptyItems()
     {

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -682,20 +682,28 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                AnyOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                AnyOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
-                                Reference = new() {
+                        AllOf =
+                        [
+                            new()
+                            {
+                                Reference = new()
+                                {
                                     Id = "BaseClass"
                                 },
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }
@@ -719,27 +727,37 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                AnyOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                AnyOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
+                        AllOf =
+                        [
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["first"] = new OpenApiSchema(),
                                 }
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["second"] = new OpenApiSchema(),
                                 }
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["third"] = new OpenApiSchema(),
                                 }
                             },
@@ -762,20 +780,28 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                AnyOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                AnyOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
-                                Reference = new() {
+                        AllOf =
+                        [
+                            new()
+                            {
+                                Reference = new()
+                                {
                                     Id = "BaseClass"
                                 },
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }
@@ -795,12 +821,17 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                AnyOf = [
-                    new() {
-                        AllOf = [
-                            new() {
+                AnyOf =
+                [
+                    new()
+                    {
+                        AllOf =
+                        [
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }
@@ -823,20 +854,28 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                OneOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                OneOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
-                                Reference = new() {
+                        AllOf =
+                        [
+                            new()
+                            {
+                                Reference = new()
+                                {
                                     Id = "BaseClass"
                                 },
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }
@@ -860,27 +899,37 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                OneOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                OneOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
+                        AllOf =
+                        [
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["first"] = new OpenApiSchema(),
                                 }
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["second"] = new OpenApiSchema(),
                                 }
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["third"] = new OpenApiSchema(),
                                 }
                             },
@@ -903,20 +952,28 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                OneOf = [
-                    new() {
-                        Properties = new Dictionary<string, OpenApiSchema>() {
+                OneOf =
+                [
+                    new()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
+                        {
                             ["one"] = new OpenApiSchema(),
                         },
-                        AllOf = [
-                            new() {
-                                Reference = new() {
+                        AllOf =
+                        [
+                            new()
+                            {
+                                Reference = new()
+                                {
                                     Id = "BaseClass"
                                 },
                             },
-                            new() {
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }
@@ -936,12 +993,17 @@ public class OpenApiSchemaExtensionsTests
             var schema = new OpenApiSchema()
             {
                 Type = "object",
-                OneOf = [
-                    new() {
-                        AllOf = [
-                            new() {
+                OneOf =
+                [
+                    new()
+                    {
+                        AllOf =
+                        [
+                            new()
+                            {
                                 Type = "object",
-                                Properties = new Dictionary<string, OpenApiSchema>() {
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
                                     ["firstName"] = new OpenApiSchema(),
                                     ["lastName"] = new OpenApiSchema()
                                 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -8870,7 +8870,7 @@ components:
         var withoutObjectClassTwoProperty = withoutObjectClass.FindChildByName<CodeProperty>("two", false);
         Assert.NotNull(withoutObjectClassTwoProperty);
         var withoutObjectClassCommonProperty = withoutObjectClass.FindChildByName<CodeProperty>("common", false);
-        Assert.NotNull(withoutObjectClassCommonProperty );
+        Assert.NotNull(withoutObjectClassCommonProperty);
         var withoutObjectClassCommon2Property = withoutObjectClass.FindChildByName<CodeProperty>("common2", false);
         Assert.NotNull(withoutObjectClassCommon2Property);
         var withoutObjectClassObjectTypeProperty = withoutObjectClass.FindChildByName<CodeProperty>("objectType", false);
@@ -9213,7 +9213,7 @@ components:
         var withoutObjectClassTwoProperty = withoutObjectClass.FindChildByName<CodeProperty>("two", false);
         Assert.NotNull(withoutObjectClassTwoProperty);
         var withoutObjectClassCommonProperty = withoutObjectClass.FindChildByName<CodeProperty>("common", false);
-        Assert.NotNull(withoutObjectClassCommonProperty );
+        Assert.NotNull(withoutObjectClassCommonProperty);
         var withoutObjectClassCommon2Property = withoutObjectClass.FindChildByName<CodeProperty>("common2", false);
         Assert.NotNull(withoutObjectClassCommon2Property);
         var withoutObjectClassObjectTypeProperty = withoutObjectClass.FindChildByName<CodeProperty>("objectType", false);


### PR DESCRIPTION
This adds these scenarios as specific cases in `KiotaBuilder.CreateModelDeclarations`. Not sure if this is the best place to handle this but at least this fixes the issue where the properties & possible inheritance were completely missing while not breaking anything existing.

Fixes #5921