### PR TITLE
Fix compiling fully named integer and boolean types when used in union and array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixes a bug where invalid C# code is generated when API path contains an underscore [#6698](https://github.com/microsoft/kiota/issues/6698)
+- Fixed a bug where union of integer and boolean types collection would not compile in dotnet. [#6834](https://github.com/microsoft/kiota/issues/6834)
 
 ## [1.28.0] - 2025-07-11
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -14,7 +14,7 @@ public class CSharpConventionService : CommonLanguageConventionService
     public override string StreamTypeName => "stream";
     public override string VoidTypeName => "void";
     public override string DocCommentPrefix => "/// ";
-    private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "bool", "float", "double", "decimal", "long", "Guid", "DateTimeOffset", "TimeSpan", "Date", "Time", "sbyte", "byte" };
+    private static readonly HashSet<string> NullableTypes = new(StringComparer.OrdinalIgnoreCase) { "int", "integer", "bool", "boolean", "float", "double", "decimal", "long", "Guid", "DateTimeOffset", "TimeSpan", "Date", "Time", "sbyte", "byte" };
     public const char NullableMarker = '?';
     public static string NullableMarkerAsString => "?";
     public override string ParseNodeInterfaceName => "IParseNode";

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -652,8 +652,26 @@ public sealed class CodeMethodWriterTests : IDisposable
             Name = "double",
             CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex,
         };
+        var cType3 = new CodeType
+        {
+            Name = "integer",
+            CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex,
+        };
+        var cType4 = new CodeType
+        {
+            Name = "boolean",
+            CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Complex,
+        };
         unionTypeWrapper.OriginalComposedType.AddType(cType1);
         unionTypeWrapper.OriginalComposedType.AddType(cType2);
+        unionTypeWrapper.OriginalComposedType.AddType(cType3);
+        unionTypeWrapper.OriginalComposedType.AddType(cType4);
+        unionTypeWrapper.AddProperty(new CodeProperty
+        {
+            Name = "StringValue",
+            Type = cType1,
+            Kind = CodePropertyKind.Custom
+        });
         unionTypeWrapper.AddProperty(new CodeProperty
         {
             Name = "DoubleValue",
@@ -662,8 +680,14 @@ public sealed class CodeMethodWriterTests : IDisposable
         });
         unionTypeWrapper.AddProperty(new CodeProperty
         {
-            Name = "StringValue",
-            Type = cType1,
+            Name = "IntegerValue",
+            Type = cType3,
+            Kind = CodePropertyKind.Custom
+        });
+        unionTypeWrapper.AddProperty(new CodeProperty
+        {
+            Name = "BooleanValue",
+            Type = cType4,
             Kind = CodePropertyKind.Custom
         });
 
@@ -690,6 +714,8 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.Contains("parseNode.GetCollectionOfPrimitiveValues<double?>()?.AsList() is List<double?> doubleValue", result);
+        Assert.Contains("parseNode.GetCollectionOfPrimitiveValues<int?>()?.AsList() is List<int?> integerValue", result);
+        Assert.Contains("parseNode.GetCollectionOfPrimitiveValues<bool?>()?.AsList() is List<bool?> booleanValue", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Shortly after creating the issue, I seem to have found the fix for this.
I hope this will suffice.

Fixes #6834 