### PR TITLE
Support for generating and merging multiple API plugin manifests

### DIFF
--- a/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
+++ b/src/Kiota.Builder/Configuration/GenerationConfiguration.cs
@@ -37,6 +37,10 @@ public class GenerationConfiguration : ICloneable
     }
     public string OpenAPIFilePath { get; set; } = "openapi.yaml";
     public string ApiManifestPath { get; set; } = "apimanifest.json";
+    // Optional filename suffix to be used when generating multiple API plugins for the same OpenAPI file.
+    // Note: It can not be set from the outside, it is only used internally when generating the plugin manifest.
+    internal string FileNameSuffix { get; set; } = "";
+
     public string OutputPath { get; set; } = "./output";
     public string ClientClassName { get; set; } = "ApiClient";
     public AccessModifier TypeAccessModifier { get; set; } = AccessModifier.Public;

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -264,9 +264,13 @@ public partial class KiotaBuilder
             var pluginsService = new PluginsGenerationService(openApiDocument, openApiTree, config, Directory.GetCurrentDirectory(), logger);
             // Handle the multiple files generation
             if (handleMultipleFiles)
+            {
                 await pluginsService.GenerateAndMergeMultipleManifestsAsync(openApiDocumentDownloadService, cancellationToken).ConfigureAwait(false);
+            }
             else
