### PR TITLE
Fix Ruby isStream always evaluating to false in CodeMethodWriter

### DIFF
--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -266,7 +266,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
             writer.DecreaseIndent();
         }
         writer.WriteLine(")");
-        var isStream = conventions.StreamTypeName.Equals(StringComparison.OrdinalIgnoreCase);
+        var isStream = conventions.StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
         var genericTypeForSendMethod = GetSendRequestMethodName(isStream);
         var errorMappingVarName = "nil";
         if (codeElement.ErrorMappings.Any())


### PR DESCRIPTION
## Summary

- Fix incorrect comparison in `Ruby/CodeMethodWriter.cs` where `conventions.StreamTypeName.Equals(StringComparison.OrdinalIgnoreCase)` was passing the `StringComparison` enum value instead of the `returnType` string
- This caused `isStream` to **always** be `false`, meaning Ruby SDKs generated by Kiota would never use `send_primitive_async` for stream/binary responses

## Problem

The buggy code:
```csharp
var isStream = conventions.StreamTypeName.Equals(StringComparison.OrdinalIgnoreCase);
```

This calls `string.Equals(object, StringComparison)` which compares the string `"stdin"` against the enum value `StringComparison.OrdinalIgnoreCase`. Since a string is never equal to an enum, this always returns `false`.

## Fix

Aligns with all other language writers (CSharp, Python, Dart, PHP, TypeScript) which correctly compare the return type:
```csharp
var isStream = conventions.StreamTypeName.Equals(returnType, StringComparison.OrdinalIgnoreCase);
```

## Test plan

- [ ] Verify existing Ruby writer tests still pass
- [ ] Verify that Ruby code generation now correctly uses `send_primitive_async` for stream return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)