### PR TITLE
Chore: test multiple architectures

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -26,16 +26,10 @@ jobs:
     strategy:
       matrix:
         binaries:
-          - architecture: win-x86
-            os: windows-latest
           - architecture: win-x64
             os: windows-latest
           - architecture: linux-x64
             os: ubuntu-latest
-          # - architecture: linux-arm64
-          #   os: ubuntu-latest
-          # - architecture: osx-x64
-          #   os: macOS-latest
           - architecture: osx-arm64
             os: macOS-latest    
     runs-on: ${{ matrix.binaries.os }}
@@ -114,15 +108,11 @@ jobs:
           args: >
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info,../npm-package/coverage/lcov.info
 
-      - name: Generate binaries for ${{ matrix.binaries.architecture }}
-        run: dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output binaries/${{ matrix.binaries.architecture }} -f net9.0
-        shell: pwsh
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.binaries.architecture }}
-          path: binaries/${{ matrix.binaries.architecture }}
+          path: vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }}
           retention-days: 3
 
   build:

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -34,10 +34,10 @@ jobs:
             os: ubuntu-latest
           # - architecture: linux-arm64
           #   os: ubuntu-latest
-          - architecture: osx-x64
-            os: macOS-latest
-          # - architecture: osx-arm64
-          #   os: macOS-latest    
+          # - architecture: osx-x64
+          #   os: macOS-latest
+          - architecture: osx-arm64
+            os: macOS-latest    
     runs-on: ${{ matrix.binaries.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -32,12 +32,12 @@ jobs:
             os: windows-latest
           - architecture: linux-x64
             os: ubuntu-latest
-          - architecture: linux-arm64
-            os: ubuntu-latest
+          # - architecture: linux-arm64
+          #   os: ubuntu-latest
           - architecture: osx-x64
             os: macOS-latest
-          - architecture: osx-arm64
-            os: macOS-latest    
+          # - architecture: osx-arm64
+          #   os: macOS-latest    
     runs-on: ${{ matrix.binaries.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -48,12 +48,13 @@ jobs:
       - id: last_release
         run: |
           $releaseVersion = gh release list --exclude-drafts --exclude-pre-releases --json tagName,isLatest | ConvertFrom-Json | ? {$_.isLatest -eq $true} | select -first 1 -ExpandProperty tagName
+          $releaseVersion = "$releaseVersion" -replace '^v', ''
           Write-Output "RELEASE_VERSION=$releaseVersion" >> $Env:GITHUB_OUTPUT
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: scripts/update-vscode-releases.ps1 -version "${{ steps.last_release.outputs.RELEASE_VERSION }}" -packageJsonFilePath "./vscode/microsoft-kiota/package.json" -runtimeFilePath "./vscode/npm-package/runtime.json" -online
+      - run: scripts/update-vscode-releases.ps1 -version "v${{ steps.last_release.outputs.RELEASE_VERSION }}" -packageJsonFilePath "./vscode/microsoft-kiota/package.json" -runtimeFilePath "./vscode/npm-package/runtime.json" -online
         shell: pwsh
         
       - name: Install dependencies
@@ -64,15 +65,8 @@ jobs:
 
       - name: Publish kiota for testing - ${{ matrix.binaries.os }} - ${{ matrix.binaries.architecture }}
         run: |
-          $releaseVersion = "${{ steps.last_release.outputs.RELEASE_VERSION }}" -replace '^v', ''
-          dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }} -f net9.0
+          dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/${{ steps.last_release.outputs.RELEASE_VERSION }}/${{ matrix.binaries.architecture }} -f net9.0
         shell: pwsh
-
-      - name: List all folder contents
-        run: |
-          find . -type d -name "node_modules" -prune -o -print
-        shell: bash
-        working-directory: vscode
 
       - name: Lint
         run: npm run lint
@@ -112,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.binaries.architecture }}
-          path: vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }}
+          path: vscode/npm-package/.kiotabin/${{ steps.last_release.outputs.RELEASE_VERSION }}/${{ matrix.binaries.architecture }}
           retention-days: 3
 
   build:

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -1,4 +1,4 @@
-name: Build Frontend
+name: Build VSCode extension
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -1,4 +1,4 @@
-name: Build VSCode extension
+name: Build Frontend
 
 on:
   workflow_dispatch:
