### PR TITLE
Sideloading env variable to copy kiota zip from

### DIFF
--- a/vscode/npm-package/install.ts
+++ b/vscode/npm-package/install.ts
@@ -58,7 +58,14 @@ export async function ensureKiotaIsPresentInPath(installPath: string) {
           }
           fs.mkdirSync(installPath, { recursive: true });
           const zipFilePath = `${installPath}.zip`;
-          await downloadFileFromUrl(getDownloadUrl(currentPlatform), zipFilePath);
+          // If env variable that points to kiota binary zip exists, use it to copy the file instead of downloading it
+          const kiotaBinaryZip = process.env.SIDELOADING_KIOTA_BINARY_ZIP_PATH;
+          if (kiotaBinaryZip && fs.existsSync(kiotaBinaryZip)) {
+            fs.copyFileSync(kiotaBinaryZip, zipFilePath);
+          } else {
+            const downloadUrl = getDownloadUrl(currentPlatform);
+            await downloadFileFromUrl(downloadUrl, zipFilePath);
+          }
           unzipFile(zipFilePath, installPath);
           const kiotaPath = getKiotaPathInternal();
           if ((currentPlatform.startsWith(linuxPlatform) || currentPlatform.startsWith(osxPlatform)) && kiotaPath) {

--- a/vscode/npm-package/package.json
+++ b/vscode/npm-package/package.json
@@ -47,7 +47,7 @@
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "clean": "rimraf dist",
     "copy-files": "cpx runtime.json dist/esm && cpx runtime.json dist/cjs",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --coverage --runInBand",
     "prepack": "npm run build",
     "package": "npm pack"
   },

--- a/vscode/npm-package/tests/integration/integrationInstall.spec.ts
+++ b/vscode/npm-package/tests/integration/integrationInstall.spec.ts
@@ -37,8 +37,11 @@ describe("integration install", () => {
 
 describe("sideloading install", () => {
   beforeAll(async () => {
-    const unique_id = Math.random().toString(36).substring(7);
-    const installLocation = `.kiotabin/test_install/${unique_id}`;
+    const binaryVersion = '1.22.2';
+    setKiotaConfig({
+      binaryVersion
+    })
+    const installLocation = getKiotaPath();
     await ensureKiotaIsPresentInPath(installLocation);
     const zipFilePath = `${installLocation}.zip`;
 

--- a/vscode/npm-package/tests/integration/integrationInstall.spec.ts
+++ b/vscode/npm-package/tests/integration/integrationInstall.spec.ts
@@ -34,3 +34,30 @@ describe("integration install", () => {
   }, 30000);
 
 });
+
+describe("sideloading install", () => {
+  beforeAll(async () => {
+    const unique_id = Math.random().toString(36).substring(7);
+    const installLocation = `.kiotabin/test_install/${unique_id}`;
+    await ensureKiotaIsPresentInPath(installLocation);
+    const zipFilePath = `${installLocation}.zip`;
+
+    process.env.SIDELOADING_KIOTA_BINARY_ZIP_PATH = zipFilePath;
+  });
+  afterAll(() => {
+    process.env.SIDELOADING_KIOTA_BINARY_ZIP_PATH = undefined;
+  });
+
+  test('ensureKiotaIsPresentInPath_sideloading', async () => {
+    const unique_id = Math.random().toString(36).substring(7);
+    const installLocation = `.kiotabin/test_install/${unique_id}`;
+    await ensureKiotaIsPresentInPath(installLocation);
+
+    // check that the folder exists
+    expect(fs.existsSync(installLocation)).toBe(true);
+
+    // remove folder content after test
+    fs.rmSync(installLocation, { recursive: true });
+  }, 30000);
+
+});


### PR DESCRIPTION
This PR uses an environment variable to copy the kiota zip file instead of downloading it for development purposes.
The environment variable is named SIDELOADING_KIOTA_BINARY_ZIP_PATH.
When this variable exists, the Kiota zip file is copied from that location instead of downloading it
