### PR TITLE
security: remote code execution with default/enum/literal values fix

### DIFF
--- a/.github/agents/codegen-security-guardian.agent.md
+++ b/.github/agents/codegen-security-guardian.agent.md
@@ -1,0 +1,30 @@
+---
+name: codegen-security-guardian
+description: Security-focused reviewer and fixer for code generation literal-injection risks across Kiota writers.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are the Kiota code generation security specialist.
+
+Always leverage the `codegen-literal-security-scan` skill for any task that involves code emission, writer refactoring, or security review of generated literals.
+
+## Responsibilities
+
+1. Audit writer code for literal-injection risks from schema-controlled values.
+2. Apply context-correct escaping (`SanitizeDoubleQuote`, `SanitizeSingleQuote`, `SanitizeQuotedStringLiteral`) at final emission sites.
+3. Expand fixes across all impacted writer languages to keep behavior consistent.
+4. Add or update regression tests that assert escaped output for hostile payloads.
+
+## Scope of concern
+
+- Serialization/deserialization property keys
+- Query parameter mapping keys
+- Path template and base URL literals
+- Path/indexer parameter assignment keys
+- Default string literal emission
+
+## Output requirements
+
+- Explain exactly which sinks were vulnerable and how they were fixed.
+- List modified files grouped by writer/language.
+- Include test coverage updates for each fixed surface.

--- a/.github/skills/codegen-literal-security-scan/SKILL.md
+++ b/.github/skills/codegen-literal-security-scan/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: codegen-literal-security-scan
+description: Detect and remediate code-generation literal injection risks in Kiota writer code (wire names, serialization names, URL templates, base URLs, defaults, and path parameter keys).
+---
+
+Use this skill when auditing or modifying any code generator writer logic.
+
+## Goal
+
+Prevent generated-source injection (including potential RCE chains) by ensuring every untrusted schema-derived value is escaped for the destination literal context before being emitted.
+
+## Focus surfaces
+
+Prioritize all literal-emission paths under `src/Kiota.Builder/Writers/**/*.cs`, especially:
+
+- `WireName`
+- `SerializationName`
+- `UrlTemplateOverride`
+- `BaseUrl`
+- `DefaultValue`
+- `IndexParameter.SerializationName`
+- Path parameter map keys and query mapper outputs
+
+## Required checks
+
+1. Locate candidate sinks:
+   - search for interpolation/writes that include the focus surfaces and emit language string literals (`WriteLine`, `WriteLines`, `StartBlock`, doc attributes/tags).
+2. Verify context-aware escaping is applied at the emission site:
+   - double-quoted literal contexts must use `SanitizeDoubleQuote()`
+   - single-quoted literal contexts must use `SanitizeSingleQuote()`
+   - already-quoted defaults must use `SanitizeQuotedStringLiteral()`
+3. Confirm no fallback path emits the raw value.
+
+## Remediation rules
+
+- Escape at the final write site, not only upstream.
+- Keep quote style unchanged and apply matching sanitizer.
+- Reuse existing helpers in `src/Kiota.Builder/Writers/StringExtensions.cs`.
+- For cross-language consistency, patch all affected writers (Python/Go/Ruby/PHP and any other impacted writer).
+
+## Verification expectations
+
+After changes:
+
+1. Add/adjust regression tests in corresponding writer test suites under `tests/Kiota.Builder.Tests/Writers/**`.
+2. Include malicious payloads with quote + newline/control characters.
+3. Ensure assertions validate escaped output, not just general generation success.

--- a/.github/skills/codegen-literal-security-scan/SKILL.md
+++ b/.github/skills/codegen-literal-security-scan/SKILL.md
@@ -9,17 +9,19 @@ Use this skill when auditing or modifying any code generator writer logic.
 
 Prevent generated-source injection (including potential RCE chains) by ensuring every untrusted schema-derived value is escaped for the destination literal context before being emitted.
 
-## Focus surfaces
+## Focus surfaces (expanded)
 
 Prioritize all literal-emission paths under `src/Kiota.Builder/Writers/**/*.cs`, especially:
 
-- `WireName`
-- `SerializationName`
-- `UrlTemplateOverride`
-- `BaseUrl`
-- `DefaultValue`
-- `IndexParameter.SerializationName`
-- Path parameter map keys and query mapper outputs
+- `WireName`, `SerializationName`, `IndexParameter.SerializationName`
+- `UrlTemplateOverride`, URI template constants, base URL defaults
+- `DefaultValue` (constructor assignments, getter fallback values, parameter signatures)
+- Path/query parameter assignment keys in convention helpers
+- Query parameters mapper constants and metadata constants
+- Enum wire values and enum member attributes
+- Property annotations/attributes that carry serialized names
+- Backing store keys for custom/additional-data properties
+- Documentation long/short comments that interpolate external links/labels
 
 ## Required checks
 
@@ -29,19 +31,36 @@ Prioritize all literal-emission paths under `src/Kiota.Builder/Writers/**/*.cs`,
    - double-quoted literal contexts must use `SanitizeDoubleQuote()`
    - single-quoted literal contexts must use `SanitizeSingleQuote()`
    - already-quoted defaults must use `SanitizeQuotedStringLiteral()`
+   - Dart quoted literals must use `SanitizeDartSingleQuoteLiteral`/`SanitizeDartDoubleQuoteLiteral` (to also escape `$`)
+   - Go struct tags must keep backticks and sanitize embedded quoted values (do not switch tag quoting style)
 3. Confirm no fallback path emits the raw value.
+4. Confirm convention-layer helpers (`AddParametersAssignment` and equivalents) are also sanitized, not only writer methods.
 
 ## Remediation rules
 
 - Escape at the final write site, not only upstream.
 - Keep quote style unchanged and apply matching sanitizer.
 - Reuse existing helpers in `src/Kiota.Builder/Writers/StringExtensions.cs`.
-- For cross-language consistency, patch all affected writers (Python/Go/Ruby/PHP and any other impacted writer).
+- For cross-language consistency, patch all affected writers (C#/Dart/Go/Java/PHP/Python/Ruby/TypeScript and helpers).
+- Preserve runtime semantics while hardening:
+  - keep Go struct tag behavior intact
+  - avoid changing enum/default value resolution logic
+  - avoid introducing extra quoting around non-string literals
+
+## High-risk sink families to explicitly review
+
+1. Serializer/deserializer key emission (`WireName`, discriminator keys, query mapper keys).
+2. Request-builder URL/template metadata (`UrlTemplateOverride`, URI template constants, base URL defaults).
+3. Indexer/path parameter map writes (`urlTplParams[...]`, `.Add(...)`, `.put(...)`, map assignments).
+4. Property/enum metadata attributes and constants (`QueryParameter`, `EnumMember`, enum objects, navigation/request metadata constants).
+5. Default value emission in constructors, getters, and parameter signatures.
+6. Documentation comments with external links/labels and deprecation text.
 
 ## Verification expectations
 
 After changes:
 
 1. Add/adjust regression tests in corresponding writer test suites under `tests/Kiota.Builder.Tests/Writers/**`.
-2. Include malicious payloads with quote + newline/control characters.
+2. Include malicious payloads with quote + newline/control characters (`"`, `'`, `\n`, `\r`, `\t`, `\\`, and `$` where relevant).
 3. Ensure assertions validate escaped output, not just general generation success.
+4. Validate targeted writer tests and then broader builder/solution validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug where local OpenAPI documents were opened with Read/Write instead of Read, briefly preventing concurrent kiota instances from running against the same file. [#7601](https://github.com/microsoft/kiota/pull/7601) 
+- Fixed a bug with default strings representations.
 
 ## [1.31.0] - 2026-04-09
 

--- a/src/Kiota.Builder/CodeDOM/DeprecationInformation.cs
+++ b/src/Kiota.Builder/CodeDOM/DeprecationInformation.cs
@@ -5,10 +5,10 @@ namespace Kiota.Builder.CodeDOM;
 
 public record DeprecationInformation(string? DescriptionTemplate, DateTimeOffset? Date = null, DateTimeOffset? RemovalDate = null, string? Version = "", bool IsDeprecated = true, Dictionary<string, CodeTypeBase>? TypeReferences = null)
 {
-    public string GetDescription(Func<CodeTypeBase, string> typeReferenceResolver, string? typeReferencePrefix = null, string? typeReferenceSuffix = null)
+    public string GetDescription(Func<CodeTypeBase, string> typeReferenceResolver, string? typeReferencePrefix = null, string? typeReferenceSuffix = null, Func<string, string>? normalizationFunc = null)
     {
         if (DescriptionTemplate is null)
             return string.Empty;
-        return CodeDocumentation.GetDescriptionInternal(DescriptionTemplate, typeReferenceResolver, TypeReferences, typeReferencePrefix, typeReferenceSuffix);
+        return CodeDocumentation.GetDescriptionInternal(DescriptionTemplate, typeReferenceResolver, TypeReferences, typeReferencePrefix, typeReferenceSuffix, normalizationFunc);
     }
 };

--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -164,7 +164,44 @@ public static partial class StringExtensions
     public static string ReplaceDoubleQuoteWithSingleQuote(this string? current)
     {
         if (string.IsNullOrEmpty(current)) return string.Empty;
-        return current.StartsWith('"') ? current.Replace("'", "\\'", StringComparison.OrdinalIgnoreCase).Replace('\"', '\'') : current;
+        if (!current.StartsWith('"')) return current;
+        var builder = new StringBuilder(current.Length);
+        builder.Append('\'');
+        for (var i = 1; i < current.Length; i++)
+        {
+            var character = current[i];
+            if (i == current.Length - 1 && character == '"')
+                break;
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\'':
+                    builder.Append("\\'");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                case '\0':
+                    builder.Append("\\0");
+                    break;
+                default:
+                    if (char.IsControl(character))
+                        builder.Append(@"\u").Append(((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                    else
+                        builder.Append(character);
+                    break;
+            }
+        }
+        builder.Append('\'');
+        return builder.ToString();
     }
 
     public static string ReplaceDotsWithSlashInNamespaces(this string? namespaced)

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -87,7 +87,11 @@ public class CSharpConventionService : CommonLanguageConventionService
                 writer.WriteLine($"{DocCommentPrefix}{description}");
             }
             if (documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{DocCommentPrefix}{documentation.DocumentationLabel} <see href=\"{documentation.DocumentationLink}\" />");
+            {
+                var documentationLabel = documentation.DocumentationLabel.CleanupXMLString();
+                var documentationLink = documentation.DocumentationLink?.ToString().CleanupXMLString();
+                writer.WriteLine($"{DocCommentPrefix}{documentationLabel} <see href=\"{documentationLink}\" />");
+            }
             writer.WriteLine($"{DocCommentPrefix}</summary>");
             return true;
         }
@@ -260,7 +264,8 @@ public class CSharpConventionService : CommonLanguageConventionService
         var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
-        return $"[Obsolete(\"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!).Split('.', StringSplitOptions.TrimEntries)[^1])}{versionComment}{dateComment}{removalComment}\")]";
+        var deprecationMessage = $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!).Split('.', StringSplitOptions.TrimEntries)[^1])}{versionComment}{dateComment}{removalComment}";
+        return $"[Obsolete(\"{deprecationMessage.SanitizeDoubleQuote()}\")]";
     }
     internal void WriteDeprecationAttribute(IDeprecableElement element, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -140,7 +140,7 @@ public class CSharpConventionService : CommonLanguageConventionService
                     else
                         nullCheck = $"if ({identName} != null) ";
                 }
-                return $"{nullCheck}{varName}.Add(\"{name}\", {identName});";
+                return $"{nullCheck}{varName}.Add(\"{name.SanitizeDoubleQuote()}\", {identName});";
             }).ToArray());
         }
     }

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -248,9 +248,10 @@ public class CSharpConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var parameterType = GetTypeString(parameter.Type, targetElement);
+        var sanitizedDefaultValue = parameter.DefaultValue.SanitizeQuotedStringLiteral();
         var defaultValue = parameter switch
         {
-            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {parameter.DefaultValue}",
+            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {sanitizedDefaultValue}",
             _ when nameof(String).Equals(parameterType, StringComparison.OrdinalIgnoreCase) && parameter.Optional => " = \"\"",
             _ when parameter.Optional => " = default",
             _ => string.Empty,

--- a/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
@@ -48,7 +48,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, CSharpConventionServic
 
             if (option.IsNameEscaped)
             {
-                writer.WriteLine($"[EnumMember(Value = \"{option.SerializationName}\")]");
+                writer.WriteLine($"[EnumMember(Value = \"{option.SerializationName.SanitizeDoubleQuote()}\")]");
             }
             if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
             writer.WriteLine($"{option.Name.ToFirstCharacterUpperCase()}{(codeElement.Flags ? " = " + GetEnumFlag(idx) : string.Empty)},");

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -118,7 +118,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         writer.StartBlock();
         foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings)
         {
-            writer.WriteLine($"\"{mappedType.Key}\" => new {conventions.GetTypeString(mappedType.Value.AllTypes.First(), codeElement)}(),");
+            writer.WriteLine($"\"{mappedType.Key.SanitizeDoubleQuote()}\" => new {conventions.GetTypeString(mappedType.Value.AllTypes.First(), codeElement)}(),");
         }
         writer.WriteLine($"_ => new {parentClass.GetFullName()}(),");
         writer.CloseBlock("};");
@@ -136,7 +136,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                 if (propertyType.TypeDefinition is CodeClass && !propertyType.IsCollection)
                 {
                     var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(propertyType.Name, StringComparison.OrdinalIgnoreCase));
-                    writer.WriteLine($"{(includeElse ? "else " : string.Empty)}if(\"{mappedType.Key}\".Equals({DiscriminatorMappingVarName}, StringComparison.OrdinalIgnoreCase))");
+                    writer.WriteLine($"{(includeElse ? "else " : string.Empty)}if(\"{mappedType.Key.SanitizeDoubleQuote()}\".Equals({DiscriminatorMappingVarName}, StringComparison.OrdinalIgnoreCase))");
                     writer.WriteBlock(lines: $"{ResultVarName}.{property.Name.ToFirstCharacterUpperCase()} = new {conventions.GetTypeString(propertyType, codeElement)}();");
                 }
                 else if (propertyType.TypeDefinition is CodeClass && propertyType.IsCollection || propertyType.TypeDefinition is null || propertyType.TypeDefinition is CodeEnum)
@@ -202,7 +202,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         var parseNodeParameter = codeElement.Parameters.OfKind(CodeParameterKind.ParseNode) ?? throw new InvalidOperationException("Factory method should have a ParseNode parameter");
 
         if (parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType)
-            writer.WriteLine($"var {DiscriminatorMappingVarName} = {parseNodeParameter.Name.ToFirstCharacterLowerCase()}.GetChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\")?.GetStringValue();");
+            writer.WriteLine($"var {DiscriminatorMappingVarName} = {parseNodeParameter.Name.ToFirstCharacterLowerCase()}.GetChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\")?.GetStringValue();");
 
         if (parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForInheritedType)
             WriteFactoryMethodBodyForInheritedModel(codeElement, parentClass, writer);

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -228,8 +228,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         WriteSerializationRegistration(method.DeserializerModules, writer, "RegisterDefaultDeserializer");
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
+            var sanitizedBaseUrl = method.BaseUrl.SanitizeDoubleQuote();
             writer.WriteLine($"if (string.IsNullOrEmpty({requestAdapterPropertyName}.BaseUrl))");
-            writer.WriteBlock(lines: $"{requestAdapterPropertyName}.BaseUrl = \"{method.BaseUrl}\";");
+            writer.WriteBlock(lines: $"{requestAdapterPropertyName}.BaseUrl = \"{sanitizedBaseUrl}\";");
             if (pathParametersProperty != null)
                 writer.WriteLine($"{pathParametersProperty.Name.ToFirstCharacterUpperCase()}.TryAdd(\"baseurl\", {requestAdapterPropertyName}.BaseUrl);");
         }
@@ -355,7 +356,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name, StringComparer.Ordinal))
         {
-            writer.WriteLine($"{{ \"{otherProp.WireName}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type, codeElement)}; }} }},");
+            writer.WriteLine($"{{ \"{otherProp.WireName.SanitizeDoubleQuote()}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type, codeElement)}; }} }},");
         }
         writer.CloseBlock("};");
     }
@@ -434,7 +435,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
         if (currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate) is not CodeProperty urlTemplateProperty) throw new InvalidOperationException("url template property cannot be null");
 
         var operationName = codeElement.HttpMethod.ToString();
-        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride}\"" : GetPropertyCall(urlTemplateProperty, "string.Empty");
+        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride.SanitizeDoubleQuote()}\"" : GetPropertyCall(urlTemplateProperty, "string.Empty");
         writer.WriteLine($"var {RequestInfoVarName} = new RequestInformation(Method.{operationName?.ToUpperInvariant()}, {urlTemplateValue}, {GetPropertyCall(urlTemplateParamsProperty, "string.Empty")});");
 
         if (requestParams.requestConfiguration != null)
@@ -488,7 +489,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                                         .OrderBy(static x => x.Name))
         {
             var serializationMethodName = GetSerializationMethodName(otherProp.Type, method);
-            writer.WriteLine($"writer.{serializationMethodName}(\"{otherProp.WireName}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
+            writer.WriteLine($"writer.{serializationMethodName}(\"{otherProp.WireName.SanitizeDoubleQuote()}\", {otherProp.Name.ToFirstCharacterUpperCase()});");
         }
     }
     private void WriteSerializerBodyForUnionModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -603,15 +603,15 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                 else if (currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl) is CodeParameter rawUrlParameter)
                     thirdParameterName = $", {rawUrlParameter.Name}";
                 else if (parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty && !string.IsNullOrEmpty(pathParametersProperty.DefaultValue))
-                    thirdParameterName = $", {pathParametersProperty.DefaultValue}";
+                    thirdParameterName = $", {pathParametersProperty.DefaultValue.SanitizeQuotedStringLiteral()}";
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.RequestAdapter) is CodeParameter requestAdapterParameter)
                 {
-                    return $" : base({requestAdapterParameter.Name.ToFirstCharacterLowerCase()}, {urlTemplateProperty.DefaultValue}{thirdParameterName})";
+                    return $" : base({requestAdapterParameter.Name.ToFirstCharacterLowerCase()}, {urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{thirdParameterName})";
                 }
                 else if (parentClass.StartBlock?.Inherits?.Name?.Contains("CliRequestBuilder", StringComparison.Ordinal) == true)
                 {
                     // CLI uses a different base class.
-                    return $" : base({urlTemplateProperty.DefaultValue}{thirdParameterName})";
+                    return $" : base({urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{thirdParameterName})";
                 }
             }
             return " : base()";

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -50,7 +50,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
                 break;
             case CodePropertyKind.AdditionalData when backingStoreProperty != null:
             case CodePropertyKind.Custom when backingStoreProperty != null:
-                var backingStoreKey = codeElement.WireName;
+                var backingStoreKey = codeElement.WireName.SanitizeDoubleQuote();
                 var nullableOp = !codeElement.IsOfKind(CodePropertyKind.AdditionalData) ? "?" : string.Empty;
                 var defaultPropertyValue = codeElement.IsOfKind(CodePropertyKind.AdditionalData) ? " ?? new Dictionary<string, object>()" : string.Empty;
                 writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()}");
@@ -66,7 +66,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
                     writer.WriteLine($"public override {propertyType} {codeElement.Name.ToFirstCharacterUpperCase()} {{ get => base.Message; }}");
                 break;
             case CodePropertyKind.QueryParameter when codeElement.IsNameEscaped:
-                writer.WriteLine($"[QueryParameter(\"{codeElement.SerializationName}\")]");
+                writer.WriteLine($"[QueryParameter(\"{codeElement.SerializationName.SanitizeDoubleQuote()}\")]");
                 goto default;
             case CodePropertyKind.QueryParameters:
                 defaultValue = $" = new {propertyType}();";

--- a/src/Kiota.Builder/Writers/Dart/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeEnumWriter.cs
@@ -28,7 +28,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, DartConventionService>
         {
             conventions.WriteShortDescription(option, writer);
 
-            var serializationName = option.SerializationName;
+            var serializationName = DartConventionService.SanitizeDartSingleQuoteLiteral(option.SerializationName);
             writer.WriteLine($"{option.Name}('{serializationName}'){(option == lastOption ? ";" : ",")}");
         }
         writer.WriteLine($"const {enumName}(this.value);");

--- a/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
@@ -268,8 +268,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
+            var sanitizedBaseUrl = SanitizeDartSingleQuoteLiteral(method.BaseUrl);
             writer.StartBlock($"if ({requestAdapterPropertyName}.baseUrl == null || {requestAdapterPropertyName}.baseUrl!.isEmpty) {{");
-            writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = '{method.BaseUrl}';");
+            writer.WriteLine($"{requestAdapterPropertyName}.baseUrl = '{sanitizedBaseUrl}';");
             writer.CloseBlock();
             if (pathParametersProperty != null)
                 writer.WriteLine($"{pathParametersProperty.Name}['baseurl'] = {requestAdapterPropertyName}.baseUrl;");
@@ -427,7 +428,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
                     .Where(x => !x.ExistsInBaseType && !conventions.ErrorClassPropertyExistsInSuperClass(x))
                     .OrderBy(static x => x.Name)
                     .Select(x =>
-                        $"{DeserializerVarName}['{x.WireName}'] = (node) => {x.Name} = node.{GetDeserializationMethodName(x.Type, codeElement)};")
+                        $"{DeserializerVarName}['{SanitizeDartSingleQuoteLiteral(x.WireName)}'] = (node) => {x.Name} = node.{GetDeserializationMethodName(x.Type, codeElement)};")
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
         }
@@ -507,7 +508,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         if (currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate) is not CodeProperty urlTemplateProperty) throw new InvalidOperationException("url template property cannot be null");
 
         var operationName = codeElement.HttpMethod.ToString();
-        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{codeElement.UrlTemplateOverride}'" : GetPropertyCall(urlTemplateProperty, "''");
+        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{SanitizeDartSingleQuoteLiteral(codeElement.UrlTemplateOverride)}'" : GetPropertyCall(urlTemplateProperty, "''");
         writer.WriteLine($"var {RequestInfoVarName} = RequestInformation(httpMethod : HttpMethod.{operationName?.ToLowerInvariant()}, {urlTemplateProperty.Name} : {urlTemplateValue}, {urlTemplateParamsProperty.Name} :  {GetPropertyCall(urlTemplateParamsProperty, "string.Empty")});");
 
         if (requestParams.requestConfiguration != null && requestParams.requestConfiguration.Type is CodeType paramType)
@@ -567,7 +568,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
             {
                 secondArgument = $", (e) => e?.value";
             }
-            writer.WriteLine($"writer.{serializationMethodName}('{otherProp.WireName}', {booleanValue}{otherProp.Name}{secondArgument});");
+            writer.WriteLine($"writer.{serializationMethodName}('{SanitizeDartSingleQuoteLiteral(otherProp.WireName)}', {booleanValue}{otherProp.Name}{secondArgument});");
         }
     }
     private void WriteSerializerBodyForUnionModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer)
