### PR TITLE
Rename Rubocop config switch 'Naming/PredicateName'

### DIFF
--- a/it/ruby/.rubocop.yml
+++ b/it/ruby/.rubocop.yml
@@ -110,7 +110,7 @@ Metrics/AbcSize:
 Naming/ConstantName:
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Metrics/ClassLength:


### PR DESCRIPTION
When executing Ruby integration tests, the console is flooded with a lot of warnings - I had to scroll over them all the last few days while hacking on the Ruby tests.

This pull request just fixes the first warning about a renamed parameter.

```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Gemspec/AddRuntimeDependency: # new in 1.65
  Enabled: true
Gemspec/AttributeAssignment: # new in 1.77
  Enabled: true
Gemspec/DeprecatedAttributeAssignment: # new in 1.30
  Enabled: true
Gemspec/DevelopmentDependencies: # new in 1.44
  Enabled: true
Gemspec/RequireMFA: # new in 1.23
  Enabled: true
Layout/EmptyLinesAfterModuleInclusion: # new in 1.79
  Enabled: true
Layout/LineContinuationLeadingSpace: # new in 1.31
  Enabled: true
Layout/LineContinuationSpacing: # new in 1.31
  Enabled: true
Layout/LineEndStringConcatenationIndentation: # new in 1.18
  Enabled: true
Layout/SpaceBeforeBrackets: # new in 1.7
  Enabled: true
Lint/AmbiguousAssignment: # new in 1.7
  Enabled: true
Lint/AmbiguousOperatorPrecedence: # new in 1.21
  Enabled: true
Lint/AmbiguousRange: # new in 1.19
  Enabled: true
Lint/ArrayLiteralInRegexp: # new in 1.71
  Enabled: true
Lint/ConstantOverwrittenInRescue: # new in 1.31
  Enabled: true
Lint/ConstantReassignment: # new in 1.70
  Enabled: true
Lint/CopDirectiveSyntax: # new in 1.72
  Enabled: true
Lint/DataDefineOverride: # new in 1.85
  Enabled: true
Lint/DeprecatedConstants: # new in 1.8
  Enabled: true
Lint/DuplicateBranch: # new in 1.3
  Enabled: true
Lint/DuplicateMagicComment: # new in 1.37
  Enabled: true
Lint/DuplicateMatchPattern: # new in 1.50
  Enabled: true
Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
  Enabled: true
Lint/DuplicateSetElement: # new in 1.67
  Enabled: true
Lint/EmptyBlock: # new in 1.1
  Enabled: true
Lint/EmptyClass: # new in 1.3
  Enabled: true
Lint/EmptyInPattern: # new in 1.16
  Enabled: true
Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
  Enabled: true
Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
  Enabled: true
Lint/ItWithoutArgumentsInBlock: # new in 1.59
  Enabled: true
Lint/LambdaWithoutLiteralBlock: # new in 1.8
  Enabled: true
Lint/LiteralAssignmentInCondition: # new in 1.58
  Enabled: true
Lint/MixedCaseRange: # new in 1.53
  Enabled: true
Lint/NoReturnInBeginEndBlocks: # new in 1.2
  Enabled: true
Lint/NonAtomicFileOperation: # new in 1.31
  Enabled: true
Lint/NumberedParameterAssignment: # new in 1.9
  Enabled: true
Lint/NumericOperationWithConstantResult: # new in 1.69
  Enabled: true
Lint/OrAssignmentToConstant: # new in 1.9
  Enabled: true
Lint/RedundantDirGlobSort: # new in 1.8
  Enabled: true
Lint/RedundantRegexpQuantifiers: # new in 1.53
  Enabled: true
Lint/RedundantTypeConversion: # new in 1.72
  Enabled: true
Lint/RefinementImportMethods: # new in 1.27
  Enabled: true
Lint/RequireRangeParentheses: # new in 1.32
  Enabled: true
Lint/RequireRelativeSelfPath: # new in 1.22
  Enabled: true
Lint/SharedMutableDefault: # new in 1.70
  Enabled: true
Lint/SuppressedExceptionInNumberConversion: # new in 1.72
  Enabled: true
Lint/SymbolConversion: # new in 1.9
  Enabled: true
Lint/ToEnumArguments: # new in 1.1
  Enabled: true
Lint/TripleQuotes: # new in 1.9
  Enabled: true
Lint/UnescapedBracketInRegexp: # new in 1.68
  Enabled: true
Lint/UnexpectedBlockArity: # new in 1.5
  Enabled: true
Lint/UnmodifiedReduceAccumulator: # new in 1.1
  Enabled: true
Lint/UnreachablePatternBranch: # new in 1.85
  Enabled: true
Lint/UselessConstantScoping: # new in 1.72
  Enabled: true
Lint/UselessDefaultValueArgument: # new in 1.76
  Enabled: true
Lint/UselessDefined: # new in 1.69
  Enabled: true
Lint/UselessNumericOperation: # new in 1.66
  Enabled: true
Lint/UselessOr: # new in 1.76
  Enabled: true
Lint/UselessRescue: # new in 1.43
  Enabled: true
Lint/UselessRuby2Keywords: # new in 1.23
  Enabled: true
Metrics/CollectionLiteralLength: # new in 1.47
  Enabled: true
Naming/BlockForwarding: # new in 1.24
  Enabled: true
Naming/PredicateMethod: # new in 1.76
  Enabled: true
Security/CompoundHash: # new in 1.28
  Enabled: true
Security/IoMethods: # new in 1.22
  Enabled: true
Style/AmbiguousEndlessMethodDefinition: # new in 1.68
  Enabled: true
Style/ArgumentsForwarding: # new in 1.1
  Enabled: true
Style/ArrayIntersect: # new in 1.40
  Enabled: true
Style/ArrayIntersectWithSingleElement: # new in 1.81
  Enabled: true
Style/BitwisePredicate: # new in 1.68
  Enabled: true
Style/CollectionCompact: # new in 1.2
  Enabled: true
Style/CollectionQuerying: # new in 1.77
  Enabled: true
Style/CombinableDefined: # new in 1.68
  Enabled: true
Style/ComparableBetween: # new in 1.74
  Enabled: true
Style/ComparableClamp: # new in 1.44
  Enabled: true
Style/ConcatArrayLiterals: # new in 1.41
  Enabled: true
Style/DataInheritance: # new in 1.49
  Enabled: true
Style/DigChain: # new in 1.69
  Enabled: true
Style/DirEmpty: # new in 1.48
  Enabled: true
Style/DocumentDynamicEvalDefinition: # new in 1.1
  Enabled: true
Style/EmptyClassDefinition: # new in 1.84
  Enabled: true
Style/EmptyHeredoc: # new in 1.32
  Enabled: true
Style/EmptyStringInsideInterpolation: # new in 1.76
  Enabled: true
Style/EndlessMethod: # new in 1.8
  Enabled: true
Style/EnvHome: # new in 1.29
  Enabled: true
Style/ExactRegexpMatch: # new in 1.51
  Enabled: true
Style/FetchEnvVar: # new in 1.28
  Enabled: true
Style/FileEmpty: # new in 1.48
  Enabled: true
Style/FileNull: # new in 1.69
  Enabled: true
Style/FileOpen: # new in 1.85
  Enabled: true
Style/FileRead: # new in 1.24
  Enabled: true
Style/FileTouch: # new in 1.69
  Enabled: true
Style/FileWrite: # new in 1.24
  Enabled: true
Style/HashConversion: # new in 1.10
  Enabled: true
Style/HashExcept: # new in 1.7
  Enabled: true
Style/HashFetchChain: # new in 1.75
  Enabled: true
Style/HashSlice: # new in 1.71
  Enabled: true
Style/IfWithBooleanLiteralBranches: # new in 1.9
  Enabled: true
Style/InPatternThen: # new in 1.16
  Enabled: true
Style/ItAssignment: # new in 1.70
  Enabled: true
Style/ItBlockParameter: # new in 1.75
  Enabled: true
Style/KeywordArgumentsMerging: # new in 1.68
  Enabled: true
Style/MagicCommentFormat: # new in 1.35
  Enabled: true
Style/MapCompactWithConditionalBlock: # new in 1.30
  Enabled: true
Style/MapIntoArray: # new in 1.63
  Enabled: true
Style/MapJoin: # new in 1.85
  Enabled: true
Style/MapToHash: # new in 1.24
  Enabled: true
Style/MapToSet: # new in 1.42
  Enabled: true
Style/MinMaxComparison: # new in 1.42
  Enabled: true
Style/ModuleMemberExistenceCheck: # new in 1.82
  Enabled: true
Style/MultilineInPatternThen: # new in 1.16
  Enabled: true
Style/NegatedIfElseCondition: # new in 1.2
  Enabled: true
Style/NegativeArrayIndex: # new in 1.84
  Enabled: true
Style/NestedFileDirname: # new in 1.26
  Enabled: true
Style/NilLambda: # new in 1.3
  Enabled: true
Style/NumberedParameters: # new in 1.22
  Enabled: true
Style/NumberedParametersLimit: # new in 1.22
  Enabled: true
Style/ObjectThen: # new in 1.28
  Enabled: true
Style/OneClassPerFile: # new in 1.85
  Enabled: true
Style/OpenStructUse: # new in 1.23
  Enabled: true
Style/OperatorMethodCall: # new in 1.37
  Enabled: true
Style/PartitionInsteadOfDoubleSelect: # new in 1.85
  Enabled: true
Style/PredicateWithKind: # new in 1.85
  Enabled: true
Style/QuotedSymbols: # new in 1.16
  Enabled: true
Style/ReduceToHash: # new in 1.85
  Enabled: true
Style/RedundantArgument: # new in 1.4
  Enabled: true
Style/RedundantArrayConstructor: # new in 1.52
  Enabled: true
Style/RedundantArrayFlatten: # new in 1.76
  Enabled: true
Style/RedundantConstantBase: # new in 1.40
  Enabled: true
Style/RedundantCurrentDirectoryInPath: # new in 1.53
  Enabled: true
Style/RedundantDoubleSplatHashBraces: # new in 1.41
  Enabled: true
Style/RedundantEach: # new in 1.38
  Enabled: true
Style/RedundantFilterChain: # new in 1.52
  Enabled: true
Style/RedundantFormat: # new in 1.72
  Enabled: true
Style/RedundantHeredocDelimiterQuotes: # new in 1.45
  Enabled: true
Style/RedundantInitialize: # new in 1.27
  Enabled: true
Style/RedundantInterpolationUnfreeze: # new in 1.66
  Enabled: true
Style/RedundantLineContinuation: # new in 1.49
  Enabled: true
Style/RedundantMinMaxBy: # new in 1.85
  Enabled: true
Style/RedundantRegexpArgument: # new in 1.53
  Enabled: true
Style/RedundantRegexpConstructor: # new in 1.52
  Enabled: true
Style/RedundantSelfAssignmentBranch: # new in 1.19
  Enabled: true
Style/RedundantStringEscape: # new in 1.37
  Enabled: true
Style/RedundantStructKeywordInit: # new in 1.85
  Enabled: true
Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
  Enabled: true
Style/ReverseFind: # new in 1.84
  Enabled: true
Style/SafeNavigationChainLength: # new in 1.68
  Enabled: true
Style/SelectByKind: # new in 1.85
  Enabled: true
Style/SelectByRange: # new in 1.85
  Enabled: true
Style/SelectByRegexp: # new in 1.22
  Enabled: true
Style/SendWithLiteralMethodName: # new in 1.64
  Enabled: true
Style/SingleLineDoEndBlock: # new in 1.57
  Enabled: true
Style/StringChars: # new in 1.12
  Enabled: true
Style/SuperArguments: # new in 1.64
  Enabled: true
Style/SuperWithArgsParentheses: # new in 1.58
  Enabled: true
Style/SwapValues: # new in 1.1
  Enabled: true
Style/TallyMethod: # new in 1.85
  Enabled: true
Style/YAMLFileRead: # new in 1.53
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 17 files
Warning: Using `Naming/PredicateName` configuration in E:/Projekte/Github/kiota/it/ruby/.rubocop.yml for `Naming/PredicatePrefix`.
```