+            {
                 await pluginsService.GenerateManifestAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             StopLogAndReset(sw, $"step {++stepId} - generate plugin - took");
             return stepId;

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -265,7 +265,7 @@ public partial class KiotaBuilder
             // Handle the multiple files generation
             if (handleMultipleFiles)
             {
-                await pluginsService.GenerateAndMergeMultipleManifestsAsync(openApiDocumentDownloadService, cancellationToken).ConfigureAwait(false);
+                await pluginsService.GenerateAndMergeMultipleManifestsAsync(cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -253,7 +253,7 @@ public partial class KiotaBuilder
     /// </summary>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>Whether the generated plugin was updated or not</returns>
-    public async Task<bool> GeneratePluginAsync(CancellationToken cancellationToken)
+    public async Task<bool> GeneratePluginAsync(CancellationToken cancellationToken, Boolean handleMultipleFiles = true)
     {
         return await GenerateConsumerAsync(async (sw, stepId, openApiTree, CancellationToken) =>
         {
@@ -262,7 +262,12 @@ public partial class KiotaBuilder
             // generate plugin
             sw.Start();
             var pluginsService = new PluginsGenerationService(openApiDocument, openApiTree, config, Directory.GetCurrentDirectory(), logger);
-            await pluginsService.GenerateManifestAsync(cancellationToken).ConfigureAwait(false);
+            // Handle the multiple files generation
+            if (handleMultipleFiles)
+                await pluginsService.GenerateAndMergeMultipleManifestsAsync(openApiDocumentDownloadService, cancellationToken).ConfigureAwait(false);
+            else
+                await pluginsService.GenerateManifestAsync(cancellationToken).ConfigureAwait(false);
+
             StopLogAndReset(sw, $"step {++stepId} - generate plugin - took");
             return stepId;
         }, cancellationToken).ConfigureAwait(false);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -265,6 +265,7 @@ public partial class KiotaBuilder
             // Handle the multiple files generation
             if (handleMultipleFiles)
             {
+                pluginsService.DownloadService = openApiDocumentDownloadService;
                 await pluginsService.GenerateAndMergeMultipleManifestsAsync(cancellationToken).ConfigureAwait(false);
             }
             else

--- a/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
+++ b/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
@@ -18,7 +18,7 @@ using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Validations;
 
 namespace Kiota.Builder;
-internal class OpenApiDocumentDownloadService
+public class OpenApiDocumentDownloadService
 {
     private readonly ILogger Logger;
     private readonly HttpClient HttpClient;

--- a/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
+++ b/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
@@ -18,7 +18,7 @@ using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Validations;
 
 namespace Kiota.Builder;
-public class OpenApiDocumentDownloadService
+internal class OpenApiDocumentDownloadService
 {
     private readonly ILogger Logger;
     private readonly HttpClient HttpClient;

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -98,12 +98,12 @@ public partial class PluginsGenerationService
         return manifestOutputPath;
     }
 
-    internal string GetFileNameSuffixForMultipleFiles(int fileNumber, int filesCount)
+    internal string GetFileNameSuffixForMultipleFiles(uint fileNumber, uint filesCount)
     {
         // throw ArgumentException if either parameter is negative
-        if (fileNumber < 1)
+        if (fileNumber == 0)
             throw new ArgumentException($"The file number {fileNumber} is invalid. It should be greater than 0.");
-        if (filesCount < 1)
+        if (filesCount == 0)
             throw new ArgumentException($"The files count {filesCount} is invalid. It should be greater than 0.");
 
         return $"{MultipleFilesPrefix}{fileNumber}-{filesCount}";
@@ -125,8 +125,8 @@ public partial class PluginsGenerationService
         var generatedApiPluginManifestPaths = new List<string>();
         string originalClientClassName = Configuration.ClientClassName;
         string originalFilePath = Configuration.OpenAPIFilePath;
-        int fileNumber = 1;
-        int filesCount = 1;
+        uint fileNumber = 1;
+        uint filesCount = 1;
 
         if (TryMatchMultipleFilesRequest(originalFilePath, out fileNumber, out filesCount) && filesCount > 1)
         {
@@ -202,7 +202,7 @@ public partial class PluginsGenerationService
     /// <param name="filesCount">The total number of files in the sequence if the pattern matches.</param>
     /// <returns>True if the file path matches the multiple files pattern; otherwise, false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the <paramref name="originalFilePath"/> is null.</exception>
-    internal bool TryMatchMultipleFilesRequest(string originalFilePath, out int fileNumber, out int filesCount)
+    internal bool TryMatchMultipleFilesRequest(string originalFilePath, out uint fileNumber, out uint filesCount)
     {
         ArgumentNullException.ThrowIfNull(originalFilePath, nameof(originalFilePath));
         fileNumber = filesCount = 0;
@@ -215,8 +215,8 @@ public partial class PluginsGenerationService
         }
 
         // Validate both numbers from the regular expression
-        if (!int.TryParse(multipleFilesRequestMatch.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture, out fileNumber) ||
-            !int.TryParse(multipleFilesRequestMatch.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture, out filesCount))
+        if (!uint.TryParse(multipleFilesRequestMatch.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture, out fileNumber) ||
+            !uint.TryParse(multipleFilesRequestMatch.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture, out filesCount))
         {
             // Return false if any of these two numbers could not have been parsed
             return false;
@@ -399,7 +399,7 @@ public partial class PluginsGenerationService
         return documentValidationResults.Document!;
     }
 
-    private async Task PrepareContextForNextFileAsync(OpenApiDocumentDownloadService downloadService, string originalFilePath, int fileNumber, int filesCount, CancellationToken cancellationToken)
+    private async Task PrepareContextForNextFileAsync(OpenApiDocumentDownloadService downloadService, string originalFilePath, uint fileNumber, uint filesCount, CancellationToken cancellationToken)
     {
         Configuration.FileNameSuffix = GetFileNameSuffixForMultipleFiles(fileNumber, filesCount);
         Configuration.OpenAPIFilePath = GetNextFilePath(originalFilePath, fileNumber);
@@ -426,7 +426,7 @@ public partial class PluginsGenerationService
     /// <param name="fileNumber">The number of the file to process next, starting from 2 for subsequent files.</param>
     /// <returns>The updated OpenAPI file path for the next file.</returns>
     /// <exception cref="ArgumentException">Thrown if the original client class name or file path is null or empty, or if the file path does not contain the required prefix.</exception>
-    internal string GetNextFilePath(string originalFilePath, int fileNumber)
+    internal string GetNextFilePath(string originalFilePath, uint fileNumber)
     {
         ArgumentException.ThrowIfNullOrEmpty(originalFilePath, nameof(originalFilePath));
 

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -44,7 +44,10 @@ public partial class PluginsGenerationService
     private readonly GenerationConfiguration Configuration;
     private readonly string WorkingDirectory;
     private readonly ILogger<KiotaBuilder> Logger;
-    internal OpenApiDocumentDownloadService? DownloadService { get; set; }
+    internal OpenApiDocumentDownloadService? DownloadService
+    {
+        get; set;
+    }
 
     public PluginsGenerationService(OpenApiDocument document, OpenApiUrlTreeNode openApiUrlTreeNode,
         GenerationConfiguration configuration, string workingDirectory, ILogger<KiotaBuilder> logger)

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -24,8 +24,23 @@ namespace Kiota.Builder.Plugins;
 
 public partial class PluginsGenerationService
 {
-    private readonly OpenApiDocument OAIDocument;
-    private readonly OpenApiUrlTreeNode TreeNode;
+    private static readonly OpenAPIRuntimeComparer _openAPIRuntimeComparer = new();
+    private const string ManifestFileExt = ".json";
+    private const string DescriptionFileExt = ".yml";
+
+    /// <summary>
+    /// Prefix used for identifying multiple OpenAPI files in a sequence, for example: openapi.agentname.actionname-partial-1-2.json
+    /// </summary>
+    private const string MultipleFilesPrefix = "-partial-";
+
+    /// <summary>
+    /// Regular expression pattern used to identify multiple OpenAPI files in a sequence.
+    /// For example: openapi.agentname.actionname-partial-1-2.yaml
+    /// </summary>
+    private const string MultipleFilesPattern = MultipleFilesPrefix + @"(\d+)-(\d+)\.";
+
+    private OpenApiDocument OAIDocument; // Can not be readonly anymore because of the GenerateMultipleManifestsAsync method
+    private OpenApiUrlTreeNode TreeNode; // Can not be readonly anymore because of the GenerateMultipleManifestsAsync method
     private readonly GenerationConfiguration Configuration;
     private readonly string WorkingDirectory;
     private readonly ILogger<KiotaBuilder> Logger;
@@ -44,76 +59,470 @@ public partial class PluginsGenerationService
         Logger = logger;
     }
 
-    private static readonly OpenAPIRuntimeComparer _openAPIRuntimeComparer = new();
-    private const string ManifestFileNameSuffix = ".json";
-    private const string DescriptionPathSuffix = "openapi.yml";
-    public async Task GenerateManifestAsync(CancellationToken cancellationToken = default)
+    public async Task<Dictionary<PluginType, string>> GenerateManifestAsync(CancellationToken cancellationToken = default)
     {
+        Logger.LogInformation("Starting GenerateManifestAsync");
+
         // 1. cleanup any namings to be used later on.
-        Configuration.ClientClassName =
-            PluginNameCleanupRegex().Replace(Configuration.ClientClassName, string.Empty); //drop any special characters
+        Configuration.ClientClassName = SanitizeClientClassName(); //drop any special characters
+
         // 2. write the OpenApi description
-        var descriptionRelativePath = $"{Configuration.ClientClassName.ToLowerInvariant()}-{DescriptionPathSuffix}";
+        Logger.LogDebug("Writing OpenAPI description.");
+        var descriptionRelativePath = $"{Configuration.ClientClassName.ToLowerInvariant()}-openapi{Configuration.FileNameSuffix}{DescriptionFileExt}";
         var descriptionFullPath = Path.Combine(Configuration.OutputPath, descriptionRelativePath);
-        var directory = Path.GetDirectoryName(descriptionFullPath);
-        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-            Directory.CreateDirectory(directory);
+        EnsureOutputDirectoryExists(descriptionFullPath);
+
+        await WriteOpenApiDescriptionAsync(descriptionFullPath, cancellationToken).ConfigureAwait(false);
+        Logger.LogInformation("OpenAPI description written to {DescriptionPath}.", descriptionFullPath);
+
+        // Step 3: Generate Plugin Manifests and collect paths
+        var manifestPaths = new Dictionary<PluginType, string>();
+        foreach (var pluginType in Configuration.PluginTypes)
+        {
+            Logger.LogDebug("Generating plugin manifest for plugin type: {PluginType}.", pluginType);
+            var manifestOutputPath = getManifestOutputPath(Configuration, pluginType);
+
+            await GeneratePluginManifestAsync(pluginType, descriptionRelativePath, manifestOutputPath, cancellationToken).ConfigureAwait(false);
+            Logger.LogInformation("Plugin manifest generated for {PluginType} at {ManifestPath}.", pluginType, manifestOutputPath);
+
+            manifestPaths[pluginType] = manifestOutputPath;
+        }
+
+        return manifestPaths;
+    }
+    internal string getManifestOutputPath(GenerationConfiguration configuration, PluginType pluginType)
+    {
+        var manifestFileName = $"{configuration.ClientClassName.ToLowerInvariant()}-{pluginType.ToString().ToLowerInvariant()}{configuration.FileNameSuffix}{ManifestFileExt}";
+        var manifestOutputPath = Path.Combine(configuration.OutputPath, manifestFileName);
+
+        return manifestOutputPath;
+    }
+
+    internal string GetFileNameSuffixForMultipleFiles(int fileNumber, int filesCount)
+    {
+        // throw ArgumentException if either parameter is negative
+        if (fileNumber < 1)
+            throw new ArgumentException($"The file number {fileNumber} is invalid. It should be greater than 0.");
+        if (filesCount < 1)
+            throw new ArgumentException($"The files count {filesCount} is invalid. It should be greater than 0.");
+
+        return $"{MultipleFilesPrefix}{fileNumber}-{filesCount}";
+    }
+
+    /// <summary>
+    /// Generates multiple plugin manifests based on the OpenAPI document and configuration.
+    /// This method processes the primary OpenAPI file and additional files if the configuration specifies multiple files by following the naming convention <see cref="MultipleFilesPattern"/>."/>
+    /// It ensures that each file is downloaded, processed, and its corresponding manifest is generated using <see cref="GenerateManifestAsync"/>.
+    /// Only the APIPlugin type is processed in this method, other types are ignored.
+    /// </summary>
+    /// <param name="downloadService">The service used to download OpenAPI documents.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation. The result is a list of file paths to the generated API plugin manifests.</returns>
+    private async Task<List<string>> GenerateMultipleManifestsAsync(OpenApiDocumentDownloadService downloadService, CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("Starting GenerateMultipleManifestsAsync");
+        ArgumentNullException.ThrowIfNull(downloadService, nameof(downloadService));
+        var generatedApiPluginManifestPaths = new List<string>();
+        string originalClientClassName = Configuration.ClientClassName;
+        string originalFilePath = Configuration.OpenAPIFilePath;
+        int fileNumber = 1;
+        int filesCount = 1;
+
+        if (TryMatchMultipleFilesRequest(originalFilePath, out fileNumber, out filesCount) && filesCount > 1)
+        {
+            // Set the file name suffix so that the generated manifest file names follow the naming convention
+            Configuration.FileNameSuffix = GetFileNameSuffixForMultipleFiles(fileNumber, filesCount);
+        }
+        Logger.LogInformation("Number of files: {FileNumber} out of {FilesCount} extracted from {FileName}", fileNumber, filesCount, originalFilePath);
+
+        // Generate the first manifest
+        var manifestPaths = await GenerateManifestAsync(cancellationToken).ConfigureAwait(false);
+        if (manifestPaths.TryGetValue(PluginType.APIPlugin, out var apiPluginManifestPath))
+        {
+            generatedApiPluginManifestPaths.Add(apiPluginManifestPath);
+        }
+
+        // Check if the file path matches the pattern for multiple OpenAPI files
+        if (filesCount < 2)
+        {
+            Logger.LogInformation("No multiple files to process. Only one file will be processed: {Path}", originalFilePath);
+            return generatedApiPluginManifestPaths;
+        }
+
+        // We are only processing API plugins below and ignoring any other plugin types.
+        if (!Configuration.PluginTypes.Contains(PluginType.APIPlugin))
+        {
+            Logger.LogWarning("Skipping APIPlugin generation as it is not included in the plugin types: {PluginTypes}", Configuration.PluginTypes);
+            return generatedApiPluginManifestPaths;
+        }
+
+        // Generate manifests for all files
+        for (++fileNumber; fileNumber <= filesCount; fileNumber++)
+        {
+            // Prepare the context for the next file to follow the naming convention
+            await PrepareContextForNextFileAsync(downloadService, originalFilePath, fileNumber, filesCount, cancellationToken).ConfigureAwait(false);
+
+            // Generate the manifest for the new file
+            manifestPaths = await GenerateManifestAsync(cancellationToken).ConfigureAwait(false);
+            if (manifestPaths.TryGetValue(PluginType.APIPlugin, out apiPluginManifestPath))
+            {
+                generatedApiPluginManifestPaths.Add(apiPluginManifestPath);
+            }
+
+        }
+
+        return generatedApiPluginManifestPaths;
+    }
+
+    /// <summary>
+    /// Extracts the first partial file name from the given file path by replacing the sequence number with "1".
+    /// </summary>
+    /// <param name="originalFilePath">The original file path containing the sequence number.</param>
+    /// <returns>The updated file path with the sequence number replaced by "1".</returns>
+    /// <exception cref="ArgumentException">Thrown when the provided file path is null or empty.</exception>
+    internal static string GetFirstPartialFileName(string originalFilePath)
+    {
+        if (string.IsNullOrEmpty(originalFilePath))
+            throw new ArgumentException("The file path cannot be null or empty.", nameof(originalFilePath));
+
+        string result = Regex.Replace(
+            originalFilePath,
+            MultipleFilesPattern,
+            match => $"{MultipleFilesPrefix}1-{match.Groups[2].Value}.",
+            RegexOptions.IgnoreCase
+        );
+        return result;
+    }
+
+    /// <summary>
+    /// Checks if the provided file path matches the pattern for multiple OpenAPI files
+    /// and extracts the total number of files in the sequence.
+    /// </summary>
+    /// <param name="originalFilePath">The file path to check against the multiple files pattern.</param>
+    /// <param name="filesCount">The total number of files in the sequence if the pattern matches.</param>
+    /// <returns>True if the file path matches the multiple files pattern; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="originalFilePath"/> is null.</exception>
+    internal bool TryMatchMultipleFilesRequest(string originalFilePath, out int fileNumber, out int filesCount)
+    {
+        ArgumentNullException.ThrowIfNull(originalFilePath, nameof(originalFilePath));
+        fileNumber = filesCount = 0;
+
+        // Check if the file path matches the pattern for multiple OpenAPI files
+        var multipleFilesRequestMatch = Regex.Match(originalFilePath, MultipleFilesPattern, RegexOptions.IgnoreCase);
+        if (!multipleFilesRequestMatch.Success)
+        {
+            return false;
+        }
+
+        // Validate both numbers from the regular expression
+        if (!int.TryParse(multipleFilesRequestMatch.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture, out fileNumber) ||
+            !int.TryParse(multipleFilesRequestMatch.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture, out filesCount))
+        {
+            // Return false if any of these two numbers could not have been parsed
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Generates and merges plugin manifests based on the OpenAPI document and configuration.
+    /// This method processes multiple OpenAPI files if specified, generates their respective manifests,
+    /// and merges them into a single manifest file.
+    /// </summary>
+    /// <param name="downloadService">The service used to download OpenAPI documents.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation. The result is a list of file paths to the generated manifests and the merged plugin manifest (as the last element). 
+    /// The merged manifest file will have the suffix defined by <see cref="MergedManifestFileSuffix"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no plugin manifests are generated.</exception>
+    public async Task<List<string>> GenerateAndMergeMultipleManifestsAsync(OpenApiDocumentDownloadService downloadService, CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("Starting GenerateAndMergeManifestsAsync");
+
+        // Get the main plugin manifest output path before generating the manifests, as we need FileNameSuffix not to be set in GenerateMultipleManifestsAsync() for the output manifest path here
+        var mainPluginManifestOutputPath = getManifestOutputPath(Configuration, PluginType.APIPlugin);
+        Logger.LogInformation("Main plugin manifest output path: {MainPluginManifestOutputPath}", mainPluginManifestOutputPath);
+
+        var manifestPaths = await GenerateMultipleManifestsAsync(downloadService, cancellationToken).ConfigureAwait(false);
+        if (manifestPaths.Count == 0)
+            throw new InvalidOperationException("No plugin manifests were generated.");
+        if (manifestPaths.Count == 1)
+        {
+            Logger.LogInformation("Only one plugin manifest was generated. No merging required.");
+            return manifestPaths;
+        }
+
+        // Assign the first manifest path to a local variable mainManifest
+        var mainManifestPath = manifestPaths[0];
+
+        // Read the main manifest content
+        var mainPluginManifestDocument = await ReadManifestContentAsync(mainManifestPath, cancellationToken).ConfigureAwait(false);
+
+        // for each manifest path, read the content and merge it into the main manifest
+
+        for (int manifestIndex = 1; manifestIndex < manifestPaths.Count; manifestIndex++) // Skip the first one as it's already read
+        {
+            var manifestPath = manifestPaths[manifestIndex];
+            var pluginManifestDocument = await ReadManifestContentAsync(manifestPath, cancellationToken).ConfigureAwait(false);
+
+            // Merge the data into the main manifest
+            MergeConversationStarters(mainPluginManifestDocument, pluginManifestDocument);
+            MergeFunctions(mainPluginManifestDocument, pluginManifestDocument, manifestIndex);
+        }
+
+        // Write the merged manifest to a new file
+        Logger.LogInformation("Writing merged plugin manifest to {ManifestPath}", mainPluginManifestOutputPath);
+        await SavePluginManifestAsync(mainPluginManifestOutputPath, mainPluginManifestDocument).ConfigureAwait(false);
+        manifestPaths.Add(mainPluginManifestOutputPath);
+
+        return manifestPaths;
+    }
+
+    internal static async Task SavePluginManifestAsync(string manifestPath, PluginManifestDocument pluginManifestDocument)
+    {
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
-        await using var descriptionStream = File.Create(descriptionFullPath, 4096);
-        await using var fileWriter = new StreamWriter(descriptionStream);
+        await using var fileStream = File.Create(manifestPath, 4096);
+        await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
-        var descriptionWriter = new OpenApiYamlWriter(fileWriter, new() { InlineLocalReferences = true, InlineExternalReferences = true });
+
+        pluginManifestDocument.Write(writer);
+    }
+
+    /// <summary>
+    /// Merges conversation starters from the provided plugin manifest document into the main plugin manifest document.
+    /// </summary>
+    /// <param name="mainPluginManifestDocument">The main plugin manifest document where conversation starters will be merged.</param>
+    /// <param name="pluginManifestDocument">The plugin manifest document containing conversation starters to merge.</param>
+    internal void MergeConversationStarters(PluginManifestDocument mainPluginManifestDocument, PluginManifestDocument pluginManifestDocument)
+    {
+        if (pluginManifestDocument.Capabilities?.ConversationStarters != null)
+        {
+            foreach (var conversationStarter in pluginManifestDocument.Capabilities.ConversationStarters)
+            {
+                // Initialize the conversation starters if null
+                mainPluginManifestDocument.Capabilities ??= new Capabilities();
+                mainPluginManifestDocument.Capabilities.ConversationStarters ??= new List<ConversationStarter>();
+                if (!mainPluginManifestDocument.Capabilities.ConversationStarters.Any(cs => cs.Text == conversationStarter.Text))
+                {
+                    mainPluginManifestDocument.Capabilities.ConversationStarters.Add(conversationStarter);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merges functions from the provided plugin manifest document into the main plugin manifest document.
+    /// This method ensures that functions are uniquely named to avoid conflicts and updates runtimes accordingly.
+    /// </summary>
+    /// <param name="mainPluginManifestDocument">The main plugin manifest document where functions will be merged.</param>
+    /// <param name="pluginManifestDocument">The plugin manifest document containing functions to merge.</param>
+    /// <param name="manifestIndex">The index of the current manifest being processed, used for renaming functions to avoid conflicts.</param>
+    internal void MergeFunctions(PluginManifestDocument mainPluginManifestDocument, PluginManifestDocument pluginManifestDocument, int manifestIndex)
+    {
+        // return if runtimes is null
+        if (pluginManifestDocument.Runtimes == null)
+            return;
+        mainPluginManifestDocument.Functions ??= new List<Function>();
+
+        // Reference all functions in the original runtimes in the main document explicitly
+        foreach (var runtime in mainPluginManifestDocument.Runtimes)
+        {
+            // Initialize the list of functions to run for if it's null or empty
+            runtime.RunForFunctions ??= new List<string>();
+            if (!runtime.RunForFunctions.Any())
+            {
+                // Add all current functions in the first manifest if not already referenced
+                runtime.RunForFunctions.AddRange(
+                    mainPluginManifestDocument.Functions
+                        .Where(function => !runtime.RunForFunctions.Contains(function.Name))
+                        .Select(function => function.Name)
+                );
+            }
+        }
+
+        // Merge runtimes and referenced functions
+        foreach (var runtime2 in pluginManifestDocument.Runtimes)
+        {
+            // We need to process either explicitly defined functions or all functions
+            runtime2.RunForFunctions ??= new List<string>();
+            var isExplicit = runtime2.RunForFunctions?.Count > 0;
+            var functionNamesToProcess = isExplicit ? runtime2.RunForFunctions : pluginManifestDocument.Functions?.Select(f => f.Name).ToList();
+            if (functionNamesToProcess == null || pluginManifestDocument.Functions == null)
+            {
+                // log warning and continue
+                Logger.LogWarning("No functions to process in the plugin manifest runtime {Runtime}", runtime2);
+                continue;
+            }
+            Logger.LogDebug("Adding {FunctionCount} functions: {FunctionNames}", functionNamesToProcess.Count, string.Join(", ", functionNamesToProcess!));
+
+            // Add all functions referenced from the runtime
+            for (int i = 0; i < functionNamesToProcess.Count; i++)
+            {
+                var functionName = functionNamesToProcess[i];
+                var function = pluginManifestDocument.Functions.Single(f => f.Name == functionName);
+                // Rename the function when adding to the main manifest document to prevent naming conflicts if needed
+                var existingFunction = mainPluginManifestDocument.Functions.FirstOrDefault(f => f.Name == functionName);
+                if (existingFunction != null)
+                {
+                    var newName = $"{functionName}_{manifestIndex + 1}";
+                    Logger.LogDebug("Renaming function {FunctionName} to {NewName} in manifest {ManifestIndex}", functionName, newName, manifestIndex);
+                    function.Name = newName;
+                }
+                mainPluginManifestDocument.Functions.Add(function);
+                // Change the function name in the runtime
+                if (isExplicit)
+                {
+                    // Replace the function name in the runtime
+                    runtime2.RunForFunctions![i] = function.Name;
+                }
+                else
+                {
+                    // Add the function name to the runtime to make it explicitly referenced so it works with other runtimes
+                    runtime2.RunForFunctions!.Add(function.Name);
+                }
+                // Add the runtime itself into the main manifest
+                mainPluginManifestDocument.Runtimes.Add(runtime2);
+            }
+        }
+    }
+
+    private static async Task<PluginManifestDocument> ReadManifestContentAsync(string manifestPath, CancellationToken cancellationToken)
+    {
+        var manifestContent = await File.ReadAllTextAsync(manifestPath, cancellationToken).ConfigureAwait(false);
+        var jsonDocument = JsonDocument.Parse(manifestContent);
+        var documentValidationResults = PluginManifestDocument.Load(jsonDocument.RootElement);
+
+        // Throw exception if the manifest is not valid
+        if (!documentValidationResults.IsValid || documentValidationResults.Document is null)
+            throw new InvalidOperationException($"The manifest at {manifestPath} is not valid. Issues found: {documentValidationResults.Problems}");
+
+        return documentValidationResults.Document!;
+    }
+
+    private async Task PrepareContextForNextFileAsync(OpenApiDocumentDownloadService downloadService, string originalFilePath, int fileNumber, int filesCount, CancellationToken cancellationToken)
+    {
+        Configuration.FileNameSuffix = GetFileNameSuffixForMultipleFiles(fileNumber, filesCount);
+        Configuration.OpenAPIFilePath = GetNextFilePath(originalFilePath, fileNumber);
+        Logger.LogInformation("Processing file {FileNumber} with FileNameSuffix: {FileNameSuffix}, OpenAPIFilePath: {OpenAPIFilePath}", fileNumber, Configuration.FileNameSuffix, Configuration.OpenAPIFilePath);
+
+        // Now, we need to update the status to process the next file
+        var (openAPIDocumentStream, _) = await downloadService.LoadStreamAsync(Configuration.OpenAPIFilePath, Configuration, null, false, cancellationToken).ConfigureAwait(false);
+        var openApiDocument = await downloadService.GetDocumentFromStreamAsync(openAPIDocumentStream, Configuration, false, cancellationToken).ConfigureAwait(false);
+        if (openApiDocument is null)
+            throw new InvalidOperationException($"Failed to load OpenAPI document from {Configuration.OpenAPIFilePath}");
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+
+        // Update the fields to reflect on the new file
+        this.OAIDocument = openApiDocument;
+        this.TreeNode = urlTreeNode;
+    }
+
+    /// <summary>
+    /// Generates the next file path based on the original file path.
+    /// This method is used to handle multiple OpenAPI files by following a specific naming convention <see cref="MultipleFilesPrefix" />
+    /// </summary>
+    /// <param name="originalFilePath">The original file path of the OpenAPI document, which is used to derive the next file's path.</param>
+    /// <param name="fileNumber">The number of the file to process next, starting from 2 for subsequent files.</param>
+    /// <returns>The updated OpenAPI file path for the next file.</returns>
+    /// <exception cref="ArgumentException">Thrown if the original client class name or file path is null or empty, or if the file path does not contain the required prefix.</exception>
+    internal string GetNextFilePath(string originalFilePath, int fileNumber)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(originalFilePath, nameof(originalFilePath));
+
+        // Check that originalFilePath contains the expected prefix
+        if (!originalFilePath.Contains(MultipleFilesPrefix, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"The originalFilePath '{originalFilePath}' does not contain the prefix '{MultipleFilesPrefix}'.");
+
+        var updatedOpenAPIFilePath = Regex.Replace(originalFilePath, $"{MultipleFilesPrefix}1-", $"{MultipleFilesPrefix}{fileNumber}-", RegexOptions.IgnoreCase);
+
+        return updatedOpenAPIFilePath;
+    }
+
+    internal string SanitizeClientClassName()
+    {
+        return PluginNameCleanupRegex().Replace(Configuration.ClientClassName, string.Empty);
+    }
+
+    internal void EnsureOutputDirectoryExists(string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    private async Task WriteOpenApiDescriptionAsync(string descriptionFullPath, CancellationToken cancellationToken)
+    {
         var trimmedPluginDocument = GetDocumentWithTrimmedComponentsAndResponses(OAIDocument);
         PrepareDescriptionForCopilot(trimmedPluginDocument);
+
         // trimming a second time to remove any components that are no longer used after the inlining
         trimmedPluginDocument = GetDocumentWithTrimmedComponentsAndResponses(trimmedPluginDocument);
-        trimmedPluginDocument.Info.Title = trimmedPluginDocument.Info.Title?[..^9]; // removing the second ` - Subset` suffix from the title
+        trimmedPluginDocument.Info.Title = trimmedPluginDocument.Info.Title?[..^9]; // Remove the second ` - Subset` suffix
 
         trimmedPluginDocument = GetDocumentWithDefaultResponses(trimmedPluginDocument);
         // Ensure reference_id extension value is written according to the plugin auth
         EnsureSecuritySchemeExtensions(trimmedPluginDocument);
-        trimmedPluginDocument.SerializeAsV3(descriptionWriter);
-        await descriptionWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
-
-        // 3. write the plugins
-        foreach (var pluginType in Configuration.PluginTypes)
-        {
-            var manifestFileName = $"{Configuration.ClientClassName.ToLowerInvariant()}-{pluginType.ToString().ToLowerInvariant()}";
-            var manifestOutputPath = Path.Combine(Configuration.OutputPath, $"{manifestFileName}{ManifestFileNameSuffix}");
 
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
-            await using var fileStream = pluginType == PluginType.OpenAI ? Stream.Null : File.Create(manifestOutputPath, 4096);
-            await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });
+        await using var descriptionStream = File.Create(descriptionFullPath, 4096);
+        await using var fileWriter = new StreamWriter(descriptionStream);
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
 
-            switch (pluginType)
-            {
-                case PluginType.APIPlugin:
-                    var pluginDocument = GetManifestDocument(descriptionRelativePath);
-                    pluginDocument.Write(writer);
-                    break;
-                case PluginType.APIManifest:
-                    var apiManifest = new ApiManifestDocument("application"); //TODO add application name
-                    // pass empty config hash so that its not included in this manifest.
-                    apiManifest.ApiDependencies[Configuration.ClientClassName] = Configuration.ToApiDependency(string.Empty, TreeNode?.GetRequestInfo().ToDictionary(static x => x.Key, static x => x.Value) ?? [], WorkingDirectory);
-                    var publisherName = string.IsNullOrEmpty(OAIDocument.Info?.Contact?.Name)
-                        ? DefaultContactName
-                        : OAIDocument.Info.Contact.Name;
-                    var publisherEmail = string.IsNullOrEmpty(OAIDocument.Info?.Contact?.Email)
-                        ? DefaultContactEmail
-                        : OAIDocument.Info.Contact.Email;
-                    apiManifest.Publisher = new Publisher(publisherName, publisherEmail);
-                    apiManifest.Write(writer);
-                    break;
-                case PluginType.OpenAI:
-                    // OpenAI plugins have been retired and are no longer supported. They only require the OpenAPI description now.
-                    break;
-                default:
-                    throw new NotImplementedException($"The {pluginType} plugin is not implemented.");
-            }
+        // Write the OpenAPI description to the file
+        var descriptionWriter = new OpenApiYamlWriter(fileWriter, new() { InlineLocalReferences = true, InlineExternalReferences = true });
+        trimmedPluginDocument.SerializeAsV3(descriptionWriter);
+        await descriptionWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
 
-            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    private ApiManifestDocument CreateApiManifestDocument(string descriptionRelativePath)
+    {
+        var apiManifest = new ApiManifestDocument("application"); // TODO: Add application name
+        // pass empty config hash so that its not included in this manifest.
+        apiManifest.ApiDependencies[Configuration.ClientClassName] = Configuration.ToApiDependency(
+            string.Empty,
+            TreeNode?.GetRequestInfo().ToDictionary(static x => x.Key, static x => x.Value) ?? [],
+            WorkingDirectory
+        );
+
+        var publisherName = string.IsNullOrEmpty(OAIDocument.Info?.Contact?.Name)
+            ? DefaultContactName
+            : OAIDocument.Info.Contact.Name;
+        var publisherEmail = string.IsNullOrEmpty(OAIDocument.Info?.Contact?.Email)
+            ? DefaultContactEmail
+            : OAIDocument.Info.Contact.Email;
+
+        apiManifest.Publisher = new Publisher(publisherName, publisherEmail);
+        return apiManifest;
+    }
+
+    private async Task GeneratePluginManifestAsync(PluginType pluginType, string descriptionRelativePath, string manifestOutputPath, CancellationToken cancellationToken)
+    {
+#pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
+        await using var fileStream = pluginType == PluginType.OpenAI ? Stream.Null : File.Create(manifestOutputPath, 4096);
+        await using var writer = new Utf8JsonWriter(fileStream, new JsonWriterOptions { Indented = true });
+#pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
+
+        switch (pluginType)
+        {
+            case PluginType.APIPlugin:
+                var pluginDocument = GetManifestDocument(descriptionRelativePath);
+                pluginDocument.Write(writer);
+                break;
+            case PluginType.APIManifest:
+                var apiManifest = CreateApiManifestDocument(descriptionRelativePath);
+                apiManifest.Write(writer);
+                break;
+            case PluginType.OpenAI:
+                // OpenAI plugins are no longer supported.
+                break;
+            default:
+                throw new NotImplementedException($"The {pluginType} plugin is not implemented.");
         }
+
+        await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static string? GetExistingReferenceId(IOpenApiSecurityScheme schema)

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -6,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Kiota.Builder.Configuration;
+using Kiota.Builder.Extensions;
 using Kiota.Builder.Plugins;
 using Microsoft.DeclarativeAgents.Manifest;
 using Microsoft.Extensions.Logging;
@@ -20,6 +22,7 @@ public sealed class PluginsGenerationServiceTests : IDisposable
 {
     private readonly HttpClient _httpClient = new();
     private readonly ILogger<KiotaBuilder> _logger = new Mock<ILogger<KiotaBuilder>>().Object;
+
     [Fact]
     public void Defensive()
     {
@@ -93,8 +96,14 @@ paths:
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
-        await pluginsGenerationService.GenerateManifestAsync();
 
+        var manifestPaths = await pluginsGenerationService.GenerateManifestAsync();
+        Console.WriteLine($"Generated manifest paths: {string.Join(", ", manifestPaths.Select(kvp => $"{kvp.Key}: {kvp.Value}"))}");
+
+        // Validate that the dictionary contains the plugin path for API plugin
+        var apiPluginPath = Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-apiplugin.json");
+        Assert.Equal(manifestPaths[PluginType.APIPlugin], apiPluginPath);
+        Assert.True(File.Exists(apiPluginPath), $"The API plugin path '{apiPluginPath}' was not found.");
         Assert.True(File.Exists(Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-apiplugin.json")));
         Assert.True(File.Exists(Path.Combine(outputDirectory, $"{expectedPluginName.ToLower()}-apimanifest.json")));
         // v1 plugins are not generated anymore
@@ -582,6 +591,456 @@ paths:
         Assert.NotNull(resultingManifest.Document);
         Assert.Single(resultingSpec.Paths["/test"].Operations[HttpMethod.Get].Responses);
     }
+
+    const string ManifestContent1 = @"openapi: 3.0.0
+info:
+  title: test
+  version: 1.0
+servers:
+  - url: http://localhost/
+    description: There's no place like home
+paths:
+  /test:
+    get:
+      description: description for test path
+      externalDocs:
+        description: external docs for test path
+        url: http://localhost/test
+      responses:
+        '200':
+          description: test
+        '400':
+          description: client error response
+  /test/{id}:
+    get:
+      summary: description for test path with id
+      operationId: test.WithId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: The id of the test
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.message'
+        '500':
+          description: api error response
+components:
+  schemas:
+    microsoft.graph.entity:
+      title: entity
+      required:
+        - '@odata.type'
+      type: object
+      properties:
+        id:
+          anyOf:
+          - type: string
+          - type: integer
+        '@odata.type':
+          type: string
+    microsoft.graph.message:
+      allOf:
+      - $ref: '#/components/schemas/microsoft.graph.entity'
+      - type: object
+        title: message
+        properties:
+          subject:
+            type: string
+          body:
+            type: string";
+
+    const string ManifestContent2 = @"openapi: 3.0.0
+info:
+  title: test
+  version: 1.0
+servers:
+  - url: http://localhost/
+    description: There's no place like home
+paths:
+  /test/{id}:
+    get:
+      summary: description 2 for test path with id
+      operationId: test.WithId
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: The id of the test
+        schema:
+          type: integer
+          format: int32
+      - name: mode
+        in: query
+        required: true
+        description: The search mode
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.message'
+        '500':
+          description: api error response
+components:
+  schemas:
+    microsoft.graph.entity:
+      title: entity
+      required:
+        - '@odata.type'
+      type: object
+      properties:
+        id:
+          anyOf:
+          - type: string
+          - type: integer
+        '@odata.type':
+          type: string
+    microsoft.graph.message:
+      allOf:
+      - $ref: '#/components/schemas/microsoft.graph.entity'
+      - type: object
+        title: message
+        properties:
+          subject:
+            type: string
+          body:
+            type: string";
+
+    [Fact]
+    public async Task GenerateAndMergePluginManifestsAsync_SingleFileTest()
+    {
+        // Arrange
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+
+        var simpleDescriptionPath1 = Path.Combine(workingDirectory, "description-partial-1-1.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath1, ManifestContent1);
+
+        var openAPIDocumentDS = new OpenApiDocumentDownloadService(_httpClient, _logger);
+        var outputDirectory = Path.Combine(workingDirectory, "output");
+        var generationConfiguration = new GenerationConfiguration
+        {
+            OutputPath = outputDirectory,
+            OpenAPIFilePath = simpleDescriptionPath1,
+            PluginTypes = [PluginType.APIPlugin],
+            ClientClassName = "client",
+            ApiRootUrl = "http://localhost/", // Kiota builder would set this for us
+        };
+
+        var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath1, generationConfiguration, null, false);
+        var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+
+        var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+
+        // Act
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+
+        // Assert
+        Assert.NotNull(manifestPaths);
+        string ManifestFileNameMerged = "client-apiplugin.json";
+        string manifestPathMerged = Path.Combine(outputDirectory, ManifestFileNameMerged);
+        var expectedManifestPaths = new List<string>
+            {
+                manifestPathMerged
+            };
+        Assert.Equal(expectedManifestPaths, manifestPaths);
+    }
+
+    [Fact]
+    public async Task GeneratesManifestWithMultipleRuntimesAsync_TwoFilesTest()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+
+        // Write the first description
+        var simpleDescriptionPath1 = Path.Combine(workingDirectory, "description-partial-1-2.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath1, ManifestContent1);
+        // Write the second description
+        var simpleDescriptionPath2 = Path.Combine(workingDirectory, "description-partial-2-2.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath2, ManifestContent2);
+
+        var openAPIDocumentDS = new OpenApiDocumentDownloadService(_httpClient, _logger);
+        var outputDirectory = Path.Combine(workingDirectory, "output");
+        var generationConfiguration = new GenerationConfiguration
+        {
+            OutputPath = outputDirectory,
+            OpenAPIFilePath = simpleDescriptionPath1,
+            PluginTypes = [PluginType.APIPlugin],
+            ClientClassName = "client",
+            ApiRootUrl = "http://localhost/", //Kiota builder would set this for us
+        };
+        // Generate the first manifest
+        var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath1, generationConfiguration, null, false);
+        var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+
+        var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+        List<string> manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+
+        string ManifestFileName1 = "client-apiplugin-partial-1-2.json";
+        string OpenApiFileName1 = "client-openapi-partial-1-2.yml";
+        string ManifestFileName2 = "client-apiplugin-partial-2-2.json";
+        string OpenApiFileName2 = "client-openapi-partial-2-2.yml";
+        string ManifestFileNameMerged = "client-apiplugin.json";
+
+        // assert that the paths are correct
+        string manifestPath1 = Path.Combine(outputDirectory, ManifestFileName1);
+        string manifestPath2 = Path.Combine(outputDirectory, ManifestFileName2);
+        string manifestPathMerged = Path.Combine(outputDirectory, ManifestFileNameMerged);
+        Assert.NotNull(manifestPaths);
+        var expectedManifestPaths = new List<string>
+        {
+            manifestPath1,
+            manifestPath2,
+            manifestPathMerged
+        };
+        Assert.Equal(expectedManifestPaths, manifestPaths);
+
+        // Test that all manifests were created
+        foreach (var manifestPath in manifestPaths)
+        {
+            Assert.True(File.Exists(manifestPath));
+        }
+
+        // Test that all OpenAPI files were created
+        Assert.True(File.Exists(Path.Combine(outputDirectory, OpenApiFileName1)));
+        Assert.True(File.Exists(Path.Combine(outputDirectory, OpenApiFileName2)));
+
+        // Validate the v2 plugin
+        var manifestContent = await File.ReadAllTextAsync(manifestPathMerged);
+        using var jsonDocument = JsonDocument.Parse(manifestContent);
+        var resultingManifest = PluginManifestDocument.Load(jsonDocument.RootElement);
+        Assert.NotNull(resultingManifest.Document);
+        Assert.Equal(OpenApiFileName1, resultingManifest.Document.Runtimes.OfType<OpenApiRuntime>().First().Spec.Url);
+        Assert.Equal(3, resultingManifest.Document.Functions.Count);
+        Assert.Equal("test_get", resultingManifest.Document.Functions[0].Name);
+        Assert.Equal("test_WithId", resultingManifest.Document.Functions[1].Name);
+        Assert.Equal("test_WithId_2", resultingManifest.Document.Functions[2].Name);
+        Assert.Equal(2, resultingManifest.Document.Runtimes.Count);
+        Assert.Equal(3, resultingManifest.Document.Capabilities.ConversationStarters.Count);
+
+        // Check that every runtime has at least one function
+        foreach (var runtime in resultingManifest.Document.Runtimes)
+        {
+            Assert.NotEmpty(runtime.RunForFunctions);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAndMergePluginManifestsAsync_ThreeFilesTest()
+    {
+        // Arrange
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+
+        var simpleDescriptionPath1 = Path.Combine(workingDirectory, "description-partial-1-3.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath1, ManifestContent1);
+
+        var simpleDescriptionPath2 = Path.Combine(workingDirectory, "description-partial-2-3.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath2, ManifestContent2);
+
+        var simpleDescriptionPath3 = Path.Combine(workingDirectory, "description-partial-3-3.yaml");
+        var manifestContent3 = """
+            openapi: 3.0.0
+            info:
+              title: test
+              version: 1.0
+            servers:
+              - url: http://localhost/
+                description: There's no place like home
+            paths:
+              /test/{id}/details:
+                get:
+                  summary: description for test path with details
+                  operationId: test.WithDetails
+                  parameters:
+                  - name: id
+                    in: path
+                    required: true
+                    description: The id of the test
+                    schema:
+                      type: integer
+                      format: int32
+                  responses:
+                    '200':
+                      description: success
+            """;
+        await File.WriteAllTextAsync(simpleDescriptionPath3, manifestContent3);
+
+        var openAPIDocumentDS = new OpenApiDocumentDownloadService(_httpClient, _logger);
+        var outputDirectory = Path.Combine(workingDirectory, "output");
+        var generationConfiguration = new GenerationConfiguration
+        {
+            OutputPath = outputDirectory,
+            OpenAPIFilePath = simpleDescriptionPath1,
+            PluginTypes = [PluginType.APIPlugin],
+            ClientClassName = "client",
+            ApiRootUrl = "http://localhost/", // Kiota builder would set this for us
+        };
+
+        var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath1, generationConfiguration, null, false);
+        var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+
+        var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+
+        // Act
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+
+        // Assert
+        Assert.NotNull(manifestPaths);
+        string ManifestFileName1 = "client-apiplugin-partial-1-3.json";
+        string ManifestFileName2 = "client-apiplugin-partial-2-3.json";
+        string ManifestFileName3 = "client-apiplugin-partial-3-3.json";
+        string ManifestFileNameMerged = "client-apiplugin.json";
+        string manifestPath1 = Path.Combine(outputDirectory, ManifestFileName1);
+        string manifestPath2 = Path.Combine(outputDirectory, ManifestFileName2);
+        string manifestPath3 = Path.Combine(outputDirectory, ManifestFileName3);
+        string manifestPathMerged = Path.Combine(outputDirectory, ManifestFileNameMerged);
+        var expectedManifestPaths = new List<string>
+        {
+            manifestPath1,
+            manifestPath2,
+            manifestPath3,
+            manifestPathMerged
+        };
+        Assert.Equal(expectedManifestPaths, manifestPaths);
+        foreach (var manifestPath in manifestPaths)
+        {
+            Assert.True(File.Exists(manifestPath));
+        }
+    }
+
+
+    [Fact]
+    public async Task GenerateAndMergePluginManifestsAsync_ThreeFiles_StartingFromSecondTest()
+    {
+        // Arrange
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+
+        var simpleDescriptionPath1 = Path.Combine(workingDirectory, "description-partial-1-3.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath1, ManifestContent1);
+
+        var simpleDescriptionPath2 = Path.Combine(workingDirectory, "description-partial-2-3.yaml");
+        await File.WriteAllTextAsync(simpleDescriptionPath2, ManifestContent2);
+
+        var simpleDescriptionPath3 = Path.Combine(workingDirectory, "description-partial-3-3.yaml");
+        var manifestContent3 = """
+            openapi: 3.0.0
+            info:
+              title: test
+              version: 1.0
+            servers:
+              - url: http://localhost/
+                description: There's no place like home
+            paths:
+              /test/{id}/details:
+                get:
+                  summary: description for test path with details
+                  operationId: test.WithDetails
+                  parameters:
+                  - name: id
+                    in: path
+                    required: true
+                    description: The id of the test
+                    schema:
+                      type: integer
+                      format: int32
+                  responses:
+                    '200':
+                      description: success
+            """;
+        await File.WriteAllTextAsync(simpleDescriptionPath3, manifestContent3);
+
+        var openAPIDocumentDS = new OpenApiDocumentDownloadService(_httpClient, _logger);
+        var outputDirectory = Path.Combine(workingDirectory, "output");
+        var generationConfiguration = new GenerationConfiguration
+        {
+            OutputPath = outputDirectory,
+            OpenAPIFilePath = simpleDescriptionPath2,
+            PluginTypes = [PluginType.APIPlugin],
+            ClientClassName = "client",
+            ApiRootUrl = "http://localhost/", // Kiota builder would set this for us
+        };
+
+        // Start with the second manifest
+        var (openAPIDocumentStream, _) = await openAPIDocumentDS.LoadStreamAsync(simpleDescriptionPath2, generationConfiguration, null, false);
+        var openApiDocument = await openAPIDocumentDS.GetDocumentFromStreamAsync(openAPIDocumentStream, generationConfiguration);
+        KiotaBuilder.CleanupOperationIdForPlugins(openApiDocument);
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+
+        var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+
+        // Act
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+
+        // Assert
+        Assert.NotNull(manifestPaths);
+        string ManifestFileName1 = "client-apiplugin-partial-1-3.json";
+        string ManifestFileName2 = "client-apiplugin-partial-2-3.json";
+        string ManifestFileName3 = "client-apiplugin-partial-3-3.json";
+        string ManifestFileNameMerged = "client-apiplugin.json";
+        string manifestPath1 = Path.Combine(outputDirectory, ManifestFileName1);
+        string manifestPath2 = Path.Combine(outputDirectory, ManifestFileName2);
+        string manifestPath3 = Path.Combine(outputDirectory, ManifestFileName3);
+        string manifestPathMerged = Path.Combine(outputDirectory, ManifestFileNameMerged);
+        var expectedManifestPaths = new List<string>
+        {
+            manifestPath2,
+            manifestPath3,
+            manifestPathMerged
+        };
+        Assert.Equal(expectedManifestPaths, manifestPaths);
+        Assert.False(File.Exists(manifestPath1));
+        foreach (var manifestPath in manifestPaths)
+        {
+            Assert.True(File.Exists(manifestPath));
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAndMergePluginManifestsAsync_ThrowsException_WhenNoManifestsGenerated()
+    {
+        // Arrange
+        var mockDownloadService = new Mock<OpenApiDocumentDownloadService>(Mock.Of<HttpClient>(), Mock.Of<ILogger>());
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var generationConfiguration = new GenerationConfiguration
+        {
+            PluginTypes = new HashSet<PluginType> { PluginType.APIPlugin },
+            OutputPath = Path.GetTempPath(),
+            OpenAPIFilePath = "description-partial-1-1.yaml"
+        };
+        var service = new PluginsGenerationService(
+            new OpenApiDocument(),
+            OpenApiUrlTreeNode.Create(),
+            generationConfiguration,
+            generationConfiguration.OutputPath,
+            mockLogger.Object
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.GenerateAndMergeMultipleManifestsAsync(mockDownloadService.Object, CancellationToken.None));
+    }
+
+
 
 
     #region Security
@@ -1310,4 +1769,694 @@ paths:
     }
 
     #endregion
+
+    #region Tests for helper methods
+
+    /// <summary>
+    /// Creates an instance of <see cref="PluginsGenerationService"/> with an empty OpenAPI document and URL tree node.
+    /// This is useful for testing scenarios where no OpenAPI document is provided.
+    /// </summary>
+    /// <param name="generationConfiguration">The configuration to use for the generation process.</param>
+    /// <returns>An instance of <see cref="PluginsGenerationService"/> initialized with empty data.</returns>
+    private PluginsGenerationService CreateEmptyPluginsGenerationService(GenerationConfiguration generationConfiguration)
+    {
+        var openApiDocument = new OpenApiDocument();
+        var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        return new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+    }
+
+    [Fact]
+    public void SanitizeClientClassName_RemovesSpecialCharacters()
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            ClientClassName = "My@Client#Name!"
+        });
+
+        // Act
+        var result = pluginsGenerationService.SanitizeClientClassName();
+
+        // Assert
+        Assert.Equal("MyClientName", result);
+    }
+
+    [Theory]
+    [InlineData("My@Client#Name!", "MyClientName")]
+    [InlineData("Client123Name", "Client123Name")]
+    [InlineData("", "")]
+    public void SanitizeClientClassName_ValidatesVariousInputs(string inputClientClassName, string expectedSanitizedName)
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            ClientClassName = inputClientClassName
+        });
+
+        // Act
+        var result = pluginsGenerationService.SanitizeClientClassName();
+
+        // Assert
+        Assert.Equal(expectedSanitizedName, result);
+    }
+
+    [Fact]
+    public void SanitizeClientClassName_ThrowsArgumentNullException_WhenInputIsNull()
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            ClientClassName = null
+        });
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => pluginsGenerationService.SanitizeClientClassName());
+    }
+
+    [Fact]
+    public void EnsureOutputDirectoryExists_CreatesDirectory_WhenItDoesNotExist()
+    {
+        // Arrange
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "TestDirectory");
+        var tempFilePath = Path.Combine(tempDirectory, "testfile.txt");
+        if (Directory.Exists(tempDirectory))
+            Directory.Delete(tempDirectory, true);
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            ClientClassName = "Client123Name"
+        });
+
+        // Act
+        pluginsGenerationService.EnsureOutputDirectoryExists(tempFilePath);
+
+        // Assert
+        Assert.True(Directory.Exists(tempDirectory));
+
+        // Cleanup
+        Directory.Delete(tempDirectory, true);
+    }
+
+    [Fact]
+    public void EnsureOutputDirectoryExists_DoesNothing_WhenDirectoryExists()
+    {
+        // Arrange
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "TestDirectory");
+        Directory.CreateDirectory(tempDirectory);
+        var tempFilePath = Path.Combine(tempDirectory, "testfile.txt");
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            ClientClassName = "Client123Name"
+        });
+
+        // Act
+        pluginsGenerationService.EnsureOutputDirectoryExists(tempFilePath);
+
+        // Assert
+        Assert.True(Directory.Exists(tempDirectory));
+
+        // Cleanup
+        Directory.Delete(tempDirectory, true);
+    }
+
+    [Theory]
+    [InlineData("description-partial-1-1.yaml", 1, "description-partial-1-1.yaml")]
+    [InlineData("description-partial-1-2.yaml", 2, "description-partial-2-2.yaml")]
+    [InlineData("description-partial-1-3.yaml", 2, "description-partial-2-3.yaml")]
+    [InlineData("description-partial-1-3.yaml", 3, "description-partial-3-3.yaml")]
+    [InlineData("description-partial-1-9.yaml", 5, "description-partial-5-9.yaml")]
+    [InlineData("description-partial-1-8.yaml", 3, "description-partial-3-8.yaml")]
+    [InlineData("description-partial-1-8.yaml", 8, "description-partial-8-8.yaml")]
+    public void GetNextFileInfo_ValidInputs_ReturnsExpectedResults(String originalFilePath, int fileNumber, string expectedFilePath)
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
+        {
+            OpenAPIFilePath = originalFilePath
+        });
+
+        // Act
+        string updatedOpenAPIFilePath = pluginsGenerationService.GetNextFilePath(originalFilePath, fileNumber);
+
+        // Assert
+        Assert.Equal(expectedFilePath, updatedOpenAPIFilePath);
+    }
+
+    [Fact]
+    public void GetNextFileInfo_InvalidRegex_ThrowsException()
+    {
+        // Arrange
+        var generationConfiguration = new GenerationConfiguration
+        {
+            ClientClassName = "TestClient",
+            OpenAPIFilePath = "invalid_file_name.yaml"
+        };
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(generationConfiguration);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetNextFilePath(generationConfiguration.OpenAPIFilePath, 2));
+    }
+
+    [Theory]
+    [InlineData("openapi.agentname.actionname-partial-1-3.yaml", true, 1, 3)] // Valid pattern with 3 files
+    [InlineData("openapi.agentname.actionname-partial-1-2.yaml", true, 1, 2)] // Valid pattern with 2 files
+    [InlineData("openapi.agentname.actionname-partial-1-10.yaml", true, 1, 10)] // Valid pattern with 10 files
+    [InlineData("openapi.agentname.actionname.yaml", false, 0, 0)] // Invalid pattern, no partial prefix
+    [InlineData("openapi.agentname.actionname-partial-2.yaml", false, 0, 0)] // Invalid pattern, not having the second number
+    [InlineData("openapi.agentname.actionname-partial-2-2.yaml", true, 2, 2)] // Valid pattern with 2 file
+    [InlineData("openapi.agentname.actionname-partial-2-5.yaml", true, 2, 5)] // Valid pattern with 5 files
+    [InlineData("openapi.agentname.actionname-partial-2-20.yaml", true, 2, 20)] // Valid pattern with 20 files
+    [InlineData("openapi.agentname.actionname-partial-1-0.yaml", true, 1, 0)] // Invalid pattern, zero files
+    [InlineData("openapi.agentname.actionname-partial-a-2.yaml", false, 0, 0)] // Invalid pattern, wrong first number
+    [InlineData("openapi.agentname.actionname-partial-1-b.yaml", false, 0, 0)] // Invalid pattern, wrong second number
+    [InlineData("randomfile.yaml", false, 0, 0)] // Completely invalid file name
+    [InlineData("", false, 0, 0)] // Empty file name
+    public void TryMatchMultipleFilesRequest_ValidatesFilePatterns(string filePath, bool expectedResult, int expectedFileNumber, int expectedFilesCount)
+    {
+        // Arrange
+        var generationConfiguration = new GenerationConfiguration
+        {
+            ClientClassName = "TestClient",
+            OpenAPIFilePath = filePath
+        };
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(generationConfiguration);
+
+        // Act
+        var result = pluginsGenerationService.TryMatchMultipleFilesRequest(filePath, out var fileNumber, out var filesCount);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedFileNumber, fileNumber);
+        Assert.Equal(expectedFilesCount, filesCount);
+    }
+
+    [Fact]
+    public void TryMatchMultipleFilesRequest_ThrowsArgumentNullException_WhenFilePathIsNull()
+    {
+        // Arrange  
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act & Assert  
+        Assert.Throws<ArgumentNullException>(() => pluginsGenerationService.TryMatchMultipleFilesRequest(null, out _, out _));
+    }
+
+    [Fact]
+    public async Task SavePluginManifestAsync_SavesManifestSuccessfully()
+    {
+        // Arrange
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+        var manifestPath = Path.Combine(workingDirectory, "test-manifest.json");
+        var pluginManifestDocument = new PluginManifestDocument
+        {
+            Namespace = "TestNamespace",
+            DescriptionForHuman = "Test Description"
+        };
+
+        // Act
+        await PluginsGenerationService.SavePluginManifestAsync(manifestPath, pluginManifestDocument);
+
+        // Assert
+        Assert.True(File.Exists(manifestPath), "The manifest file was not created.");
+        var savedContent = await File.ReadAllTextAsync(manifestPath);
+        Assert.Contains("\"namespace\": \"TestNamespace\"", savedContent);
+        Assert.Contains("\"description_for_human\": \"Test Description\"", savedContent);
+
+        // Cleanup
+        Directory.Delete(workingDirectory, true);
+    }
+
+    [Fact]
+    public async Task SavePluginManifestAsync_ThrowsException_WhenPathIsInvalid()
+    {
+        // Arrange
+        var invalidPath = Path.Combine("Invalid", "Path", "test-manifest.json");
+        var pluginManifestDocument = new PluginManifestDocument
+        {
+            Namespace = "TestNamespace",
+            DescriptionForHuman = "Test Description"
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(async () =>
+            await PluginsGenerationService.SavePluginManifestAsync(invalidPath, pluginManifestDocument));
+    }
+
+    [Fact]
+    public async Task SavePluginManifestAsync_OverwritesExistingFile()
+    {
+        // Arrange
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDirectory);
+        var manifestPath = Path.Combine(workingDirectory, "test-manifest.json");
+        await File.WriteAllTextAsync(manifestPath, "{\"Namespace\":\"OldNamespace\"}");
+        var pluginManifestDocument = new PluginManifestDocument
+        {
+            Namespace = "NewNamespace",
+            DescriptionForHuman = "Updated Description"
+        };
+
+        // Act
+        await PluginsGenerationService.SavePluginManifestAsync(manifestPath, pluginManifestDocument);
+
+        // Assert
+        var savedContent = await File.ReadAllTextAsync(manifestPath);
+        Assert.Contains("\"namespace\": \"NewNamespace\"", savedContent);
+        Assert.Contains("\"description_for_human\": \"Updated Description\"", savedContent);
+
+        // Cleanup
+        Directory.Delete(workingDirectory, true);
+    }
+    [Fact]
+    public void MergeConversationStarters_MergesUniqueStarters()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter1" },
+                    new ConversationStarter { Text = "Starter2" }
+                }
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter2" }, // Duplicate
+                    new ConversationStarter { Text = "Starter3" }
+                }
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeConversationStarters(mainManifest, additionalManifest);
+
+        // Assert
+        Assert.NotNull(mainManifest.Capabilities.ConversationStarters);
+        Assert.Equal(3, mainManifest.Capabilities.ConversationStarters.Count);
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter1");
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter2");
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter3");
+    }
+
+    [Fact]
+    public void MergeConversationStarters_HandlesNullStartersInMainManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = null
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter1" }
+                }
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeConversationStarters(mainManifest, additionalManifest);
+
+        // Assert
+        Assert.NotNull(mainManifest.Capabilities.ConversationStarters);
+        Assert.Single(mainManifest.Capabilities.ConversationStarters);
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter1");
+    }
+
+    [Fact]
+    public void MergeConversationStarters_HandlesNullStartersInAdditionalManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter1" }
+                }
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = null
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeConversationStarters(mainManifest, additionalManifest);
+
+        // Assert
+        Assert.NotNull(mainManifest.Capabilities.ConversationStarters);
+        Assert.Single(mainManifest.Capabilities.ConversationStarters);
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter1");
+    }
+
+    [Fact]
+    public void MergeConversationStarters_HandlesNullCapabilitiesInAdditionalManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter1" }
+                }
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Capabilities = null
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeConversationStarters(mainManifest, additionalManifest);
+
+        // Assert
+        Assert.NotNull(mainManifest.Capabilities.ConversationStarters);
+        Assert.Single(mainManifest.Capabilities.ConversationStarters);
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter1");
+    }
+
+    [Fact]
+    public void MergeConversationStarters_HandlesNullCapabilitiesInMainManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Capabilities = null
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Capabilities = new Capabilities
+            {
+                ConversationStarters = new List<ConversationStarter>
+                {
+                    new ConversationStarter { Text = "Starter1" }
+                }
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeConversationStarters(mainManifest, additionalManifest);
+
+        // Assert
+        Assert.NotNull(mainManifest.Capabilities);
+        Assert.NotNull(mainManifest.Capabilities.ConversationStarters);
+        Assert.Single(mainManifest.Capabilities.ConversationStarters);
+        Assert.Contains(mainManifest.Capabilities.ConversationStarters, cs => cs.Text == "Starter1");
+    }
+
+
+    [Fact]
+    public void MergeFunctions_MergesUniqueFunctions()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function1" },
+                new Function { Name = "Function2" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function3" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeFunctions(mainManifest, additionalManifest, 1);
+
+        // Assert
+        Assert.NotNull(mainManifest.Functions);
+        Assert.Equal(3, mainManifest.Functions.Count);
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function1");
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function2");
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function3");
+    }
+
+    [Fact]
+    public void MergeFunctions_AppendsManifestIndexToFunctionNames()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function1" },
+                new Function { Name = "Function2" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function2" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeFunctions(mainManifest, additionalManifest, 1);
+
+        // Assert
+        Assert.NotNull(mainManifest.Functions);
+        Assert.Equal(3, mainManifest.Functions.Count);
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function1");
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function2");
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function2_2");
+    }
+
+    [Fact]
+    public void MergeFunctions_HandlesNullFunctionsInMainManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Functions = null,
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function1" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeFunctions(mainManifest, additionalManifest, 1);
+
+        // Assert
+        Assert.NotNull(mainManifest.Functions);
+        Assert.Single(mainManifest.Functions);
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function1");
+    }
+
+    [Fact]
+    public void MergeFunctions_HandlesNullFunctionsInAdditionalManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function1" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Functions = null,
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeFunctions(mainManifest, additionalManifest, 1);
+
+        // Assert
+        Assert.NotNull(mainManifest.Functions);
+        Assert.Single(mainManifest.Functions);
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function1");
+    }
+
+    [Fact]
+    public void MergeFunctions_HandlesEmptyFunctionsInAdditionalManifest()
+    {
+        // Arrange
+        var mainManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>
+            {
+                new Function { Name = "Function1" }
+            },
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var additionalManifest = new PluginManifestDocument
+        {
+            Functions = new List<Function>(),
+            Runtimes = new List<Runtime>
+            {
+                new OpenApiRuntime()
+            }
+        };
+
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        pluginsGenerationService.MergeFunctions(mainManifest, additionalManifest, 1);
+
+        // Assert
+        Assert.NotNull(mainManifest.Functions);
+        Assert.Single(mainManifest.Functions);
+        Assert.Contains(mainManifest.Functions, f => f.Name == "Function1");
+    }
+
+    [Theory]
+    [InlineData(1, 3, "-partial-1-3")]
+    [InlineData(2, 5, "-partial-2-5")]
+    [InlineData(10, 10, "-partial-10-10")]
+    [InlineData(1, 1, "-partial-1-1")]
+    public void GetFileNameSuffixForMultipleFiles_ValidInputs_ReturnsExpectedSuffix(int fileNumber, int filesCount, string expectedSuffix)
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act
+        var result = pluginsGenerationService.GetFileNameSuffixForMultipleFiles(fileNumber, filesCount);
+
+        // Assert
+        Assert.Equal(expectedSuffix, result);
+    }
+
+    [Fact]
+    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFileNumberIsNegative()
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(-1, 3));
+    }
+
+    [Fact]
+    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFilesCountIsNegative()
+    {
+        // Arrange
+        var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(1, -3));
+    }
+
+    [Theory]
+    [InlineData("description-partial-1-3.yaml", "description-partial-1-3.yaml")]
+    [InlineData("description-partial-2-3.yaml", "description-partial-1-3.yaml")]
+    [InlineData("description-partial-5-10.yaml", "description-partial-1-10.yaml")]
+    [InlineData("description-partial-10-10.yaml", "description-partial-1-10.yaml")]
+    [InlineData("description-partial-1-1.yaml", "description-partial-1-1.yaml")]
+    [InlineData("description-partial-a-b.yaml", "description-partial-a-b.yaml")]
+    [InlineData("description.yaml", "description.yaml")]
+    public void GetFirstPartialFileName_ValidInputs_ReturnsExpectedResults(string inputFilePath, string expectedFilePath)
+    {
+        // Act
+        var result = PluginsGenerationService.GetFirstPartialFileName(inputFilePath);
+
+        // Assert
+        Assert.Equal(expectedFilePath, result);
+    }
+
+    [Fact]
+    public void GetFirstPartialFileName_ThrowsArgumentException_WhenInputIsNullOrEmpty()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => PluginsGenerationService.GetFirstPartialFileName(null));
+        Assert.Throws<ArgumentException>(() => PluginsGenerationService.GetFirstPartialFileName(string.Empty));
+    }
+
+    #endregion
 }