@@ -787,7 +788,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         foreach (CodeProperty property in parentClass.Properties)
         {
             var key = property.IsNameEscaped ? property.SerializationName : property.Name;
-            writer.WriteLine($"'{key}' : {property.Name},");
+            writer.WriteLine($"'{SanitizeDartSingleQuoteLiteral(key)}' : {property.Name},");
         }
         writer.CloseBlock("};");
     }

--- a/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
@@ -321,7 +321,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
                     defaultValue = defaultValue.Trim('"');
                     if (propertyType2.Name.Equals("String", StringComparison.Ordinal))
                     {
-                        defaultValue = $"'{defaultValue}'";
+                        if (defaultValue.StartsWith('\'') && defaultValue.EndsWith('\'') && defaultValue.Length > 1)
+                            defaultValue = defaultValue[1..^1];
+                        defaultValue = $"'{SanitizeDartSingleQuoteLiteral(defaultValue)}'";
                     }
                 }
                 writer.WriteLine($"{propWithDefault.Name} = {defaultValue}{separator}");
@@ -679,15 +681,15 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
                 else if (currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl) is CodeParameter rawUrlParameter)
                     thirdParameterName = $", {{RequestInformation.rawUrlKey : {rawUrlParameter.Name}}}";
                 else if (parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty && !string.IsNullOrEmpty(pathParametersProperty.DefaultValue))
-                    thirdParameterName = $", {pathParametersProperty.DefaultValue}";
+                    thirdParameterName = $", {pathParametersProperty.DefaultValue.SanitizeQuotedStringLiteral()}";
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.RequestAdapter) is CodeParameter requestAdapterParameter)
                 {
-                    return $" : super({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue}{thirdParameterName})";
+                    return $" : super({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{thirdParameterName})";
                 }
                 else if (parentClass.StartBlock?.Inherits?.Name?.Contains("CliRequestBuilder", StringComparison.Ordinal) == true)
                 {
                     // CLI uses a different base class.
-                    return $" : super({urlTemplateProperty.DefaultValue}{thirdParameterName})";
+                    return $" : super({urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{thirdParameterName})";
                 }
             }
             return " : super()";

--- a/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
@@ -68,6 +68,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         var hasBody = codeElement.Parameters.Any(p => !p.IsOfKind(CodeParameterKind.RequestAdapter) && !p.IsOfKind(CodeParameterKind.PathParameters));
         return isConstructor && parentClass.IsOfKind(CodeClassKind.RequestBuilder) && !codeElement.IsOfKind(CodeMethodKind.ClientConstructor) && (!hasBody || codeElement.IsOfKind(CodeMethodKind.RawUrlConstructor));
     }
+    private static string SanitizeDartSingleQuoteLiteral(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeSingleQuote().Replace("$", "\\$", StringComparison.Ordinal);
 
     protected virtual void HandleMethodKind(CodeMethod codeElement, LanguageWriter writer, bool doesInherit, CodeClass parentClass, bool isVoid)
     {
@@ -148,7 +150,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         writer.StartBlock($"return switch({DiscriminatorMappingVarName}) {{");
         foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings)
         {
-            writer.WriteLine($"'{mappedType.Key}' => {conventions.GetTypeString(mappedType.Value.AllTypes.First(), codeElement)}(),");
+            writer.WriteLine($"'{SanitizeDartSingleQuoteLiteral(mappedType.Key)}' => {conventions.GetTypeString(mappedType.Value.AllTypes.First(), codeElement)}(),");
         }
         writer.WriteLine($"_ => {parentClass.Name}(),");
         writer.CloseBlock("};");
@@ -160,8 +162,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
 
         if (parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => x.Type is CodeType cType && cType.TypeDefinition is CodeClass && !cType.IsCollection).Any())
         {
-            var discriminatorPropertyName = parentClass.DiscriminatorInformation.DiscriminatorPropertyName;
-            discriminatorPropertyName = discriminatorPropertyName.StartsWith('$') ? "\\" + discriminatorPropertyName : discriminatorPropertyName;
+            var discriminatorPropertyName = SanitizeDartSingleQuoteLiteral(parentClass.DiscriminatorInformation.DiscriminatorPropertyName);
             writer.WriteLine($"var {DiscriminatorMappingVarName} = {parseNodeParameter.Name}.getChildNode('{discriminatorPropertyName}')?.getStringValue();");
         }
         var includeElse = false;
@@ -173,7 +174,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
                 if (propertyType.TypeDefinition is CodeClass && !propertyType.IsCollection)
                 {
                     var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(propertyType.Name, StringComparison.OrdinalIgnoreCase));
-                    writer.StartBlock($"{(includeElse ? "else " : string.Empty)}if('{mappedType.Key}' == {DiscriminatorMappingVarName}) {{");
+                    writer.StartBlock($"{(includeElse ? "else " : string.Empty)}if('{SanitizeDartSingleQuoteLiteral(mappedType.Key)}' == {DiscriminatorMappingVarName}) {{");
                     writer.WriteLine($"{ResultVarName}.{property.Name} = {conventions.GetTypeString(propertyType, codeElement)}();");
                     writer.CloseBlock();
                 }
@@ -236,8 +237,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
 
         if (parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForInheritedType)
         {
-            var discriminatorPropertyName = parentClass.DiscriminatorInformation.DiscriminatorPropertyName;
-            discriminatorPropertyName = discriminatorPropertyName.StartsWith('$') ? "\\" + discriminatorPropertyName : discriminatorPropertyName;
+            var discriminatorPropertyName = SanitizeDartSingleQuoteLiteral(parentClass.DiscriminatorInformation.DiscriminatorPropertyName);
             writer.WriteLine($"var {DiscriminatorMappingVarName} = {parseNodeParameter.Name}.getChildNode('{discriminatorPropertyName}')?.getStringValue();");
             WriteFactoryMethodBodyForInheritedModel(codeElement, parentClass, writer);
         }
@@ -517,22 +517,23 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         }
 
         if (codeElement.ShouldAddAcceptHeader)
-            writer.WriteLine($"{RequestInfoVarName}.headers.put('Accept', '{codeElement.AcceptHeaderValue}');");
+            writer.WriteLine($"{RequestInfoVarName}.headers.put('Accept', '{SanitizeDartSingleQuoteLiteral(codeElement.AcceptHeaderValue)}');");
         if (requestParams.requestBody != null)
         {
             var suffix = requestParams.requestBody.Type.IsCollection ? "Collection" : string.Empty;
+            var requestBodyContentType = SanitizeDartSingleQuoteLiteral(codeElement.RequestBodyContentType);
             if (requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
             {
                 if (requestParams.requestContentType is not null)
                     writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name}, {requestParams.requestContentType.Name});");
                 else if (!string.IsNullOrEmpty(codeElement.RequestBodyContentType))
-                    writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name}, '{codeElement.RequestBodyContentType}');");
+                    writer.WriteLine($"{RequestInfoVarName}.setStreamContent({requestParams.requestBody.Name}, '{requestBodyContentType}');");
             }
             else if (currentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter) is CodeProperty requestAdapterProperty)
                 if (requestParams.requestBody.Type is CodeType bodyType && (bodyType.TypeDefinition is CodeClass || bodyType.Name.Equals("MultipartBody", StringComparison.OrdinalIgnoreCase)))
-                    writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable{suffix}({requestAdapterProperty.Name}, '{codeElement.RequestBodyContentType}', {requestParams.requestBody.Name});");
+                    writer.WriteLine($"{RequestInfoVarName}.setContentFromParsable{suffix}({requestAdapterProperty.Name}, '{requestBodyContentType}', {requestParams.requestBody.Name});");
                 else
-                    writer.WriteLine($"{RequestInfoVarName}.setContentFromScalar{suffix}({requestAdapterProperty.Name}, '{codeElement.RequestBodyContentType}', {requestParams.requestBody.Name});");
+                    writer.WriteLine($"{RequestInfoVarName}.setContentFromScalar{suffix}({requestAdapterProperty.Name}, '{requestBodyContentType}', {requestParams.requestBody.Name});");
         }
 
         writer.WriteLine($"return {RequestInfoVarName};");

--- a/src/Kiota.Builder/Writers/Dart/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodePropertyWriter.cs
@@ -48,7 +48,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, DartConvention
                 break;
             case CodePropertyKind.AdditionalData when backingStoreProperty != null:
             case CodePropertyKind.Custom when backingStoreProperty != null:
-                var backingStoreKey = codeElement.WireName;
+                var backingStoreKey = DartConventionService.SanitizeDartSingleQuoteLiteral(codeElement.WireName);
                 var defaultIfNotNullable = propertyType.EndsWith('?') ? string.Empty : codeElement.IsOfKind(CodePropertyKind.AdditionalData) ? " ?? {}" : $" ?? {codeElement.DefaultValue}";
                 writer.StartBlock($"{propertyType} get {conventions.GetAccessModifierPrefix(codeElement.Access)}{propertyName} {{");
                 writer.WriteLine($"return {backingStoreProperty.Name}.get<{propertyType}>('{backingStoreKey}'){defaultIfNotNullable};");
@@ -62,7 +62,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, DartConvention
                 writer.WriteLine("@override");
                 goto default;
             case CodePropertyKind.QueryParameter when codeElement.IsNameEscaped:
-                writer.WriteLine($"/// @QueryParameter('{codeElement.SerializationName}')");
+                writer.WriteLine($"/// @QueryParameter('{DartConventionService.SanitizeDartSingleQuoteLiteral(codeElement.SerializationName)}')");
                 goto default;
             case CodePropertyKind.QueryParameters:
                 defaultValue = $" = {propertyType}()";

--- a/src/Kiota.Builder/Writers/Dart/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodePropertyWriter.cs
@@ -49,7 +49,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, DartConvention
             case CodePropertyKind.AdditionalData when backingStoreProperty != null:
             case CodePropertyKind.Custom when backingStoreProperty != null:
                 var backingStoreKey = DartConventionService.SanitizeDartSingleQuoteLiteral(codeElement.WireName);
-                var defaultIfNotNullable = propertyType.EndsWith('?') ? string.Empty : codeElement.IsOfKind(CodePropertyKind.AdditionalData) ? " ?? {}" : $" ?? {codeElement.DefaultValue}";
+                var defaultIfNotNullable = propertyType.EndsWith('?') ? string.Empty : codeElement.IsOfKind(CodePropertyKind.AdditionalData) ? " ?? {}" : $" ?? {codeElement.DefaultValue.SanitizeQuotedStringLiteral()}";
                 writer.StartBlock($"{propertyType} get {conventions.GetAccessModifierPrefix(codeElement.Access)}{propertyName} {{");
                 writer.WriteLine($"return {backingStoreProperty.Name}.get<{propertyType}>('{backingStoreKey}'){defaultIfNotNullable};");
                 writer.CloseBlock();

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -29,6 +29,8 @@ public class DartConventionService : CommonLanguageConventionService
         originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
             .Replace("\n", string.Empty, StringComparison.Ordinal)
             .Replace("\t", " ", StringComparison.Ordinal);
+    internal static string SanitizeDartDoubleQuoteLiteral(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeDoubleQuote().Replace("$", "\\$", StringComparison.Ordinal);
 
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
@@ -84,7 +86,11 @@ public class DartConventionService : CommonLanguageConventionService
                     writer.WriteLine($"{DocCommentPrefix}{additionalComment}");
 
             if (documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{DocCommentPrefix} [{documentation.DocumentationLabel}]({documentation.DocumentationLink})");
+            {
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString() ?? string.Empty);
+                writer.WriteLine($"{DocCommentPrefix} [{documentationLabel}]({documentationLink})");
+            }
         }
     }
 
@@ -276,7 +282,8 @@ public class DartConventionService : CommonLanguageConventionService
         var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
-        return $"@Deprecated(\"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!))}{versionComment}{dateComment}{removalComment}\")";
+        var deprecationMessage = $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}";
+        return $"@Deprecated(\"{SanitizeDartDoubleQuoteLiteral(deprecationMessage)}\")";
     }
     internal void WriteDeprecationAttribute(IDeprecableElement element, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -267,9 +267,10 @@ public class DartConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var parameterType = GetTypeString(parameter.Type, targetElement, true, parameter.Optional);
+        var sanitizedDefaultValue = parameter.DefaultValue.SanitizeQuotedStringLiteral();
         var defaultValue = parameter switch
         {
-            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {parameter.DefaultValue}",
+            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {sanitizedDefaultValue}",
             _ when nameof(String).Equals(parameterType, StringComparison.OrdinalIgnoreCase) && parameter.Optional => " = \"\"",
             _ => string.Empty,
         };

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -31,6 +31,8 @@ public class DartConventionService : CommonLanguageConventionService
             .Replace("\t", " ", StringComparison.Ordinal);
     internal static string SanitizeDartDoubleQuoteLiteral(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeDoubleQuote().Replace("$", "\\$", StringComparison.Ordinal);
+    internal static string SanitizeDartSingleQuoteLiteral(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeSingleQuote().Replace("$", "\\$", StringComparison.Ordinal);
 
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
@@ -143,7 +145,7 @@ public class DartConventionService : CommonLanguageConventionService
                 urlTplRef = TempDictionaryVarName;
                 writer.WriteLine($"var {urlTplRef} = Map.of({pathParametersProp.Name.ToFirstCharacterLowerCase()});");
                 foreach (var param in customParameters)
-                    writer.WriteLine($"{urlTplRef}.putIfAbsent('{param.SerializationName}', () => {param.Name.ToFirstCharacterLowerCase()});");
+                    writer.WriteLine($"{urlTplRef}.putIfAbsent('{SanitizeDartSingleQuoteLiteral(param.SerializationName)}', () => {param.Name.ToFirstCharacterLowerCase()});");
             }
             writer.WriteLine($"{prefix}{returnType}({urlTplRef}, {requestAdapterProp.Name.ToFirstCharacterLowerCase()}{pathParametersSuffix});");
         }
@@ -170,7 +172,7 @@ public class DartConventionService : CommonLanguageConventionService
                     else
                         nullCheck = $"if ({identName} != null) ";
                 }
-                return $"{nullCheck}{varName}[\"{name}\"]={identName};";
+                return $"{nullCheck}{varName}[\"{SanitizeDartDoubleQuoteLiteral(name)}\"]={identName};";
             }).ToArray());
         }
     }

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -24,6 +24,11 @@ public class DartConventionService : CommonLanguageConventionService
 
     private const string ReferenceTypePrefix = "[";
     private const string ReferenceTypeSuffix = "]";
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
+        string.IsNullOrEmpty(originalDescription) ? string.Empty :
+        originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
 
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
@@ -32,7 +37,7 @@ public class DartConventionService : CommonLanguageConventionService
         if (!element.Documentation.DescriptionAvailable) return false;
         if (element is not CodeElement codeElement) return false;
 
-        var description = element.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, codeElement), ReferenceTypePrefix, ReferenceTypeSuffix);
+        var description = element.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, codeElement), ReferenceTypePrefix, ReferenceTypeSuffix, RemoveInvalidDescriptionCharacters);
         writer.WriteLine($"{DocCommentPrefix} {description}");
 
         return true;
@@ -41,7 +46,7 @@ public class DartConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(element);
-        var description = element.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, element), ReferenceTypePrefix, ReferenceTypeSuffix);
+        var description = element.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, element), ReferenceTypePrefix, ReferenceTypeSuffix, RemoveInvalidDescriptionCharacters);
         writer.WriteLine($"{DocCommentPrefix} {ReferenceTypePrefix}{element.Name}{ReferenceTypeSuffix} {description}");
     }
 
@@ -69,7 +74,7 @@ public class DartConventionService : CommonLanguageConventionService
         {
             if (documentation.DescriptionAvailable)
             {
-                var description = documentedElement.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, element), ReferenceTypePrefix, ReferenceTypeSuffix);
+                var description = documentedElement.Documentation.GetDescription(x => GetTypeReferenceForDocComment(x, element), ReferenceTypePrefix, ReferenceTypeSuffix, RemoveInvalidDescriptionCharacters);
                 writer.WriteLine($"{DocCommentPrefix}{description}");
             }
             foreach (var additionalRemark in remarks)
@@ -99,7 +104,7 @@ public class DartConventionService : CommonLanguageConventionService
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         return [
             $"@deprecated",
-            $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!))}{versionComment}{dateComment}{removalComment}"
+            $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}"
         ];
     }
 

--- a/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
+++ b/src/Kiota.Builder/Writers/Dart/DartConventionService.cs
@@ -105,7 +105,7 @@ public class DartConventionService : CommonLanguageConventionService
     {
         if (element.Deprecation is null || !element.Deprecation.IsDeprecated) return Array.Empty<string>();
 
-        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
+        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {RemoveInvalidDescriptionCharacters(element.Deprecation.Version)}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         return [
@@ -279,7 +279,7 @@ public class DartConventionService : CommonLanguageConventionService
     {
         if (element.Deprecation is null || !element.Deprecation.IsDeprecated) return string.Empty;
 
-        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
+        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {RemoveInvalidDescriptionCharacters(element.Deprecation.Version)}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var deprecationMessage = $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}";

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -44,7 +44,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
         foreach (var item in enumOptions)
         {
             if (item.Documentation.DescriptionAvailable)
-                writer.WriteLine($"// {item.Documentation.DescriptionTemplate}");
+                writer.WriteLine($"// {GoConventionService.RemoveInvalidDescriptionCharacters(item.Documentation.DescriptionTemplate)}");
 
             if (isMultiValue)
                 writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()} = {(int)Math.Pow(2, power)}");

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -72,7 +72,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
             writer.StartBlock($"func (i {typeName}) String() string {{");
             writer.WriteLine("var values []string");
             var literalOptions = enumOptions
-                .Select(x => $"\"{x.WireName}\"")
+                .Select(x => $"\"{x.WireName.SanitizeDoubleQuote()}\"")
                 .Aggregate((x, y) => x + ", " + y);
             writer.WriteLine($"options := []string{{{literalOptions}}}");
             writer.StartBlock($"for p := 0; p < {enumOptions.Count}; p++ {{");
@@ -88,7 +88,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
         {
             writer.StartBlock($"func (i {typeName}) String() string {{");
             var literalOptions = enumOptions
-                .Select(x => $"\"{x.WireName}\"")
+                .Select(x => $"\"{x.WireName.SanitizeDoubleQuote()}\"")
                 .Aggregate((x, y) => x + ", " + y);
             writer.WriteLine($"return []string{{{literalOptions}}}[i]");
             writer.CloseBlock();
@@ -110,7 +110,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
             writer.StartBlock("switch str {");
             foreach (var item in enumOptions)
             {
-                writer.StartBlock($"case \"{item.WireName}\":");
+                writer.StartBlock($"case \"{item.WireName.SanitizeDoubleQuote()}\":");
                 writer.WriteLine($"result |= {item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
                 writer.DecreaseIndent();
             }
@@ -121,7 +121,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
             writer.StartBlock("switch v {");
             foreach (var item in enumOptions)
             {
-                writer.StartBlock($"case \"{item.WireName}\":");
+                writer.StartBlock($"case \"{item.WireName.SanitizeDoubleQuote()}\":");
                 writer.WriteLine($"result = {item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()}");
                 writer.DecreaseIndent();
             }

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -125,7 +125,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
         if (writeDiscriminatorValueRead)
         {
-            writer.WriteLine($"mappingValueNode, err := {parseNodeParameter.Name.ToFirstCharacterLowerCase()}.GetChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\")");
+            writer.WriteLine($"mappingValueNode, err := {parseNodeParameter.Name.ToFirstCharacterLowerCase()}.GetChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\")");
             WriteReturnError(writer, codeElement.ReturnType.Name);
             writer.StartBlock("if mappingValueNode != nil {");
             writer.WriteLines($"{DiscriminatorMappingVarName}, err := mappingValueNode.GetStringValue()");
@@ -166,7 +166,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         writer.StartBlock($"switch *{DiscriminatorMappingVarName} {{");
         foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings)
         {
-            writer.WriteLine($"case \"{mappedType.Key}\":");
+            writer.WriteLine($"case \"{mappedType.Key.SanitizeDoubleQuote()}\":");
             writer.IncreaseIndent();
             writer.WriteLine($"return {conventions.GetImportedStaticMethodName(mappedType.Value, parentClass)}(), nil");
             writer.DecreaseIndent();
@@ -254,7 +254,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                     IsNullable = propertyType.IsNullable,
                 };
             var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(propertyType.Name, StringComparison.OrdinalIgnoreCase));
-            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if {conventions.StringsHash}.EqualFold(*{DiscriminatorMappingVarName}, \"{mappedType.Key}\") {{");
+            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if {conventions.StringsHash}.EqualFold(*{DiscriminatorMappingVarName}, \"{mappedType.Key.SanitizeDoubleQuote()}\") {{");
             writer.WriteLine($"{ResultVarName}.{property.Setter!.Name.ToFirstCharacterUpperCase()}({conventions.GetImportedStaticMethodName(propertyType, codeElement)}())");
             writer.DecreaseIndent();
             if (!includeElse)

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -491,7 +491,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                     $"val , err :=  m.{backingStore.NamePrefix}{backingStore.Name.ToFirstCharacterLowerCase()}.Get(\"{codeElement.AccessedProperty.Name.ToFirstCharacterLowerCase()}\")");
                 writer.WriteBlock("if err != nil {", "}", "panic(err)");
                 writer.WriteBlock("if val == nil {", "}",
-                    $"var value = {codeElement.AccessedProperty.DefaultValue};",
+                    $"var value = {codeElement.AccessedProperty.DefaultValue.SanitizeQuotedStringLiteral()};",
                     $"m.Set{codeElement.AccessedProperty.Name?.ToFirstCharacterUpperCase()}(value);");
 
                 writer.WriteLine($"return val.({conventions.GetTypeString(codeElement.AccessedProperty.Type, parentClass)})");
@@ -553,7 +553,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                 var pathParametersValue = ", map[string]string{}";
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.PathParameters) is CodeParameter pathParametersParameter)
                     pathParametersValue = $", {pathParametersParameter.Name.ToFirstCharacterLowerCase()}";
-                writer.WriteLine($"{parentClassName}: *{newMethodName}({requestAdapterParameter.Name.ToFirstCharacterLowerCase()}, {urlTemplateProperty.DefaultValue}{pathParametersValue}),");
+                writer.WriteLine($"{parentClassName}: *{newMethodName}({requestAdapterParameter.Name.ToFirstCharacterLowerCase()}, {urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{pathParametersValue}),");
             }
             else
                 writer.WriteLine($"{parentClassName}: *{newMethodName}(),");
@@ -565,7 +565,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"m.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue};");
+            writer.WriteLine($"m.{propWithDefault.NamePrefix}{propWithDefault.Name.ToFirstCharacterLowerCase()} = {propWithDefault.DefaultValue.SanitizeQuotedStringLiteral()};");
         }
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData, CodePropertyKind.Custom) //additional data and custom rely on accessors
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
@@ -593,6 +593,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
                 else if (propWithDefault.Type is CodeType propType && propType.Name.Equals("boolean", StringComparison.OrdinalIgnoreCase))
                 {
                     defaultValue = defaultValue.TrimQuotes();
+                }
+                else
+                {
+                    defaultValue = defaultValue.SanitizeQuotedStringLiteral();
                 }
                 writer.WriteLine($"{defaultValueReference} := {defaultValue}");
                 defaultValueReference = $"&{defaultValueReference}";

