### PR TITLE
fix: set a proper default value for non-nullable python fields

### DIFF
--- a/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
@@ -40,7 +40,8 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, PythonConventi
             case CodePropertyKind.QueryParameter:
                 conventions.WriteInLineDescription(codeElement, writer);
                 var isNonNullableCollection = !codeElement.Type.IsNullable && codeElement.Type.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{codeElement.NamePrefix}{codeElement.Name}: {(codeElement.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(codeElement.Type.IsNullable ? "]" : string.Empty)} {(isNonNullableCollection ? "= []" : "= None")}");
+                var defaultFactoryType = codeElement.Type.CollectionKind.IsArray() ? "list" : "dict";
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{codeElement.NamePrefix}{codeElement.Name}: {(codeElement.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(codeElement.Type.IsNullable ? "]" : string.Empty)} {(isNonNullableCollection ? $"= field(default_factory={defaultFactoryType})" : "= None")}");
                 writer.WriteLine();
                 break;
             case CodePropertyKind.ErrorMessageOverride when parentClass.IsErrorDefinition:

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodePropertyWriterTests.cs
@@ -102,12 +102,22 @@ public sealed class CodePropertyWriterTests : IDisposable
         Assert.Contains($"property_name: Optional[Graphtests.models.{TypeName}]", result);
     }
     [Fact]
-    public void WritesDefaultValuesForProperties()
+    public void WritesDefaultValuesForNullableProperties()
     {
         property.Kind = CodePropertyKind.Headers;
         writer.Write(property);
         var result = tw.ToString();
         Assert.Contains("= None", result);
+    }
+    [Fact]
+    public void WritesDefaultValuesForNonNullableArrayProperties()
+    {
+        property.Kind = CodePropertyKind.Headers;
+        property.Type.IsNullable = false;
+        property.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains("= field(default_factory=list)", result);
     }
 
     [Fact]


### PR DESCRIPTION
`TODO`