### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-
-
   - package-ecosystem: nuget
     directory: "/it/csharp"
     schedule:
@@ -31,7 +29,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: gomod
     directory: "/it/go"
     schedule:
@@ -41,7 +38,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: composer
     directory: "/it/php"
     schedule:
@@ -51,7 +47,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: pip
     directory: "/it/python"
     schedule:
@@ -61,7 +56,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: bundler
     directory: "/it/ruby"
     schedule:
@@ -71,7 +65,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: maven
     directory: "/it/java"
     schedule:
@@ -81,7 +74,6 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
-
   - package-ecosystem: npm
     directory: "/it/typescript"
     schedule:
@@ -94,7 +86,6 @@ updates:
       eslint:
         patterns:
           - "*eslint*"
-
   - package-ecosystem: npm
     directory: "/vscode/microsoft-kiota"
     schedule:
@@ -104,3 +95,13 @@ updates:
       eslint:
         patterns:
           - "*eslint*"
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/