### PR TITLE
fix: Don't overwrite serialization name if it is already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where path items with a trailing slash would be missing query parameters. [#6569](https://github.com/microsoft/kiota/issues/6569)
 - Fixed an issue where migration from lock to workspace would fail because of stream management. [#6515](https://github.com/microsoft/kiota/issues/6515)
 - Fixed a bug where media types from error responses would be missing from the accept header. [#6572](https://github.com/microsoft/kiota/issues/6572)
+- Fixed a bug where serialization names for Dart were not correct [#6624](https://github.com/microsoft/kiota/issues/6624)
 
 ## [1.26.1] - 2025-05-15
 

--- a/src/Kiota.Builder/Refiners/DartRefiner.cs
+++ b/src/Kiota.Builder/Refiners/DartRefiner.cs
@@ -315,7 +315,9 @@ public class DartRefiner : CommonLanguageRefiner, ILanguageRefiner
         }
         else
         {
-            currentProperty.SerializationName = currentProperty.Name;
+            if (!currentProperty.IsNameEscaped)
+                currentProperty.SerializationName = currentProperty.Name;
+
             currentProperty.Name = currentProperty.Name.ToFirstCharacterLowerCase();
         }
         currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();

--- a/tests/Kiota.Builder.Tests/Refiners/DartLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/DartLanguageRefinerTests.cs
@@ -451,5 +451,27 @@ public class DartLanguageRefinerTests
         Assert.Equal("property", model.Properties.First().Name);
         Assert.Equal("Property", model.Properties.First().WireName);
     }
+
+    [Fact]
+    public async Task DoesntOverwriteSerializationNameIfAlreadySet()
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "model",
+            Kind = CodeClassKind.Model,
+        }).First();
+        model.AddProperty(new CodeProperty
+        {
+            Name = "CustomType",
+            SerializationName = "$type",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Dart }, root);
+        Assert.Equal("customType", model.Properties.First().Name);
+        Assert.Equal("\\$type", model.Properties.First().WireName);
+    }
     #endregion
 }


### PR DESCRIPTION
Fixes #6444.

This fixes an oversight I accidentially introduced in #6393.

I adjusted the serialization name so it is correctly preserved in its original casing, but I forgot to check if it was already explicitly set.