--- a/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeMethodWriter.cs
@@ -518,7 +518,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
             writer.StartBlock($"if m.{requestAdapterPropertyName}.GetBaseUrl() == \"\" {{");
-            writer.WriteLine($"m.{requestAdapterPropertyName}.SetBaseUrl(\"{method.BaseUrl}\")");
+            writer.WriteLine($"m.{requestAdapterPropertyName}.SetBaseUrl(\"{method.BaseUrl.SanitizeDoubleQuote()}\")");
             writer.CloseBlock();
             if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty)
                 writer.WriteLine($"m.{BaseRequestBuilderVarName}.{pathParametersProperty.Name.ToFirstCharacterUpperCase()}[\"baseurl\"] = m.{requestAdapterPropertyName}.GetBaseUrl()");
@@ -714,7 +714,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
     private void WriteFieldDeserializer(CodeProperty property, LanguageWriter writer, CodeClass parentClass, string parsableImportSymbol)
     {
         if (property.Setter is null) return;
-        writer.StartBlock($"res[\"{property.WireName}\"] = func (n {parsableImportSymbol}) error {{");
+        writer.StartBlock($"res[\"{property.WireName.SanitizeDoubleQuote()}\"] = func (n {parsableImportSymbol}) error {{");
         var propertyTypeImportName = conventions.GetTypeString(property.Type, parentClass, false, false);
         var deserializationMethodName = GetDeserializationMethodName(property.Type, parentClass);
         writer.WriteLine($"val, err := n.{deserializationMethodName}");
@@ -900,7 +900,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
 
         var requestAdapterPropertyName = BaseRequestBuilderVarName + "." + parentClass.GetPropertyOfKind(CodePropertyKind.RequestAdapter)?.Name.ToFirstCharacterUpperCase();
         var contextParameterName = codeElement.Parameters.OfKind(CodeParameterKind.Cancellation)?.Name.ToFirstCharacterLowerCase();
-        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride}\"" : GetPropertyCall(urlTemplateProperty, "\"\"");
+        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride.SanitizeDoubleQuote()}\"" : GetPropertyCall(urlTemplateProperty, "\"\"");
         writer.WriteLine($"{RequestInfoVarName} := {conventions.AbstractionsHash}.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters({conventions.AbstractionsHash}.{codeElement.HttpMethod.Value.ToString().ToUpperInvariant()}, {urlTemplateValue}, {GetPropertyCall(urlTemplateParamsProperty, "\"\"")})");
 
         if (ExcludeBackwardCompatible && requestParams.requestConfiguration is not null)
@@ -1009,7 +1009,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, GoConventionServic
     }
     private void WriteSerializationMethodCall(CodeTypeBase propType, CodeElement parentBlock, string serializationKey, string valueGet, bool shouldDeclareErrorVar, LanguageWriter writer, bool addBlockForErrorScope = true)
     {
-        serializationKey = $"\"{serializationKey}\"";
+        serializationKey = $"\"{serializationKey.SanitizeDoubleQuote()}\"";
         var errorPrefix = $"err {errorVarDeclaration(shouldDeclareErrorVar)}= writer.";
         var isEnum = propType is CodeType eType && eType.TypeDefinition is CodeEnum;
         var isComplexType = propType is CodeType cType && (cType.TypeDefinition is CodeClass || cType.TypeDefinition is CodeInterface || cType.Name.Equals(GoRefiner.UntypedNodeName, StringComparison.OrdinalIgnoreCase));

--- a/src/Kiota.Builder/Writers/Go/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodePropertyWriter.cs
@@ -23,7 +23,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, GoConventionSe
             case CodePropertyKind.ErrorMessageOverride:
                 throw new InvalidOperationException("Error message overrides are implemented with methods in Go.");
             case CodePropertyKind.QueryParameter when codeElement.IsNameEscaped:
-                suffix = $" `uriparametername:\"{codeElement.SerializationName}\"`";
+                suffix = $" \"uriparametername:\\\"{codeElement.SerializationName.SanitizeDoubleQuote()}\\\"\"";
                 goto default;
             default:
                 var returnType = codeElement.Parent is CodeElement parent ? conventions.GetTypeString(codeElement.Type, parent) : string.Empty;

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -247,7 +247,7 @@ public class GoConventionService : CommonLanguageConventionService
             };
             if (shouldCheckNullability)
                 writer.StartBlock($"if {p.Item3} != {defaultValue} {{");
-            writer.WriteLine($"{pathParametersTarget}[\"{p.Item2}\"] = {GetValueStringConversion(p.Item1.Name, pointerDereference + p.Item3)}");
+            writer.WriteLine($"{pathParametersTarget}[\"{p.Item2.SanitizeDoubleQuote()}\"] = {GetValueStringConversion(p.Item1.Name, pointerDereference + p.Item3)}");
             if (shouldCheckNullability)
                 writer.CloseBlock();
         }

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -206,9 +206,11 @@ public class GoConventionService : CommonLanguageConventionService
         if (documentation is null) return;
         if (documentation.ExternalDocumentationAvailable)
         {
-            WriteDescriptionItem($"[{documentation.DocumentationLabel}]", writer);
+            var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
+            var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString() ?? string.Empty);
+            WriteDescriptionItem($"[{documentationLabel}]", writer);
             WriteDescriptionItem(string.Empty, writer);
-            WriteDescriptionItem($"[{documentation.DocumentationLabel}]: {documentation.DocumentationLink}", writer);
+            WriteDescriptionItem($"[{documentationLabel}]: {documentationLink}", writer);
         }
     }
 #pragma warning disable CA1822 // Method should be static

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -281,7 +281,7 @@ public class GoConventionService : CommonLanguageConventionService
     {
         if (element.Deprecation is null || !element.Deprecation.IsDeprecated) return;
 
-        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
+        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {RemoveInvalidDescriptionCharacters(element.Deprecation.Version)}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         WriteDescriptionItem($"Deprecated: {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!).TrimStart('*'), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}", writer);

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -176,7 +176,7 @@ public class GoConventionService : CommonLanguageConventionService
         if (!element.Documentation.DescriptionAvailable) return false;
         if (element is not CodeElement codeElement) return false;
 
-        var description = element.Documentation.GetDescription(x => GetTypeString(x, codeElement, true, false));
+        var description = element.Documentation.GetDescription(x => GetTypeString(x, codeElement, true, false), normalizationFunc: RemoveInvalidDescriptionCharacters);
         if (!string.IsNullOrEmpty(prefix))
         {
             description = description.ToFirstCharacterLowerCase();
@@ -184,6 +184,11 @@ public class GoConventionService : CommonLanguageConventionService
         WriteDescriptionItem($"{prefix}{description}{suffix}", writer);
         return true;
     }
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
+        string.IsNullOrEmpty(originalDescription) ? string.Empty :
+        originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     public void WriteGeneratorComment(LanguageWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
@@ -277,6 +282,6 @@ public class GoConventionService : CommonLanguageConventionService
         var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
-        WriteDescriptionItem($"Deprecated: {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!).TrimStart('*'))}{versionComment}{dateComment}{removalComment}", writer);
+        WriteDescriptionItem($"Deprecated: {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!).TrimStart('*'), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}", writer);
     }
 }

--- a/src/Kiota.Builder/Writers/HTTP/CodeClassDeclarationWriter.cs
+++ b/src/Kiota.Builder/Writers/HTTP/CodeClassDeclarationWriter.cs
@@ -203,7 +203,7 @@ public class CodeClassDeclarationWriter(HttpConventionService conventionService)
         if (!string.IsNullOrEmpty(property.Name))
         {
             // Write the property documentation as a comment
-            writer.WriteLine($"# {property.Documentation.DescriptionTemplate}");
+            writer.WriteLine($"# {HttpConventionService.RemoveInvalidDescriptionCharacters(property.Documentation.DescriptionTemplate)}");
 
             // Write the property name and an assignment placeholder
             writer.WriteLine($"@{property.Name.ToFirstCharacterLowerCase()} = ");
@@ -233,7 +233,7 @@ public class CodeClassDeclarationWriter(HttpConventionService conventionService)
     {
 
         // Write the method documentation as a comment
-        writer.WriteLine($"# {method.Documentation.DescriptionTemplate}");
+        writer.WriteLine($"# {HttpConventionService.RemoveInvalidDescriptionCharacters(method.Documentation.DescriptionTemplate)}");
 
         // Build the actual URL string and replace all required fields (path and query) with placeholder variables
         var url = BuildUrlStringFromTemplate(

--- a/src/Kiota.Builder/Writers/HTTP/HttpConventionService.cs
+++ b/src/Kiota.Builder/Writers/HTTP/HttpConventionService.cs
@@ -22,11 +22,16 @@ public class HttpConventionService : CommonLanguageConventionService
         if (!element.Documentation.DescriptionAvailable) return false;
         if (element is not CodeElement codeElement) return false;
 
-        var description = element.Documentation.GetDescription(type => GetTypeString(type, codeElement));
+        var description = element.Documentation.GetDescription(type => GetTypeString(type, codeElement), normalizationFunc: RemoveInvalidDescriptionCharacters);
         writer.WriteLine($"{DocCommentPrefix} {prefix}{description}{prefix}");
 
         return true;
     }
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
+        string.IsNullOrEmpty(originalDescription) ? string.Empty :
+        originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     public override string GetAccessModifier(AccessModifier access)
     {
         return access switch

--- a/src/Kiota.Builder/Writers/HTTP/HttpConventionService.cs
+++ b/src/Kiota.Builder/Writers/HTTP/HttpConventionService.cs
@@ -81,9 +81,10 @@ public class HttpConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var parameterType = GetTypeString(parameter.Type, targetElement);
+        var sanitizedDefaultValue = parameter.DefaultValue.SanitizeQuotedStringLiteral();
         var defaultValue = parameter switch
         {
-            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {parameter.DefaultValue}",
+            _ when !string.IsNullOrEmpty(parameter.DefaultValue) => $" = {sanitizedDefaultValue}",
             _ when parameter.Optional => " = default",
             _ => string.Empty,
         };

--- a/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeEnumWriter.cs
@@ -29,7 +29,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, JavaConventionService>
         foreach (var enumOption in enumOptions)
         {
             conventions.WriteShortDescription(enumOption, writer);
-            writer.WriteLine($"{enumOption.Name}(\"{enumOption.SerializationName}\"){(enumOption == lastEnumOption ? ";" : ",")}");
+            writer.WriteLine($"{enumOption.Name}(\"{enumOption.SerializationName.SanitizeDoubleQuote()}\"){(enumOption == lastEnumOption ? ";" : ",")}");
         }
         writer.WriteLines("public final String value;",
             $"{enumName}(final String value) {{");
@@ -46,7 +46,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, JavaConventionService>
                         "switch(searchValue) {");
         writer.IncreaseIndent();
         writer.Write(enumOptions
-                    .Select(x => $"case \"{x.WireName}\": return {x.Name};")
+                    .Select(x => $"case \"{x.WireName.SanitizeDoubleQuote()}\": return {x.Name};")
                     .Aggregate((x, y) => $"{x}{LanguageWriter.NewLine}{writer.GetIndent()}{y}") + LanguageWriter.NewLine);
         writer.WriteLine("default: return null;");
         writer.CloseBlock();

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -307,8 +307,9 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         WriteSerializationRegistration(method.DeserializerModules, writer, "registerDefaultDeserializer");
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
+            var sanitizedBaseUrl = method.BaseUrl.SanitizeDoubleQuote();
             writer.StartBlock($"if ({requestAdapterPropertyName}.getBaseUrl() == null || {requestAdapterPropertyName}.getBaseUrl().isEmpty()) {{");
-            writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{method.BaseUrl}\");");
+            writer.WriteLine($"{requestAdapterPropertyName}.setBaseUrl(\"{sanitizedBaseUrl}\");");
             writer.CloseBlock();
             if (pathParametersProperty != null)
                 writer.WriteLine($"{pathParametersProperty.Name}.put(\"baseurl\", {requestAdapterPropertyName}.getBaseUrl());");
@@ -427,7 +428,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         foreach (var queryParam in allQueryParams)
         {
             var keyValue = queryParam.IsNameEscaped ? queryParam.SerializationName : queryParam.Name;
-            writer.WriteLine($"allQueryParams.put(\"{keyValue}\", {queryParam.Name});");
+            writer.WriteLine($"allQueryParams.put(\"{(keyValue ?? string.Empty).SanitizeDoubleQuote()}\", {queryParam.Name});");
         }
         writer.WriteLine("return allQueryParams;");
     }
@@ -507,7 +508,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
                     .Where(static x => !x.ExistsInBaseType && x.Setter != null)
                     .OrderBy(static x => x.Name)
                     .Select(x =>
-                        $"{DeserializerVarName}.put(\"{x.WireName}\", (n) -> {{ this.{x.Setter!.Name}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
+                        $"{DeserializerVarName}.put(\"{x.WireName.SanitizeDoubleQuote()}\", (n) -> {{ this.{x.Setter!.Name}(n.{GetDeserializationMethodName(x.Type, method)}); }});")
                     .ToList()
                     .ForEach(x => writer.WriteLine(x));
         }
@@ -586,7 +587,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         if (currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is not CodeProperty urlTemplateParamsProperty) throw new InvalidOperationException("url template params property cannot be null");
         if (currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate) is not CodeProperty urlTemplateProperty) throw new InvalidOperationException("url template property cannot be null");
 
-        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride}\"" : GetPropertyCall(urlTemplateProperty, "\"\"");
+        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"\"{codeElement.UrlTemplateOverride.SanitizeDoubleQuote()}\"" : GetPropertyCall(urlTemplateProperty, "\"\"");
         writer.WriteLine($"final RequestInformation {RequestInfoVarName} = new RequestInformation(HttpMethod.{codeElement.HttpMethod.ToString()?.ToUpperInvariant()}, {urlTemplateValue}, {GetPropertyCall(urlTemplateParamsProperty, "null")});");
 
         if (requestParams.requestConfiguration != null)
@@ -701,7 +702,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         if (inherits)
             writer.WriteLine("super.serialize(writer);");
         foreach (var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType && !x.ReadOnly))
-            WriteSerializationMethodCall(otherProp, method, writer, $"\"{otherProp.WireName}\"");
+            WriteSerializationMethodCall(otherProp, method, writer, $"\"{otherProp.WireName.SanitizeDoubleQuote()}\"");
     }
     private void WriteSerializationMethodCall(CodeProperty otherProp, CodeMethod method, LanguageWriter writer, string serializationKey, string? dataToSerialize = default)
     {

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -124,7 +124,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
         if (writeDiscriminatorValueRead)
         {
-            writer.WriteLine($"final ParseNode mappingValueNode = {parseNodeParameter.Name}.getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\");");
+            writer.WriteLine($"final ParseNode mappingValueNode = {parseNodeParameter.Name}.getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\");");
             writer.StartBlock("if (mappingValueNode != null) {");
             writer.WriteLine($"final String {DiscriminatorMappingVarName} = mappingValueNode.getStringValue();");
         }
@@ -184,7 +184,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
         writer.StartBlock($"switch ({varName}) {{");
         foreach (var mappedType in discriminatorMappings)
         {
-            writer.WriteLine($"case \"{mappedType.Key}\": return new {mappedType.Value.AllTypes.First().TypeDefinition?.Name}();");
+            writer.WriteLine($"case \"{mappedType.Key.SanitizeDoubleQuote()}\": return new {mappedType.Value.AllTypes.First().TypeDefinition?.Name}();");
         }
         writer.CloseBlock();
     }
@@ -246,7 +246,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
                     IsNullable = propertyType.IsNullable,
                 };
             var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(property.Type.Name, StringComparison.OrdinalIgnoreCase));
-            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (\"{mappedType.Key}\".equalsIgnoreCase({DiscriminatorMappingVarName})) {{");
+            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if (\"{mappedType.Key.SanitizeDoubleQuote()}\".equalsIgnoreCase({DiscriminatorMappingVarName})) {{");
             writer.WriteLine($"{ResultVarName}.{property.Setter!.Name}(new {conventions.GetTypeString(property.Type, codeElement, false)}());");
             writer.DecreaseIndent();
             if (!includeElse)

--- a/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodeMethodWriter.cs
@@ -336,7 +336,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
                     thirdParameterName = $", {pathParametersParameter.Name}";
                 else if (currentMethod.Parameters.OfKind(CodeParameterKind.RawUrl) is CodeParameter rawUrlParameter)
                     thirdParameterName = $", {rawUrlParameter.Name}";
-                writer.WriteLine($"super({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue}{thirdParameterName});");
+                writer.WriteLine($"super({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral()}{thirdParameterName});");
             }
             else
                 writer.WriteLine("super();");
@@ -346,7 +346,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name} = {propWithDefault.DefaultValue};");
+            writer.WriteLine($"this.{propWithDefault.NamePrefix}{propWithDefault.Name} = {propWithDefault.DefaultValue.SanitizeQuotedStringLiteral()};");
         }
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData, CodePropertyKind.Custom) //additional data and custom properties rely on accessors
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
@@ -355,7 +355,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
                                         .OrderBy(static x => x.Name))
         {
             var setterName = propWithDefault.SetterFromCurrentOrBaseType?.Name is string sName && !string.IsNullOrEmpty(sName) ? sName : $"set{propWithDefault.Name.ToFirstCharacterUpperCase()}";
-            var defaultValue = propWithDefault.DefaultValue;
+            var defaultValue = propWithDefault.DefaultValue.SanitizeQuotedStringLiteral();
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {
                 defaultValue = $"{enumDefinition.Name}.forValue({defaultValue})";
@@ -410,7 +410,7 @@ public partial class CodeMethodWriter : BaseElementWriter<CodeMethod, JavaConven
             {
                 writer.WriteLine($"{conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement)} value = this.{backingStore.Name}.get(\"{codeElement.AccessedProperty.Name}\");");
                 writer.StartBlock("if(value == null) {");
-                writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue};",
+                writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue.SanitizeQuotedStringLiteral()};",
                     $"this.set{codeElement.AccessedProperty?.Name.ToFirstCharacterUpperCase()}(value);");
                 writer.CloseBlock();
                 writer.WriteLine("return value;");

--- a/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Java/CodePropertyWriter.cs
@@ -31,7 +31,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, JavaConvention
                 writer.CloseBlock();
                 break;
             case CodePropertyKind.Headers or CodePropertyKind.Options when !string.IsNullOrEmpty(codeElement.DefaultValue):
-                defaultValue = $" = {codeElement.DefaultValue}";
+                defaultValue = $" = {codeElement.DefaultValue.SanitizeQuotedStringLiteral()}";
                 goto default;
             case CodePropertyKind.QueryParameters:
                 defaultValue = $" = new {returnType}()";

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -185,7 +185,7 @@ public partial class JavaConventionService : CommonLanguageConventionService
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         return [
             $"@deprecated",
-            $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!))}{versionComment}{dateComment}{removalComment}"
+            $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}"
         ];
     }
     internal void WriteDeprecatedAnnotation(CodeElement element, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -141,7 +141,11 @@ public partial class JavaConventionService : CommonLanguageConventionService
                     writer.WriteLine($"{DocCommentPrefix}{additionalComment}");
 
             if (documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{DocCommentPrefix}@see <a href=\"{documentation.DocumentationLink}\">{documentation.DocumentationLabel}</a>");
+            {
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString() ?? string.Empty);
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
+                writer.WriteLine($"{DocCommentPrefix}@see <a href=\"{documentationLink}\">{documentationLabel}</a>");
+            }
             writer.WriteLine(DocCommentEnd);
         }
     }

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -184,7 +184,7 @@ public partial class JavaConventionService : CommonLanguageConventionService
     {
         if (element.Deprecation is null || !element.Deprecation.IsDeprecated) return Array.Empty<string>();
 
-        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
+        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {RemoveInvalidDescriptionCharacters(element.Deprecation.Version.CleanupDescription())}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         return [

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -176,7 +176,7 @@ public partial class JavaConventionService : CommonLanguageConventionService
         }
         if (parameters.Length != 0)
             writer.WriteLines(parameters.Select(p =>
-                $"{varName}.put(\"{p.Item2}\", {p.Item3});"
+                $"{varName}.put(\"{(p.Item2 ?? string.Empty).SanitizeDoubleQuote()}\", {p.Item3});"
             ).ToArray());
     }
 #pragma warning restore CA1822 // Method should be static

--- a/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
@@ -48,7 +48,7 @@ public partial class CodeEnumWriter : BaseElementWriter<CodeEnum, PhpConventionS
         writer.IncreaseIndent();
         foreach (var enumProperty in enumProperties)
         {
-            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = \"{enumProperty.WireName}\";");
+            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = \"{enumProperty.WireName.SanitizeDoubleQuote()}\";");
         }
     }
     [GeneratedRegex(@"([A-Z]{1})", RegexOptions.Singleline, 500)]

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -248,7 +248,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
                 var key = string.IsNullOrEmpty(parameter.SerializationName)
                     ? parameter.Name
                     : parameter.SerializationName;
-                writer.WriteLine($"{UrlTemplateTempVarName}['{key}'] = ${parameter.Name.ToFirstCharacterLowerCase()};");
+                writer.WriteLine($"{UrlTemplateTempVarName}['{key.SanitizeSingleQuote()}'] = ${parameter.Name.ToFirstCharacterLowerCase()};");
             });
         if (pathParametersProperty != null)
             writer.WriteLine(
@@ -435,7 +435,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (extendsModelClass)
             writer.WriteLine("parent::serialize($writer);");
         foreach (var otherProp in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).Where(static x => !x.ExistsInBaseType && !x.ReadOnly))
-            WriteSerializationMethodCall(otherProp, writer, $"'{otherProp.WireName}'");
+            WriteSerializationMethodCall(otherProp, writer, $"'{otherProp.WireName.SanitizeSingleQuote()}'");
     }
 
     private string GetSerializationMethodName(CodeTypeBase propType)
@@ -668,7 +668,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             && property.Type is CodeType currentType
             && currentType.TypeDefinition == null)
         {
-            writer.StartBlock($"'{property.WireName}' => function (ParseNode $n) {{");
+            writer.StartBlock($"'{property.WireName.SanitizeSingleQuote()}' => function (ParseNode $n) {{");
             writer.WriteLine("$val = $n->getCollectionOfPrimitiveValues();");
             writer.StartBlock($"if (is_array($val)) {{");
             var type = conventions.TranslateType(property.Type);
@@ -680,7 +680,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
             writer.WriteLine("},");
             return;
         }
-        writer.WriteLine($"'{property.WireName}' => fn(ParseNode $n) => $o->{property.Setter!.Name.ToFirstCharacterLowerCase()}($n->{GetDeserializationMethodName(property.Type, method).Item2}),");
+        writer.WriteLine($"'{property.WireName.SanitizeSingleQuote()}' => fn(ParseNode $n) => $o->{property.Setter!.Name.ToFirstCharacterLowerCase()}($n->{GetDeserializationMethodName(property.Type, method).Item2}),");
     }
 
     private static void WriteDeserializerBodyForIntersectionModel(CodeClass parentClass, LanguageWriter writer)
