### PR TITLE
Fix: Plugin generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable-file MD024 -->
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
 ## [1.22.1] - 2025-01-10
 
 ### Added
 
 ### Changed
-Fixed a bug in the VS Code extension plugin generation [#5978](https://github.com/microsoft/kiota/issues/5978)
+- Fixed a bug in the VS Code extension plugin generation [#5978](https://github.com/microsoft/kiota/issues/5978)
 
 ## [1.22.0] - 2025-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable-file MD024 -->
 
-## [Unreleased]
+## [1.22.1] - 2025-01-10
 
 ### Added
 
 ### Changed
+Fixed a bug in the VS Code extension plugin generation [#5978](https://github.com/microsoft/kiota/issues/5978)
 
 ## [1.22.0] - 2025-01-09
 

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.23.0</VersionPrefix>
+    <VersionPrefix>1.22.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.23.0</VersionPrefix>
+    <VersionPrefix>1.22.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/vscode/microsoft-kiota/CHANGELOG.md
+++ b/vscode/microsoft-kiota/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.22.100000001] - 2025-01-10
+
+### Added
+
+### Changed
+- Fixed a bug in the VS Code extension plugin generation [#5978](https://github.com/microsoft/kiota/issues/5978)
+
 ## [1.20.000000001] - 2024-11-07
 
 ## [1.19.100000001] - 2024-10-03

--- a/vscode/microsoft-kiota/src/commands/generate/generateClientCommand.ts
+++ b/vscode/microsoft-kiota/src/commands/generate/generateClientCommand.ts
@@ -201,7 +201,7 @@ export class GenerateClientCommand extends Command {
         settings.cleanOutput,
         settings.disableValidationRules,
         ConsumerOperation.Add,
-        undefined,
+        null,
         '',
         config.workingDirectory
       );
@@ -247,7 +247,7 @@ export class GenerateClientCommand extends Command {
         settings.cleanOutput,
         settings.disableValidationRules,
         ConsumerOperation.Add,
-        undefined,
+        null,
         '',
         config.workingDirectory
       );


### PR DESCRIPTION
### Overview
Closes #5978 

### Notes
The RPC server function to create plugins has a set number of arguments. Passing undefined for 'optional' arguments is interpreted as not having passed required arguments.

The changes included in this pull request update the `GenerateClientCommand` class in the `generateClientCommand.ts` file to use `null` instead of `undefined` for the `optional` argument.