### PR TITLE
typescript: allow mixed types for `anyOf`

### DIFF
--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -6687,6 +6687,145 @@ components:
         var actorsItemRequestBuilder = actorsItemRequestBuilderNamespace.FindChildByName<CodeClass>("actorItemRequestBuilder");
         Assert.Equal(actorsCollectionIndexer.ReturnType.Name, actorsItemRequestBuilder.Name);
     }
+    
+    [Fact]
+    public async Task IndexerSupportsUnionOfPrimitiveTypesForPathParametersAsync()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(@"openapi: 3.0.0
+info:
+  title: Test API with Union Path Parameters
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /keys/{ssh_key_identifier}:
+    get:
+      parameters:
+        - name: ssh_key_identifier
+          in: path
+          required: true
+          description: Either the ID or the fingerprint of an existing SSH key.
+          schema:
+            anyOf:
+              - type: string
+              - type: integer
+          example: 512189
+      responses:
+        200:
+          description: Success!
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SSHKey'
+components:
+  schemas:
+    SSHKey:
+      type: object
+      properties:
+        id:
+          type: integer
+        fingerprint:
+          type: string
+        key:
+          type: string");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs);
+        var node = builder.CreateUriSpace(document!);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var keysCollectionRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.keys");
+        Assert.NotNull(keysCollectionRequestBuilderNamespace);
+        var keysCollectionRequestBuilder = keysCollectionRequestBuilderNamespace.FindChildByName<CodeClass>("keysRequestBuilder");
+        var keysCollectionIndexer = keysCollectionRequestBuilder.Indexer;
+        Assert.NotNull(keysCollectionIndexer);
+        
+        // Check that the indexer parameter type is a union type containing both string and integer
+        var parameterType = keysCollectionIndexer.IndexParameter.Type;
+        Assert.IsType<CodeUnionType>(parameterType);
+        var unionType = (CodeUnionType)keysCollectionIndexer.IndexParameter.Type;
+        Assert.Equal(2, unionType.Types.Count());
+        
+        // Verify both types are present in the union
+        Assert.Contains(unionType.Types, t => t.Name.Equals("string", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(unionType.Types, t => t.Name.Equals("integer", StringComparison.OrdinalIgnoreCase));
+        
+        // Verify description
+        Assert.Equal("Either the ID or the fingerprint of an existing SSH key.", keysCollectionIndexer.IndexParameter.Documentation.DescriptionTemplate);
+        Assert.False(keysCollectionIndexer.IndexParameter.Type.IsNullable);
+        Assert.False(keysCollectionIndexer.Deprecation.IsDeprecated);
+    }
+    
+    [Fact]
+    public async Task IndexerSupportsUnionOfPrimitiveTypesForPathParametersWithOneOfAsync()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(@"openapi: 3.0.0
+info:
+  title: Test API with OneOf Path Parameters
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /keys/{ssh_key_identifier}:
+    get:
+      parameters:
+        - name: ssh_key_identifier
+          in: path
+          required: true
+          description: Either the ID or the fingerprint of an existing SSH key.
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+          example: 512189
+      responses:
+        200:
+          description: Success!
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SSHKey'
+components:
+  schemas:
+    SSHKey:
+      type: object
+      properties:
+        id:
+          type: integer
+        fingerprint:
+          type: string
+        key:
+          type: string");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs);
+        var node = builder.CreateUriSpace(document!);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var keysCollectionRequestBuilderNamespace = codeModel.FindNamespaceByName("ApiSdk.keys");
+        Assert.NotNull(keysCollectionRequestBuilderNamespace);
+        var keysCollectionRequestBuilder = keysCollectionRequestBuilderNamespace.FindChildByName<CodeClass>("keysRequestBuilder");
+        var keysCollectionIndexer = keysCollectionRequestBuilder.Indexer;
+        Assert.NotNull(keysCollectionIndexer);
+        
+        // Check that the indexer parameter type is a union type containing both string and integer
+        var parameterType = keysCollectionIndexer.IndexParameter.Type;
+        Assert.IsType<CodeUnionType>(parameterType);
+        var unionType = (CodeUnionType)keysCollectionIndexer.IndexParameter.Type;
+        Assert.Equal(2, unionType.Types.Count());
+        
+        // Verify both types are present in the union
+        Assert.Contains(unionType.Types, t => t.Name.Equals("string", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(unionType.Types, t => t.Name.Equals("integer", StringComparison.OrdinalIgnoreCase));
+        
+        // Verify description
+        Assert.Equal("Either the ID or the fingerprint of an existing SSH key.", keysCollectionIndexer.IndexParameter.Documentation.DescriptionTemplate);
+        Assert.False(keysCollectionIndexer.IndexParameter.Type.IsNullable);
+        Assert.False(keysCollectionIndexer.Deprecation.IsDeprecated);
+    }
+    
     [Fact]
     public async Task MapsBooleanEnumToBooleanTypeAsync()
     {


### PR DESCRIPTION
Described the bug here:
[https://github.com/microsoft/kiota/issues/6801#issuecomment-3160393844](https://github.com/microsoft/kiota/issues/6801#issuecomment-3160393844)


Now it can properly handle anyOf (e.g. [here](https://github.com/danaelhe/kiota_bug/blob/main/DigitalOcean-public.v2.yaml#L256)) of mixed types. 

Example OpenAPI 3.0 spec:
```
    components:
        parameters:
            ssh_key_identifier:
                in: path
                name: ssh_key_identifier
                required: true
                description: Either the ID or the fingerprint of an existing SSH key.
                schema:
                    anyOf:
                    - $ref: '#/components/schemas/ssh_key_id'
                    - $ref: '#/components/schemas/ssh_key_fingerprint'
                example: 512189


....
        schema:
            ssh_key_id:
                type: integer
                description: >-
                    A unique identification number for this key. Can be used to embed a 
                    specific SSH key into a Droplet.
                readOnly: true
                example: 512189
            
            ssh_key_fingerprint:
                type: string
                description: >-
                    A unique identifier that differentiates this key from other keys using 
                    a format that SSH recognizes. The fingerprint is created when the key is
                    added to your account.
                readOnly: true
                example: 3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa
    
```

Now generates:

```
export interface KeysRequestBuilder extends BaseRequestBuilder<KeysRequestBuilder> {
    /**
     * Gets an item from the ApiSdk.v2.account.keys.item collection
     * @param ssh_key_identifier Either the ID or the fingerprint of an existing SSH key.
     * @returns {WithSsh_key_identifierItemRequestBuilder}
     */
     bySsh_key_identifier(ssh_key_identifier: string | number) : WithSsh_key_identifierItemRequestBuilder;
}
```


Re-ran our mocked tests and it all seems to pass...doesn't seem to have broke anything else 🤞 