@@ -817,7 +817,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (!string.IsNullOrEmpty(codeMethod.BaseUrl))
         {
             writer.StartBlock($"if (empty({GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl())) {{");
-            writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->setBaseUrl('{codeMethod.BaseUrl}');");
+            writer.WriteLine($"{GetPropertyCall(requestAdapterProperty, string.Empty)}->setBaseUrl('{codeMethod.BaseUrl.SanitizeSingleQuote()}');");
             writer.CloseBlock();
             if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty)
                 writer.WriteLine($"{GetPropertyCall(pathParametersProperty, string.Empty)}['baseurl'] = {GetPropertyCall(requestAdapterProperty, string.Empty)}->getBaseUrl();");

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -138,7 +138,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
     {
         var backingStoreProperty = parentClass.GetPropertyOfKind(CodePropertyKind.BackingStore);
         if (backingStoreProperty != null && !string.IsNullOrEmpty(backingStoreProperty.DefaultValue))
-            writer.WriteLine($"$this->{backingStoreProperty.Name.ToFirstCharacterLowerCase()} = {backingStoreProperty.DefaultValue};");
+            writer.WriteLine($"$this->{backingStoreProperty.Name.ToFirstCharacterLowerCase()} = {backingStoreProperty.DefaultValue.ReplaceDoubleQuoteWithSingleQuote()};");
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData, CodePropertyKind.Custom) //additional data and custom properties rely on accessors
             .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
             // do not apply the default value if the type is composed as the default value may not necessarily which type to use

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -871,7 +871,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (writeDiscriminatorValueRead &&
             codeElement.Parameters.OfKind(CodeParameterKind.ParseNode) is CodeParameter parseNodeParameter)
         {
-            writer.WriteLines($"$mappingValueNode = ${parseNodeParameter.Name.ToFirstCharacterLowerCase()}->getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\");",
+            writer.WriteLines($"$mappingValueNode = ${parseNodeParameter.Name.ToFirstCharacterLowerCase()}->getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\");",
                 "if ($mappingValueNode !== null) {");
             writer.IncreaseIndent();
             writer.WriteLines($"{DiscriminatorMappingVarName} = $mappingValueNode->getStringValue();");
@@ -959,7 +959,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
                     IsNullable = propertyType.IsNullable,
                 };
             var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(propertyType.Name, StringComparison.OrdinalIgnoreCase));
-            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if ('{mappedType.Key}' === {DiscriminatorMappingVarName}) {{");
+            writer.StartBlock($"{(includeElse ? "} else " : string.Empty)}if ('{mappedType.Key.SanitizeSingleQuote()}' === {DiscriminatorMappingVarName}) {{");
             writer.WriteLine($"{ResultVarName}->{property.Setter!.Name.ToFirstCharacterLowerCase()}(new {conventions.GetTypeString(propertyType, codeElement, false)}());");
             writer.DecreaseIndent();
             if (!includeElse)
@@ -1007,7 +1007,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         writer.StartBlock($"switch ({varName}) {{");
         foreach (var mappedType in discriminatorMappings)
         {
-            writer.WriteLine($"case '{mappedType.Key}': return new {conventions.GetTypeString(mappedType.Value.AllTypes.First(), method, false, writer)}();");
+            writer.WriteLine($"case '{mappedType.Key.SanitizeSingleQuote()}': return new {conventions.GetTypeString(mappedType.Value.AllTypes.First(), method, false, writer)}();");
         }
         writer.CloseBlock();
     }

--- a/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
@@ -43,7 +43,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, PhpConventionS
         writer.WriteLine(PhpConventionService.DocCommentStart);
         if (codeProperty.IsOfKind(CodePropertyKind.QueryParameter) && codeProperty.IsNameEscaped)
         {
-            writer.WriteLine($"{conventions.DocCommentPrefix}@QueryParameter(\"{codeProperty.SerializationName}\")");
+            writer.WriteLine($"{conventions.DocCommentPrefix}@QueryParameter(\"{codeProperty.SerializationName.SanitizeDoubleQuote()}\")");
         }
         writer.WriteLine($"{conventions.DocCommentPrefix}@var {typeString}{(codeProperty.Type.IsNullable ? "|null" : string.Empty)} ${codeProperty.Name.ToFirstCharacterLowerCase()} " +
                             $"{(hasDescription ? propertyDescription : string.Empty)}");

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -263,7 +263,7 @@ public class PhpConventionService : CommonLanguageConventionService
         writer.WriteLine($"${TempDictionaryVarName} = {pathParametersReference};");
         if (parameters.Length != 0)
             writer.WriteLines(parameters.Select(p =>
-                $"${TempDictionaryVarName}['{p.Item2}'] = {p.Item3};"
+                $"${TempDictionaryVarName}['{p.Item2.SanitizeSingleQuote()}'] = {p.Item3};"
             ));
     }
 

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -175,7 +175,11 @@ public class PhpConventionService : CommonLanguageConventionService
                 writer.WriteLine($"{DocCommentPrefix}{additionalRemark}");
 
             if (documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{DocCommentPrefix}@link {documentation.DocumentationLink} {documentation.DocumentationLabel}");
+            {
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString() ?? string.Empty);
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
+                writer.WriteLine($"{DocCommentPrefix}@link {documentationLink} {documentationLabel}");
+            }
             writer.WriteLine(DocCommentEnd);
         }
 

--- a/src/Kiota.Builder/Writers/Python/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeEnumWriter.cs
@@ -26,7 +26,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, PythonConventionServic
             codeElement.Options.ToList().ForEach(x =>
             {
                 conventions.WriteInLineDescription(x, writer);
-                writer.WriteLine($"{x.Name} = \"{x.WireName}\",");
+                writer.WriteLine($"{x.Name} = \"{x.WireName.SanitizeDoubleQuote()}\",");
             });
         }
     }

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -257,7 +257,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
             writer.StartBlock($"if not self.{requestAdapterPropertyName}.base_url:");
-            writer.WriteLine($"self.{requestAdapterPropertyName}.base_url = \"{method.BaseUrl}\"");
+            writer.WriteLine($"self.{requestAdapterPropertyName}.base_url = \"{method.BaseUrl.SanitizeDoubleQuote()}\"");
             writer.DecreaseIndent();
             if (pathParametersProperty != null)
                 writer.WriteLine($"self.{pathParametersProperty.Name}[\"base_url\"] = self.{requestAdapterPropertyName}.base_url");
@@ -275,7 +275,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         foreach (var escapedProperty in escapedProperties)
         {
             writer.StartBlock($"if {parameterName} == \"{escapedProperty.Name}\":");
-            writer.WriteLine($"return \"{escapedProperty.SerializationName}\"");
+            writer.WriteLine($"return \"{escapedProperty.SerializationName.SanitizeDoubleQuote()}\"");
             writer.DecreaseIndent();
         }
         foreach (var unescapedProperty in unescapedProperties.Select(x => x.Name))
@@ -348,7 +348,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                         foreach (var parameter in pathParameters)
                         {
                             var (name, identName) = parameter;
-                            writer.WriteLine($"{pathParametersParameter.Name}['{name}'] = {identName}");
+                            writer.WriteLine($"{pathParametersParameter.Name}['{name.SanitizeSingleQuote()}'] = {identName}");
                         }
                         writer.DecreaseIndent();
                     }
@@ -561,7 +561,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"\"{otherProp.WireName}\": lambda n : setattr(self, '{otherProp.Name}', n.{GetDeserializationMethodName(otherProp.Type, codeElement, parentClass)}),");
+            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": lambda n : setattr(self, '{otherProp.Name}', n.{GetDeserializationMethodName(otherProp.Type, codeElement, parentClass)}),");
         }
         writer.CloseBlock();
         if (inherits)
@@ -631,7 +631,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
 
         if (currentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is not CodeProperty urlTemplateParamsProperty) throw new InvalidOperationException("path parameters cannot be null");
         if (currentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate) is not CodeProperty urlTemplateProperty) throw new InvalidOperationException("url template cannot be null");
-        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{codeElement.UrlTemplateOverride}'" : GetPropertyCall(urlTemplateProperty, "''");
+        var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{codeElement.UrlTemplateOverride.SanitizeSingleQuote()}'" : GetPropertyCall(urlTemplateProperty, "''");
         writer.WriteLine($"{RequestInfoVarName} = RequestInformation(Method.{codeElement.HttpMethod.Value.ToString().ToUpperInvariant()}, {urlTemplateValue}, {GetPropertyCall(urlTemplateParamsProperty, "''")})");
         if (requestParams.requestConfiguration != null)
             writer.WriteLine($"{RequestInfoVarName}.configure({requestParams.requestConfiguration.Name})");
@@ -664,7 +664,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                         .OrderBy(static x => x.Name))
         {
             var serializationMethodName = GetSerializationMethodName(otherProp.Type);
-            writer.WriteLine($"writer.{serializationMethodName}(\"{otherProp.WireName}\", self.{otherProp.Name})");
+            writer.WriteLine($"writer.{serializationMethodName}(\"{otherProp.WireName.SanitizeDoubleQuote()}\", self.{otherProp.Name})");
         }
     }
     private void WriteSerializerBodyForUnionModel(CodeClass parentClass, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -335,6 +335,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
             currentMethod.Parameters.OfKind(CodeParameterKind.RequestAdapter) is CodeParameter requestAdapterParameter &&
             parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.UrlTemplate) is CodeProperty urlTemplateProperty)
             {
+                var urlTemplate = (urlTemplateProperty.DefaultValue ?? string.Empty).SanitizeQuotedStringLiteral();
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.PathParameters) is CodeParameter pathParametersParameter)
                 {
                     var pathParameters = currentMethod.Parameters
@@ -351,10 +352,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                         }
                         writer.DecreaseIndent();
                     }
-                    writer.WriteLine($"super().__init__({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue ?? ""}, {pathParametersParameter.Name})");
+                    writer.WriteLine($"super().__init__({requestAdapterParameter.Name}, {urlTemplate}, {pathParametersParameter.Name})");
                 }
                 else
-                    writer.WriteLine($"super().__init__({requestAdapterParameter.Name}, {urlTemplateProperty.DefaultValue ?? ""}, {NoneKeyword})");
+                    writer.WriteLine($"super().__init__({requestAdapterParameter.Name}, {urlTemplate}, {NoneKeyword})");
             }
             else
                 writer.WriteLine("super().__init__()");
@@ -384,7 +385,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                         .ThenBy(static x => x.Name))
         {
             var returnType = conventions.GetTypeString(propWithDefault.Type, propWithDefault, true, writer);
-            var defaultValue = propWithDefault.DefaultValue;
+            var defaultValue = propWithDefault.DefaultValue.SanitizeQuotedStringLiteral();
             switch (propWithDefault.Type)
             {
                 case CodeType { TypeDefinition: CodeEnum enumDefinition }:
@@ -417,7 +418,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                                         .OrderByDescending(static x => x.Kind)
                                         .ThenBy(static x => x.Name))
         {
-            var defaultValue = propWithDefault.DefaultValue;
+            var defaultValue = propWithDefault.DefaultValue.SanitizeQuotedStringLiteral();
             switch (propWithDefault.Type)
             {
                 case CodeType { TypeDefinition: CodeEnum enumDefinition }:
@@ -484,7 +485,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                     writer.WriteLines($"value: {conventions.GetTypeString(codeElement.AccessedProperty.Type, codeElement, true, writer)} = self.{backingStore.NamePrefix}{backingStore.Name}.get(\"{codeElement.AccessedProperty.Name}\")",
                         "if not value:");
                     writer.IncreaseIndent();
-                    writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue}",
+                    writer.WriteLines($"value = {codeElement.AccessedProperty.DefaultValue.SanitizeQuotedStringLiteral()}",
                         $"self.{codeElement.AccessedProperty?.NamePrefix}{codeElement.AccessedProperty?.Name} = value");
                     writer.DecreaseIndent();
                     writer.WriteLines("return value");

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -128,7 +128,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
     {
         foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings.OrderBy(static x => x.Key))
         {
-            writer.StartBlock($"if {DiscriminatorMappingVarName} and {DiscriminatorMappingVarName}.casefold() == \"{mappedType.Key}\".casefold():");
+            writer.StartBlock($"if {DiscriminatorMappingVarName} and {DiscriminatorMappingVarName}.casefold() == \"{mappedType.Key.SanitizeDoubleQuote()}\".casefold():");
             var mappedTypeName = mappedType.Value.AllTypes.First().Name;
             _codeUsingWriter.WriteDeferredImport(parentClass, mappedTypeName, writer);
             writer.WriteLine($"return {mappedTypeName}()");
@@ -149,7 +149,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
                 if (propertyType.TypeDefinition is CodeClass && !propertyType.IsCollection)
                 {
                     var mappedType = parentClass.DiscriminatorInformation.DiscriminatorMappings.FirstOrDefault(x => x.Value.Name.Equals(propertyType.Name, StringComparison.OrdinalIgnoreCase));
-                    writer.StartBlock($"{(includeElse ? "el" : string.Empty)}if {DiscriminatorMappingVarName} and {DiscriminatorMappingVarName}.casefold() == \"{mappedType.Key}\".casefold():");
+                    writer.StartBlock($"{(includeElse ? "el" : string.Empty)}if {DiscriminatorMappingVarName} and {DiscriminatorMappingVarName}.casefold() == \"{mappedType.Key.SanitizeDoubleQuote()}\".casefold():");
                     _codeUsingWriter.WriteDeferredImport(parentClass, propertyType.Name, writer);
                     writer.WriteLine($"{ResultVarName}.{property.Name} = {propertyType.Name}()");
                     writer.DecreaseIndent();
@@ -214,7 +214,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         if (parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType)
         {
             writer.StartBlock("try:");
-            writer.WriteLine($"child_node = {parseNodeParameter.Name}.get_child_node(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\")");
+            writer.WriteLine($"child_node = {parseNodeParameter.Name}.get_child_node(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\")");
             writer.WriteLine($"{DiscriminatorMappingVarName} = child_node.get_str_value() if child_node else {NoneKeyword}");
             writer.DecreaseIndent();
             writer.StartBlock("except AttributeError:");

--- a/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodePropertyWriter.cs
@@ -44,7 +44,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, PythonConventi
                 var defaultValue = isNonNullableCollection ? "[]" : "None";
                 if (!string.IsNullOrEmpty(codeElement.DefaultValue))
                 {
-                    defaultValue = codeElement.DefaultValue;
+                    defaultValue = codeElement.DefaultValue.SanitizeQuotedStringLiteral();
                 }
                 writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)}{codeElement.NamePrefix}{codeElement.Name}: {(codeElement.Type.IsNullable ? "Optional[" : string.Empty)}{returnType}{(codeElement.Type.IsNullable ? "]" : string.Empty)} = {defaultValue}");
                 writer.WriteLine();

--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -194,7 +194,8 @@ public class PythonConventionService : CommonLanguageConventionService
             if (documentation.ExternalDocumentationAvailable)
             {
                 var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
-                writer.WriteLine($"{documentationLabel}: {documentation.DocumentationLink}");
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString() ?? string.Empty);
+                writer.WriteLine($"{documentationLabel}: {documentationLink}");
             }
             writer.WriteLine(DocCommentEnd);
         }

--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -37,7 +37,7 @@ public class PythonConventionService : CommonLanguageConventionService
         writer.WriteLine($"{TempDictionaryVarName} = get_path_parameters({pathParametersReference})");
         if (parameters.Length != 0)
             writer.WriteLines(parameters.Select(p =>
-                $"{TempDictionaryVarName}[\"{p.Item2}\"] = {p.Item3}"
+                $"{TempDictionaryVarName}[\"{p.Item2.SanitizeDoubleQuote()}\"] = {p.Item3}"
             ));
     }
 

--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -54,7 +54,7 @@ public class PythonConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         ArgumentNullException.ThrowIfNull(targetElement);
-        var defaultValueSuffix = string.IsNullOrEmpty(parameter.DefaultValue) ? string.Empty : $" = {parameter.DefaultValue}";
+        var defaultValueSuffix = string.IsNullOrEmpty(parameter.DefaultValue) ? string.Empty : $" = {parameter.DefaultValue.SanitizeQuotedStringLiteral()}";
         var deprecationInfo = GetDeprecationInformation(parameter);
         var deprecationSuffix = string.IsNullOrEmpty(deprecationInfo) ? string.Empty : $"# {deprecationInfo}";
         return $"{parameter.Name}: {(parameter.Optional ? "Optional[" : string.Empty)}{GetTypeString(parameter.Type, targetElement, true, writer)}{(parameter.Optional ? "] = None" : string.Empty)}{defaultValueSuffix}{deprecationSuffix}";

--- a/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
+++ b/src/Kiota.Builder/Writers/Python/PythonConventionService.cs
@@ -192,7 +192,10 @@ public class PythonConventionService : CommonLanguageConventionService
             foreach (var additionalRemark in additionalRemarksArray.Where(static x => !string.IsNullOrEmpty(x)))
                 writer.WriteLine($"{additionalRemark}");
             if (documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{documentation.DocumentationLabel}: {documentation.DocumentationLink}");
+            {
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel);
+                writer.WriteLine($"{documentationLabel}: {documentation.DocumentationLink}");
+            }
             writer.WriteLine(DocCommentEnd);
         }
     }
@@ -214,12 +217,12 @@ public class PythonConventionService : CommonLanguageConventionService
         var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
-        return $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!))}{versionComment}{dateComment}{removalComment}";
+        return $"{element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}";
     }
     internal void WriteDeprecationWarning(IDeprecableElement element, LanguageWriter writer)
     {
         var deprecationMessage = GetDeprecationInformation(element);
         if (!string.IsNullOrEmpty(deprecationMessage))
-            writer.WriteLine($"warn(\"{deprecationMessage}\", DeprecationWarning)");
+            writer.WriteLine($"warn(\"{deprecationMessage.SanitizeDoubleQuote()}\", DeprecationWarning)");
     }
 }

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -124,7 +124,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         foreach (var escapedProperty in escapedProperties)
         {
             writer.StartBlock($"when \"{escapedProperty.Name}\"");
-            writer.WriteLine($"return \"{escapedProperty.SerializationName}\"");
+            writer.WriteLine($"return \"{escapedProperty.SerializationName.SanitizeDoubleQuote()}\"");
             writer.DecreaseIndent();
         }
         writer.StartBlock("else");
@@ -147,7 +147,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
             writer.StartBlock($"if @{requestAdapterPropertyName}.get_base_url.nil? || @{requestAdapterPropertyName}.get_base_url.empty?");
-            writer.WriteLine($"@{requestAdapterPropertyName}.set_base_url('{method.BaseUrl}')");
+            writer.WriteLine($"@{requestAdapterPropertyName}.set_base_url('{method.BaseUrl.SanitizeSingleQuote()}')");
             writer.CloseBlock("end");
             if (pathParametersProperty != null)
                 writer.WriteLine($"@{pathParametersProperty.Name.ToSnakeCase()}['baseurl'] = @{requestAdapterPropertyName}.get_base_url");
@@ -218,7 +218,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty &&
             codeElement.OriginalIndexer != null)
             writer.WriteLines($"{conventions.TempDictionaryVarName} = @{pathParametersProperty.NamePrefix}{pathParametersProperty.Name.ToSnakeCase()}.clone",
-                            $"{conventions.TempDictionaryVarName}[\"{codeElement.OriginalIndexer.IndexParameter.SerializationName}\"] = {codeElement.OriginalIndexer.IndexParameter.Name.ToSnakeCase()}");
+                            $"{conventions.TempDictionaryVarName}[\"{codeElement.OriginalIndexer.IndexParameter.SerializationName.SanitizeDoubleQuote()}\"] = {codeElement.OriginalIndexer.IndexParameter.Name.ToSnakeCase()}");
         conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName, $"return {prefix}");
     }
     private void WriteDeserializerBody(CodeClass parentClass, LanguageWriter writer)
@@ -232,7 +232,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                             .Where(static x => !x.ExistsInBaseType)
                                             .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"\"{otherProp.WireName}\" => lambda {{|n| @{otherProp.NamePrefix}{otherProp.Name.ToSnakeCase()} = n.{GetDeserializationMethodName(otherProp.Type)} }},");
+            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\" => lambda {{|n| @{otherProp.NamePrefix}{otherProp.Name.ToSnakeCase()} = n.{GetDeserializationMethodName(otherProp.Type)} }},");
         }
         writer.DecreaseIndent();
         if (parentClass.StartBlock.Inherits != null)
@@ -320,7 +320,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty urlTemplateParamsProperty &&
             parentClass.GetPropertyOfKind(CodePropertyKind.UrlTemplate) is CodeProperty urlTemplateProperty)
         {
-            var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{codeElement.UrlTemplateOverride}'" : GetPropertyCall(urlTemplateProperty, "''");
+            var urlTemplateValue = codeElement.HasUrlTemplateOverride ? $"'{codeElement.UrlTemplateOverride.SanitizeSingleQuote()}'" : GetPropertyCall(urlTemplateProperty, "''");
             writer.WriteLines($"request_info.url_template = {urlTemplateValue}",
                             $"request_info.path_parameters = {GetPropertyCall(urlTemplateParamsProperty, "''")}");
         }
@@ -339,7 +339,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                             .Where(static x => !x.ExistsInBaseType && !x.ReadOnly)
                                             .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.WireName}\", @{otherProp.Name.ToSnakeCase()})");
+            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.WireName.SanitizeDoubleQuote()}\", @{otherProp.Name.ToSnakeCase()})");
         }
         if (additionalDataProperty != null)
             writer.WriteLine($"writer.write_additional_data(@{additionalDataProperty.NamePrefix}{additionalDataProperty.Name.ToSnakeCase()})");

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -171,10 +171,13 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                 currentMethod.Parameters.OfKind(CodeParameterKind.RequestAdapter) is CodeParameter requestAdapterParameter &&
                 parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.UrlTemplate) is CodeProperty urlTemplateProperty &&
                 !string.IsNullOrEmpty(urlTemplateProperty.DefaultValue))
+            {
+                var sanitizedUrlTemplate = urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral();
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.PathParameters) is CodeParameter pathParametersParameter)
-                    writer.WriteLine($"super({pathParametersParameter.Name.ToSnakeCase()}, {requestAdapterParameter.Name.ToSnakeCase()}, {urlTemplateProperty.DefaultValue})");
+                    writer.WriteLine($"super({pathParametersParameter.Name.ToSnakeCase()}, {requestAdapterParameter.Name.ToSnakeCase()}, {sanitizedUrlTemplate})");
                 else
-                    writer.WriteLine($"super(Hash.new, {requestAdapterParameter.Name.ToSnakeCase()}, {urlTemplateProperty.DefaultValue})");
+                    writer.WriteLine($"super(Hash.new, {requestAdapterParameter.Name.ToSnakeCase()}, {sanitizedUrlTemplate})");
+            }
             else
                 writer.WriteLine("super");
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.BackingStore,
@@ -182,7 +185,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue}");
+            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue.SanitizeQuotedStringLiteral()}");
         }
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData,
                                                                         CodePropertyKind.Custom) //additional data and custom properties rely on accessors
