### PR TITLE
Python: Set a default value for non-nullable array fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where media types from error responses would be missing from the accept header. [#6572](https://github.com/microsoft/kiota/issues/6572)
 - Fixed a bug where serialization names for Dart were not correct [#6624](https://github.com/microsoft/kiota/issues/6624)
 - Fixed a bug where imports from __future__ would appear below other imports in python generated code. [#4600](https://github.com/microsoft/kiota/issues/4600)
+- Python: Set a default value for non-nullable array fields. [#6350](https://github.com/microsoft/kiota/issues/6350)
 
 ## [1.26.1] - 2025-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Python: Set a default value for non-nullable array fields. [#6350](https://github.com/microsoft/kiota/issues/6350)
+
 ## [1.27.0] - 2025-06-11
 
 ### Added
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where media types from error responses would be missing from the accept header. [#6572](https://github.com/microsoft/kiota/issues/6572)
 - Fixed a bug where serialization names for Dart were not correct [#6624](https://github.com/microsoft/kiota/issues/6624)
 - Fixed a bug where imports from __future__ would appear below other imports in python generated code. [#4600](https://github.com/microsoft/kiota/issues/4600)
-- Python: Set a default value for non-nullable array fields. [#6350](https://github.com/microsoft/kiota/issues/6350)
 
 ## [1.26.1] - 2025-05-15
 

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -8,6 +8,7 @@ using Kiota.Builder.Configuration;
 using Kiota.Builder.Extensions;
 
 namespace Kiota.Builder.Refiners;
+
 public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
 {
     public PythonRefiner(GenerationConfiguration configuration) : base(configuration) { }
@@ -293,6 +294,12 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
         {
             currentProperty.DefaultValue = "None";
             currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();
+        }
+        else if (currentProperty.IsOfKind(CodePropertyKind.QueryParameters, CodePropertyKind.QueryParameter)
+                 && currentProperty.Type.IsArray && !currentProperty.Type.IsNullable)
+        {
+            currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();
+            currentProperty.DefaultValue = "field(default_factory=list)";
         }
         else
         {

--- a/src/Kiota.Builder/Refiners/PythonRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PythonRefiner.cs
@@ -298,6 +298,13 @@ public class PythonRefiner : CommonLanguageRefiner, ILanguageRefiner
         else if (currentProperty.IsOfKind(CodePropertyKind.QueryParameters, CodePropertyKind.QueryParameter)
                  && currentProperty.Type.IsArray && !currentProperty.Type.IsNullable)
         {
+            // Set the default_factory so that one single instance of the default values
+            // are not shared across instances of the class.
+            // This is required as of Python 3.11 with dataclasses.
+            // https://github.com/python/cpython/issues/8884
+            //
+            // Also handle the case change that would otherwise have been done
+            // below in the final else block.
             currentProperty.Type.Name = currentProperty.Type.Name.ToFirstCharacterUpperCase();
             currentProperty.DefaultValue = "field(default_factory=list)";
         }

--- a/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
@@ -3,6 +3,7 @@ using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 
 namespace Kiota.Builder.Writers.Python;
+
 public class CodePropertyWriter : BaseElementWriter<CodeProperty, PythonConventionService>
 {
     private readonly CodeUsingWriter _codeUsingWriter;
@@ -40,7 +41,12 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, PythonConventi
             case CodePropertyKind.QueryParameter:
                 conventions.WriteInLineDescription(codeElement, writer);
                 var isNonNullableCollection = !codeElement.Type.IsNullable && codeElement.Type.CollectionKind != CodeTypeBase.CodeTypeCollectionKind.None;
-                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{codeElement.NamePrefix}{codeElement.Name}: {(codeElement.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(codeElement.Type.IsNullable ? "]" : string.Empty)} {(isNonNullableCollection ? "= []" : "= None")}");
+                var defaultValue = isNonNullableCollection ? "[]" : "None";
+                if (!string.IsNullOrEmpty(codeElement.DefaultValue))
+                {
+                    defaultValue = codeElement.DefaultValue;
+                }
+                writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{codeElement.NamePrefix}{codeElement.Name}: {(codeElement.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(codeElement.Type.IsNullable ? "]" : string.Empty)} = {defaultValue}");
                 writer.WriteLine();
                 break;
             case CodePropertyKind.ErrorMessageOverride when parentClass.IsErrorDefinition:

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodePropertyWriterTests.cs
@@ -7,6 +7,7 @@ using Kiota.Builder.Writers;
 using Xunit;
 
 namespace Kiota.Builder.Tests.Writers.Python;
+
 public sealed class CodePropertyWriterTests : IDisposable
 {
     private const string DefaultPath = "./";
@@ -108,6 +109,18 @@ public sealed class CodePropertyWriterTests : IDisposable
         writer.Write(property);
         var result = tw.ToString();
         Assert.Contains("= None", result);
+    }
+
+    [Fact]
+    public void WritesDefaultValuesForNonNullableArrayPropertiesWhenDefaultValueSet()
+    {
+        property.Kind = CodePropertyKind.QueryParameter;
+        property.Type.IsNullable = false;
+        property.Type.CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array;
+        property.DefaultValue = "field(default_factory=list)";
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains("= field(default_factory=list)", result);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #6350
closes #6489

* Use the PythonRefiner to set the default value for non-nullable array types.
* Update the CodePropertyWriter to respect the default value if set.
* Add tests for the changes