@@ -20,20 +20,14 @@ jobs:
         id: checksecret_job
         run: |
           echo "is_SONAR_TOKEN_set=${{ env.SONAR_TOKEN != '' }}" >> $GITHUB_OUTPUT
-  build:
+  
+  test_and_generate_binaries:
     needs: [checksecret]
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        builds:
-          - name: "VS Code Extension"
-            path: "microsoft-kiota"
-            id: "vscode"
-            item: "vsix"
-          - name: "Npm Package"
-            path: "npm-package"
-            id: "package"
-            item: "tgz"
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        architecture: [win-x86, win-x64, linux-x64, linux-arm64, osx-x64, osx-arm64]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -56,31 +50,41 @@ jobs:
 
       - run: scripts/update-vscode-releases.ps1 -version "${{ steps.last_release.outputs.RELEASE_VERSION }}" -packageJsonFilePath "./vscode/microsoft-kiota/package.json" -runtimeFilePath "./vscode/npm-package/runtime.json" -online
         shell: pwsh
-
+        
       - name: Install dependencies
         run: |
           npm install
           npm list
         working-directory: vscode
 
-      - name: Publish kiota for testing
+      - name: Publish kiota for testing - ${{ matrix.os }} - ${{ matrix.architecture }}
         run: |
           $releaseVersion = "${{ steps.last_release.outputs.RELEASE_VERSION }}" -replace '^v', ''
-          dotnet publish src/kiota/kiota.csproj -c Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/linux-x64 -f net9.0
+          dotnet publish src/kiota/kiota.csproj -c Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.architecture }} -f net9.0
         shell: pwsh
 
       - name: Lint
         run: npm run lint
         working-directory: vscode
 
-      - name: run tests(linux) - ${{ matrix.builds.id }}
-        if: runner.os == 'Linux' 
-        run: xvfb-run -a npm run test:${{ matrix.builds.id }}:coverage
+      - name: Run tests - package
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            xvfb-run -a npm run test:package:coverage
+          else
+            npm run test:package:coverage
+          fi
+        shell: bash
         working-directory: vscode
 
-      - name: run tests - ${{ matrix.builds.id }}
-        if: runner.os != 'Linux' 
-        run: npm run test:${{ matrix.builds.id }}:coverage
+      - name: Run tests - vscode
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            xvfb-run -a npm run test:vscode:coverage
+          else
+            npm run test:vscode:coverage
+          fi
+        shell: bash
         working-directory: vscode
 
       - name: Run sonar cloud analysis
@@ -92,6 +96,48 @@ jobs:
           projectBaseDir: vscode
           args: >
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info,../npm-package/coverage/lcov.info
+
+      - name: Generate binaries for ${{ matrix.architecture }}
+        run: dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.architecture }} -p:PublishSingleFile=true --self-contained --output binaries/${{ matrix.architecture }} -f net9.0
+        shell: pwsh
+
+  build:
+    needs: [test_and_generate_binaries]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        builds:
+          - name: "VS Code Extension"
+            path: "microsoft-kiota"
+            id: "vscode"
+            item: "vsix"
+          - name: "Npm Package"
+            path: "npm-package"
+            id: "package"
+            item: "tgz"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - id: last_release
+        run: |
+          $releaseVersion = gh release list --exclude-drafts --exclude-pre-releases --json tagName,isLatest | ConvertFrom-Json | ? {$_.isLatest -eq $true} | select -first 1 -ExpandProperty tagName
+          Write-Output "RELEASE_VERSION=$releaseVersion" >> $Env:GITHUB_OUTPUT
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: scripts/update-vscode-releases.ps1 -version "${{ steps.last_release.outputs.RELEASE_VERSION }}" -packageJsonFilePath "./vscode/microsoft-kiota/package.json" -runtimeFilePath "./vscode/npm-package/runtime.json" -online
+        shell: pwsh
+
+      - name: Install dependencies
+        run: |
+          npm install
+          npm list
+        working-directory: vscode
 
       - run: npm run package:${{ matrix.builds.id }}
         if: matrix.builds.id == 'package'
