### PR TITLE
Allow schemas with additionalProperties to generate AdditionalData prop

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2104,7 +2104,7 @@ public partial class KiotaBuilder
 
         // Add the class to the namespace after the serialization members
         // as other threads looking for the existence of the class may find the class but the additional data/backing store properties may not be fully populated causing duplication
-        var includeAdditionalDataProperties = config.IncludeAdditionalData && schema.AdditionalPropertiesAllowed;
+        var includeAdditionalDataProperties = config.IncludeAdditionalData && (schema.AdditionalPropertiesAllowed || schema.AdditionalProperties is not null);
         AddSerializationMembers(newClassStub, includeAdditionalDataProperties, config.UsesBackingStore, static s => s);
 
         var newClass = currentNamespace.AddClass(newClassStub).First();

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -2847,7 +2847,7 @@ paths:
                         {
                             Responses = new OpenApiResponses
                             {
-                                ["200"] = new OpenApiResponseReference("weatherForecast")
+                                ["200"] = new OpenApiResponseReference("weatherForecastResponse")
                             }
                         }
                     }
@@ -2855,7 +2855,7 @@ paths:
             },
         };
         document.AddComponent("weatherForecast", weatherForecastSchema);
-        document.AddComponent("weatherForecast", weatherForecastResponse);
+        document.AddComponent("weatherForecastResponse", weatherForecastResponse);
         document.SetReferenceHostDocument();
         var mockLogger = new Mock<ILogger<KiotaBuilder>>();
         var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
@@ -2866,6 +2866,72 @@ paths:
         Assert.NotNull(weatherType);
         Assert.DoesNotContain(weatherType.StartBlock.Implements, x => x.Name.Equals("IAdditionalDataHolder", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(weatherType.Properties, x => x.IsOfKind(CodePropertyKind.AdditionalData));
+    }
+    [Fact]
+    public void AddPropertyHolderOnAdditionalPropertiesSchema()
+    {
+        var weatherForecastSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            AdditionalProperties = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Object,
+            },
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                {
+                    "date", new OpenApiSchema {
+                        Type = JsonSchemaType.String,
+                        Format = "date-time"
+                    }
+                },
+                {
+                    "temperature", new OpenApiSchema {
+                        Type = JsonSchemaType.Integer,
+                        Format = "int32"
+                    }
+                }
+            },
+        };
+        var weatherForecastResponse = new OpenApiResponse
+        {
+            Content =
+            {
+                ["application/json"] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchemaReference("weatherForecast")
+                }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["weatherforecast"] = new OpenApiPathItem
+                {
+                    Operations = {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponseReference("weatherForecastResponse")
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("weatherForecast", weatherForecastSchema);
+        document.AddComponent("weatherForecastResponse", weatherForecastResponse);
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        builder.SetOpenApiDocument(document);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var weatherType = codeModel.FindChildByName<CodeClass>("WeatherForecast");
+        Assert.NotNull(weatherType);
+        Assert.Contains(weatherType.StartBlock.Implements, x => x.Name.Equals("IAdditionalDataHolder", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(weatherType.Properties, x => x.IsOfKind(CodePropertyKind.AdditionalData));
     }
     [Fact]
     public void SquishesLonelyNullables()


### PR DESCRIPTION
When generating from a schema with `additionalProperties` set to a schema instead of `true`, no `AdditionalData` property is generated (only using the `OpenApiSchema` model because reading it from serialized format the `AdditionalPropertiesAllowed` is `true` by default).

This PR addresses parts of this [comment](https://github.com/microsoft/kiota/issues/6443#issuecomment-2796899519), asking for this fix.

However it doesn't address the whole Issue yet. The type of the `AdditionalData` property should use the proper type indicated in the `additionalProperties`, but that needs to be discussed further on whether that could break client's code.