### PR TITLE
Fix: serialization of binary types in Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed mapping of Binary Types to array buffer in TypeScript. [#6124](https://github.com/microsoft/kiota/issues/6124)
+
 ## [1.23.0] - 2025-02-06
 
 ### Added
@@ -20,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for net9 only installations of the dotnet tool. [#5887](https://github.com/microsoft/kiota/issues/5887)
 
 ### Changed
+
 - Fixes serialization of collection of enums. [microsoft/kiota-typescript#1276](https://github.com/microsoft/kiota-typescript/issues/1276)
 
 ## [1.22.3]

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -205,7 +205,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         return type?.Name switch
         {
             TYPE_INTEGER or TYPE_INT or TYPE_INT64 or TYPE_FLOAT or TYPE_DOUBLE or TYPE_BYTE or TYPE_SBYTE or TYPE_DECIMAL => TYPE_NUMBER,
-            TYPE_BINARY or TYPE_BASE64 or TYPE_BASE64URL => TYPE_STRING,
+            TYPE_BINARY or TYPE_BASE64 or TYPE_BASE64URL => "ArrayBuffer",
             TYPE_STRING or TYPE_OBJECT or TYPE_BOOLEAN or TYPE_VOID or TYPE_LOWERCASE_STRING or TYPE_LOWERCASE_OBJECT or TYPE_LOWERCASE_BOOLEAN or TYPE_LOWERCASE_VOID => type.Name.ToFirstCharacterLowerCase(),
             null => TYPE_OBJECT,
             _ when type is CodeComposedTypeBase composedType => composedType.Name.ToFirstCharacterUpperCase(),

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodePropertyWriterTests.cs
@@ -123,4 +123,16 @@ public sealed class CodePropertyWriterTests : IDisposable
         };
         Assert.Throws<InvalidOperationException>(() => writer.Write(property));
     }
+    [Fact]
+    public void WritesCorrectTypeForProperty()
+    {
+        property.Kind = CodePropertyKind.Custom;
+        property.Type = new CodeType
+        {
+            Name = "base64"
+        };
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains($"{PropertyName}?: ArrayBuffer | null", result);
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota/issues/6124

Binary data types in TypeScript are now correctly mapped to `ArrayBuffer` instead of `String`.