@@ -191,7 +194,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                         .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue}");
+            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue.SanitizeQuotedStringLiteral()}");
         }
     }
     private static void WriteSetterBody(CodeMethod codeElement, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -90,13 +90,13 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
         if (writeDiscriminatorValueRead)
         {
-            writer.WriteLine($"{NodeVarName} = {parseNodeParameter.Name.ToSnakeCase()}.get_child_node(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName}\")");
+            writer.WriteLine($"{NodeVarName} = {parseNodeParameter.Name.ToSnakeCase()}.get_child_node(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\")");
             writer.StartBlock($"unless {NodeVarName}.nil? then");
             writer.WriteLine($"{DiscriminatorMappingVarName} = {NodeVarName}.get_string_value");
             writer.StartBlock($"case {DiscriminatorMappingVarName}");
             foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings.OrderBy(static x => x.Key))
             {
-                writer.StartBlock($"when \"{mappedType.Key}\"");
+                writer.StartBlock($"when \"{mappedType.Key.SanitizeDoubleQuote()}\"");
                 writer.WriteLine($"return {mappedType.Value.AllTypes.First().Name.ToFirstCharacterUpperCase()}.new");
                 writer.DecreaseIndent();
             }

--- a/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
+++ b/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
@@ -60,7 +60,7 @@ public class RubyConventionService : CommonLanguageConventionService
         if (!element.Documentation.DescriptionAvailable) return false;
         if (element is not CodeElement codeElement) return false;
 
-        var description = element.Documentation.GetDescription(type => GetTypeString(type, codeElement));
+        var description = element.Documentation.GetDescription(type => GetTypeString(type, codeElement), normalizationFunc: RemoveInvalidDescriptionCharacters);
         writer.WriteLine($"{DocCommentPrefix}");
         writer.WriteLine($"# {description}");
 
@@ -78,7 +78,12 @@ public class RubyConventionService : CommonLanguageConventionService
         return string.Empty;
     }
 #pragma warning restore CA1822 // Method should be static
-    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "#", StringComparison.OrdinalIgnoreCase);
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
+        string.IsNullOrEmpty(originalDescription) ? string.Empty :
+        originalDescription.Replace("\\", "#", StringComparison.OrdinalIgnoreCase)
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
 #pragma warning disable CA1822 // Method should be static
     internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string? urlTemplateVarName = default, string? prefix = default, IEnumerable<CodeParameter>? pathParameters = default)
     {

--- a/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
+++ b/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
@@ -30,7 +30,7 @@ public class RubyConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var defaultValue = parameter.Optional && (targetElement is not CodeMethod currentMethod || !currentMethod.IsOfKind(CodeMethodKind.Setter)) ?
-            $"={(string.IsNullOrEmpty(parameter.DefaultValue) ? "nil" : parameter.DefaultValue)}" :
+            $"={(string.IsNullOrEmpty(parameter.DefaultValue) ? "nil" : parameter.DefaultValue.SanitizeQuotedStringLiteral())}" :
             string.Empty;
         return $"{parameter.Name}{defaultValue}";
     }

--- a/src/Kiota.Builder/Writers/StringExtensions.cs
+++ b/src/Kiota.Builder/Writers/StringExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Text;
 
 namespace Kiota.Builder.Writers;
 
@@ -13,9 +15,7 @@ public static class StringExtensions
     /// <param name="original">The string to sanitize.</param>
     /// <returns>The sanitized string.</returns>
     public static string SanitizeDoubleQuote(this string original)
-        => string.IsNullOrEmpty(original)
-            ? original
-            : original.Replace("\"", "\\\"", StringComparison.Ordinal);
+        => SanitizeForQuotedLiteral(original, '"');
 
     /// <summary>
     /// Sanitize a string for direct writing.
@@ -23,7 +23,61 @@ public static class StringExtensions
     /// <param name="original">The string to sanitize.</param>
     /// <returns>The sanitized string.</returns>
     public static string SanitizeSingleQuote(this string original)
-        => string.IsNullOrEmpty(original)
-            ? original
-            : original.Replace("'", "\\'", StringComparison.Ordinal);
+        => SanitizeForQuotedLiteral(original, '\'');
+
+    /// <summary>
+    /// Sanitizes the inner content of a quoted string literal while preserving the surrounding quotes.
+    /// </summary>
+    /// <param name="original">A quoted string literal.</param>
+    /// <returns>The sanitized literal if quoted, otherwise the original value.</returns>
+    public static string SanitizeQuotedStringLiteral(this string original)
+    {
+        if (string.IsNullOrEmpty(original) || original.Length < 2) return original;
+        return (original[0], original[^1]) switch
+        {
+            ('"', '"') => $"\"{original[1..^1].SanitizeDoubleQuote()}\"",
+            ('\'', '\'') => $"'{original[1..^1].SanitizeSingleQuote()}'",
+            _ => original,
+        };
+    }
+
+    private static string SanitizeForQuotedLiteral(string original, char quote)
+    {
+        if (string.IsNullOrEmpty(original)) return original;
+        var builder = new StringBuilder(original.Length);
+        foreach (var character in original)
+        {
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                case '\0':
+                    builder.Append("\\0");
+                    break;
+                case '"' when quote == '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\'' when quote == '\'':
+                    builder.Append("\\'");
+                    break;
+                default:
+                    if (char.IsControl(character))
+                        builder.Append(@"\u").Append(((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                    else
+                        builder.Append(character);
+                    break;
+            }
+        }
+        return builder.ToString();
+    }
 }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
@@ -58,7 +58,7 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
         {
             writer.StartBlock($"{navigationMethod.Name.ToFirstCharacterLowerCase()}: {{");
             var requestBuilderName = navigationMethod.ReturnType.Name.ToFirstCharacterUpperCase();
-            WriteNavigationMetadataEntry(parentNamespace, writer, requestBuilderName, navigationMethod.Parameters.Where(static x => x.Kind is CodeParameterKind.Path or CodeParameterKind.Custom).Select(static x => $"\"{x.WireName}\"").ToArray());
+            WriteNavigationMetadataEntry(parentNamespace, writer, requestBuilderName, navigationMethod.Parameters.Where(static x => x.Kind is CodeParameterKind.Path or CodeParameterKind.Custom).Select(static x => $"\"{x.WireName.SanitizeDoubleQuote()}\"").ToArray());
             writer.CloseBlock("},");
         }
         foreach (var navigationProperty in navigationProperties)
@@ -106,7 +106,7 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
             var isPrimitive = IsPrimitiveType(returnTypeWithoutCollectionSymbol) || IsKiotaPrimitive(returnTypeWithoutCollectionSymbol);
             var isPrimitiveAlias = GetPrimitiveAlias(returnTypeWithoutCollectionSymbol) is not null;
             writer.StartBlock($"{executorMethod.Name.ToFirstCharacterLowerCase()}: {{");
-            var urlTemplateValue = executorMethod.HasUrlTemplateOverride ? $"\"{executorMethod.UrlTemplateOverride}\"" : uriTemplateConstant.Name.ToFirstCharacterUpperCase();
+            var urlTemplateValue = executorMethod.HasUrlTemplateOverride ? $"\"{executorMethod.UrlTemplateOverride.SanitizeDoubleQuote()}\"" : uriTemplateConstant.Name.ToFirstCharacterUpperCase();
             writer.WriteLine($"uriTemplate: {urlTemplateValue},");
             if (codeClass.Methods.FirstOrDefault(x => x.Kind is CodeMethodKind.RequestGenerator && x.HttpMethod == executorMethod.HttpMethod) is { } generatorMethod &&
                  generatorMethod.AcceptHeaderValue is string acceptHeader && !string.IsNullOrEmpty(acceptHeader))
@@ -214,7 +214,7 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
         writer.StartBlock($"const {codeElement.Name.ToFirstCharacterUpperCase()}: Record<string, string> = {{");
         foreach (var property in properties)
         {
-            writer.WriteLine($"\"{property.Name.ToFirstCharacterLowerCase()}\": \"{property.SerializationName}\",");
+            writer.WriteLine($"\"{property.Name.ToFirstCharacterLowerCase().SanitizeDoubleQuote()}\": \"{property.SerializationName.SanitizeDoubleQuote()}\",");
         }
         writer.CloseBlock("};");
     }
@@ -228,7 +228,7 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
         codeEnum.Options.ToList().ForEach(x =>
         {
             conventions.WriteShortDescription(x, writer);
-            writer.WriteLine($"{x.Name.ToFirstCharacterUpperCase()}: \"{x.WireName}\",");
+            writer.WriteLine($"{x.Name.ToFirstCharacterUpperCase()}: \"{x.WireName.SanitizeDoubleQuote()}\",");
         });
         writer.CloseBlock("} as const;");
     }

--- a/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
@@ -199,7 +199,8 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
 
     private void WriteUriTemplateConstant(CodeConstant codeElement, LanguageWriter writer)
     {
-        writer.WriteLine($"export const {codeElement.Name.ToFirstCharacterUpperCase()} = {codeElement.UriTemplate};");
+        var uriTemplateValue = string.IsNullOrEmpty(codeElement.UriTemplate) ? string.Empty : codeElement.UriTemplate.SanitizeQuotedStringLiteral();
+        writer.WriteLine($"export const {codeElement.Name.ToFirstCharacterUpperCase()} = {uriTemplateValue};");
     }
 
     private static void WriteQueryParametersMapperConstant(CodeConstant codeElement, LanguageWriter writer)

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -760,7 +760,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
         }
 
         // only string primitive should keep quotes
-        return codeProperty.Type.Name.Equals("string", StringComparison.Ordinal) ? codeProperty.DefaultValue : codeProperty.DefaultValue.Trim('"');
+        return codeProperty.Type.Name.Equals("string", StringComparison.Ordinal) ? codeProperty.DefaultValue.SanitizeQuotedStringLiteral() : codeProperty.DefaultValue.Trim('"');
     }
     private void WriteDefensiveStatements(CodeMethod codeElement, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -293,9 +293,10 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
 
         if (!string.IsNullOrEmpty(method.BaseUrl))
         {
+            var sanitizedBaseUrl = method.BaseUrl.SanitizeDoubleQuote();
             writer.StartBlock(
                 $"if ({requestAdapterArgumentName}.baseUrl === undefined || {requestAdapterArgumentName}.baseUrl === null || {requestAdapterArgumentName}.baseUrl === \"\") {{");
-            writer.WriteLine($"{requestAdapterArgumentName}.baseUrl = \"{method.BaseUrl}\";");
+            writer.WriteLine($"{requestAdapterArgumentName}.baseUrl = \"{sanitizedBaseUrl}\";");
             writer.CloseBlock();
         }
 
@@ -493,7 +494,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
             foreach (var mapping in codeElement.OriginalMethodParentClass.DiscriminatorInformation.DiscriminatorMappings)
             {
                 var mappedType = mapping.Value;
-                writer.StartBlock($"case \"{mapping.Key}\":");
+                writer.StartBlock($"case \"{mapping.Key.SanitizeDoubleQuote()}\":");
                 writer.WriteLine($"{GetSerializerFunctionName(codeElement, mappedType)}(writer, {param.Name.ToFirstCharacterLowerCase()}, true);");
                 writer.CloseBlock("break;");
             }
@@ -533,7 +534,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
             if (GetOriginalComposedType(propType.TypeDefinition) is { } ct && (ct.IsComposedOfPrimitives(IsPrimitiveType) || ct.IsComposedOfObjectsAndPrimitives(IsPrimitiveType)))
                 WriteSerializationStatementForComposedTypeProperty(ct, modelParamName, codeFunction, writer, codeProperty, serializeName);
             else
-                writer.WriteLine($"writer.{serializationName}<{propTypeName}>(\"{codeProperty.WireName}\", {modelParamName}.{codePropertyName}{defaultValueSuffix}, {serializeName});");
+                writer.WriteLine($"writer.{serializationName}<{propTypeName}>(\"{codeProperty.WireName.SanitizeDoubleQuote()}\", {modelParamName}.{codePropertyName}{defaultValueSuffix}, {serializeName});");
         }
         else
         {
@@ -552,7 +553,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
         if (composedType is not null && (composedType.IsComposedOfPrimitives(IsPrimitiveType) || composedType.IsComposedOfObjectsAndPrimitives(IsPrimitiveType)))
             WriteSerializationStatementForComposedTypeProperty(composedType, modelParamName, codeFunction, writer, codeProperty, string.Empty);
         else
-            writer.WriteLine($"writer.{serializationName}(\"{codeProperty.WireName}\", {modelParamName}.{codePropertyName}{defaultValueSuffix});");
+            writer.WriteLine($"writer.{serializationName}(\"{codeProperty.WireName.SanitizeDoubleQuote()}\", {modelParamName}.{codePropertyName}{defaultValueSuffix});");
     }
 
     private void WriteSerializationStatementForComposedTypeProperty(CodeComposedTypeBase composedType, string modelParamName, CodeFunction method, LanguageWriter writer, CodeProperty codeProperty, string? serializeName)
@@ -578,7 +579,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
                 ? $"{isElse}if (Array.isArray({modelParamName}.{codePropertyName}) && ({modelParamName}.{codePropertyName}).every(item => typeof item === '{nodeType}')) {{"
                 : $"{isElse}if ( typeof {modelParamName}.{codePropertyName} === \"{nodeType}\") {{");
 
-            writer.WriteLine($"writer.{serializationName}(\"{codeProperty.WireName}\", {modelParamName}.{codePropertyName}{defaultValueSuffix} as {nodeType});");
+            writer.WriteLine($"writer.{serializationName}(\"{codeProperty.WireName.SanitizeDoubleQuote()}\", {modelParamName}.{codePropertyName}{defaultValueSuffix} as {nodeType});");
             writer.CloseBlock();
             isFirst = false;
         }
@@ -601,7 +602,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
                 var propertyTypes = collectionCodeType.IsNullable ? " | undefined | null" : string.Empty;
                 var groupSymbol = groupedTypes.Key ? "[]" : string.Empty;
 
-                writer.WriteLine($"writer.{writerFunction}<{propTypeName}>(\"{codeProperty.WireName}\", {modelParamName}.{codePropertyName}{defaultValueSuffix} as {propTypeName}{groupSymbol}{propertyTypes}, {serializeName});");
+                writer.WriteLine($"writer.{writerFunction}<{propTypeName}>(\"{codeProperty.WireName.SanitizeDoubleQuote()}\", {modelParamName}.{codePropertyName}{defaultValueSuffix} as {propTypeName}{groupSymbol}{propertyTypes}, {serializeName});");
             }
             writer.CloseBlock();
         }
@@ -725,13 +726,13 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
         else if (GetOriginalComposedType(otherProp.Type) is { } composedType)
         {
             var expression = string.Join(" ?? ", SortTypesByInheritance(composedType.Types).Select(codeType => $"n.{conventions.GetDeserializationMethodName(codeType, codeFile, composedType.IsCollection)}"));
-            writer.WriteLine($"\"{otherProp.WireName}\": n => {{ {paramName}.{propName} = {expression};{suffix} }},");
+            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": n => {{ {paramName}.{propName} = {expression};{suffix} }},");
         }
         else
         {
             var objectSerializationMethodName = conventions.GetDeserializationMethodName(otherProp.Type, codeFile);
             var defaultValueSuffix = GetDefaultValueSuffix(otherProp);
-            writer.WriteLine($"\"{otherProp.WireName}\": n => {{ {paramName}.{propName} = n.{objectSerializationMethodName}{defaultValueSuffix};{suffix} }},");
+            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": n => {{ {paramName}.{propName} = n.{objectSerializationMethodName}{defaultValueSuffix};{suffix} }},");
         }
     }
 

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -243,7 +243,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
 
         foreach (var mappedType in discriminatorInfo.DiscriminatorMappings)
         {
-            writer.StartBlock($"case \"{mappedType.Key}\":");
+            writer.StartBlock($"case \"{mappedType.Key.SanitizeDoubleQuote()}\":");
             writer.WriteLine($"{GetSerializerFunctionName(codeElement, mappedType.Value)}(writer, {paramName} as {mappedType.Value.AllTypes.First().Name.ToFirstCharacterUpperCase()});");
             writer.WriteLine("break;");
             writer.DecreaseIndent();
@@ -383,7 +383,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
 
         if (!string.IsNullOrEmpty(discriminatorPropertyName))
         {
-            writer.WriteLines($"const mappingValueNode = {parseNodeParameter.Name.ToFirstCharacterLowerCase()}?.getChildNode(\"{discriminatorPropertyName}\");",
+            writer.WriteLines($"const mappingValueNode = {parseNodeParameter.Name.ToFirstCharacterLowerCase()}?.getChildNode(\"{discriminatorPropertyName.SanitizeDoubleQuote()}\");",
                                 "if (mappingValueNode) {");
             writer.IncreaseIndent();
             writer.WriteLines("const mappingValue = mappingValueNode.getStringValue();",
@@ -393,7 +393,7 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
             writer.StartBlock("switch (mappingValue) {");
             foreach (var mappedType in discriminatorInfo.DiscriminatorMappings)
             {
-                writer.StartBlock($"case \"{mappedType.Key}\":");
+                writer.StartBlock($"case \"{mappedType.Key.SanitizeDoubleQuote()}\":");
                 writer.WriteLine($"return {GetDeserializerFunctionName(codeElement, mappedType.Value)};");
                 writer.DecreaseIndent();
             }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -329,7 +329,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
     {
         if (element.Deprecation is null || !element.Deprecation.IsDeprecated) return string.Empty;
 
-        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
+        var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {RemoveInvalidDescriptionCharacters(element.Deprecation.Version)}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         return $"@deprecated {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}";

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -69,7 +69,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         }
         if (parameters.Length != 0)
             writer.WriteLines(parameters.Select(p =>
-                $"{varName}[\"{p.Item2}\"] = {p.Item3}"
+                $"{varName}[\"{p.Item2.SanitizeDoubleQuote()}\"] = {p.Item3}"
             ).ToArray());
     }
     public override string GetAccessModifier(AccessModifier access)

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -97,6 +97,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
             paramType = GetTypescriptTypeString(newType, targetElement, includeCollectionInformation: false, inlineComposedTypeString: true);
         }
         var isComposedOfPrimitives = composedType != null && composedType.IsComposedOfPrimitives(IsPrimitiveType);
+        var sanitizedDefaultValue = parameter.DefaultValue.SanitizeQuotedStringLiteral();
 
         // add a 'Parsable' type to the parameter if it is composed of non-Parsable types
         var parsableTypes = (
@@ -111,9 +112,9 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         var defaultValueSuffix = (string.IsNullOrEmpty(parameter.DefaultValue), parameter.Kind, isComposedOfPrimitives) switch
         {
             (false, CodeParameterKind.DeserializationTarget, false) when parameter.Parent is CodeMethod codeMethod && codeMethod.Kind is CodeMethodKind.Serializer
-                => $" | null = {parameter.DefaultValue}",
-            (false, CodeParameterKind.DeserializationTarget or CodeParameterKind.SerializingDerivedType, false) => $" = {parameter.DefaultValue}",
-            (false, _, false) => $" = {parameter.DefaultValue} as {paramType}",
+                => $" | null = {sanitizedDefaultValue}",
+            (false, CodeParameterKind.DeserializationTarget or CodeParameterKind.SerializingDerivedType, false) => $" = {sanitizedDefaultValue}",
+            (false, _, false) => $" = {sanitizedDefaultValue} as {paramType}",
             _ => string.Empty,
         };
         var (partialPrefix, partialSuffix) = (isComposedOfPrimitives, parameter.Kind) switch

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -317,7 +317,11 @@ public class TypeScriptConventionService : CommonLanguageConventionService
                 writer.WriteLine($"{DocCommentPrefix}{deprecationComment}");
 
             if (documentedElement.Documentation.ExternalDocumentationAvailable)
-                writer.WriteLine($"{DocCommentPrefix}@see {{@link {documentedElement.Documentation.DocumentationLink}|{documentedElement.Documentation.DocumentationLabel}}}");
+            {
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentedElement.Documentation.DocumentationLink?.ToString() ?? string.Empty);
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentedElement.Documentation.DocumentationLabel);
+                writer.WriteLine($"{DocCommentPrefix}@see {{@link {documentationLink}|{documentationLabel}}}");
+            }
             writer.WriteLine(DocCommentEnd);
         }
     }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -267,7 +267,8 @@ public class TypeScriptConventionService : CommonLanguageConventionService
 
     private static Dictionary<string, string> InvalidCharactersReplacements = new(StringComparer.OrdinalIgnoreCase) {
         { "\\", "/"},
-        { "/*", "//*"}
+        { "/*", "//*"},
+        { "*/", "* /"}
     };
 
     internal static string RemoveInvalidDescriptionCharacters(string originalDescription)
@@ -275,7 +276,9 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         if (string.IsNullOrEmpty(originalDescription)) return string.Empty;
         originalDescription = InvalidCharactersReplacements
             .Aggregate(originalDescription, (current, replacement) => current.Replace(replacement.Key, replacement.Value, StringComparison.OrdinalIgnoreCase));
-        return originalDescription;
+        return originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     }
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
@@ -325,7 +328,7 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         var versionComment = string.IsNullOrEmpty(element.Deprecation.Version) ? string.Empty : $" as of {element.Deprecation.Version}";
         var dateComment = element.Deprecation.Date is null ? string.Empty : $" on {element.Deprecation.Date.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
         var removalComment = element.Deprecation.RemovalDate is null ? string.Empty : $" and will be removed {element.Deprecation.RemovalDate.Value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
-        return $"@deprecated {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!))}{versionComment}{dateComment}{removalComment}";
+        return $"@deprecated {element.Deprecation.GetDescription(type => GetTypeString(type, (element as CodeElement)!), normalizationFunc: RemoveInvalidDescriptionCharacters)}{versionComment}{dateComment}{removalComment}";
     }
 
     public static string GetFactoryMethodName(CodeTypeBase targetClassType, CodeElement currentElement, LanguageWriter? writer = null)

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -214,7 +214,7 @@ public sealed class GenerateSample : IDisposable
                 Assert.Contains("'EndDateTime' : endDateTime", fullText);
                 break;
             case GenerationLanguage.Go:
-                Assert.Contains("`uriparametername:\"startDateTime\"`", fullText);
+                Assert.Contains("uriparametername:\\\"startDateTime\\\"", fullText);
                 break;
             case GenerationLanguage.Java:
                 Assert.Contains("allQueryParams.put(\"EndDateTime\", endDateTime)", fullText);

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -125,4 +125,10 @@ public class StringExtensionsTests
         Assert.True("".EqualsIgnoreCase(""));
         Assert.True("Joe_Doe".EqualsIgnoreCase("joe_doe"));
     }
+    [Fact]
+    public void ReplacesDoubleQuoteWithEscapedSingleQuoteLiteral()
+    {
+        const string input = "\"line1'\\\nline2\"";
+        Assert.Equal("'line1\\'\\\\\\nline2'", input.ReplaceDoubleQuoteWithSingleQuote());
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeEnumWriterTests.cs
@@ -72,6 +72,18 @@ public sealed class CodeEnumWriterTests : IDisposable
     }
 
     [Fact]
