### PR TITLE
Change FileStream to allow shared read access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where local OpenAPI documents were opened with Read/Write instead of Read, briefly preventing concurrent kiota instances from running against the same file. [#7601](https://github.com/microsoft/kiota/pull/7601) 
+
 ## [1.31.0] - 2026-04-09
 
 ### Added

--- a/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
+++ b/src/Kiota.Builder/OpenApiDocumentDownloadService.cs
@@ -74,7 +74,7 @@ internal partial class OpenApiDocumentDownloadService
                 var inMemoryStream = new MemoryStream();
                 using (await localFilesLock.LockAsync(inputPath, cancellationToken).ConfigureAwait(false))
                 {// To avoid deadlocking on update with multiple clients for the same local description
-                    using var fileStream = new FileStream(inputPath, FileMode.Open);
+                    using var fileStream = new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     await fileStream.CopyToAsync(inMemoryStream, cancellationToken).ConfigureAwait(false);
                 }
                 inMemoryStream.Position = 0;


### PR DESCRIPTION
I have a project that calls `kiota generate` multiple times, sometimes with the same `openapi` parameter. Every now and then, it'll fail to build because two kiota instances collided - one kiota instance has a handle on the file while the other was trying to read it. I can reproduce this by debugging this project and breaking on the `copyToAsync` line, then running my project build. With this change, breaking on that line and building (and making the build use my modified kiota) never throws that error. 