### PR TITLE
Dart: fix wrong property name casing for serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where Dart properties casing would change for serialization.
+
 ## [1.25.1] - 2025-04-03
 
 ### Changed

--- a/src/Kiota.Builder/Refiners/DartRefiner.cs
+++ b/src/Kiota.Builder/Refiners/DartRefiner.cs
@@ -289,6 +289,7 @@ public class DartRefiner : CommonLanguageRefiner, ILanguageRefiner
         else if (currentProperty.IsOfKind(CodePropertyKind.BackingStore))
         {
             currentProperty.Type.Name = currentProperty.Type.Name[1..]; // removing the "I"
+            currentProperty.SerializationName = currentProperty.Name;
             currentProperty.Name = currentProperty.Name.ToFirstCharacterLowerCase();
         }
         else if (currentProperty.IsOfKind(CodePropertyKind.QueryParameter))
@@ -314,6 +315,7 @@ public class DartRefiner : CommonLanguageRefiner, ILanguageRefiner
         }
         else
         {
+            currentProperty.SerializationName = currentProperty.Name;
             currentProperty.Name = currentProperty.Name.ToFirstCharacterLowerCase();
         }
         currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();

--- a/tests/Kiota.Builder.Tests/Refiners/DartLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/DartLanguageRefinerTests.cs
@@ -431,5 +431,26 @@ public class DartLanguageRefinerTests
         Assert.Contains(buildermethods, x => x.IsOfKind(CodeMethodKind.Custom) && x.Name.Equals("clone", StringComparison.Ordinal));
         Assert.Contains(modelmethods, x => x.IsOfKind(CodeMethodKind.Custom) && x.Name.Equals("copyWith", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public async Task PreservesPropertyNames()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "model",
+            Kind = CodeClassKind.Model,
+        }).First();
+        model.AddProperty(new CodeProperty
+        {
+            Name = "Property",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Dart }, root);
+        Assert.Equal("property", model.Properties.First().Name);
+        Assert.Equal("Property", model.Properties.First().WireName);
+    }
     #endregion
 }


### PR DESCRIPTION
This fixes an issue in the Dart refiner, where property names are adjusted for code style, but their serialized name is also changed by accident.

<details>
<summary>Example spec</summary>

```yaml
openapi: 3.0.1
info:
  title: Test
  version: 0.0.1

paths:
  /action:
    post:
      summary: Action
      operationId: action
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/ActionRequest'
      responses:
        '200':
          description: Action Processed
          content:
            application/json:
              type: object
              additionalProperties: true

components:
  schemas:
    ActionRequest:
      type: object
      properties:
        Token:
          type: string
        type:
          type: string

```

</details>

In the example above, a body serialized by kiota would send it like:

```json
{"token":"foo","type":"bar"}
```

whereas the expected body is:

```json
{"Token":"foo","type":"bar"}
```

(notice the capitalized `Token`, like it is in the spec)

This PR fixes the refiner by storing the serialized name before changing the property name.