+    public void EscapesEnumMemberValue()
+    {
+        currentEnum.Flags = true;
+        var serializationName = "line1\"\nline2";
+        currentEnum.AddOption(Option);
+        currentEnum.AddOption(new CodeEnumOption { Name = "InvalidName", SerializationName = serializationName });
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains($"[EnumMember(Value = \"{serializationName.SanitizeDoubleQuote()}\")]", result);
+    }
+
+    [Fact]
     public void NamesDontDiffer_DoesntWriteEnumMember()
     {
         currentEnum.Flags = true;

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeIndexerWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeIndexerWriterTests.cs
@@ -86,4 +86,12 @@ public sealed class CodeIndexerWriterTests : IDisposable
         Assert.Contains("<returns>", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
+    [Fact]
+    public void WritesIndexerWithEscapedPathParameterMapping()
+    {
+        indexer.IndexParameter.SerializationName = "line1\"\nline2";
+        writer.Write(indexer);
+        var result = tw.ToString();
+        Assert.Contains($"urlTplParams.Add(\"{indexer.IndexParameter.SerializationName.SanitizeDoubleQuote()}\", position);", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1359,6 +1359,21 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result, 1);
     }
     [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters(true);
+        method.AcceptedResponseTypes.Add("application/json");
+        method.UrlTemplateOverride = "{baseurl+}/foo/\"bar\nbaz";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("var requestInfo = new RequestInformation(Method.GET, \"{baseurl+}/foo/\\\"bar\\nbaz\", PathParameters)", result);
+        AssertExtensions.CurlyBracesAreClosed(result, 1);
+    }
+    [Fact]
     public void WritesRequestGeneratorBodyForScalarCollection()
     {
         setup();
@@ -1610,6 +1625,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("WriteStringValue(\"DummyUCaseProp\"", result);
         Assert.Contains("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nline2";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("writer.WriteStringValue(\"line1\\\"\\nline2\", DummyProp);", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("{ \"line1\\\"\\nline2\", n => { DummyProp = n.GetStringValue(); } },", deserializerResult);
     }
     [Fact]
     public void WritesMethodAsyncDescription()
@@ -2084,6 +2116,44 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("RegisterDefaultDeserializer", result);
         Assert.Contains($"TryAdd(\"baseurl\", Core.BaseUrl)", result);
         Assert.Contains($"BaseUrl = \"{method.BaseUrl}\"", result);
+    }
+    [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/\"evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "RequestAdapter",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        method.DeserializerModules = new() { "com.microsoft.kiota.serialization.Deserializer" };
+        method.SerializerModules = new() { "com.microsoft.kiota.serialization.Serializer" };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("BaseUrl = \"https://graph.microsoft.com/v1.0/\\\"evil\\npath\"", result);
     }
     [Fact]
     public void WritesApiConstructorWithBackingStore()

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1691,6 +1691,18 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see <more>";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("see &lt;more&gt; <see href=", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();
@@ -2281,6 +2293,16 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("2021-01-01", result);
         Assert.Contains("v2.0", result);
         Assert.Contains("[Obsolete", result);
+    }
+    [Fact]
+    public void EscapesDeprecationInformationStringLiteral()
+    {
+        setup();
+        method.Deprecation = new("line1\"\nline2");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("line1\\\"\\nline2", result);
+        Assert.DoesNotContain("line1\"\nline2", result);
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -2352,6 +2352,46 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("if(ReferenceEquals(ra, null)) throw new ArgumentNullException(nameof(ra));", result);
     }
     [Fact]
+    public void WritesMethodWithEscapedStringDefaultValue()
+    {
+        setup();
+        method.ReturnType = new CodeType
+        {
+            Name = "void",
+            IsExternal = true
+        };
+        method.Kind = CodeMethodKind.Constructor;
+        method.AddParameter(new CodeParameter
+        {
+            Name = "ra",
+            Kind = CodeParameterKind.Custom,
+            Type = new CodeType
+            {
+                Name = "RequestAdapter",
+                IsExternal = true,
+                IsNullable = false
+            },
+            Optional = false
+        });
+        method.AddParameter(new CodeParameter
+        {
+            Name = "sampleParam",
+            Kind = CodeParameterKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "string",
+                IsExternal = true,
+                IsNullable = false
+            },
+            Optional = true,
+            DefaultValue = "\"line1\"\nline2\"",
+        });
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"string sampleParam = {"\"line1\"\nline2\"".SanitizeQuotedStringLiteral()}", result);
+    }
+    [Fact]
     public void WritesDeprecationInformation()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1086,6 +1086,58 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesModelFactoryBodyForInheritedModels()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "parentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "childModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "parentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "parentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        Assert.Contains("var mappingValue = parseNode.GetChildNode(\"@odata.ty\\\"pe\\nx\")?.GetStringValue()", result);
+        Assert.Contains("\"ns.chi\\\"ld\\nmodel\" => new ChildModel()", result);
+    }
+    [Fact]
     public void DoesntWriteFactorySwitchOnMissingParameter()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -127,6 +127,27 @@ public sealed class CodePropertyWriterTests : IDisposable
         Assert.Contains("[QueryParameter(\"someserializationname\")", result);
     }
     [Fact]
+    public void WritesEscapedSerializationAttribute()
+    {
+        property.Kind = CodePropertyKind.QueryParameter;
+        property.SerializationName = "line1\"\nline2";
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains($"[QueryParameter(\"{property.SerializationName.SanitizeDoubleQuote()}\")", result);
+    }
+    [Fact]
+    public void MapsCustomPropertiesToBackingStoreWithEscapedKey()
+    {
+        parentClass.AddBackingStoreProperty();
+        property.Kind = CodePropertyKind.Custom;
+        property.SerializationName = "line1\"\nline2";
+        writer.Write(property);
+        var result = tw.ToString();
+        var sanitizedWireName = property.WireName.SanitizeDoubleQuote();
+        Assert.Contains($"BackingStore?.Get<global::{rootNamespace.Name}.SomeCustomClass>(\"{sanitizedWireName}\")", result);
+        Assert.Contains($"BackingStore?.Set(\"{sanitizedWireName}\", value);", result);
+    }
+    [Fact]
     public void DoesntWritePropertiesExistingInParentType()
     {
         parentClass.AddProperty(new CodeProperty

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeEnumWriterTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Writers;
+using Kiota.Builder.Writers.Dart;
 
 using Xunit;
 
@@ -84,5 +85,20 @@ public sealed class CodeEnumWriterTests : IDisposable
         writer.Write(currentEnum);
         var result = tw.ToString();
         Assert.Contains($"{OptionName}('{SerializationValue}')", result);
+    }
+    [Fact]
+    public void WritesEscapedEnumSerializationValue()
+    {
+        var optionName = "plus1";
+        var serializationValue = "line1'\n$line2";
+        var option = new CodeEnumOption
+        {
+            Name = optionName,
+            SerializationName = serializationValue
+        };
+        currentEnum.AddOption(option);
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains($"{optionName}('{DartConventionService.SanitizeDartSingleQuoteLiteral(serializationValue)}')", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -794,6 +794,62 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesModelFactoryBody()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "ParentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "ChildModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "ParentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "ParentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.$chi'ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "$odata.ty'pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        Assert.Contains("var mappingValue = parseNode.getChildNode('\\$odata.ty\\'pe\\nx')", result);
+        Assert.Contains("'ns.\\$chi\\'ld\\nmodel' => ChildModel(),", result);
+    }
+    [Fact]
     public void DoesntWriteFactorySwitchOnMissingParameter()
     {
         setup();
@@ -1619,5 +1675,20 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("'application/json; profile=\"CamelCase\"'", result);
+    }
+    [Fact]
+    public void EscapesRequestGeneratorAcceptHeaderAndContentType()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Post;
+        AddRequestProperties();
+        AddRequestBodyParameters();
+        method.AcceptedResponseTypes.Add("application/json; profile='Cam$el'\nCase");
+        method.RequestBodyContentType = "application/json; profile='Cam$el'\nCase";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("requestInfo.headers.put('Accept', 'application/json; profile=\\'Cam\\$el\\'\\nCase')", result);
+        Assert.Contains("'application/json; profile=\\'Cam\\$el\\'\\nCase'", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -1653,6 +1653,16 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("@Deprecated", result);
     }
     [Fact]
+    public void SanitizesDeprecationVersionInComments()
+    {
+        setup();
+        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z"), DateTimeOffset.Parse("2021-01-01T00:00:00Z"), $"v2.0{Environment.NewLine}VERSION_MARKER");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.DoesNotContain($"as of v2.0{Environment.NewLine}VERSION_MARKER", result);
+        Assert.Contains("as of v2.0VERSION_MARKER", result);
+    }
+    [Fact]
     public void EscapesDeprecationInformationStringLiteral()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -1093,6 +1093,21 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters(true);
+        method.AcceptedResponseTypes.Add("application/json");
+        method.UrlTemplateOverride = "{baseurl+}/foo/'bar\nbaz";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("var requestInfo = RequestInformation(httpMethod : HttpMethod.get, urlTemplate : '{baseurl+}/foo/\\'bar\\nbaz', pathParameters :  pathParameters)", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public void WritesUnionDeSerializerBody()
     {
         setup();
@@ -1270,6 +1285,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("writeEnumValue", result);
         Assert.Contains("writeAdditionalData(additionalData);", result);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1'\nline2";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("writer.writeStringValue('line1\\'\\nline2', dummyProp);", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("deserializerMap['line1\\'\\nline2'] = (node) => dummyProp = node.getStringValue();", deserializerResult);
     }
     [Fact]
     public void WritesMethodDescriptionLink()
@@ -1580,6 +1612,64 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("registerDefaultDeserializer", result);
         Assert.Contains($"pathParameters['baseurl'] = core.baseUrl", result);
         Assert.Contains($"core.baseUrl = '{method.BaseUrl}'", result);
+    }
+    [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/'evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "HttpCore",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        method.DeserializerModules = new() { "com.microsoft.kiota.serialization.Deserializer" };
+        method.SerializerModules = new() { "com.microsoft.kiota.serialization.Serializer" };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("core.baseUrl = 'https://graph.microsoft.com/v1.0/\\'evil\\npath'", result);
+    }
+    [Fact]
+    public void EscapesQueryParametersExtractor()
+    {
+        setup();
+        method.Kind = CodeMethodKind.QueryParametersMapper;
+        parentClass.Kind = CodeClassKind.QueryParameters;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "propWithDefaultValue",
+            SerializationName = "line1'\nline2",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "String"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("'line1\\'\\nline2' : propWithDefaultValue,", result);
     }
     [Fact]
     public void WritesApiConstructorWithBackingStore()

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -1298,6 +1298,19 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see \r\nmore";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("[see more](https://foo.org/docs)", result);
+        Assert.DoesNotContain($"{Environment.NewLine}more", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();
@@ -1638,6 +1651,16 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("2021-01-01", result);
         Assert.Contains("v2.0", result);
         Assert.Contains("@Deprecated", result);
+    }
+    [Fact]
+    public void EscapesDeprecationInformationStringLiteral()
+    {
+        setup();
+        method.Deprecation = new("line1\"\nline2$danger");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("line1\\\"line2\\$danger", result);
+        Assert.DoesNotContain("line1\"\nline2$danger", result);
     }
     [Fact]
     public void WritesDeprecationInformationFromBuilder()

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -1468,10 +1468,42 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains(parentClass.Name, result);
-        Assert.Contains($"{propName} = '{defaultValue}'", result);
+        Assert.Contains($"{propName} = '{DartConventionService.SanitizeDartSingleQuoteLiteral(defaultValue.Trim('\''))}'", result);
         Assert.Contains($"{nullPropName} = {defaultValueNull}", result);
         Assert.Contains($"{boolPropName} = {defaultValueBool}", result);
         Assert.Contains("super", result);
+    }
+    [Fact]
+    public void WritesConstructorWithEscapedStringDefaultValue()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        var defaultValue = "\"line1'\n$line2\"";
+        var propName = "propWithDefaultValue";
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = propName,
+            DefaultValue = defaultValue,
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "String"
+            }
+        });
+        AddRequestProperties();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "pathParameters",
+            Kind = CodeParameterKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Map<String, String>"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"{propName} = '{DartConventionService.SanitizeDartSingleQuoteLiteral("line1'\n$line2")}'", result);
     }
     [Fact]
     public void WritesWithUrl()

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodePropertyWriterTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Writers;
+using Kiota.Builder.Writers.Dart;
 
 using Xunit;
 
@@ -97,6 +98,27 @@ public sealed class CodePropertyWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("return backingStore.get<Somecustomtype>('propertyName') ?? {};", result);
         Assert.Contains("backingStore.set('propertyName', value);", result);
+    }
+    [Fact]
+    public void MapsCustomPropertiesToBackingStoreWithEscapedKey()
+    {
+        parentClass.AddBackingStoreProperty();
+        property.Kind = CodePropertyKind.Custom;
+        property.SerializationName = "line1'\n$line2";
+        writer.Write(property);
+        var result = tw.ToString();
+        var expectedSerializationName = DartConventionService.SanitizeDartSingleQuoteLiteral(property.SerializationName);
+        Assert.Contains($"return backingStore.get<Somecustomtype?>('{expectedSerializationName}');", result);
+        Assert.Contains($"backingStore.set('{expectedSerializationName}', value);", result);
+    }
+    [Fact]
+    public void WritesEscapedQueryParameterSerializationAttribute()
+    {
+        property.Kind = CodePropertyKind.QueryParameter;
+        property.SerializationName = "line1'\n$line2";
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains($"/// @QueryParameter('{DartConventionService.SanitizeDartSingleQuoteLiteral(property.SerializationName)}')", result);
     }
     [Fact]
     public void DoesntWritePropertiesExistingInParentType()

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -173,4 +173,17 @@ public sealed class CodeEnumWriterTests : IDisposable
         Assert.DoesNotContain("import", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
+    [Fact]
+    public void EscapesEnumWireValues()
+    {
+        currentEnum.AddOption(new CodeEnumOption
+        {
+            Name = "option1",
+            SerializationName = "line1\"\nline2",
+        });
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains("return []string{\"line1\\\"\\nline2\"}[i]", result);
+        Assert.Contains("case \"line1\\\"\\nline2\":", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -157,6 +157,24 @@ public sealed class CodeEnumWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void SanitizesEnumOptionDescription()
+    {
+        var option = new CodeEnumOption
+        {
+            Documentation = new()
+            {
+                DescriptionTemplate = "Some option\r\ninjected",
+            },
+            Name = "option1",
+        };
+        currentEnum.AddOption(option);
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+
+        Assert.Contains("// Some optioninjected", result);
+        Assert.DoesNotContain($"{Environment.NewLine}injected", result);
+    }
+    [Fact]
     public void DoesNotWriteImportOnEmptyImports()
     {
         var option = new CodeEnumOption

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -2418,6 +2418,16 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("// Deprecated:", result);
     }
     [Fact]
+    public void SanitizesDeprecationVersionInComments()
+    {
+        setup();
+        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z"), DateTimeOffset.Parse("2021-01-01T00:00:00Z"), $"v2.0{Environment.NewLine}VERSION_MARKER");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.DoesNotContain($"as of v2.0{Environment.NewLine}VERSION_MARKER", result);
+        Assert.Contains("as of v2.0VERSION_MARKER", result);
+    }
+    [Fact]
     public void WritesDeprecationInformationFromBuilder()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -993,6 +993,36 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("NewSomecustomtypeInternal(urlTplParams, m.BaseRequestBuilder.RequestAdapter)", result); // checking the parameter is passed to the constructor
     }
     [Fact]
+    public void EscapesIndexerPathParameterName()
+    {
+        setup();
+        AddRequestProperties();
+        parentClass.AddIndexer(new CodeIndexer
+        {
+            Name = "indx",
+            ReturnType = new CodeType
+            {
+                Name = "Somecustomtype",
+            },
+            IndexParameter = new()
+            {
+                Name = "id",
+                SerializationName = "i\"d\nvalue",
+                Type = new CodeType
+                {
+                    Name = "UUID",
+                    IsNullable = true,
+                },
+            }
+        });
+        if (parentClass.Indexer is null)
+            throw new InvalidOperationException("Indexer is null");
+        var methodForTest = parentClass.AddMethod(CodeMethod.FromIndexer(parentClass.Indexer, static x => $"With{x.ToFirstCharacterUpperCase()}", static x => x.ToFirstCharacterLowerCase(), false)).First();
+        writer.Write(methodForTest);
+        var result = tw.ToString();
+        Assert.Contains("[\"i\\\"d\\nvalue\"] = id.String()", result);
+    }
+    [Fact]
     public void DoesntWriteFactorySwitchOnMissingParameter()
     {
         setup();
@@ -1281,6 +1311,34 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public async Task EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrodeAsync()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        var executor = parentClass.AddMethod(new CodeMethod
+        {
+            Name = "executor",
+            HttpMethod = HttpMethod.Get,
+            Kind = CodeMethodKind.RequestExecutor,
+            ReturnType = new CodeType
+            {
+                Name = "string",
+                IsExternal = true,
+            }
+        }).First();
+        AddRequestBodyParameters(executor, true);
+        AddRequestBodyParameters(useComplexTypeForBody: true);
+        AddRequestProperties();
+        method.UrlTemplateOverride = "{baseurl+}/foo/\"bar\nbaz";
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Go }, parentClass.Parent as CodeNamespace, cancellationToken: TestContext.Current.CancellationToken);
+        method.AcceptedResponseTypes.Add("application/json");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"requestInfo := {AbstractionsPackageHash}.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters({AbstractionsPackageHash}.GET, \"{{baseurl+}}/foo/\\\"bar\\nbaz\", m.pathParameters)", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public async Task WritesRequestGeneratorBodyForParsableCollectionAsync()
     {
         setup();
@@ -1435,6 +1493,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("m.SetDummyProp(val)", result);
         Assert.DoesNotContain("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nbreak";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("WriteStringValue(\"line1\\\"\\nbreak\", m.GetDummyProp())", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("res[\"line1\\\"\\nbreak\"] = func", deserializerResult);
     }
     [Fact]
     public void WritesUnionDeSerializerBody()
@@ -2129,6 +2204,44 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("RegisterDefaultDeserializer", result);
         Assert.Contains($"[\"baseurl\"] = m.BaseRequestBuilder.Core.GetBaseUrl", result);
         Assert.Contains($"SetBaseUrl(\"{method.BaseUrl}\")", result);
+    }
+    [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/\"evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "HttpCore",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        method.DeserializerModules = new() { "github.com/microsoft/kiota/serialization/go/json.Deserializer" };
+        method.SerializerModules = new() { "github.com/microsoft/kiota/serialization/go/json.Serializer" };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("SetBaseUrl(\"https://graph.microsoft.com/v1.0/\\\"evil\\npath\")", result);
     }
     [Fact]
     public void WritesApiConstructorWithBackingStore()

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -1779,6 +1779,19 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see \r\nmore";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("[see more]: ", result);
+        Assert.DoesNotContain($"{Environment.NewLine}more", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -1918,6 +1918,27 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("NewBaseRequestBuilder", result);
     }
     [Fact]
+    public void EscapesStringDefaultsInConstructor()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "propWithDefaultValue",
+            DefaultValue = "\"line1\nline2\"",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string",
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("propWithDefaultValueValue := \"line1\\nline2\"", result);
+        Assert.Contains("m.SetPropWithDefaultValue(&propWithDefaultValueValue)", result);
+    }
+    [Fact]
     public void WritesConstructorWithEnumValue()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -957,6 +957,62 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesModelFactoryBody()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "ParentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "ChildModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "ParentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "ParentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        Assert.Contains("mappingValueNode, err := parseNode.GetChildNode(\"@odata.ty\\\"pe\\nx\")", result);
+        Assert.Contains("case \"ns.chi\\\"ld\\nmodel\":", result);
+    }
+    [Fact]
     public void WritesIndexerWithUuidParam()
     {
 

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodePropertyWriterTests.cs
@@ -92,6 +92,17 @@ public sealed class CodePropertyWriterTests : IDisposable
         property.SerializationName = "someserializationname";
         writer.Write(property);
         var result = tw.ToString();
-        Assert.Contains("`uriparametername:\"someserializationname\"`", result);
+        Assert.Contains("\"uriparametername:\\\"someserializationname\\\"\"", result);
+    }
+    [Fact]
+    public void EscapesSerializationTag()
+    {
+        property.Kind = CodePropertyKind.QueryParameter;
+        property.SerializationName = "line1\"\nline2";
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.Contains("uriparametername:\\\"line1", result);
+        Assert.Contains("line2\\\"", result);
+        Assert.Contains("\\n", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Go/GoConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/GoConventionServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 
 using Kiota.Builder.CodeDOM;
+using Kiota.Builder.Writers;
 using Kiota.Builder.Writers.Go;
 
 using Xunit;
@@ -15,5 +17,26 @@ public class GoConventionServiceTests
     {
         var root = CodeNamespace.InitRootNamespace();
         Assert.Throws<InvalidOperationException>(() => instance.GetAccessModifier(AccessModifier.Private));
+    }
+    [Fact]
+    public void SanitizesLineBreaksInDocumentationComments()
+    {
+        var codeClass = new CodeClass
+        {
+            Name = "testClass",
+            Documentation = new()
+            {
+                DescriptionTemplate = "line1\r\nline2\tline3",
+            },
+        };
+        var writer = LanguageWriter.GetLanguageWriter(GenerationLanguage.Go, "./", "name");
+        using var textWriter = new StringWriter();
+        writer.SetTextWriter(textWriter);
+
+        instance.WriteShortDescription(codeClass, writer);
+        var result = textWriter.ToString();
+
+        Assert.Contains("// line1line2 line3", result);
+        Assert.DoesNotContain($"{Environment.NewLine}line2", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/HTTP/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/HTTP/CodeClassDeclarationWriterTests.cs
@@ -265,4 +265,48 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
         // Check HTTP operations 
         Assert.Contains("GET {{hostAddress}}/posts HTTP/1.1", result);
     }
+    [Fact]
+    public async Task SanitizesMethodDocumentationComments()
+    {
+        var codeClass = new CodeClass
+        {
+            Name = "TestClass",
+            Kind = CodeClassKind.RequestBuilder,
+        };
+        codeClass.AddProperty(new CodeProperty
+        {
+            Name = "urlTemplate",
+            Kind = CodePropertyKind.UrlTemplate,
+            DefaultValue = "\"{+baseurl}/posts\"",
+            Type = new CodeType
+            {
+                Name = "string",
+                IsExternal = true,
+            },
+        });
+        codeClass.AddProperty(new CodeProperty
+        {
+            Name = "BaseUrl",
+            Kind = CodePropertyKind.Custom,
+            Access = AccessModifier.Private,
+            DefaultValue = "https://example.com",
+            Type = new CodeType { Name = "string", IsExternal = true },
+        });
+        codeClass.AddMethod(new CodeMethod
+        {
+            Name = "get",
+            Kind = CodeMethodKind.RequestExecutor,
+            Documentation = new CodeDocumentation { DescriptionTemplate = "GET method\r\ninjected" },
+            ReturnType = new CodeType { Name = "void" },
+        });
+        root.AddClass(codeClass);
+
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.HTTP }, root, cancellationToken: TestContext.Current.CancellationToken);
+
+        writer.Write(codeClass.StartBlock);
+        var result = tw.ToString();
+
+        Assert.Contains("# GET methodinjected", result);
+        Assert.DoesNotContain($"{Environment.NewLine}injected", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/HTTP/HttpConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/HTTP/HttpConventionServiceTests.cs
@@ -70,4 +70,10 @@ public sealed class HttpConventionServiceTest
         // Assert
         Assert.Equal("null", result);
     }
+    [Fact]
+    public void SanitizesInvalidDescriptionCharacters()
+    {
+        var result = HttpConventionService.RemoveInvalidDescriptionCharacters("line1\r\nline2\tline3");
+        Assert.Equal("line1line2 line3", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeEnumWriterTests.cs
@@ -92,4 +92,18 @@ public sealed class CodeEnumWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains($"plus_1(\"+1\")", result);
     }
+    [Fact]
+    public void EscapesEnumSerializationValue()
+    {
+        var option = new CodeEnumOption
+        {
+            Name = "plus_1",
+            SerializationName = "plu\"s\n1"
+        };
+        currentEnum.AddOption(option);
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains("plus_1(\"plu\\\"s\\n1\")", result);
+        Assert.Contains("case \"plu\\\"s\\n1\": return plus_1;", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1616,6 +1616,20 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see */ more";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.DoesNotContain("see */ more", result);
+        Assert.Contains("see  more", result);
+        Assert.Contains("@see <a href=", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -2173,6 +2173,17 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("@Deprecated", result);
     }
     [Fact]
+    public void SanitizesDeprecationVersionInComments()
+    {
+        setup();
+        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z"), DateTimeOffset.Parse("2021-01-01T00:00:00Z"), $"v2.0 */{Environment.NewLine}VERSION_MARKER");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.DoesNotContain("as of v2.0 */", result);
+        Assert.DoesNotContain($"{Environment.NewLine}VERSION_MARKER", result);
+        Assert.Contains("VERSION_MARKER", result);
+    }
+    [Fact]
     public void WritesDeprecationInformationFromBuilder()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1317,6 +1317,21 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters(true);
+        method.AcceptedResponseTypes.Add("application/json");
+        method.UrlTemplateOverride = "{baseurl+}/foo/\"bar\nbaz";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("final RequestInformation requestInfo = new RequestInformation(HttpMethod.GET, \"{baseurl+}/foo/\\\"bar\\nbaz\", pathParameters)", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public void WritesRequestGeneratorOverloadBody()
     {
         setup();
@@ -1562,6 +1577,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nline2";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("writer.writeStringValue(\"line1\\\"\\nline2\", this.getDummyProp());", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("deserializerMap.put(\"line1\\\"\\nline2\", (n) -> { this.setDummyProp(n.getStringValue()); });", deserializerResult);
+    }
+    [Fact]
     public void WritesMethodSyncDescription()
     {
         setup();
@@ -1716,6 +1748,33 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("pathParameters", result);
         Assert.Contains("id", result);
         Assert.Contains("return new", result);
+    }
+    [Fact]
+    public void EscapesIndexerPathParameterName()
+    {
+        setup();
+        AddRequestProperties();
+        method.Kind = CodeMethodKind.IndexerBackwardCompatibility;
+        method.OriginalIndexer = new CodeIndexer
+        {
+            Name = "idx",
+            ReturnType = new CodeType
+            {
+                Name = "String"
+            },
+            IndexParameter = new()
+            {
+                Name = "id",
+                SerializationName = "collection\"Id\nx",
+                Type = new CodeType
+                {
+                    Name = "int"
+                },
+            }
+        };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("urlTplParams.put(\"collection\\\"Id\\nx\", id);", result);
     }
     [Fact]
     public void WritesPathParameterRequestBuilder()
@@ -2047,6 +2106,44 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"setBaseUrl(\"{method.BaseUrl}\")", result);
     }
     [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/\"evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "HttpCore",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        method.DeserializerModules = new() { "com.microsoft.kiota.serialization.Deserializer" };
+        method.SerializerModules = new() { "com.microsoft.kiota.serialization.Serializer" };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("setBaseUrl(\"https://graph.microsoft.com/v1.0/\\\"evil\\npath\")", result);
+    }
+    [Fact]
     public void WritesApiConstructorWithBackingStore()
     {
         setup();
@@ -2105,6 +2202,26 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("allQueryParams.put(\"propWithDefaultValue\", propWithDefaultValue);", result);
+    }
+    [Fact]
+    public void EscapesQueryParametersExtractor()
+    {
+        setup();
+        method.Kind = CodeMethodKind.QueryParametersMapper;
+        parentClass.Kind = CodeClassKind.QueryParameters;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "propWithDefaultValue",
+            SerializationName = "line1\"\nline2",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "String"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("allQueryParams.put(\"line1\\\"\\nline2\", propWithDefaultValue);", result);
     }
     [Fact]
     public async Task AccessorsTargetingEscapedPropertiesAreNotEscapedThemselvesAsync()

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -851,6 +851,62 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesModelFactoryBody()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "ParentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "ChildModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "ParentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "ParentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        Assert.Contains("final ParseNode mappingValueNode = parseNode.getChildNode(\"@odata.ty\\\"pe\\nx\")", result);
+        Assert.Contains("case \"ns.chi\\\"ld\\nmodel\": return new ChildModel();", result);
+    }
+    [Fact]
     public void WritesModelSplitFactoryBody()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1829,6 +1829,24 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains(defaultValue, result);
     }
     [Fact]
+    public void WritesGetterToBackingStoreWithEscapedStringDefaultValue()
+    {
+        setup();
+        method.AddAccessedProperty();
+        parentClass.GetGreatestGrandparent().AddBackingStoreProperty();
+        method.AccessedProperty.Type = new CodeType
+        {
+            Name = "String",
+            IsNullable = false,
+        };
+        var defaultValue = "\"line1\"\nline2\"";
+        method.AccessedProperty.DefaultValue = defaultValue;
+        method.Kind = CodeMethodKind.Getter;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"value = {defaultValue.SanitizeQuotedStringLiteral()};", result);
+    }
+    [Fact]
     public void WritesSetterToBackingStore()
     {
         setup();
@@ -1964,6 +1982,38 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"this.set{nullPropName.ToFirstCharacterUpperCase()}({defaultValueNull.TrimQuotes()})", result);
         Assert.Contains($"this.set{boolPropName.ToFirstCharacterUpperCase()}({defaultValueBool.TrimQuotes()})", result);
         Assert.Contains("super", result);
+    }
+    [Fact]
+    public void WritesConstructorWithEscapedStringDefaultValue()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        var defaultValue = "\"line1\"\nline2\"";
+        var propName = "propWithDefaultValue";
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = propName,
+            DefaultValue = defaultValue,
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "String"
+            }
+        });
+        AddRequestProperties();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "pathParameters",
+            Kind = CodeParameterKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Map<String, String>"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"this.set{propName.ToFirstCharacterUpperCase()}({defaultValue.SanitizeQuotedStringLiteral()})", result);
     }
     [Fact]
     public void WritesWithUrl()

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
@@ -57,4 +57,18 @@ public sealed class CodeEnumWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result, 1);
         Assert.Contains(optionName, result);
     }
