### PR TITLE
ci: fix vscode extension versioning script to support more than one patch version

### DIFF
--- a/scripts/update-vscode-releases.ps1
+++ b/scripts/update-vscode-releases.ps1
@@ -39,8 +39,9 @@ if ($version -like "*-preview.*") {
   $updatedPatchVersion += (Get-Date).ToString("yyMMdd") + $sequenceNumber
 }
 else {
-  if ($updatedPatchVersion -eq "1") {
-    $updatedPatchVersion = "100000002"
+  $updatedPatchVersionAsNumber = 0;
+  if ([int]::TryParse($updatedPatchVersion, [ref]$updatedPatchVersionAsNumber)) {
+    $updatedPatchVersion = "10000000$($updatedPatchVersionAsNumber + 1)"
   }
   elseif ([string]::IsNullOrWhiteSpace($updatedPatchVersion)) {
     $updatedPatchVersion = "100000001"


### PR DESCRIPTION
```pwsh
./scripts/update-vscode-releases.ps1 -version "1.22.2" -filePath ./vscode/microsoft-kiota/package.json -online
```

now produces 1.22.100000003

instead of 1.22.2