### PR TITLE
Stop writing index file name in generated typescript

### DIFF
--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptRelativeImportManager.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptRelativeImportManager.cs
@@ -4,7 +4,6 @@ using Kiota.Builder.Extensions;
 namespace Kiota.Builder.Writers.TypeScript;
 public class TypescriptRelativeImportManager(string namespacePrefix, char namespaceSeparator) : RelativeImportManager(namespacePrefix, namespaceSeparator)
 {
-    private const string IndexFileName = "index.js";
     /// <summary>
     /// Returns the relative import path for the given using and import context namespace.
     /// </summary>
@@ -23,13 +22,13 @@ public class TypescriptRelativeImportManager(string namespacePrefix, char namesp
         } : (codeUsing.Name, null);
 
         if (typeDef == null)
-            return (importSymbol, codeUsing.Alias, $"./{IndexFileName}"); // it's relative to the folder, with no declaration (default failsafe)
+            return (importSymbol, codeUsing.Alias, $"."); // it's relative to the folder, with no declaration (default failsafe)
         var importNamespace = typeDef.GetImmediateParentOfType<CodeNamespace>();
         var importPath = GetImportRelativePathFromNamespaces(currentNamespace, importNamespace);
-        if (importPath.EndsWith('/'))
-            importPath += IndexFileName;
-        else
-            importPath += ".js";
+
+        // In TypeScript, default imports for a module folder are from the index file
+        importPath = importPath.TrimEnd('/');
+
         return (importSymbol, codeUsing.Alias, importPath);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/TypeScriptRelativeImportManagerTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScriptRelativeImportManagerTests.cs
@@ -44,7 +44,7 @@ public class TypeScriptRelativeImportManagerTests
         };
         declaration.AddUsings(nUsing);
         var result = importManager.GetRelativeImportPathForUsing(nUsing, graphNS);
-        Assert.Equal("./messages/index.js", result.Item3);
+        Assert.Equal("./messages", result.Item3);
     }
     [Fact]
     public void ReplacesImportsParentNamespace()
@@ -70,7 +70,7 @@ public class TypeScriptRelativeImportManagerTests
         };
         declaration.AddUsings(nUsing);
         var result = importManager.GetRelativeImportPathForUsing(nUsing, modelsNS);
-        Assert.Equal("../messages/index.js", result.Item3);
+        Assert.Equal("../messages", result.Item3);
     }
     [Fact]
     public void ReplacesImportsInOtherTrunk()
@@ -118,8 +118,8 @@ public class TypeScriptRelativeImportManagerTests
         declaration2.AddUsings(nUsing2);
         var result = importManager.GetRelativeImportPathForUsing(nUsing, usedRangeNS1);
         var result2 = importManager.GetRelativeImportPathForUsing(nUsing2, usedRangeNS2);
-        Assert.Equal("../../../../index.js", result.Item3);
-        Assert.Equal("../../index.js", result2.Item3);
+        Assert.Equal("../../../..", result.Item3);
+        Assert.Equal("../..", result2.Item3);
     }
     [Fact]
     public void ReplacesImportsSameNamespace()
@@ -141,7 +141,7 @@ public class TypeScriptRelativeImportManagerTests
         };
         declaration.AddUsings(nUsing);
         var result = importManager.GetRelativeImportPathForUsing(nUsing, graphNS);
-        Assert.Equal("./index.js", result.Item3);
+        Assert.Equal(".", result.Item3);
     }
 
     [Fact]
@@ -165,6 +165,6 @@ public class TypeScriptRelativeImportManagerTests
         };
         declaration.AddUsings(nUsing);
         var result = importManager.GetRelativeImportPathForUsing(nUsing, graphNS);
-        Assert.Equal("./index.js", result.Item3);
+        Assert.Equal(".", result.Item3);
     }
 }


### PR DESCRIPTION
Including `index.js` in typescript import statement causes failures while building React/Expo apps

Fixes #5485 

_Before_
```
import { createFooFromDiscriminatorValue, type Foo } from '../models/index.js';
```

_After_
```
import { createFooFromDiscriminatorValue, type Foo } from '../models';
```