+

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -1890,7 +1890,7 @@ paths:
     [InlineData("description-partial-1-9.yaml", 5, "description-partial-5-9.yaml")]
     [InlineData("description-partial-1-8.yaml", 3, "description-partial-3-8.yaml")]
     [InlineData("description-partial-1-8.yaml", 8, "description-partial-8-8.yaml")]
-    public void GetNextFileInfo_ValidInputs_ReturnsExpectedResults(String originalFilePath, int fileNumber, string expectedFilePath)
+    public void GetNextFileInfo_ValidInputs_ReturnsExpectedResults(String originalFilePath, uint fileNumber, string expectedFilePath)
     {
         // Arrange
         var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration
@@ -1934,7 +1934,7 @@ paths:
     [InlineData("openapi.agentname.actionname-partial-1-b.yaml", false, 0, 0)] // Invalid pattern, wrong second number
     [InlineData("randomfile.yaml", false, 0, 0)] // Completely invalid file name
     [InlineData("", false, 0, 0)] // Empty file name
-    public void TryMatchMultipleFilesRequest_ValidatesFilePatterns(string filePath, bool expectedResult, int expectedFileNumber, int expectedFilesCount)
+    public void TryMatchMultipleFilesRequest_ValidatesFilePatterns(string filePath, bool expectedResult, uint expectedFileNumber, uint expectedFilesCount)
     {
         // Arrange
         var generationConfiguration = new GenerationConfiguration
@@ -2400,7 +2400,7 @@ paths:
     [InlineData(2, 5, "-partial-2-5")]
     [InlineData(10, 10, "-partial-10-10")]
     [InlineData(1, 1, "-partial-1-1")]
-    public void GetFileNameSuffixForMultipleFiles_ValidInputs_ReturnsExpectedSuffix(int fileNumber, int filesCount, string expectedSuffix)
+    public void GetFileNameSuffixForMultipleFiles_ValidInputs_ReturnsExpectedSuffix(uint fileNumber, uint filesCount, string expectedSuffix)
     {
         // Arrange
         var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
@@ -2413,23 +2413,23 @@ paths:
     }
 
     [Fact]
-    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFileNumberIsNegative()
+    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFileNumberIsZero()
     {
         // Arrange
         var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(-1, 3));
+        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(0, 3));
     }
 
     [Fact]
