### PR TITLE
fix: a bug where a trailing slash in the path item lead to missing query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where path items with a trailing slash would be missing query parameters. [#6569](https://github.com/microsoft/kiota/issues/6569)
+
 ## [1.26.1] - 2025-05-15
 
 ### Added

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Services;
 
 namespace Kiota.Builder.Extensions;
+
 public static partial class OpenApiUrlTreeNodeExtensions
 {
     private static string GetDotIfBothNotNullOfEmpty(string x, string y) => string.IsNullOrEmpty(x) || string.IsNullOrEmpty(y) ? string.Empty : ".";
@@ -204,6 +205,22 @@ public static partial class OpenApiUrlTreeNodeExtensions
             .Any(static x => x.Required);
     }
 
+    private static IOpenApiParameter[] GetParameters(this IOpenApiPathItem pathItem, HttpMethod? operationType = null)
+    {
+        var operationQueryParameters = (operationType, pathItem.Operations is not null && pathItem.Operations.Any()) switch
+        {
+            (HttpMethod ot, _) when pathItem.Operations!.TryGetValue(ot, out var operation) && operation.Parameters is not null => operation.Parameters,
+            (null, true) => pathItem.Operations!.SelectMany(static x => x.Value.Parameters ?? Enumerable.Empty<IOpenApiParameter>()).Where(static x => x.In == ParameterLocation.Query),
+            _ => [],
+        };
+        return pathItem.Parameters?
+                        .Union(operationQueryParameters)
+                        .Where(static x => x.In == ParameterLocation.Query)
+                        .DistinctBy(static x => x.Name, StringComparer.Ordinal)
+                        .OrderBy(static x => x.Name, StringComparer.Ordinal)
+                        .ToArray() ?? [];
+    }
+
     public static string GetUrlTemplate(this OpenApiUrlTreeNode currentNode, HttpMethod? operationType = null, bool includeQueryParameters = true, bool includeBaseUrl = true)
     {
         ArgumentNullException.ThrowIfNull(currentNode);
@@ -211,18 +228,14 @@ public static partial class OpenApiUrlTreeNodeExtensions
         if (currentNode.HasOperations(Constants.DefaultOpenApiLabel) && includeQueryParameters)
         {
             var pathItem = currentNode.PathItems[Constants.DefaultOpenApiLabel];
-            var operationQueryParameters = (operationType, pathItem.Operations is not null && pathItem.Operations.Any()) switch
+
+            var parameters = pathItem.GetParameters(operationType);
+            if (currentNode.Children.TryGetValue($"{currentNode.Path}\\", out var currentNodeWithTrailingSlash))
             {
-                (HttpMethod ot, _) when pathItem.Operations!.TryGetValue(ot, out var operation) && operation.Parameters is not null => operation.Parameters,
-                (null, true) => pathItem.Operations!.SelectMany(static x => x.Value.Parameters ?? Enumerable.Empty<IOpenApiParameter>()).Where(static x => x.In == ParameterLocation.Query),
-                _ => [],
-            };
-            var parameters = pathItem.Parameters?
-                                    .Union(operationQueryParameters)
-                                    .Where(static x => x.In == ParameterLocation.Query)
-                                    .DistinctBy(static x => x.Name, StringComparer.Ordinal)
-                                    .OrderBy(static x => x.Name, StringComparer.Ordinal)
-                                    .ToArray() ?? [];
+                // having a node with a trailing slash means we have 2 nodes in the tree
+                parameters = parameters.Union(currentNodeWithTrailingSlash.PathItems[Constants.DefaultOpenApiLabel].GetParameters(operationType))
+                            .ToArray();
+            }
             if (parameters.Length != 0)
             {
                 var requiredParameters = string.Join("&", parameters.Where(static x => x.Required)

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -29,6 +29,7 @@ using Xunit;
 using NetHttpMethod = System.Net.Http.HttpMethod;
 
 namespace Kiota.Builder.Tests;
+
 public sealed partial class KiotaBuilderTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -4480,6 +4481,98 @@ components:
         Assert.NotNull(property);
         Assert.Equal(expected, property.Type.Name);
         Assert.True(property.Type.AllTypes.First().IsExternal);
+    }
+    [Fact]
+    public void IncludesQueryParameterInUriTemplate()
+    {
+        var documentJSON =
+"""
+{
+	"openapi": "3.1.0",
+	"info": {
+		"title": "Rest API",
+		"version": "25.05.15",
+		"description": ""
+	},
+	"paths": {
+		"/api/contracts/": {
+			"get": {
+				"operationId": "rest_backend_api_contract_get_contracts",
+				"summary": "Get Contracts",
+				"parameters": [
+					{
+						"in": "query",
+						"name": "type",
+						"schema": {
+							"allOf": [
+								{
+									"enum": [
+										"PROPERTY",
+										"LEASE",
+										"SUBLEASE",
+										"EXCHANGE"
+									],
+									"title": "ContractType",
+									"type": "string"
+								}
+							]
+						},
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Vertrag"
+				]
+			}
+		},
+		"/api/contracts/lease/": {
+			"get": {
+				"operationId": "rest_backend_api_contract_get_lease_contracts",
+				"summary": "Get Lease Contracts",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"type": "string"
+									},
+									"title": "Response",
+									"type": "array"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+""";
+        var (document, _) = OpenApiDocument.Parse(documentJSON, OpenApiConstants.Json);
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var requestBuilder = codeModel.FindChildByName<CodeClass>("ContractsRequestBuilder");
+        Assert.NotNull(requestBuilder);
+        var property = requestBuilder.Properties.First(static x => x.Kind is CodePropertyKind.UrlTemplate);
+        Assert.NotNull(property);
+        Assert.Equal("\"{+baseurl}/api/contracts/{?type*}\"", property.DefaultValue);
     }
     [Fact]
     public void MapsArrayOfTypesAsUnionType()


### PR DESCRIPTION
fixes #6569