If I follow the Rubocop suggestion to enable all new cops...

```yaml
AllCops:
  NewCops: enable
  TargetRubyVersion: 3.2
```
.... this command
```
\it\exec-cmd.ps1 -descriptionUrl "./tests/Kiota.Builder.IntegrationTests/DiscriminatorSample.yaml" -language Ruby
```

...prints a lot of new warnings:

```
Offenses:

integration_test.gemspec:5:1: W: [Correctable] Gemspec/RequireMFA: metadata['rubygems_mfa_required'] must be set to 'true'.
Gem::Specification.new do |spec| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/integration_test/client/api_client.rb:3:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './client'
                  ^^
lib/integration_test/client/api_client.rb:4:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './discriminateme/discriminateme_request_builder'
                  ^^
lib/integration_test/client/discriminateme/discriminateme_request_builder.rb:4:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './discriminateme'
                  ^^
lib/integration_test/client/models/component.rb:3:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './models'
                  ^^
lib/integration_test/client/models/component.rb:11:17: C: [Correctable] Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.
                include MicrosoftKiotaAbstractions::Parsable
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/integration_test/client/models/component.rb:56:52: C: [Correctable] Style/MultilineIfThen: Do not use then for multi-line unless.
                    unless mapping_value_node.nil? then
                                                   ^^^^
lib/integration_test/client/models/component.rb:59:29: C: [Correctable] Layout/CaseIndentation: Indent when as deep as case.
                            when "obj1"
                            ^^^^
lib/integration_test/client/models/component.rb:61:29: C: [Correctable] Layout/CaseIndentation: Indent when as deep as case.
                            when "obj2"
                            ^^^^
lib/integration_test/client/models/component1.rb:3:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './models'
                  ^^
lib/integration_test/client/models/component1.rb:9:17: C: [Correctable] Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.
                include MicrosoftKiotaAbstractions::AdditionalDataHolder, MicrosoftKiotaAbstractions::Parsable
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/integration_test/client/models/component2.rb:3:19: C: [Correctable] Style/RedundantCurrentDirectoryInPath: Remove the redundant current directory path.
require_relative './models'
                  ^^
lib/integration_test/client/models/component2.rb:9:17: C: [Correctable] Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.
                include MicrosoftKiotaAbstractions::AdditionalDataHolder, MicrosoftKiotaAbstractions::Parsable
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

17 files inspected, 13 offenses detected, 13 offenses autocorrectable

```

How to handle this? They all would mean changes to Kiota.

Or we could disable them all.

Or we could keep the long initial warning as it is. I do not plan to execute the Ruby tests much more ;-)