### PR TITLE
Let dependabot update the "it/language/basic" projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,9 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: nuget
-    directory: "/it/csharp"
+    directories:
+      - "/it/csharp"
+      - "/it/csharp/basic"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -33,7 +35,9 @@ updates:
         patterns:
           - "*kiota*"
   - package-ecosystem: gomod
-    directory: "/it/go"
+    directories:
+      - "/it/go"
+      - "/it/go/basic"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -75,7 +79,9 @@ updates:
         patterns:
           - "*kiota*"
   - package-ecosystem: maven
-    directory: "/it/java"
+    directories:
+      - "/it/java"
+      - "/it/java/basic"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
Nuget package references in "kiota\it\csharp\basic\basic.csproj" are outdated. I modified the dependabot config to handle them also.
Same applies to Go und Java.

"basic" is a template for running integration tests using a MockServer: it should be copied to a new directory and test methods shall be added.

Other languages did not contain a "basic" directory.