### PR TITLE
Fix incorrect command hints and telemetry in plugin generate handler

### DIFF
--- a/src/kiota/Handlers/Plugin/GenerateHandler.cs
+++ b/src/kiota/Handlers/Plugin/GenerateHandler.cs
@@ -73,7 +73,7 @@ internal class GenerateHandler : BaseKiotaCommandHandler
                                             .ToArray();
                 if (clientEntries.Length == 0 && !clientNameWasNotProvided)
                 {
-                    DisplayError($"No client found with the provided name {className}");
+                    DisplayError($"No plugin found with the provided name {className}");
                     return 1;
                 }
                 foreach (var clientEntry in clientEntries)
@@ -102,7 +102,7 @@ internal class GenerateHandler : BaseKiotaCommandHandler
                     else
                     {
                         DisplayWarning($"Update of {clientEntry.Key} skipped, no changes detected");
-                        DisplayCleanHint("client generate", "--refresh");
+                        DisplayCleanHint("plugin generate", "--refresh");
                     }
                 }
 
@@ -137,7 +137,7 @@ internal class GenerateHandler : BaseKiotaCommandHandler
             new(TelemetryLabels.TagCommandSource, TelemetryLabels.CommandSourceCliValue),
             new($"{TelemetryLabels.TagCommandParams}.refresh", refresh),
         } : null;
-        if (className is not null) tags?.Add(new KeyValuePair<string, object?>($"{TelemetryLabels.TagCommandParams}.client_name", TelemetryLabels.RedactedValuePlaceholder));
+        if (className is not null) tags?.Add(new KeyValuePair<string, object?>($"{TelemetryLabels.TagCommandParams}.plugin_name", TelemetryLabels.RedactedValuePlaceholder));
         if (logLevel is { } ll) tags?.Add(new KeyValuePair<string, object?>($"{TelemetryLabels.TagCommandParams}.log_level", ll.ToString("G")));
     }
 }


### PR DESCRIPTION
## Summary

- Fix `DisplayCleanHint` showing "client generate" instead of "plugin generate" when an update is skipped
- Fix error message saying "No client found" instead of "No plugin found" when a named plugin doesn't exist
- Fix telemetry tag using `client_name` instead of `plugin_name`, causing plugin operations to be miscategorized in telemetry

## Problem

The plugin generate handler (`Handlers/Plugin/GenerateHandler.cs`) was copy-pasted from the client generate handler without updating all references. Three places incorrectly referenced "client" instead of "plugin":

1. Line 105: `DisplayCleanHint("client generate", "--refresh")` — users see `"kiota client generate --refresh"` instead of `"kiota plugin generate --refresh"`
2. Line 76: `"No client found with the provided name"` — misleading when working with plugins
3. Line 140: Telemetry tag `.client_name` — plugin operations miscategorized as client operations

## Test plan

- [ ] Run `kiota plugin generate` with a non-existent name, verify error message says "plugin"
- [ ] Run `kiota plugin generate` with `--refresh` on an unchanged plugin, verify hint says "plugin generate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)