### PR TITLE
Fix: Remove post-generation error popup

### DIFF
--- a/vscode/microsoft-kiota/src/commands/generate/generation-util.ts
+++ b/vscode/microsoft-kiota/src/commands/generate/generation-util.ts
@@ -12,7 +12,9 @@ export async function displayGenerationResults(openApiTreeProvider: OpenApiTreeP
     const content = await fs.promises.readFile(getWorkspaceJsonPath(), 'utf-8');
     const workspace = JSON.parse(content);
     const clientOrPluginObject = workspace.plugins[clientNameOrPluginName] || workspace.clients[clientNameOrPluginName];
-    await openApiTreeProvider.loadEditPaths(clientNameOrPluginName, clientOrPluginObject);
+    if (clientOrPluginObject) {
+      await openApiTreeProvider.loadEditPaths(clientNameOrPluginName, clientOrPluginObject);
+    }
   }
   openApiTreeProvider.resetInitialState();
   await updateTreeViewIcons(treeViewId, false, true);

--- a/vscode/microsoft-kiota/src/commands/generate/generation-util.ts
+++ b/vscode/microsoft-kiota/src/commands/generate/generation-util.ts
@@ -1,14 +1,15 @@
 import * as vscode from "vscode";
+import * as fs from 'fs';
 
 import { KIOTA_WORKSPACE_FILE, treeViewId } from "../../constants";
 import { OpenApiTreeProvider } from "../../providers/openApiTreeProvider";
-import { updateTreeViewIcons } from "../../util";
+import { getWorkspaceJsonPath, updateTreeViewIcons } from "../../util";
 
 export async function displayGenerationResults(openApiTreeProvider: OpenApiTreeProvider, config: any) {
   const clientNameOrPluginName = config.clientClassName || config.pluginName;
   const workspaceJson = vscode.workspace.textDocuments.find(doc => doc.fileName.endsWith(KIOTA_WORKSPACE_FILE));
   if (workspaceJson) {
-    const content = workspaceJson.getText();
+    const content = await fs.promises.readFile(getWorkspaceJsonPath(), 'utf-8');
     const workspace = JSON.parse(content);
     const clientOrPluginObject = workspace.plugins[clientNameOrPluginName] || workspace.clients[clientNameOrPluginName];
     await openApiTreeProvider.loadEditPaths(clientNameOrPluginName, clientOrPluginObject);


### PR DESCRIPTION
### Overview
Fixes #5988 

### Notes
The workspace file update after generation wasn't being captured by this function hence an undefined `clientNamespaceName` property down the line causing the error. 
This change enables the extension to read the workspace JSON file directly from the file system each time the function is called, making it get the latest information. 