### PR TITLE
ci: fixes path for ADO coverage report generation

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -260,7 +260,7 @@ extends:
                 condition: succeededOrFailed()
                 displayName: "Install ReportGenerator"
 
-              - pwsh: reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/reports/coverage -reporttypes:"HtmlInline_AzurePipelines;Cobertura"
+              - pwsh: reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/reports/coverage -reporttypes:"HtmlInline_AzurePipelines;Cobertura"
                 condition: succeeded()
                 displayName: "Generate coverage report"
 


### PR DESCRIPTION
1.31.0 publishing is blocked because of this issue

closes #7566