### PR TITLE
Added CSharp13 Support

### DIFF
--- a/src/Kiota.Builder/Export/PublicAPIExportService.cs
+++ b/src/Kiota.Builder/Export/PublicAPIExportService.cs
@@ -116,7 +116,8 @@ internal class PublicApiExportService
     {
         return generationConfiguration.Language switch
         {
-            GenerationLanguage.CSharp => new CSharpConventionService(),
+            GenerationLanguage.CSharp => new CSharpConventionService(false),
+            GenerationLanguage.CSharp13 => new CSharpConventionService(true),
             GenerationLanguage.Java => new JavaConventionService(),
             GenerationLanguage.TypeScript => new TypeScriptConventionService(),
             GenerationLanguage.PHP => new PhpConventionService(),

--- a/src/Kiota.Builder/GenerationLanguage.cs
+++ b/src/Kiota.Builder/GenerationLanguage.cs
@@ -2,6 +2,7 @@
 public enum GenerationLanguage
 {
     CSharp,
+    CSharp13,
     Java,
     TypeScript,
     PHP,

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1277,7 +1277,7 @@ public partial class KiotaBuilder
         {
             var suffix = $"{operationType}Response";
             var modelType = CreateModelDeclarations(currentNode, schema, operation, parentClass, suffix);
-            if (modelType is not null && config.IncludeBackwardCompatible && config.Language is GenerationLanguage.CSharp or GenerationLanguage.Go && modelType.Name.EndsWith(suffix, StringComparison.Ordinal))
+            if (modelType is not null && config.IncludeBackwardCompatible && config.Language is GenerationLanguage.CSharp or GenerationLanguage.CSharp13 or GenerationLanguage.Go && modelType.Name.EndsWith(suffix, StringComparison.Ordinal))
             { //TODO remove for v2
                 var obsoleteTypeName = modelType.Name[..^suffix.Length] + "Response";
                 if (modelType is CodeType codeType &&
@@ -2530,7 +2530,7 @@ public partial class KiotaBuilder
 
         if (!parameterClass.ContainsPropertyWithWireName(prop.WireName))
         {
-            if (addBackwardCompatibleParameter && config.IncludeBackwardCompatible && config.Language is GenerationLanguage.CSharp or GenerationLanguage.Go)
+            if (addBackwardCompatibleParameter && config.IncludeBackwardCompatible && config.Language is GenerationLanguage.CSharp or GenerationLanguage.CSharp13 or GenerationLanguage.Go)
             { //TODO remove for v2
                 var modernProp = (CodeProperty)prop.Clone();
                 modernProp.Name = $"{prop.Name}As{modernProp.Type.Name.ToFirstCharacterUpperCase()}";

--- a/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/ILanguageRefiner.cs
@@ -14,6 +14,7 @@ public interface ILanguageRefiner
         switch (config.Language)
         {
             case GenerationLanguage.CSharp:
+            case GenerationLanguage.CSharp13:
                 await new CSharpRefiner(config).RefineAsync(generatedCode, cancellationToken).ConfigureAwait(false);
                 break;
             case GenerationLanguage.TypeScript:

--- a/src/Kiota.Builder/Writers/CLI/CliWriter.cs
+++ b/src/Kiota.Builder/Writers/CLI/CliWriter.cs
@@ -3,9 +3,9 @@
 namespace Kiota.Builder.Writers.Cli;
 class CliWriter : CSharpWriter
 {
-    public CliWriter(string rootPath, string clientNamespaceName) : base(rootPath, clientNamespaceName)
+    public CliWriter(string rootPath, string clientNamespaceName) : base(rootPath, clientNamespaceName, false)
     {
-        var conventionService = new CSharpConventionService();
+        var conventionService = new CSharpConventionService(false);
         AddOrReplaceCodeElementWriter(new CodeClassDeclarationWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeBlockEndWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeEnumWriter(conventionService));

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -176,7 +176,7 @@ public class CSharpConventionService(bool useCSharp13 = false) : CommonLanguageC
                 {
                     if (nameof(String).Equals(ct.Name, StringComparison.OrdinalIgnoreCase))
                         nullCheck = $"if (!string.IsNullOrWhiteSpace({identName})) ";
-                    else if(UseCSharp13)
+                    else if (UseCSharp13)
                         nullCheck = $"if ({identName} is not null) ";
                     else
                         nullCheck = $"if ({identName} != null) ";

--- a/src/Kiota.Builder/Writers/CSharp/CSharpWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpWriter.cs
@@ -3,10 +3,10 @@
 namespace Kiota.Builder.Writers.CSharp;
 public class CSharpWriter : LanguageWriter
 {
-    public CSharpWriter(string rootPath, string clientNamespaceName)
+    public CSharpWriter(string rootPath, string clientNamespaceName, bool useCSharp13)
     {
         PathSegmenter = new CSharpPathSegmenter(rootPath, clientNamespaceName);
-        var conventionService = new CSharpConventionService();
+        var conventionService = new CSharpConventionService(useCSharp13);
         AddOrReplaceCodeElementWriter(new CodeClassDeclarationWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeBlockEndWriter(conventionService));
         AddOrReplaceCodeElementWriter(new CodeEnumWriter(conventionService));

--- a/src/Kiota.Builder/Writers/CSharp/CodeBlockEndWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeBlockEndWriter.cs
@@ -11,7 +11,10 @@ public class CodeBlockEndWriter : BaseElementWriter<BlockEnd, CSharpConventionSe
         writer.CloseBlock();
         if (codeElement?.Parent is CodeClass codeClass && codeClass.Parent is CodeNamespace)
         {
-            writer.CloseBlock();
+            if (!conventions.UseCSharp13)
+            {
+                writer.CloseBlock();
+            }
             conventions.WritePragmaRestore(writer, CSharpConventionService.CS0618);
         }
     }

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -18,6 +18,10 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         if (codeElement.Parent?.Parent is CodeNamespace)
         {
             writer.WriteLine(AutoGenerationHeader);
+            if(conventions.UseCSharp13)
+            {
+                writer.WriteLine(CSharpConventionService.NullableEnableDirective);
+            }
             conventions.WritePragmaDisable(writer, CSharpConventionService.CS0618);
             codeElement.Usings
                     .Where(x => (x.Declaration?.IsExternal ?? true) || !x.Declaration.Name.Equals(codeElement.Name, StringComparison.OrdinalIgnoreCase)) // needed for circular requests patterns like message folder
@@ -28,8 +32,11 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
                     .OrderBy(static x => x, StringComparer.Ordinal)
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
-            writer.WriteLine($"namespace {codeElement.Parent.Parent.Name}");
-            writer.StartBlock();
+            writer.WriteLine($"namespace {codeElement.Parent.Parent.Name}" + (conventions.UseCSharp13 ? ";" : string.Empty));
+            if(!conventions.UseCSharp13)
+            {
+                writer.StartBlock();
+            }
         }
 
         var derivedTypes = (codeElement.Inherits is null ? Enumerable.Empty<string?>() : new string?[] { conventions.GetTypeString(codeElement.Inherits, parentClass) })

--- a/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeClassDeclarationWriter.cs
@@ -18,7 +18,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
         if (codeElement.Parent?.Parent is CodeNamespace)
         {
             writer.WriteLine(AutoGenerationHeader);
-            if(conventions.UseCSharp13)
+            if (conventions.UseCSharp13)
             {
                 writer.WriteLine(CSharpConventionService.NullableEnableDirective);
             }
@@ -33,7 +33,7 @@ public class CodeClassDeclarationWriter : BaseElementWriter<ClassDeclaration, CS
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
             writer.WriteLine($"namespace {codeElement.Parent.Parent.Name}" + (conventions.UseCSharp13 ? ";" : string.Empty));
-            if(!conventions.UseCSharp13)
+            if (!conventions.UseCSharp13)
             {
                 writer.StartBlock();
             }

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -625,27 +625,23 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         var baseSuffix = GetBaseSuffix(isConstructor, inherits, parentClass, code);
         var parameters = string.Join(", ", code.Parameters.OrderBy(x => x, parameterOrderComparer).Select(p => conventions.GetParameterSignature(p, code)).ToList());
         var methodName = isConstructor ? parentClass.Name.ToFirstCharacterUpperCase() : code.Name.ToFirstCharacterUpperCase();
+        var accessModifier = conventions.GetAccessModifier(code.Access);
         var includeNullableReferenceType = code.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator);
-        if (includeNullableReferenceType)
-        {
-            var completeReturnTypeWithNullable = isConstructor || string.IsNullOrEmpty(genericTypeSuffix) ? completeReturnType : $"{completeReturnType[..^2].TrimEnd('?')}?{genericTypeSuffix} ";
-            var nullableParameters = string.Join(", ", code.Parameters.Order(parameterOrderComparer)
-                                                          .Select(p => p.IsOfKind(CodeParameterKind.RequestConfiguration) ?
-                                                                                        GetParameterSignatureWithNullableRefType(p, code) :
-                                                                                        conventions.GetParameterSignature(p, code))
-                                                          .ToList());
-            CSharpConventionService.WriteNullableOpening(writer);
-            writer.WriteLine($"{conventions.GetAccessModifier(code.Access)} {staticModifier}{hideModifier}{completeReturnTypeWithNullable}{methodName}({nullableParameters}){baseSuffix}");
-            writer.WriteLine("{");
-            CSharpConventionService.WriteNullableMiddle(writer);
-        }
+        var completeReturnTypeWithNullable = isConstructor || string.IsNullOrEmpty(genericTypeSuffix) ? completeReturnType : $"{completeReturnType[..^2].TrimEnd('?')}?{genericTypeSuffix} ";
+        var nullableParameters = string.Join(", ", code.Parameters.Order(parameterOrderComparer)
+                                                        .Select(p => p.IsOfKind(CodeParameterKind.RequestConfiguration) ?
+                                                                                    GetParameterSignatureWithNullableRefType(p, code) :
+                                                                                    conventions.GetParameterSignature(p, code))
+                                                        .ToList());
+        var nullableSignature = $"{accessModifier} {staticModifier}{hideModifier}{completeReturnTypeWithNullable}{methodName}({nullableParameters}){baseSuffix}";
+        var nonNullableSignature = $"{accessModifier} {staticModifier}{hideModifier}{completeReturnType}{methodName}({parameters}){baseSuffix}";
 
-        writer.WriteLine($"{conventions.GetAccessModifier(code.Access)} {staticModifier}{hideModifier}{completeReturnType}{methodName}({parameters}){baseSuffix}");
-        writer.WriteLine("{");
-
-        if (includeNullableReferenceType)
-            CSharpConventionService.WriteNullableClosing(writer);
-
+        conventions.WriteNullableAware(
+            writer,
+            includeNullableReferenceType,
+            writer => CSharpConventionService.WriteStartingBlock(writer, nullableSignature),
+            writer => CSharpConventionService.WriteStartingBlock(writer, nonNullableSignature)
+        );
     }
 
     private string GetParameterSignatureWithNullableRefType(CodeParameter parameter, CodeElement targetElement)

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -184,7 +184,8 @@ public abstract class LanguageWriter
     {
         return language switch
         {
-            GenerationLanguage.CSharp => new CSharpWriter(outputPath, clientNamespaceName),
+            GenerationLanguage.CSharp => new CSharpWriter(outputPath, clientNamespaceName, false),
+            GenerationLanguage.CSharp13 => new CSharpWriter(outputPath, clientNamespaceName, true),
             GenerationLanguage.Java => new JavaWriter(outputPath, clientNamespaceName),
             GenerationLanguage.TypeScript => new TypeScriptWriter(outputPath, clientNamespaceName),
             GenerationLanguage.Ruby => new RubyWriter(outputPath, clientNamespaceName),

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -17,12 +17,14 @@ public sealed class GenerateSample : IDisposable
     }
     private readonly HttpClient _httpClient = new();
     [InlineData(GenerationLanguage.CSharp, false)]
+    [InlineData(GenerationLanguage.CSharp13, false)]
     [InlineData(GenerationLanguage.Java, false)]
     [InlineData(GenerationLanguage.TypeScript, false)]
     [InlineData(GenerationLanguage.Go, false)]
     [InlineData(GenerationLanguage.Dart, false)]
     [InlineData(GenerationLanguage.Ruby, false)]
     [InlineData(GenerationLanguage.CSharp, true)]
+    [InlineData(GenerationLanguage.CSharp13, true)]
     [InlineData(GenerationLanguage.Java, true)]
     [InlineData(GenerationLanguage.PHP, false)]
     [InlineData(GenerationLanguage.TypeScript, true)]
@@ -45,12 +47,14 @@ public sealed class GenerateSample : IDisposable
         await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
     }
     [InlineData(GenerationLanguage.CSharp, false)]
+    [InlineData(GenerationLanguage.CSharp13, false)]
     [InlineData(GenerationLanguage.Java, false)]
     [InlineData(GenerationLanguage.TypeScript, false)]
     [InlineData(GenerationLanguage.Go, false)]
     [InlineData(GenerationLanguage.Dart, false)]
     [InlineData(GenerationLanguage.Ruby, false)]
     [InlineData(GenerationLanguage.CSharp, true)]
+    [InlineData(GenerationLanguage.CSharp13, true)]
     [InlineData(GenerationLanguage.Java, true)]
     [InlineData(GenerationLanguage.PHP, false)]
     [InlineData(GenerationLanguage.TypeScript, true)]
@@ -73,12 +77,14 @@ public sealed class GenerateSample : IDisposable
         await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
     }
     [InlineData(GenerationLanguage.CSharp, false)]
+    [InlineData(GenerationLanguage.CSharp13, false)]
     [InlineData(GenerationLanguage.Java, false)]
     [InlineData(GenerationLanguage.TypeScript, false)]
     [InlineData(GenerationLanguage.Go, false)]
     [InlineData(GenerationLanguage.Dart, false)]
     [InlineData(GenerationLanguage.Ruby, false)]
     [InlineData(GenerationLanguage.CSharp, true)]
+    [InlineData(GenerationLanguage.CSharp13, true)]
     [InlineData(GenerationLanguage.Java, true)]
     [InlineData(GenerationLanguage.PHP, false)]
     [InlineData(GenerationLanguage.TypeScript, true)]
@@ -101,6 +107,7 @@ public sealed class GenerateSample : IDisposable
         await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
     }
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Java)]
     [InlineData(GenerationLanguage.Go)]
     [InlineData(GenerationLanguage.Dart)]
@@ -124,6 +131,7 @@ public sealed class GenerateSample : IDisposable
         await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(new());
     }
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Java)]
     [InlineData(GenerationLanguage.Go)]
     [InlineData(GenerationLanguage.Dart)]
@@ -174,6 +182,7 @@ public sealed class GenerateSample : IDisposable
         Assert.DoesNotContain("_", fullText);
     }
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Go)]
     [InlineData(GenerationLanguage.Dart)]
     [InlineData(GenerationLanguage.Java)]
@@ -208,6 +217,7 @@ public sealed class GenerateSample : IDisposable
         switch (language)
         {
             case GenerationLanguage.CSharp:
+            case GenerationLanguage.CSharp13:
                 Assert.Contains("[QueryParameter(\"startDateTime\")]", fullText);
                 break;
             case GenerationLanguage.Dart:

--- a/tests/Kiota.Builder.Tests/Export/PublicAPIExportServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Export/PublicAPIExportServiceTests.cs
@@ -76,6 +76,7 @@ components:
     private static readonly Dictionary<GenerationLanguage, Action<string[]>> Validators = new()
     {
         { GenerationLanguage.CSharp, ValidateExportCSharp },
+        { GenerationLanguage.CSharp13, ValidateExportCSharp },
         { GenerationLanguage.Go, ValidateExportGo },
         { GenerationLanguage.Python, ValidateExportPython },
         { GenerationLanguage.TypeScript, ValidateExportTypeScript },
@@ -85,6 +86,7 @@ components:
 
     [Theory]
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Go)]
     [InlineData(GenerationLanguage.Python)]
     [InlineData(GenerationLanguage.TypeScript)]

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -583,6 +583,7 @@ components:
     }
     [Theory]
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Java)]
     [InlineData(GenerationLanguage.TypeScript)]
     [InlineData(GenerationLanguage.Python)]
