### PR TITLE
Fix noContentStatusCodes accidentally containing redirect status codes

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1265,7 +1265,7 @@ public partial class KiotaBuilder
     private const string RequestBodyOctetStreamContentType = "application/octet-stream";
     private const string DefaultResponseIndicator = "default";
     private static readonly HashSet<string> redirectStatusCodes = new(StringComparer.OrdinalIgnoreCase) { "301", "302", "303", "307" };
-    private static readonly HashSet<string> noContentStatusCodes = new(redirectStatusCodes, StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "304" };
+    private static readonly HashSet<string> noContentStatusCodes = new(StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "304" };
     private static readonly HashSet<string> errorStatusCodes = new(Enumerable.Range(400, 599).Select(static x => x.ToString(CultureInfo.InvariantCulture))
                                                                                  .Concat([CodeMethod.ErrorMappingClientRange, CodeMethod.ErrorMappingServerRange]), StringComparer.OrdinalIgnoreCase);
     private static readonly HashSet<string> errorStatusCodesWithDefault = new(errorStatusCodes, StringComparer.OrdinalIgnoreCase) { DefaultResponseIndicator };


### PR DESCRIPTION
## Summary

- Removes redirect status codes (301, 302, 303, 307) from the `noContentStatusCodes` HashSet
- The HashSet was incorrectly initialized by copying from `redirectStatusCodes`, polluting the no-content set

## Problem

```csharp
private static readonly HashSet<string> noContentStatusCodes = 
    new(redirectStatusCodes, StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "304" };
```

The `HashSet` constructor copies elements from `redirectStatusCodes` first, then adds the explicitly listed ones. This means `noContentStatusCodes` contained `{301, 302, 303, 307, 201, 202, 204, 205, 304}` instead of the intended `{201, 202, 204, 205, 304}`.

## Impact

Operations returning HTTP 301/302/303/307 were treated as void/no-content responses, potentially discarding redirect response bodies.

## Fix

Remove `redirectStatusCodes` from the constructor:
```csharp
private static readonly HashSet<string> noContentStatusCodes = 
    new(StringComparer.OrdinalIgnoreCase) { "201", "202", "204", "205", "304" };
```

## Test plan

- [ ] Verify existing KiotaBuilder tests still pass
- [ ] Verify that redirect responses are no longer treated as no-content

🤖 Generated with [Claude Code](https://claude.com/claude-code)