@@ -105,56 +151,8 @@ jobs:
         name: 'Package - ${{ matrix.builds.id }}'
         if: matrix.builds.id == 'vscode'
 
-        # back to common operations
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.builds.name }}
           path: vscode/${{ matrix.builds.path }}/*.${{ matrix.builds.item }}
-
-  generate_binaries:
-      needs: [checksecret]
-      strategy:
-        matrix:
-          binaries:
-            - architecture: win-x86
-              os: windows-latest
-            - architecture: win-x64
-              os: windows-latest
-            - architecture: linux-x64
-              os: ubuntu-latest
-            - architecture: linux-arm64
-              os: ubuntu-latest
-            - architecture: osx-x64
-              os: macOS-latest
-            - architecture: osx-arm64
-              os: macOS-latest
-      runs-on: ${{ matrix.binaries.os }}
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-  
-        - name: Set up Node.js
-          uses: actions/setup-node@v4
-          with:
-            node-version: 20.x
-  
-        - name: Use .NET 9
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '9.x'
-
-        - name: Publish kiota for ${{ matrix.binaries.architecture }}
-          run: dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output binaries/${{ matrix.binaries.architecture }} -f net9.0
-          shell: pwsh
-
-        - name: Upload artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: ${{ matrix.binaries.architecture }}
-            path: binaries/${{ matrix.binaries.architecture }}
-            retention-days: 3
-
-    
-

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -25,9 +25,20 @@ jobs:
     needs: [checksecret]
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
-        architecture: [win-x86, win-x64, linux-x64, linux-arm64, osx-x64, osx-arm64]
-    runs-on: ${{ matrix.os }}
+        binaries:
+          - architecture: win-x86
+            os: windows-latest
+          - architecture: win-x64
+            os: windows-latest
+          - architecture: linux-x64
+            os: ubuntu-latest
+          - architecture: linux-arm64
+            os: ubuntu-latest
+          - architecture: osx-x64
+            os: macOS-latest
+          - architecture: osx-arm64
+            os: macOS-latest    
+    runs-on: ${{ matrix.binaries.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -57,10 +68,10 @@ jobs:
           npm list
         working-directory: vscode
 
-      - name: Publish kiota for testing - ${{ matrix.os }} - ${{ matrix.architecture }}
+      - name: Publish kiota for testing - ${{ matrix.binaries.os }} - ${{ matrix.binaries.architecture }}
         run: |
           $releaseVersion = "${{ steps.last_release.outputs.RELEASE_VERSION }}" -replace '^v', ''
-          dotnet publish src/kiota/kiota.csproj -c Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.architecture }} -f net9.0
+          dotnet publish src/kiota/kiota.csproj -c Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }} -f net9.0
         shell: pwsh
 
       - name: Lint
@@ -69,7 +80,7 @@ jobs:
 
       - name: Run tests - package
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          if [[ "${{ matrix.binaries.os }}" == "ubuntu-latest" ]]; then
             xvfb-run -a npm run test:package:coverage
           else
             npm run test:package:coverage
@@ -79,7 +90,7 @@ jobs:
 
       - name: Run tests - vscode
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          if [[ "${{ matrix.binaries.os }}" == "ubuntu-latest" ]]; then
             xvfb-run -a npm run test:vscode:coverage
           else
             npm run test:vscode:coverage
@@ -97,9 +108,16 @@ jobs:
           args: >
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info,../npm-package/coverage/lcov.info
 
-      - name: Generate binaries for ${{ matrix.architecture }}
-        run: dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.architecture }} -p:PublishSingleFile=true --self-contained --output binaries/${{ matrix.architecture }} -f net9.0
+      - name: Generate binaries for ${{ matrix.binaries.architecture }}
+        run: dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output binaries/${{ matrix.binaries.architecture }} -f net9.0
         shell: pwsh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.binaries.architecture }}
+          path: binaries/${{ matrix.binaries.architecture }}
+          retention-days: 3
 
   build:
     needs: [test_and_generate_binaries]

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -74,6 +74,12 @@ jobs:
           dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }} -f net9.0
         shell: pwsh
 
+      - name: List all folder contents
+        run: |
+          find . -type d -name "node_modules" -prune -o -print
+        shell: bash
+        working-directory: vscode
+
       - name: Lint
         run: npm run lint
         working-directory: vscode

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish kiota for testing - ${{ matrix.binaries.os }} - ${{ matrix.binaries.architecture }}
         run: |
           $releaseVersion = "${{ steps.last_release.outputs.RELEASE_VERSION }}" -replace '^v', ''
-          dotnet publish src/kiota/kiota.csproj -c Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }} -f net9.0
+          dotnet publish src/kiota/kiota.csproj -c Release --runtime ${{ matrix.binaries.architecture }} -p:PublishSingleFile=true --self-contained --output vscode/npm-package/.kiotabin/$releaseVersion/${{ matrix.binaries.architecture }} -f net9.0
         shell: pwsh
 
       - name: Lint

--- a/vscode/npm-package/install.ts
+++ b/vscode/npm-package/install.ts
@@ -143,6 +143,5 @@ function getRuntimeDependenciesPackages(): Package[] {
 
 export function getCurrentPlatform(): string {
   const binPathSegmentOS = process.platform === 'win32' ? windowsPlatform : process.platform === 'darwin' ? osxPlatform : linuxPlatform;
-  console.log('getCurrentPlatform', binPathSegmentOS, process.arch);
   return `${binPathSegmentOS}-${process.arch}`;
 }

--- a/vscode/npm-package/install.ts
+++ b/vscode/npm-package/install.ts
@@ -142,7 +142,7 @@ function getRuntimeDependenciesPackages(): Package[] {
 }
 
 export function getCurrentPlatform(): string {
-  console.log('getCurrentPlatform', process.platform);
   const binPathSegmentOS = process.platform === 'win32' ? windowsPlatform : process.platform === 'darwin' ? osxPlatform : linuxPlatform;
+  console.log('getCurrentPlatform', binPathSegmentOS, process.arch);
   return `${binPathSegmentOS}-${process.arch}`;
 }

--- a/vscode/npm-package/install.ts
+++ b/vscode/npm-package/install.ts
@@ -142,6 +142,7 @@ function getRuntimeDependenciesPackages(): Package[] {
 }
 
 export function getCurrentPlatform(): string {
+  console.log('getCurrentPlatform', process.platform);
   const binPathSegmentOS = process.platform === 'win32' ? windowsPlatform : process.platform === 'darwin' ? osxPlatform : linuxPlatform;
   return `${binPathSegmentOS}-${process.arch}`;
 }


### PR DESCRIPTION
### Overview

Restructures the job matrix to separate testing and binary generation, updating the packaging process, and refining the test execution steps.

Changes to the workflow structure:

* Renamed the `build` job to `test_and_generate_binaries` and adjusted its dependencies and matrix configuration to focus on generating binaries for different architectures and operating systems. 
* Refined the artifact upload steps to align with the new matrix configuration and ensure correct paths and names for the generated binaries. 
* Moved the `build` job to run after `test_and_generate_binaries` and updated its matrix to handle the packaging of the VS Code extension and Npm package. 