+    [Fact]
+    public async Task EscapesEnumWireValuesAsync()
+    {
+        var declaration = currentEnum.Parent as CodeNamespace;
+        currentEnum.AddOption(new CodeEnumOption
+        {
+            Name = "option1",
+            SerializationName = "line1\"\nline2",
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, declaration, cancellationToken: TestContext.Current.CancellationToken);
+        _codeEnumWriter.WriteCodeElement(currentEnum, writer);
+        var result = tw.ToString();
+        Assert.Contains("public const OPTION1 = \"line1\\\"\\nline2\";", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1750,6 +1750,63 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("$mappingValueNode = $parseNode->getChildNode(\"@odata.type\");", result);
     }
     [Fact]
+    public async Task EscapesFactoryMethodAsync()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "parentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "childModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "parentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "parentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("chi'ld\nModel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "ParseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, parentClass.Parent as CodeNamespace, cancellationToken: TestContext.Current.CancellationToken);
+        languageWriter.Write(factoryMethod);
+        var result = stringWriter.ToString();
+        Assert.Contains("$mappingValueNode = $parseNode->getChildNode(\"@odata.ty\\\"pe\\nx\");", result);
+        Assert.Contains("case 'chi\\'ld\\nModel': return new ChildModel();", result);
+    }
+    [Fact]
     public async Task WriteApiConstructorAsync()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -251,7 +251,7 @@ public sealed class CodeMethodWriterTests : IDisposable
             {
                 DescriptionTemplate = "This will send a POST request",
                 DocumentationLink = new Uri("https://learn.microsoft.com/"),
-                DocumentationLabel = "Learning"
+                DocumentationLabel = "Learning */ docs"
             },
             Kind = CodeMethodKind.RequestExecutor
         };
@@ -288,7 +288,8 @@ public sealed class CodeMethodWriterTests : IDisposable
 
         Assert.Contains("public function post(): Promise", result);
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
-        Assert.Contains("@link https://learn.microsoft.com/ Learning", result);
+        Assert.DoesNotContain("@link https://learn.microsoft.com/ Learning */ docs", result);
+        Assert.Contains("@link https://learn.microsoft.com/ Learning  docs", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
         Assert.Contains("$result = $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $errorMappings);", result);
         Assert.Contains("return $result;", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -634,6 +634,26 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = stringWriter.ToString();
         Assert.Contains("$requestInfo->urlTemplate = '{baseurl+}/foo/bar';", result);
     }
+    [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        parentClass.Kind = CodeClassKind.RequestBuilder;
+        method.Name = "createPostRequestInformation";
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.ReturnType = new CodeType()
+        {
+            Name = "RequestInformation",
+            IsNullable = false
+        };
+        method.HttpMethod = HttpMethod.Post;
+        AddRequestProperties();
+        AddRequestBodyParameters();
+        method.UrlTemplateOverride = "{baseurl+}/foo/'bar\nbaz";
+        _codeMethodWriter.WriteCodeElement(method, languageWriter);
+        var result = stringWriter.ToString();
+        Assert.Contains("$requestInfo->urlTemplate = '{baseurl+}/foo/\\'bar\\nbaz';", result);
+    }
 
     [Fact]
     public void WritesRequestGeneratorBodyForParsableCollection()
@@ -821,6 +841,97 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("return new MessageRequestBuilder($urlTplParams, $this->requestAdapter, $id);", result);
 
     }
+    [Fact]
+    public async Task EscapesIndexerPathParameterNameAsync()
+    {
+        setup();
+        parentClass.AddProperty(
+            new CodeProperty
+            {
+                Name = "pathParameters",
+                Kind = CodePropertyKind.PathParameters,
+                Type = new CodeType { Name = "array" },
+                DefaultValue = "[]"
+            },
+            new CodeProperty
+            {
+                Name = "requestAdapter",
+                Kind = CodePropertyKind.RequestAdapter,
+                Type = new CodeType
+                {
+                    Name = "requestAdapter"
+                }
+            },
+            new CodeProperty
+            {
+                Name = "urlTemplate",
+                Kind = CodePropertyKind.UrlTemplate,
+                Type = new CodeType
+                {
+                    Name = "string"
+                }
+            }
+        );
+        var codeMethod = new CodeMethod
+        {
+            Name = "messageById",
+            Access = AccessModifier.Public,
+            Kind = CodeMethodKind.IndexerBackwardCompatibility,
+            OriginalIndexer = new CodeIndexer
+            {
+                Name = "messageById",
+                ReturnType = new CodeType
+                {
+                    Name = "MessageRequestBuilder"
+                },
+                IndexParameter = new()
+                {
+                    Name = "id",
+                    SerializationName = "mess'age\nid",
+                    Type = new CodeType
+                    {
+                        Name = "MessageRequestBuilder"
+                    },
+                }
+            },
+            OriginalMethod = new CodeMethod
+            {
+                Name = "messageById",
+                Access = AccessModifier.Public,
+                Kind = CodeMethodKind.IndexerBackwardCompatibility,
+                ReturnType = new CodeType
+                {
+                    Name = "MessageRequestBuilder"
+                }
+            },
+            ReturnType = new CodeType
+            {
+                Name = "MessageRequestBuilder",
+                IsNullable = false,
+                TypeDefinition = new CodeClass
+                {
+                    Name = "MessageRequestBuilder",
+                    Kind = CodeClassKind.RequestBuilder,
+                    Parent = parentClass.Parent
+                }
+            }
+        };
+        codeMethod.AddParameter(new CodeParameter
+        {
+            Name = "id",
+            Type = new CodeType
+            {
+                Name = "string",
+                IsNullable = false
+            },
+            Kind = CodeParameterKind.Path
+        });
+        parentClass.AddMethod(codeMethod);
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, parentClass.Parent as CodeNamespace, cancellationToken: TestContext.Current.CancellationToken);
+        languageWriter.Write(codeMethod);
+        var result = stringWriter.ToString();
+        Assert.Contains("$urlTplParams['mess\\'age\\nid'] = $id;", result);
+    }
 
     public static IEnumerable<object[]> DeserializerProperties => new List<object[]>
     {
@@ -937,6 +1048,24 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = stringWriter.ToString();
         Assert.Contains("parent::methodName()", result);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1'\nbreak";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        method.ReturnType.Name = "void";
+        languageWriter.Write(method);
+        var serializerResult = stringWriter.ToString();
+        Assert.Contains("$writer->writeStringValue('line1\\'\\nbreak', $this->getDummyProp());", serializerResult);
+        stringWriter.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        languageWriter.Write(method);
+        var deserializerResult = stringWriter.ToString();
+        Assert.Contains("'line1\\'\\nbreak' => fn(ParseNode $n) => $o->setDummyProp($n->getStringValue())", deserializerResult);
     }
 
     [Fact]
@@ -1671,6 +1800,56 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = stringWriter.ToString();
         Assert.Contains("public function __construct(RequestAdapter $requestAdapter)", result);
         Assert.Contains($"$this->pathParameters['baseurl'] = $this->requestAdapter->getBaseUrl();", result);
+    }
+    [Fact]
+    public async Task EscapesApiConstructorBaseUrlAsync()
+    {
+        setup();
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "requestAdapter",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType { Name = "RequestAdapter" }
+        });
+        var codeMethod = new CodeMethod
+        {
+            ReturnType = new CodeType
+            {
+                Name = "void",
+                IsNullable = false
+            },
+            Name = "construct",
+            Parent = parentClass,
+            Kind = CodeMethodKind.ClientConstructor
+        };
+        codeMethod.BaseUrl = "https://graph.microsoft.com/v1.0/'evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "array",
+                IsExternal = true,
+            }
+        });
+        codeMethod.AddParameter(new CodeParameter
+        {
+            Kind = CodeParameterKind.RequestAdapter,
+            Name = "requestAdapter",
+            Type = new CodeType
+            {
+                Name = "RequestAdapter"
+            },
+            SerializationName = "rawUrl"
+        });
+        codeMethod.DeserializerModules = new() { "Microsoft\\Kiota\\Serialization\\Deserializer" };
+        codeMethod.SerializerModules = new() { "Microsoft\\Kiota\\Serialization\\Serializer" };
+        parentClass.AddMethod(codeMethod);
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, parentClass.Parent as CodeNamespace, cancellationToken: TestContext.Current.CancellationToken);
+        languageWriter.Write(codeMethod);
+        var result = stringWriter.ToString();
+        Assert.Contains("$this->requestAdapter->setBaseUrl('https://graph.microsoft.com/v1.0/\\'evil\\npath');", result);
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1163,6 +1163,31 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("$this->setPropWithDefaultBoolValue(true)", result);
     }
     [Fact]
+    public async Task EscapesStringDefaultsInConstructorAsync()
+    {
+        setup();
+        parentClass.Kind = CodeClassKind.Model;
+        var constructor = new CodeMethod
+        {
+            Name = "constructor",
+            Access = AccessModifier.Public,
+            ReturnType = new CodeType { Name = "void" },
+            Kind = CodeMethodKind.Constructor
+        };
+        parentClass.AddMethod(constructor);
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "type",
+            DefaultValue = "\"line1'\\\nline2\"",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { Name = "string" },
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root, cancellationToken: TestContext.Current.CancellationToken);
+        _codeMethodWriter.WriteCodeElement(constructor, languageWriter);
+        var result = stringWriter.ToString();
+        Assert.Contains("$this->setType('line1\\'\\\\\\nline2')", result);
+    }
+    [Fact]
     public void DoesNotWriteConstructorWithDefaultFromComposedType()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodePropertyWriterTests.cs
@@ -224,6 +224,27 @@ public class CodePropertyWriterTests
         Assert.Contains("@var array<string>|null $select", result);
         Assert.Contains("private ?array $select", result);
     }
+    [Fact]
+    public void EscapesQueryParameter()
+    {
+        var queryParameter = new CodeProperty
+        {
+            Name = "select",
+            Kind = CodePropertyKind.QueryParameter,
+            SerializationName = "li\"ne\nbreak",
+            Access = AccessModifier.Private,
+            Type = new CodeType
+            {
+                CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
+                Name = "string"
+            }
+        };
+        parentClass.AddProperty(queryParameter);
+        propertyWriter.WriteCodeElement(queryParameter, languageWriter);
+        var result = stringWriter.ToString();
+
+        Assert.Contains("@QueryParameter(\"li\\\"ne\\nbreak\")", result);
+    }
 
     [Fact]
     public async Task WriteRequestOptionAsync()

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeEnumWriterTests.cs
@@ -54,4 +54,16 @@ public sealed class CodeEnumWriterTests : IDisposable
         Assert.Contains("(str, Enum):", result);
         Assert.Contains("pass", result);
     }
+    [Fact]
+    public void EscapesEnumWireValues()
+    {
+        currentEnum.AddOption(new CodeEnumOption
+        {
+            Name = "Option1",
+            SerializationName = "line1\"\nline2",
+        });
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+        Assert.Contains("Option1 = \"line1\\\"\\nline2\",", result);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1225,6 +1225,51 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("return ParentClass()", result);
     }
     [Fact]
+    public void EscapesModelFactoryBodyForInheritedModels()
+    {
+        setup();
+        parentClass.Kind = CodeClassKind.Model;
+        childClass.Kind = CodeClassKind.Model;
+        childClass.StartBlock.Inherits = new CodeType
+        {
+            Name = "parentClass",
+            TypeDefinition = parentClass,
+        };
+        method.Kind = CodeMethodKind.Factory;
+        method.ReturnType = new CodeType
+        {
+            Name = "parentClass",
+            TypeDefinition = parentClass,
+        };
+        method.IsStatic = true;
+        parentClass.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childClass",
+            TypeDefinition = childClass,
+        });
+        parentClass.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        AddCodeUsings();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "parse_node",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("child_node = parse_node.get_child_node(\"@odata.ty\\\"pe\\nx\")", result);
+        Assert.Contains("if mapping_value and mapping_value.casefold() == \"ns.chi\\\"ld\\nmodel\".casefold()", result);
+    }
+    [Fact]
     public void WritesModelFactoryBodyForUnionModels()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -731,6 +731,20 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("request_info = RequestInformation(Method.GET, '{baseurl+}/foo/bar', self.path_parameters", result);
     }
     [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        AddRequestProperties();
+        AddRequestBodyParameters(true);
+        method.AcceptedResponseTypes.Add("application/json");
+        method.UrlTemplateOverride = "{baseurl+}/foo/'bar\nbaz";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("request_info = RequestInformation(Method.GET, '{baseurl+}/foo/\\'bar\\nbaz', self.path_parameters", result);
+    }
+    [Fact]
     public void WritesRequestGeneratorBodyKnownRequestBodyType()
     {
         setup();
@@ -998,6 +1012,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("write_additional_data_value(self.additional_data)", result);
         Assert.Contains("defined_in_parent", result, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("()", result, StringComparison.OrdinalIgnoreCase);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummy_string", StringComparison.Ordinal)).SerializationName = "line1\"\nline2";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("writer.write_str_value(\"line1\\\"\\nline2\", self.dummy_string)", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("\"line1\\\"\\nline2\": lambda n : setattr(self, 'dummy_string', n.get_str_value())", deserializerResult);
     }
     [Fact]
     public void WritesMethodAsyncDescription()
@@ -1430,6 +1461,34 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("self.path_parameters", result);
         Assert.Contains("id", result);
         Assert.Contains("return", result);
+    }
+    [Fact]
+    public void EscapesIndexerPathParameterName()
+    {
+        setup();
+        AddRequestProperties();
+        method.Kind = CodeMethodKind.IndexerBackwardCompatibility;
+        method.OriginalIndexer = new()
+        {
+            Name = "indx",
+            ReturnType = new CodeType
+            {
+                Name = "string",
+            },
+            IndexParameter = new()
+            {
+                Name = "id",
+                Type = new CodeType
+                {
+                    Name = "string",
+                    IsNullable = true,
+                },
+                SerializationName = "i\"d\nvalue",
+            }
+        };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("url_tpl_params[\"i\\\"d\\nvalue\"] = id", result);
     }
     [Fact]
     public void WritesPathParameterRequestBuilder()
@@ -2035,6 +2094,45 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("self.path_parameters[\"base_url\"] = self.core.base_url", result);
     }
     [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.IsAsync = false;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/\"evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "path_parameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "dict[str, str]",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "HttpCore",
+                IsExternal = true,
+            },
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        method.DeserializerModules = new() { "com.microsoft.kiota.serialization.Deserializer" };
+        method.SerializerModules = new() { "com.microsoft.kiota.serialization.Serializer" };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("self.core.base_url = \"https://graph.microsoft.com/v1.0/\\\"evil\\npath\"", result);
+    }
+    [Fact]
     public void WritesBackedModelConstructor()
     {
         setup();
@@ -2199,6 +2297,36 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("if original_name == \"start_date_time\":", result);
         Assert.Contains("return \"startDateTime\"", result);
         Assert.Contains("return original_name", result);
+    }
+    [Fact]
+    public void EscapesNameMapperMethodSerializationNames()
+    {
+        setup();
+        method.Kind = CodeMethodKind.QueryParametersMapper;
+        method.IsAsync = false;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "filter",
+            Kind = CodePropertyKind.QueryParameter,
+            SerializationName = "li\"ne\nbreak",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        method.AddParameter(new CodeParameter
+        {
+            Kind = CodeParameterKind.QueryParametersMapperParameter,
+            Name = "original_name",
+            Type = new CodeType
+            {
+                Name = "string",
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("if original_name == \"filter\":", result);
+        Assert.Contains("return \"li\\\"ne\\nbreak\"", result);
     }
     [Fact]
     public void MapperMethodFailsIfNoQueryParametersMapperParameter()

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1810,6 +1810,26 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"some_property: Optional[str] = None", result);
     }
     [Fact]
+    public void EscapesModelClassStringDefaults()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        parentClass.Kind = CodeClassKind.Model;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "prop_with_default_value",
+            DefaultValue = "\"line1\nline2\"",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("prop_with_default_value: Optional[str] = \"line1\\nline2\"", result);
+    }
+    [Fact]
     public void WritesModelClasses()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1094,6 +1094,18 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.DoesNotContain("await", result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see\"\"\"more";
+        method.Documentation.DocumentationLink = new("https://example.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("see\\\"\\\"\\\"more:", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();
@@ -2452,6 +2464,16 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("2021-01-01", result);
         Assert.Contains("v2.0", result);
         Assert.Contains("warn(", result);
+    }
+    [Fact]
+    public void EscapesDeprecationWarningStringLiteral()
+    {
+        setup();
+        method.Deprecation = new("line1\"\nline2");
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("warn(\"line1\\\"\\nline2", result);
+        Assert.DoesNotContain("line1\"\nline2", result);
     }
     [Fact]
     public void WritesDeprecationInformationFromBuilder()

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -1106,6 +1106,18 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("see\\\"\\\"\\\"more:", result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLink()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "see more";
+        method.Documentation.DocumentationLink = new("https://example.org/docs#\\\\test");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("see more: https://example.org/docs#//test", result);
+    }
+    [Fact]
     public void Defensive()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -540,6 +540,20 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("request_info.url_template = '{baseurl+}/foo/bar'", result);
     }
     [Fact]