-    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFilesCountIsNegative()
+    public void GetFileNameSuffixForMultipleFiles_ThrowsArgumentException_WhenFilesCountIsZero()
     {
         // Arrange
         var pluginsGenerationService = CreateEmptyPluginsGenerationService(new GenerationConfiguration());
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(1, -3));
+        Assert.Throws<ArgumentException>(() => pluginsGenerationService.GetFileNameSuffixForMultipleFiles(1, 0));
     }
 
     [Theory]

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -1037,7 +1037,7 @@ components:
             OpenApiUrlTreeNode.Create(),
             generationConfiguration,
             generationConfiguration.OutputPath,
-            
+
             mockLogger.Object
         );
 

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -745,9 +745,10 @@ components:
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+        pluginsGenerationService.DownloadService = openAPIDocumentDS;
 
         // Act
-        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync();
 
         // Assert
         Assert.NotNull(manifestPaths);
@@ -790,7 +791,9 @@ components:
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
-        List<string> manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+        pluginsGenerationService.DownloadService = openAPIDocumentDS;
+
+        List<string> manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync();
 
         string ManifestFileName1 = "client-apiplugin-partial-1-2.json";
         string OpenApiFileName1 = "client-openapi-partial-1-2.yml";
@@ -899,9 +902,10 @@ components:
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+        pluginsGenerationService.DownloadService = openAPIDocumentDS;
 
         // Act
