### PR TITLE
Fix for issue 6698

### DIFF
--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -31,7 +31,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             if (nameof(String).Equals(parameter.Type.Name, StringComparison.OrdinalIgnoreCase) && parameter.Type.CollectionKind == CodeTypeBase.CodeTypeCollectionKind.None)
                 writer.WriteLine($"if(string.IsNullOrEmpty({parameterName})) throw new ArgumentNullException(nameof({parameterName}));");
             else
-                writer.WriteLine($"_ = {parameterName} ?? throw new ArgumentNullException(nameof({parameterName}));");
+                writer.WriteLine($"if(ReferenceEquals({parameterName}, null)) throw new ArgumentNullException(nameof({parameterName}));");
         }
         HandleMethodKind(codeElement, writer, inherits, parentClass, isVoid);
         writer.CloseBlock();

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1942,7 +1942,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("int? sampleParam", result);
         Assert.DoesNotContain("#nullable enable", result);
         Assert.DoesNotContain("#nullable restore", result);
-        Assert.Contains("_ = ra ?? throw new ArgumentNullException(nameof(ra));", result);
+        Assert.Contains("if(ReferenceEquals(ra, null)) throw new ArgumentNullException(nameof(ra));", result);
     }
 
     [Fact]
@@ -2020,7 +2020,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.DoesNotContain("string? sampleParam = \"\"", result);
         Assert.DoesNotContain("#nullable enable", result);
         Assert.DoesNotContain("#nullable restore", result);
-        Assert.Contains("_ = ra ?? throw new ArgumentNullException(nameof(ra));", result);
+        Assert.Contains("if(ReferenceEquals(ra, null)) throw new ArgumentNullException(nameof(ra));", result);
     }
     [Fact]
     public void WritesDeprecationInformation()


### PR DESCRIPTION
Fixes the problem described in #6698 by using explicit `if(ReferenceEquals(p, null)) ...` analogous to strings.