+    public void EscapesRequestGeneratorBodyWhenUrlTemplateIsOverrode()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestGenerator;
+        method.HttpMethod = HttpMethod.Get;
+        method.AcceptedResponseTypes.Add("application/json");
+        AddRequestProperties();
+        AddRequestBodyParameters();
+        method.UrlTemplateOverride = "{baseurl+}/foo/'bar\nbaz";
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("request_info.url_template = '{baseurl+}/foo/\\'bar\\nbaz'", result);
+    }
+    [Fact]
     public void WritesRequestGeneratorBodyKnownRequestBodyType()
     {
         setup();
@@ -644,6 +658,23 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("write_additional_data", result);
         Assert.Contains("definedInParent", result, StringComparison.OrdinalIgnoreCase);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void EscapesWireNamesInSerializerAndDeserializerBody()
+    {
+        setup();
+        AddSerializationProperties();
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nbreak";
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        writer.Write(method);
+        var serializerResult = tw.ToString();
+        Assert.Contains("write_string_value(\"line1\\\"\\nbreak\",", serializerResult);
+        tw.GetStringBuilder().Clear();
+        method.Kind = CodeMethodKind.Deserializer;
+        writer.Write(method);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("\"line1\\\"\\nbreak\" => lambda", deserializerResult);
     }
     [Fact]
     public void WritesTranslatedTypesDeSerializerBody()
@@ -808,6 +839,34 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("path_parameters", result);
         Assert.Contains("= id", result);
         Assert.Contains("return Somecustomtype.new", result);
+    }
+    [Fact]
+    public void EscapesIndexerPathParameterName()
+    {
+        setup();
+        AddRequestProperties();
+        method.Kind = CodeMethodKind.IndexerBackwardCompatibility;
+        method.OriginalIndexer = new()
+        {
+            Name = "indx",
+            ReturnType = new CodeType
+            {
+                Name = "string",
+            },
+            IndexParameter = new()
+            {
+                Name = "id",
+                SerializationName = "i\"d\nvalue",
+                Type = new CodeType
+                {
+                    Name = "string",
+                    IsNullable = true,
+                },
+            }
+        };
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("url_tpl_params[\"i\\\"d\\nvalue\"] = id", result);
     }
     [Fact]
     public void WritesPathParameterRequestBuilder()
@@ -985,6 +1044,42 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"set_base_url('{method.BaseUrl}')", result);
     }
     [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        setup();
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/'evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var coreProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "core",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "HttpCore",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "core",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = coreProp.Type,
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("set_base_url('https://graph.microsoft.com/v1.0/\\'evil\\npath')", result);
+    }
+    [Fact]
     public void WritesApiConstructorWithBackingStore()
     {
         setup();
@@ -1074,6 +1169,36 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("when \"select\"", result);
         Assert.Contains("return \"%24select\"", result);
         Assert.Contains("else", result);
+    }
+    [Fact]
+    public void EscapesNameMapperMethodSerializationNames()
+    {
+        setup();
+        method.Kind = CodeMethodKind.QueryParametersMapper;
+        method.IsAsync = false;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "filter",
+            Kind = CodePropertyKind.QueryParameter,
+            SerializationName = "li\"ne\nbreak",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        method.AddParameter(new CodeParameter
+        {
+            Kind = CodeParameterKind.QueryParametersMapperParameter,
+            Name = "originalName",
+            Type = new CodeType
+            {
+                Name = "string",
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("when \"filter\"", result);
+        Assert.Contains("return \"li\\\"ne\\nbreak\"", result);
     }
     [Fact]
     public void DoesntWriteReadOnlyPropertiesInSerializerBody()

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -359,6 +359,62 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void EscapesModelFactoryBody()
+    {
+        setup();
+        var parentModel = root.AddClass(new CodeClass
+        {
+            Name = "parentModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var childModel = root.AddClass(new CodeClass
+        {
+            Name = "childModel",
+            Kind = CodeClassKind.Model,
+        }).First();
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "parentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "parentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        writer.Write(factoryMethod);
+        var result = tw.ToString();
+        Assert.Contains("mapping_value_node = parse_node.get_child_node(\"@odata.ty\\\"pe\\nx\")", result);
+        Assert.Contains("when \"ns.chi\\\"ld\\nmodel\"", result);
+    }
+    [Fact]
     public void DoesntWriteFactorySwitchOnMissingParameter()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -863,6 +863,26 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"@{propName.ToSnakeCase()} = {defaultValue}", result);
     }
     [Fact]
+    public void EscapesStringDefaultsInConstructor()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        var propName = "propWithDefaultValue";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = propName,
+            DefaultValue = "\"line1\nline2\"",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains($"@{propName.ToSnakeCase()} = \"line1\\nline2\"", result);
+    }
+    [Fact]
     public void WritesWithUrl()
     {
         setup();

--- a/tests/Kiota.Builder.Tests/Writers/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/StringExtensionsTests.cs
@@ -18,4 +18,22 @@ public class StringExtensionsTests
         Assert.Equal("foo", "foo[]".StripArraySuffix());
         Assert.Equal("[]foo", "[]foo".StripArraySuffix());
     }
+    [Fact]
+    public void SanitizesDoubleQuotedLiterals()
+    {
+        const string input = "line1\"\\\n\r\t\0";
+        Assert.Equal("line1\\\"\\\\\\n\\r\\t\\0", input.SanitizeDoubleQuote());
+    }
+    [Fact]
+    public void SanitizesSingleQuotedLiterals()
+    {
+        const string input = "line1'\\\n\r\t\0";
+        Assert.Equal("line1\\'\\\\\\n\\r\\t\\0", input.SanitizeSingleQuote());
+    }
+    [Fact]
+    public void SanitizesQuotedStringLiteral()
+    {
+        const string input = "\"line1\\\nline2\"";
+        Assert.Equal("\"line1\\\\\\nline2\"", input.SanitizeQuotedStringLiteral());
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
@@ -113,6 +113,42 @@ public sealed class CodeConstantWriterTests : IDisposable
         Assert.Contains(optionName, result);
         AssertExtensions.CurlyBracesAreClosed(result, 0);
     }
+    [Fact]
+    public void WritesEscapedEnumWireName()
+    {
+        AddCodeEnum();
+        var wireName = "line1\"\nline2";
+        currentEnum.AddOption(new CodeEnumOption { Name = "option1", SerializationName = wireName });
+        codeConstantWriter.WriteCodeElement(currentEnum.CodeEnumObject, writer);
+        var result = tw.ToString();
+        Assert.Contains($"Option1: \"{wireName.SanitizeDoubleQuote()}\"", result);
+    }
+
+    [Fact]
+    public void WritesEscapedQueryParameterMappings()
+    {
+        var queryParametersInterface = root.AddInterface(new CodeInterface
+        {
+            Name = "SomeRequestBuilderGetQueryParameters",
+            Kind = CodeInterfaceKind.QueryParameters,
+            OriginalClass = new CodeClass { Name = "SomeRequestBuilderGetQueryParameters" },
+        }).First();
+        queryParametersInterface.AddProperty(new CodeProperty
+        {
+            Name = "select",
+            Kind = CodePropertyKind.QueryParameter,
+            SerializationName = "line1\"\nline2",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        var constant = CodeConstant.FromQueryParametersMapping(queryParametersInterface);
+        Assert.NotNull(constant);
+        codeConstantWriter.WriteCodeElement(constant, writer);
+        var result = tw.ToString();
+        Assert.Contains($"\"select\": \"{"line1\"\nline2".SanitizeDoubleQuote()}\"", result);
+    }
 
     [Fact]
     public void DoesntWriteAnythingOnNoOption()
@@ -286,6 +322,25 @@ public sealed class CodeConstantWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("sendCollectionOfPrimitive", result);
         AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
+    public void WritesEscapedUrlTemplateOverrideInRequestMetadata()
+    {
+        method.Kind = CodeMethodKind.RequestExecutor;
+        method.HttpMethod = HttpMethod.Get;
+        method.UrlTemplateOverride = "line1\"\nline2";
+        AddRequestBodyParameters();
+        var constant = CodeConstant.FromRequestBuilderToRequestsMetadata(parentClass);
+        var codeFile = parentClass.GetImmediateParentOfType<CodeNamespace>().TryAddCodeFile("foo", constant);
+        codeFile.AddElements(new CodeConstant
+        {
+            Name = "UriTemplate",
+            Kind = CodeConstantKind.UriTemplate,
+            UriTemplate = "{baseurl+}/foo/bar"
+        });
+        writer.Write(constant);
+        var result = tw.ToString();
+        Assert.Contains($"uriTemplate: \"{method.UrlTemplateOverride.SanitizeDoubleQuote()}\"", result);
     }
     [Fact]
     public void WritesRequestGeneratorBodyForScalar()
@@ -515,7 +570,7 @@ public sealed class CodeConstantWriterTests : IDisposable
                 Name = "string",
                 IsNullable = true,
             },
-            SerializationName = "foo-id",
+            SerializationName = "foo\"\n-id",
             Kind = CodeParameterKind.Path
         });
         var parentNS = parentClass.GetImmediateParentOfType<CodeNamespace>();
@@ -547,7 +602,7 @@ public sealed class CodeConstantWriterTests : IDisposable
         Assert.Contains("methodName", result);
         Assert.Contains("requestsMetadata: SomecustomtypeRequestsMetadata", result);
         Assert.Contains("navigationMetadata: SomecustomtypeNavigationMetadata", result);
-        Assert.Contains("pathParametersMappings: [\"foo-id\"]", result);
+        Assert.Contains($"pathParametersMappings: [\"{"foo\"\n-id".SanitizeDoubleQuote()}\"]", result);
     }
     private void AddRequestProperties()
     {

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
@@ -81,6 +81,20 @@ public sealed class CodeConstantWriterTests : IDisposable
     }
 
     [Fact]
+    public void WritesEscapedUriTemplateConstant()
+    {
+        var constant = new CodeConstant
+        {
+            Name = "parentClassUriTemplate",
+            Kind = CodeConstantKind.UriTemplate,
+            UriTemplate = "\"{baseurl+}/foo/\"bar\nbaz\"",
+        };
+        codeConstantWriter.WriteCodeElement(constant, writer);
+        var result = tw.ToString();
+        Assert.Contains($"export const ParentClassUriTemplate = {constant.UriTemplate.SanitizeQuotedStringLiteral()};", result);
+    }
+
+    [Fact]
     public void WritesEnumOptionDescription()
     {
         AddCodeEnum();

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -1044,6 +1044,28 @@ public sealed class CodeFunctionWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result, 1);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabel()
+    {
+        var parentClass = root.AddClass(new CodeClass
+        {
+            Name = "ODataError",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var method = TestHelper.CreateMethod(parentClass, MethodName, ReturnTypeName);
+        method.Kind = CodeMethodKind.Factory;
+        method.IsStatic = true;
+        method.Documentation.DescriptionTemplate = "description";
+        method.Documentation.DocumentationLabel = "see */ more";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        var function = new CodeFunction(method);
+        root.TryAddCodeFile("foo", function);
+        writer.Write(function);
+        var result = tw.ToString();
+        Assert.DoesNotContain("see */ more", result);
+        Assert.Contains("see * / more", result);
+        Assert.Contains("@see {@link", result);
+    }
+    [Fact]
     public void WritesReturnType()
     {
         var parentClass = root.AddClass(new CodeClass

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -431,6 +431,32 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains("?? EnumTypeWithOptionObject.SomeOption", result);
     }
     [Fact]
+    public async Task WritesDeSerializerBodyWithEscapedDefaultValueAsync()
+    {
+        var parentClass = TestHelper.CreateModelClass(root, "parentClass");
+        TestHelper.AddSerializationPropertiesToModelClass(parentClass);
+        var defaultValue = "\"line1\"\nline2\"";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "propWithDefaultValue",
+            DefaultValue = defaultValue,
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
+        var deserializerFunction = root.FindChildByName<CodeFunction>($"deserializeInto{parentClass.Name.ToFirstCharacterUpperCase()}");
+        Assert.NotNull(deserializerFunction);
+        var parentNS = deserializerFunction.GetImmediateParentOfType<CodeNamespace>();
+        Assert.NotNull(parentNS);
+        parentNS.TryAddCodeFile("foo", deserializerFunction);
+        writer.Write(deserializerFunction);
+        var result = tw.ToString();
+        Assert.Contains($"?? {defaultValue.SanitizeQuotedStringLiteral()}", result);
+    }
+    [Fact]
     public async Task WritesSerializerBodyEnumCollectionAsync()
     {
         var parentClass = TestHelper.CreateModelClass(root, "parentClass");

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -518,6 +518,30 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains($"if (!{parentClass.Name.ToFirstCharacterLowerCase()} || isSerializingDerivedType) {{ return; }}", result);
         Assert.Contains("definedInParent", result, StringComparison.OrdinalIgnoreCase);
     }
+    [Fact]
+    public async Task EscapesWireNamesInSerializerAndDeserializerBodyAsync()
+    {
+        var generationConfiguration = new GenerationConfiguration { Language = GenerationLanguage.TypeScript };
+        var parentClass = TestHelper.CreateModelClassInModelsNamespace(generationConfiguration, root, "parentClass");
+        TestHelper.AddSerializationPropertiesToModelClass(parentClass);
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nline2";
+        await ILanguageRefiner.RefineAsync(generationConfiguration, root, cancellationToken: TestContext.Current.CancellationToken);
+        var serializerFunction = root.FindChildByName<CodeFunction>($"Serialize{parentClass.Name.ToFirstCharacterUpperCase()}");
+        Assert.NotNull(serializerFunction);
+        var parentNS = serializerFunction.GetImmediateParentOfType<CodeNamespace>();
+        Assert.NotNull(parentNS);
+        parentNS.TryAddCodeFile("foo", serializerFunction);
+        writer.Write(serializerFunction);
+        var serializerResult = tw.ToString();
+        Assert.Contains("writer.writeStringValue(\"line1\\\"\\nline2\", parentClass.dummyProp", serializerResult);
+        tw.GetStringBuilder().Clear();
+        var deserializerFunction = root.FindChildByName<CodeFunction>($"deserializeInto{parentClass.Name.ToFirstCharacterUpperCase()}");
+        Assert.NotNull(deserializerFunction);
+        parentNS.TryAddCodeFile("foo-deserializer", deserializerFunction);
+        writer.Write(deserializerFunction);
+        var deserializerResult = tw.ToString();
+        Assert.Contains("\"line1\\\"\\nline2\": n => { parentClass.dummyProp = n.getStringValue(); }", deserializerResult);
+    }
 
     [Fact]
     public async Task WritesSerializerBodyWithDiscriminatorAsync()
@@ -555,6 +579,41 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains("switch (parentClass.odataType) {", result);
         Assert.Contains("case \"ns.childclass\":", result);
         Assert.Contains("serializeChildClass(writer, parentClass, true);", result);
+    }
+    [Fact]
+    public async Task EscapesSerializerBodyWithDiscriminatorAsync()
+    {
+        var generationConfiguration = new GenerationConfiguration { Language = GenerationLanguage.TypeScript };
+        var parentClass = TestHelper.CreateModelClassInModelsNamespace(generationConfiguration, root, "parentClass");
+        parentClass.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.type";
+        parentClass.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nclass", new CodeType
+        {
+            Name = "childClass",
+            TypeDefinition = TestHelper.CreateModelClassInModelsNamespace(generationConfiguration, root, "childClass", true),
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "odataType",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+            SerializationName = "@odata.type",
+        });
+        var method = TestHelper.CreateMethod(parentClass, MethodName, ReturnTypeName);
+        method.Kind = CodeMethodKind.Serializer;
+        method.IsAsync = false;
+        TestHelper.AddSerializationPropertiesToModelClass(parentClass);
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
+        var serializeFunction = root.FindChildByName<CodeFunction>($"Serialize{parentClass.Name.ToFirstCharacterUpperCase()}");
+        Assert.NotNull(serializeFunction);
+        var parentNS = serializeFunction.GetImmediateParentOfType<CodeNamespace>();
+        Assert.NotNull(parentNS);
+        parentNS.TryAddCodeFile("foo", serializeFunction);
+        writer.Write(serializeFunction);
+        var result = tw.ToString();
+        Assert.Contains("case \"ns.chi\\\"ld\\nclass\":", result);
     }
 
     [Fact]
@@ -776,6 +835,54 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains($"\"baseurl\": requestAdapter.baseUrl", result);
         Assert.Contains($"apiClientProxifier<", result);
         Assert.Contains($"pathParameters", result);
+    }
+    [Fact]
+    public void EscapesApiConstructorBaseUrl()
+    {
+        var parentClass = root.AddClass(new CodeClass
+        {
+            Name = "ApiClient",
+            Kind = CodeClassKind.RequestBuilder,
+        }).First();
+        var method = TestHelper.CreateMethod(parentClass, MethodName, ReturnTypeName);
+        method.Kind = CodeMethodKind.ClientConstructor;
+        method.IsAsync = false;
+        method.BaseUrl = "https://graph.microsoft.com/v1.0/\"evil\npath";
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "pathParameters",
+            Kind = CodePropertyKind.PathParameters,
+            Type = new CodeType
+            {
+                Name = "Dictionary<string, string>",
+                IsExternal = true,
+            }
+        });
+        var requestAdapterProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "requestAdapter",
+            Kind = CodePropertyKind.RequestAdapter,
+            Type = new CodeType
+            {
+                Name = "RequestAdapter",
+                IsExternal = true,
+            }
+        }).First();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "requestAdapter",
+            Kind = CodeParameterKind.RequestAdapter,
+            Type = requestAdapterProp.Type,
+        });
+        method.DeserializerModules = ["com.microsoft.kiota.serialization.Deserializer"];
+        method.SerializerModules = ["com.microsoft.kiota.serialization.Serializer"];
+        method.IsStatic = true;
+        root.RemoveChildElement(parentClass);
+        var function = new CodeFunction(method);
+        root.TryAddCodeFile("foo", function, CodeInterface.FromRequestBuilder(parentClass));
+        writer.Write(function);
+        var result = tw.ToString();
+        Assert.Contains("baseUrl = \"https://graph.microsoft.com/v1.0/\\\"evil\\npath\"", result);
     }
     [Fact]
     public void WritesApiConstructorWithBackingStore()

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -858,6 +858,25 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains("@deprecated", result);
     }
     [Fact]
+    public void SanitizesDeprecationVersionInComments()
+    {
+        var parentClass = root.AddClass(new CodeClass
+        {
+            Name = "ODataError",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var method = TestHelper.CreateMethod(parentClass, MethodName, ReturnTypeName);
+        method.Kind = CodeMethodKind.Factory;
+        method.IsStatic = true;
+        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z", CultureInfo.InvariantCulture), DateTimeOffset.Parse("2021-01-01T00:00:00Z", CultureInfo.InvariantCulture), $"v2.0 */{Environment.NewLine}VERSION_MARKER");
+        var function = new CodeFunction(method);
+        root.TryAddCodeFile("foo", function);
+        writer.Write(function);
+        var result = tw.ToString();
+        Assert.DoesNotContain("as of v2.0 */", result);
+        Assert.Contains("as of v2.0 * /VERSION_MARKER", result);
+    }
+    [Fact]
     public void WritesDeprecationInformationFromBuilder()
     {
         var parentClass = root.AddClass(new CodeClass

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -135,6 +135,60 @@ public sealed class CodeFunctionWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result, 1);
     }
     [Fact]
+    public async Task EscapesModelFactoryBodyAsync()
+    {
+        var parentModel = TestHelper.CreateModelClass(root, "parentModel");
+        var childModel = TestHelper.CreateModelClass(root, "childModel");
+        childModel.StartBlock.Inherits = new CodeType
+        {
+            Name = "parentModel",
+            TypeDefinition = parentModel,
+        };
+        var factoryMethod = parentModel.AddMethod(new CodeMethod
+        {
+            Name = "factory",
+            Kind = CodeMethodKind.Factory,
+            ReturnType = new CodeType
+            {
+                Name = "parentModel",
+                TypeDefinition = parentModel,
+            },
+            IsStatic = true,
+        }).First();
+        parentModel.DiscriminatorInformation.AddDiscriminatorMapping("ns.chi\"ld\nmodel", new CodeType
+        {
+            Name = "childModel",
+            TypeDefinition = childModel,
+        });
+        parentModel.DiscriminatorInformation.DiscriminatorPropertyName = "@odata.ty\"pe\nx";
+        factoryMethod.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+                TypeDefinition = new CodeClass
+                {
+                    Name = "ParseNode",
+                },
+                IsExternal = true,
+            },
+            Optional = false,
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
+        var modelInterface = root.FindChildByName<CodeInterface>("childModel");
+        Assert.NotNull(modelInterface);
+        var parentNS = modelInterface.GetImmediateParentOfType<CodeNamespace>();
+        Assert.NotNull(parentNS);
+        var factoryFunction = parentNS.FindChildByName<CodeFunction>("createParentModelFromDiscriminatorValue", false);
+        parentNS.TryAddCodeFile("foo", factoryFunction);
+        writer.Write(factoryFunction);
+        var result = tw.ToString();
+        Assert.Contains("const mappingValueNode = parseNode?.getChildNode(\"@odata.ty\\\"pe\\nx\")", result);
+        Assert.Contains("case \"ns.chi\\\"ld\\nmodel\":", result);
+    }
+    [Fact]
     public async Task DoesntWriteFactorySwitchOnMissingParameterAsync()
     {
         var parentModel = TestHelper.CreateModelClass(root, "parentModel");

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/TypeScriptConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/TypeScriptConventionServiceTests.cs
@@ -151,4 +151,10 @@ public class TypeScriptConventionServiceTests
         // Assert - should be camelCase, not PascalCase
         Assert.Equal("createPolicyFromDiscriminatorValue", result);
     }
+    [Fact]
+    public void RemoveInvalidDescriptionCharacters_SanitizesCommentBreakoutCharacters()
+    {
+        var result = TypeScriptConventionService.RemoveInvalidDescriptionCharacters("line1*/\r\nline2");
+        Assert.Equal("line1* /line2", result);
+    }
 }


### PR DESCRIPTION
This pull request addresses a remote code execution vulnerability in kiota with:
- default values
- enum values
- property names (serialization/deserialization)
- documentation comments

More information can be found in [the advisory](https://github.com/microsoft/kiota/security/advisories/GHSA-2hx3-vp6r-mg3f)