### PR TITLE
fix: use correct type for byte array values (original patch by @odig)

### DIFF
--- a/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
@@ -461,7 +461,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         {
             "Iterable<int>" => "getCollectionOfPrimitiveValues<int>()",
             "UuidValue" => "getGuidValue()",
-            "byte[]" => "getByteArrayValue()",
+            "Uint8List" => "getByteArrayValue()",
             _ when conventions.IsPrimitiveType(propertyType) => $"get{propertyType.TrimEnd(DartConventionService.NullableMarker).ToFirstCharacterUpperCase()}Value()",
             _ => $"getObjectValue<{propertyType.ToFirstCharacterUpperCase()}>({propertyType}.createFromDiscriminatorValue)",
         };
@@ -810,7 +810,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
 
         return propertyType switch
         {
-            "byte[]" => "writeByteArrayValue",
+            "Uint8List" => "writeByteArrayValue",
             "String" => "writeStringValue",
             "Iterable<int>" => "writeCollectionOfPrimitiveValues<int>",
             "UuidValue" => "writeUuidValue",

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -230,7 +230,8 @@ public class DartConventionService : CommonLanguageConventionService
             "string" => "String",
             "double" or "float" or "decimal" => "double",
             "object" or "void" => type.Name.ToLowerInvariant(),// little casing hack
-            "binary" or "base64" or "base64url" => "Iterable<int>",
+            "binary" => "Iterable<int>",
+            "base64" or "base64url" => "Uint8List",
             string s when s.Contains("RequestConfiguration", StringComparison.OrdinalIgnoreCase) => "RequestConfiguration",
             "iparsenode" => "ParseNode",
             "iserializationwriter" => "SerializationWriter",


### PR DESCRIPTION
This fixes an issue originally reported by @odig (who also provided this patch) in https://github.com/microsoft/kiota-dart/issues/92

TODO:
- [ ] add tests