-        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync();
 
         // Assert
         Assert.NotNull(manifestPaths);
@@ -987,9 +991,10 @@ components:
         var urlTreeNode = OpenApiUrlTreeNode.Create(openApiDocument, Constants.DefaultOpenApiLabel);
 
         var pluginsGenerationService = new PluginsGenerationService(openApiDocument, urlTreeNode, generationConfiguration, workingDirectory, _logger);
+        pluginsGenerationService.DownloadService = openAPIDocumentDS;
 
         // Act
-        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync(openAPIDocumentDS);
+        var manifestPaths = await pluginsGenerationService.GenerateAndMergeMultipleManifestsAsync();
 
         // Assert
         Assert.NotNull(manifestPaths);
@@ -1032,12 +1037,13 @@ components:
             OpenApiUrlTreeNode.Create(),
             generationConfiguration,
             generationConfiguration.OutputPath,
+            
             mockLogger.Object
         );
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.GenerateAndMergeMultipleManifestsAsync(mockDownloadService.Object, CancellationToken.None));
+            service.GenerateAndMergeMultipleManifestsAsync(CancellationToken.None));
     }
 
 


### PR DESCRIPTION
Added support for generating and merging multiple API plugin manifests at once.
Fixes https://github.com/microsoft/kiota/issues/6140