### PR TITLE
Dependabot updates for Dart integration tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,15 @@ updates:
       kiota-dependencies:
         patterns:
           - "*kiota*"
+  - package-ecosystem: pub
+    directory: "/it/dart"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - "*kiota*"
   - package-ecosystem: npm
     directory: "/it/typescript"
     schedule:


### PR DESCRIPTION
When executing the Dart integration test with these steps...

```
.\it\generate-code.ps1 -descriptionUrl "./tests/Kiota.Builder.IntegrationTests/InheritingErrors.yaml" -language Dart -Dev
.\it\exec-cmd.ps1 -descriptionUrl "./tests/Kiota.Builder.IntegrationTests/InheritingErrors.yaml" -language Dart
```

it prints this warnings:

```
Resolving dependencies...
Downloading packages...
  lints 5.1.1 (6.1.0 available)
  microsoft_kiota_abstractions 0.0.3 (0.1.0 available)
Got dependencies!
2 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
```


I think this is caused by the "caret syntax" version declarations:

https://github.com/microsoft/kiota/blob/02dd255772e8f6862930e9582598338b508822d0/it/dart/pubspec.yaml#L10-L22

To my understanding, e.g. "microsoft_kiota_abstractions" can only be auto updated to a version "0.0.999", but not to "0.1.0": https://dart.dev/tools/pub/dependencies#version-constraints

Dependabot should support Dart since 2022 (https://github.blog/changelog/2022-11-30-dependabot-now-supports-security-updates-for-dart-and-flutter-apps-that-use-pub-packages/), and I found a sample at https://deku.posstree.com/en/flutter/github/dependabot/

Hopefully my change works as expected.

What about the SDK version definition? Does it matter here? CI installs Dart 3.11.4 according to the CI log. [kiota-dart](https://github.com/microsoft/kiota-dart) is a 3.9.0.