### PR TITLE
Fix issue with VSCode extension RPC connection

### DIFF
--- a/src/kiota/Program.cs
+++ b/src/kiota/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
 using kiota.Extension;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace kiota;
 
@@ -14,7 +15,17 @@ static class Program
         var rootCommand = KiotaHost.GetRootCommand();
         var parser = new CommandLineBuilder(rootCommand)
             .UseDefaults()
-            .UseHost(static args => Host.CreateDefaultBuilder(args).ConfigureKiotaTelemetryServices())
+            .UseHost(static args =>
+            {
+                return Host.CreateDefaultBuilder(args)
+                    .ConfigureKiotaTelemetryServices()
+                    .ConfigureLogging(static logging =>
+                    {
+                        logging.ClearProviders();
+                        logging.AddDebug();
+                        logging.AddEventSourceLogger();
+                    });
+            })
             .Build();
         var result = await parser.InvokeAsync(args);
         DisposeSubCommands(rootCommand);

--- a/src/kiota/Program.cs
+++ b/src/kiota/Program.cs
@@ -22,7 +22,9 @@ static class Program
                     .ConfigureLogging(static logging =>
                     {
                         logging.ClearProviders();
+#if DEBUG
                         logging.AddDebug();
+#endif
                         logging.AddEventSourceLogger();
                     });
             })

--- a/vscode/microsoft-kiota/.vscode/launch.json
+++ b/vscode/microsoft-kiota/.vscode/launch.json
@@ -12,9 +12,6 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js"
-      ],
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
@@ -26,10 +23,6 @@
         "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/out/**/*.js",
-        "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "tasks: watch-tests"
     }

--- a/vscode/microsoft-kiota/.vscode/settings.json
+++ b/vscode/microsoft-kiota/.vscode/settings.json
@@ -12,5 +12,9 @@
     "typescript.tsc.autoDetect": "off",
     "cSpell.words": [
         "Kiota"
-    ]
+    ],
+    "explorer.fileNesting.patterns": {
+        // Fold package json translation files
+        "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock, package.*.json"
+    }
 }


### PR DESCRIPTION
The VSCode extension uses the standard output stream to read messages from the kiota RPC server. Adding the .NET generic host broke this contract as it registered a Logger with the Console provider that also writes to the standard output stream. This PR removes the console provider and leaves the standard output stream unused.


The long fix for this is to switch from using the standard streams and instead use named pipes for the RPC communication.


Closes #6234