### PR TITLE
Add basic API info in response of getKiotaTree #6346

### DIFF
--- a/src/kiota/Rpc/PathItem.cs
+++ b/src/kiota/Rpc/PathItem.cs
@@ -6,6 +6,9 @@ public record PathItem(
     PathItem[] children,
     bool selected,
     bool isOperation = false,
+    string? operationId = null,
+    string? summary = null,
+    string? description = null,
     Uri? documentationUrl = null,
     IEnumerable<string>? servers = null,
     IDictionary<string, SecurityRequirement>? security = null);

--- a/src/kiota/Rpc/Server.cs
+++ b/src/kiota/Rpc/Server.cs
@@ -296,7 +296,10 @@ internal partial class Server : IServer
                                             [],
                                             filteredPaths.Count == 0 || filteredPaths.Contains(NormalizeOperationNodePath(node, x.Key, true)),
                                             true,
-                                            x.Value.ExternalDocs?.Url,
+                                            operationId: x.Value.OperationId,
+                                            summary: x.Value.Summary,
+                                            description: x.Value.Description,
+                                            documentationUrl: x.Value.ExternalDocs?.Url,
                                             security: SecurityRequirementMapper.FromSecurityRequirementList(x.Value?.Security),
                                             servers: ServersMapper.FromServerList(x.Value?.Servers))) :
                                         Enumerable.Empty<PathItem>())

--- a/tests/Kiota.Builder.IntegrationTests/ModelWithoutBasicInfoInOneOperation.yaml
+++ b/tests/Kiota.Builder.IntegrationTests/ModelWithoutBasicInfoInOneOperation.yaml
@@ -1,0 +1,28 @@
+﻿openapi: 3.0.0
+info:
+  title: Repair Service
+  version: 1.0.0
+servers:
+  - url: https://sample.server/api
+
+paths:
+  /repairs:
+    get:
+      operationId: listRepairs
+      summary: List all repairs with oauth
+      description: Returns a list of repairs with their details and images
+      responses:
+        "200":
+          description: A list of repairs
+          content:
+            application/json:
+              schema:
+                type: object
+    post:
+      responses:
+        "200":
+          description: A new repair
+          content:
+            application/json:
+              schema:
+                type: object

--- a/vscode/npm-package/integration_tests/integrationGetKiotaTree.spec.ts
+++ b/vscode/npm-package/integration_tests/integrationGetKiotaTree.spec.ts
@@ -19,6 +19,21 @@ describe("getKiotaTree", () => {
     expect(actual).toBeDefined();
   });
 
+  test('testGetKiotaTree_withoutBasicInfoInOneOperation', async () => {
+    const descriptionUrl = '../../tests/Kiota.Builder.IntegrationTests/ModelWithoutBasicInfoInOneOperation.yaml';
+    const actual = await getKiotaTree({ includeFilters: [], descriptionPath: descriptionUrl, excludeFilters: [], clearCache: false });
+
+    expect(actual).toBeDefined();
+    expect(actual?.rootNode?.children[0].children[0].isOperation).toBeTruthy();
+    expect(actual?.rootNode?.children[0].children[0].operationId).toEqual('listRepairs');
+    expect(actual?.rootNode?.children[0].children[0].summary).toEqual('List all repairs with oauth');
+    expect(actual?.rootNode?.children[0].children[0].description).toEqual('Returns a list of repairs with their details and images');
+    expect(actual?.rootNode?.children[0].children[1].isOperation).toBeTruthy();
+    expect(actual?.rootNode?.children[0].children[1].operationId).toEqual('repairs_post');
+    expect(actual?.rootNode?.children[0].children[1].summary).toBeUndefined();
+    expect(actual?.rootNode?.children[0].children[1].description).toBeUndefined();
+  });
+
   test('testGetKiotaTree_from_valid_external', async () => {
     const descriptionUrl = 'https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/Mail.yml';
     const actual = await getKiotaTree({ includeFilters: [], descriptionPath: descriptionUrl, excludeFilters: [], clearCache: false });

--- a/vscode/npm-package/types.ts
+++ b/vscode/npm-package/types.ts
@@ -52,6 +52,9 @@ export interface KiotaOpenApiNode {
   segment: string,
   path: string,
   children: KiotaOpenApiNode[],
+  operationId?: string,
+  summary?: string,
+  description?: string,
   selected?: boolean,
   isOperation?: boolean;
   documentationUrl?: string;


### PR DESCRIPTION
Closes #6346 

Adds these fields for operations into getKiotaTree response:
- operationId
- summary
- description