@@ -4755,6 +4756,7 @@ components:
         Assert.True(property.Type.AllTypes.First().IsExternal);
     }
     [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.CSharp13)]
     [InlineData(GenerationLanguage.Java)]
     [Theory]
     public void MapsEnumQueryParameterType(GenerationLanguage generationLanguage)
@@ -4798,7 +4800,7 @@ components:
         Assert.NotNull(queryParameters);
         var backwardCompatibleProperty = queryParameters.Properties.FirstOrDefault(static x => x.Name.Equals("query", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(backwardCompatibleProperty);
-        if (generationLanguage is GenerationLanguage.CSharp)
+        if (generationLanguage is GenerationLanguage.CSharp or GenerationLanguage.CSharp13)
         {
             Assert.Equal("string", backwardCompatibleProperty.Type.Name);
             Assert.True(backwardCompatibleProperty.Type.AllTypes.First().IsExternal);

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpWriterTests.cs
@@ -10,10 +10,10 @@ public class CSharpWriterTests
     [Fact]
     public void Instantiates()
     {
-        var writer = new CSharpWriter("./", "graph");
+        var writer = new CSharpWriter("./", "graph", false);
         Assert.NotNull(writer);
         Assert.NotNull(writer.PathSegmenter);
-        Assert.Throws<ArgumentNullException>(() => new CSharpWriter(null, "graph"));
-        Assert.Throws<ArgumentNullException>(() => new CSharpWriter("./", null));
+        Assert.Throws<ArgumentNullException>(() => new CSharpWriter(null, "graph", false));
+        Assert.Throws<ArgumentNullException>(() => new CSharpWriter("./", null, false));
     }
 }


### PR DESCRIPTION
This PR adds `CSharp13` as another language.

This will have the following effects:
* generated CSharp code will use [File Scoped Namespaces](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces)
* reverts null checking back to pattern matching (was changed in https://github.com/microsoft/kiota/pull/3842)
* sets `#nullable enable` at the beginning of generated files
* removes all the pragma for `NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER`

this also fixes: https://github.com/microsoft/kiota/issues/3944

Different than the PR https://github.com/microsoft/kiota/pull/3945 this keeps backward compatibility for net framework and older C# versions.
(@0xced thanks for the PR it inspired me to this PR)

It also allows us to incorporate newer C# feature in the future when generating C# code.