### PR TITLE
chore: fix intergration test argument passing

### DIFF
--- a/.github/workflows/idempotency-tests.yml
+++ b/.github/workflows/idempotency-tests.yml
@@ -118,7 +118,7 @@ jobs:
         shell: pwsh
       - name: Verify idempotency
         shell: pwsh
-        run: ./it/compare-generation.ps1 -descriptionUrl "${{ steps.replace_url.outputs.DESCRIPTION_PATH }}" -language "${{ matrix.language }}"
+        run: ./it/compare-generation.ps1 -descriptionUrl "${{ steps.replace_url.outputs.DESCRIPTION_PATH }}" -descriptionKey ${{ matrix.description }}  -language "${{ matrix.language }}"
         continue-on-error: ${{ steps.check-suppressed.outputs.IS_SUPPRESSED == 'true' }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -169,7 +169,7 @@ jobs:
         shell: pwsh
       - name: Generate Code
         shell: pwsh
-        run: ./it/generate-code.ps1 -descriptionUrl "${{ steps.replace_url.outputs.DESCRIPTION_PATH }}" -language "${{ matrix.language }}"
+        run: ./it/generate-code.ps1 -descriptionUrl "${{ steps.replace_url.outputs.DESCRIPTION_PATH }}" -descriptionKey ${{ matrix.description }} -language "${{ matrix.language }}"
         continue-on-error: ${{ steps.check-suppressed.outputs.IS_SUPPRESSED == 'true' }}
       - name: Execute the IT test
         shell: pwsh

--- a/it/compare-generation.ps1
+++ b/it/compare-generation.ps1
@@ -3,6 +3,7 @@
 param(
     [Parameter(Mandatory = $true)][string]$descriptionUrl,
     [Parameter(Mandatory = $true)][string]$language,
+    [Parameter(Mandatory = $false)][string]$descriptionKey,
     [Parameter(Mandatory = $false)][switch]$dev,
     [Parameter(Mandatory = $false)][switch]$preserveOutput
 )
@@ -10,6 +11,12 @@ param(
 if ([string]::IsNullOrEmpty($descriptionUrl)) {
     Write-Error "Description URL is empty"
     exit 1
+}
+
+if ([string]::IsNullOrEmpty($descriptionKey)) {
+    Write-Warning "Description Configuration Key is empty. Using the description URL as the key."
+    # If the descriptionKey is not provided, use the descriptionUrl as the key
+    $descriptionKey = $descriptionUrl
 }
 
 if ([string]::IsNullOrEmpty($language)) {
@@ -69,7 +76,7 @@ $tmpFolder1 = New-TemporaryDirectory
 $tmpFolder2 = New-TemporaryDirectory
 
 $additionalArgumentCmd = Join-Path -Path $PSScriptRoot -ChildPath "get-additional-arguments.ps1"
-$additionalArguments = Invoke-Expression "$additionalArgumentCmd -descriptionUrl $descriptionUrl -language $language -includeOutputParameter $false"
+$additionalArguments = Invoke-Expression "$additionalArgumentCmd -descriptionKey $descriptionKey -language $language -includeOutputParameter $false"
 $firstGenerationProcess = Start-Process "$kiotaExec" -ArgumentList "generate --exclude-backward-compatible --clean-output --language ${language} --openapi ${targetOpenapiPath}${additionalArguments} --dvr all --output $tmpFolder1" -Wait -NoNewWindow -PassThru
 $secondGenerationProcess = Start-Process "$kiotaExec" -ArgumentList "generate --exclude-backward-compatible --clean-output --language ${language} --openapi ${targetOpenapiPath}${additionalArguments} --dvr all --output $tmpFolder2" -Wait -NoNewWindow -PassThru
 

--- a/it/generate-code.ps1
+++ b/it/generate-code.ps1
@@ -3,6 +3,7 @@
 param(
     [Parameter(Mandatory = $true)][string]$descriptionUrl,
     [Parameter(Mandatory = $true)][string]$language,
+    [Parameter(Mandatory = $false)][string]$descriptionKey,
     [Parameter(Mandatory = $false)][switch]$dev
 )
 
@@ -11,13 +12,19 @@ if ([string]::IsNullOrEmpty($descriptionUrl)) {
     exit 1
 }
 
+if ([string]::IsNullOrEmpty($descriptionKey)) {
+    Write-Warning "Description Configuration Key is empty. Using the description URL as the key."
+    # If the descriptionKey is not provided, use the descriptionUrl as the key
+    $descriptionKey = $descriptionUrl
+}
+
 if ([string]::IsNullOrEmpty($language)) {
     Write-Error "Language is empty"
     exit 1
 }
 
 $additionalArgumentCmd = Join-Path -Path $PSScriptRoot -ChildPath "get-additional-arguments.ps1"
-$additionalArguments = Invoke-Expression "$additionalArgumentCmd -descriptionUrl $descriptionUrl -language $language"
+$additionalArguments = Invoke-Expression "$additionalArgumentCmd -descriptionKey $descriptionKey -language $language"
 $rootPath = Join-Path -Path $PSScriptRoot -ChildPath ".."
 
 $Env:KIOTA_TUTORIAL_ENABLED = "false"

--- a/it/get-additional-arguments.ps1
+++ b/it/get-additional-arguments.ps1
@@ -1,12 +1,12 @@
 #!/usr/bin/env pwsh
 
 param(
-    [Parameter(Mandatory = $true)][string]$descriptionUrl,
+    [Parameter(Mandatory = $true)][string]$descriptionKey,
     [Parameter(Mandatory = $true)][string]$language,
     [Parameter(Mandatory = $false)][string]$includeOutputParameter = $true
 )
 
-if ([string]::IsNullOrEmpty($descriptionUrl)) {
+if ([string]::IsNullOrEmpty($descriptionKey)) {
     Write-Error "Description URL is empty"
     exit 1
 }
@@ -48,7 +48,7 @@ if ($includeOutputParameter -eq $false) {
 
 $configPath = Join-Path -Path $PSScriptRoot -ChildPath "config.json"
 $jsonValue = Get-Content -Path $configPath -Raw | ConvertFrom-Json
-$descriptionValue = $jsonValue.psobject.properties.Where({ $_.name -eq $descriptionUrl }).value
+$descriptionValue = $jsonValue.psobject.properties.Where({ $_.name -eq $descriptionKey }).value
 if ($null -ne $descriptionValue) {
     if ($descriptionValue.PSObject.Properties.Name -contains "ExcludePatterns") {
         $descriptionValue.ExcludePatterns | ForEach-Object {
@@ -65,7 +65,7 @@ if ($null -ne $descriptionValue) {
     }
 }
 else {
-    Write-Information "No configuration found for $descriptionUrl"
+    Write-Information "No configuration found for $descriptionKey"
 }
 
 return $command


### PR DESCRIPTION
This PR fixes intergration test failures in other PRs like https://github.com/microsoft/kiota/pull/6267

Essentially, changes from https://github.com/microsoft/kiota/pull/6171 would update the description url but configuration parameters like `exclude-path` available from it-config.json were not read properly due to the update of the descriptionUrl to a local path. 