### PR TITLE
Task: runtime version override

### DIFF
--- a/vscode/npm-package/config.ts
+++ b/vscode/npm-package/config.ts
@@ -1,9 +1,11 @@
 export interface Config {
   binaryLocation: string;
+  binaryVersion: string;
 }
 
 let config: Config = {
-  binaryLocation: ""
+  binaryLocation: "",
+  binaryVersion: ""
 };
 
 export function setKiotaConfig(newConfig: Partial<Config>) {

--- a/vscode/npm-package/install.ts
+++ b/vscode/npm-package/install.ts
@@ -91,15 +91,20 @@ function getBaseDir(): string {
   return getKiotaConfig().binaryLocation || path.resolve(__dirname);
 }
 
+function getRuntimeVersion(): string {
+  return getKiotaConfig().binaryVersion || runtimeJson.kiotaVersion;
+}
+
 function getKiotaPathInternal(withFileName = true): string | undefined {
   const fileName = process.platform === 'win32' ? 'kiota.exe' : 'kiota';
   const runtimeDependencies = getRuntimeDependenciesPackages();
   const currentPlatform = getCurrentPlatform();
   const packageToInstall = runtimeDependencies.find((p) => p.platformId === currentPlatform);
   const baseDir = getBaseDir();
+  const runtimeVersion = getRuntimeVersion();
   if (packageToInstall) {
     const installPath = path.join(baseDir, binariesRootDirectory);
-    const directoryPath = path.join(installPath, runtimeJson.kiotaVersion, currentPlatform);
+    const directoryPath = path.join(installPath, runtimeVersion, currentPlatform);
     if (withFileName) {
       return path.join(directoryPath, fileName);
     }
@@ -131,7 +136,7 @@ function downloadFileFromUrl(url: string, destinationPath: string): Promise<void
 }
 
 function getDownloadUrl(platform: string): string {
-  return `${baseDownloadUrl}/v${runtimeJson.kiotaVersion}/${platform}.zip`;
+  return `${baseDownloadUrl}/v${getRuntimeVersion()}/${platform}.zip`;
 }
 
 function getRuntimeDependenciesPackages(): Package[] {

--- a/vscode/npm-package/tests/integration/integrationInstall.spec.ts
+++ b/vscode/npm-package/tests/integration/integrationInstall.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 
 import { setKiotaConfig } from '../../config';
-import { ensureKiotaIsPresentInPath } from '../../install';
+import { ensureKiotaIsPresentInPath, getKiotaPath } from '../../install';
 
 // Bigger timeout for the test to download the kiota binary
 describe("integration install", () => {
@@ -19,20 +19,18 @@ describe("integration install", () => {
   }, 30000);
 
   test('should install specific version', async () => {
-    const unique_id = Math.random().toString(36).substring(7);
-    const installLocation = `.kiotabin/test_install/${unique_id}`;
     const binaryVersion = '1.22.2';
     setKiotaConfig({
       binaryVersion
     })
-    await ensureKiotaIsPresentInPath(installLocation);
-
+    const kiotaPath = getKiotaPath();
+    await ensureKiotaIsPresentInPath(kiotaPath);
     // check that the folder exists
-    expect(fs.existsSync(installLocation)).toBe(true);
-    expect(installLocation.includes(binaryVersion)).toBe(true);
+    expect(fs.existsSync(kiotaPath)).toBe(true);
+    expect(kiotaPath.includes(binaryVersion)).toBe(true);
 
     // remove folder content after test
-    fs.rmSync(installLocation, { recursive: true });
+    fs.rmSync(kiotaPath, { recursive: true });
   }, 30000);
 
 });

--- a/vscode/npm-package/tests/integration/integrationInstall.spec.ts
+++ b/vscode/npm-package/tests/integration/integrationInstall.spec.ts
@@ -18,7 +18,7 @@ describe("integration install", () => {
     fs.rmSync(installLocation, { recursive: true });
   }, 30000);
 
-  test.only('should install specific version', async () => {
+  test('should install specific version', async () => {
     const unique_id = Math.random().toString(36).substring(7);
     const installLocation = `.kiotabin/test_install/${unique_id}`;
     const binaryVersion = '1.22.2';

--- a/vscode/npm-package/tests/integration/integrationInstall.spec.ts
+++ b/vscode/npm-package/tests/integration/integrationInstall.spec.ts
@@ -1,9 +1,11 @@
 import * as fs from 'fs';
+
+import { setKiotaConfig } from '../../config';
 import { ensureKiotaIsPresentInPath } from '../../install';
 
-describe("getKiotaVersionIntegration", () => {
+// Bigger timeout for the test to download the kiota binary
+describe("integration install", () => {
 
-  // Bigger timeout for the test to download the kiota binary
   test('should install to specific location', async () => {
     const unique_id = Math.random().toString(36).substring(7);
     const installLocation = `.kiotabin/test_install/${unique_id}`;
@@ -11,6 +13,23 @@ describe("getKiotaVersionIntegration", () => {
 
     // check that the folder exists
     expect(fs.existsSync(installLocation)).toBe(true);
+
+    // remove folder content after test
+    fs.rmSync(installLocation, { recursive: true });
+  }, 30000);
+
+  test.only('should install specific version', async () => {
+    const unique_id = Math.random().toString(36).substring(7);
+    const installLocation = `.kiotabin/test_install/${unique_id}`;
+    const binaryVersion = '1.22.2';
+    setKiotaConfig({
+      binaryVersion
+    })
+    await ensureKiotaIsPresentInPath(installLocation);
+
+    // check that the folder exists
+    expect(fs.existsSync(installLocation)).toBe(true);
+    expect(installLocation.includes(binaryVersion)).toBe(true);
 
     // remove folder content after test
     fs.rmSync(installLocation, { recursive: true });


### PR DESCRIPTION
### Overview

Allows overriding the package version downloaded and used by passing `binaryVersion` to the `setKiotaConfig` function