### PR TITLE
Fix download handler returning exit code 0 for error cases

### DIFF
--- a/src/kiota/Handlers/KiotaDownloadCommandHandler.cs
+++ b/src/kiota/Handlers/KiotaDownloadCommandHandler.cs
@@ -116,7 +116,10 @@ internal class KiotaDownloadCommandHandler : BaseKiotaCommandHandler
     private async Task<int> SaveResultsAsync(string searchTerm, string version, IDictionary<string, SearchResult> results, ILogger logger, CancellationToken cancellationToken)
     {
         if (!results.Any())
+        {
             DisplayError("No matching result found, use the search command to find the right key");
+            return 1;
+        }
         else if (results.Any() && !string.IsNullOrEmpty(searchTerm) && searchTerm.Contains(KiotaSearcher.ProviderSeparator) && results.ContainsKey(searchTerm))
         {
             var (path, statusCode) = await SaveResultAsync(results.First(), logger, cancellationToken);
@@ -129,9 +132,10 @@ internal class KiotaDownloadCommandHandler : BaseKiotaCommandHandler
             return statusCode;
         }
         else
+        {
             DisplayError("Multiple matches found, use the key to select a specific description. You can find the key by using the search command.");
-
-        return 0;
+            return 1;
+        }
     }
     private async Task<(string, int)> SaveResultAsync(KeyValuePair<string, SearchResult> result, ILogger logger, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary

- Fix `SaveResultsAsync` returning exit code 0 (success) when no results are found or multiple ambiguous matches exist
- Both error paths now correctly return exit code 1

## Problem

```csharp
if (!results.Any())
    DisplayError("No matching result found...");
else if (...)
{
    ...
    return statusCode;
}
else
    DisplayError("Multiple matches found...");

return 0;  // ← Error cases fall through to return success!
```

When no matching result is found or multiple ambiguous matches exist, error messages are displayed but the method returns `0` (success exit code). This causes:
- CI/CD pipelines to report green when the download actually failed
- Scripts using `kiota download` to silently fail

## Test plan

- [ ] Run `kiota download` with a search term that has no results, verify exit code is 1
- [ ] Run `kiota download` with an ambiguous search term, verify exit code is 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)