### PR TITLE
fix: Replace rmdirSync with rmSync due to API changes

### DIFF
--- a/vscode/packages/npm-package/install.ts
+++ b/vscode/packages/npm-package/install.ts
@@ -106,7 +106,7 @@ export async function ensureKiotaIsPresentInPath(installPath: string, runtimeDep
             makeExecutable(kiotaFilePath);
           }
         } catch (error) {
-          fs.rmdirSync(installPath, { recursive: true });
+          fs.rmSync(installPath, { recursive: true, force: true });
           throw new Error("Kiota download failed. Check the logs for more information.");
         }
       });


### PR DESCRIPTION
ci has been failing since the upgrade to node types 25.
The options were previously ignored anyway.
https://nodejs.org/api/fs.html#fsrmdirsyncpath-options

This switched to the latest API