### PR TITLE
fix(Java): normalize PascalCase acronyms in class/enum names to prevent casing mismatch

### DIFF
--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -20,6 +20,30 @@ public static partial class StringExtensions
     public static string ToFirstCharacterUpperCase(this string? input)
         => string.IsNullOrEmpty(input) ? string.Empty : char.ToUpperInvariant(input[0]) + input[1..];
 
+    /// <summary>
+    /// Normalizes PascalCase names by lowering consecutive uppercase acronyms so that only
+    /// the first letter of each acronym remains uppercase (e.g., "ComplianceDLPApplications" becomes
+    /// "ComplianceDlpApplications"). When the last uppercase letter in a run is followed by a
+    /// lowercase letter, it is kept uppercase because it starts a new word.
+    /// </summary>
+    public static string NormalizePascalCaseAcronyms(this string? input)
+    {
+        if (string.IsNullOrEmpty(input) || input.Length < 2) return input ?? string.Empty;
+
+        var result = input.ToCharArray();
+        for (var i = 1; i < input.Length; i++)
+        {
+            if (char.IsUpper(input[i]) && char.IsUpper(input[i - 1]))
+            {
+                // Keep uppercase if this is the last uppercase letter before a lowercase letter (new word start)
+                if (i + 1 < input.Length && char.IsLower(input[i + 1]))
+                    continue;
+                result[i] = char.ToLowerInvariant(input[i]);
+            }
+        }
+        return new string(result);
+    }
+
     private static readonly char[] defaultSeparators = ['-'];
     /// <summary>
     /// Converts a string delimited by a symbol to camel case, conserving the casing for the first character

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -60,6 +60,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 else
                     return s;
             });
+            CorrectNames(generatedCode, s => s.NormalizePascalCaseAcronyms());
             RemoveClassNamePrefixFromNestedClasses(generatedCode);
             InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode,

--- a/src/Kiota.Builder/Refiners/JavaRefiner.cs
+++ b/src/Kiota.Builder/Refiners/JavaRefiner.cs
@@ -60,7 +60,7 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
                 else
                     return s;
             });
-            CorrectNames(generatedCode, s => s.NormalizePascalCaseAcronyms());
+            NormalizeAcronymCasing(generatedCode);
             RemoveClassNamePrefixFromNestedClasses(generatedCode);
             InsertOverrideMethodForRequestExecutorsAndBuildersAndConstructors(generatedCode);
             ReplaceIndexersByMethodsWithParameter(generatedCode,
@@ -552,5 +552,28 @@ public class JavaRefiner : CommonLanguageRefiner, ILanguageRefiner
             });
         }
         CrawlTree(currentElement, x => AddQueryParameterExtractorMethod(x, methodName));
+    }
+    /// <summary>
+    /// Normalizes acronym casing in class and enum names to prevent file name mismatches
+    /// when upstream metadata changes acronym casing (e.g., powerBi → powerBI).
+    /// Unlike CorrectNames, this allows case-only renames since InnerChildElements uses OrdinalIgnoreCase.
+    /// </summary>
+    private static void NormalizeAcronymCasing(CodeElement current)
+    {
+        if (current is CodeClass currentClass &&
+            currentClass.Name.NormalizePascalCaseAcronyms() is string refinedClassName &&
+            !currentClass.Name.Equals(refinedClassName, StringComparison.Ordinal) &&
+            currentClass.Parent is IBlock classParentBlock)
+        {
+            classParentBlock.RenameChildElement(currentClass.Name, refinedClassName);
+        }
+        else if (current is CodeEnum currentEnum &&
+            currentEnum.Name.NormalizePascalCaseAcronyms() is string refinedEnumName &&
+            !currentEnum.Name.Equals(refinedEnumName, StringComparison.Ordinal) &&
+            currentEnum.Parent is IBlock enumParentBlock)
+        {
+            enumParentBlock.RenameChildElement(currentEnum.Name, refinedEnumName);
+        }
+        CrawlTree(current, NormalizeAcronymCasing);
     }
 }

--- a/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/StringExtensionsTests.cs
@@ -47,6 +47,25 @@ public class StringExtensionsTests
         Assert.Equal("Toto", "toto".ToPascalCase());
         Assert.Equal("TotoPascalCase", "toto-pascal-case".ToPascalCase());
     }
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("A", "A")]
+    [InlineData("Ab", "Ab")]
+    [InlineData("ComplianceDLPApplicationsAuditRecord", "ComplianceDlpApplicationsAuditRecord")]
+    [InlineData("PowerBIAuditRecord", "PowerBiAuditRecord")]
+    [InlineData("PowerBIDlpAuditRecord", "PowerBiDlpAuditRecord")]
+    [InlineData("OnPremisesSharePointScannerDLPAuditRecord", "OnPremisesSharePointScannerDlpAuditRecord")]
+    [InlineData("ComplianceDLPExchangeClassificationCdpRecord", "ComplianceDlpExchangeClassificationCdpRecord")]
+    [InlineData("XMLHTTPRequest", "XmlhttpRequest")]
+    [InlineData("AuditRecord", "AuditRecord")]
+    [InlineData("somemodel", "somemodel")]
+    [InlineData("ABC", "Abc")]
+    [InlineData("ABCDef", "AbcDef")]
+    public void NormalizePascalCaseAcronyms(string input, string expected)
+    {
+        Assert.Equal(expected, input.NormalizePascalCaseAcronyms());
+    }
     [Fact]
     public void ToPascalCaseCustomSeparator()
     {

--- a/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/JavaLanguageRefinerTests.cs
@@ -616,6 +616,33 @@ public class JavaLanguageRefinerTests
         await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Java }, root, cancellationToken: TestContext.Current.CancellationToken);
         Assert.True(string.IsNullOrEmpty(model.Properties.First(static x => "custom".Equals(x.Name))!.NamePrefix));
     }
+    [Theory]
+    [InlineData("ComplianceDLPApplicationsAuditRecord", "ComplianceDlpApplicationsAuditRecord")]
+    [InlineData("PowerBIAuditRecord", "PowerBiAuditRecord")]
+    [InlineData("OnPremisesSharePointScannerDLPAuditRecord", "OnPremisesSharePointScannerDlpAuditRecord")]
+    [InlineData("SimpleModel", "SimpleModel")]
+    public async Task NormalizesModelClassAcronymCasingAsync(string originalName, string expectedName)
+    {
+        var model = root.AddClass(new CodeClass
+        {
+            Name = originalName,
+            Kind = CodeClassKind.Model
+        }).First();
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Java }, root, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(expectedName, model.Name);
+    }
+    [Theory]
+    [InlineData("AuditLogRecordDLP", "AuditLogRecordDlp")]
+    [InlineData("SimpleEnum", "SimpleEnum")]
+    public async Task NormalizesEnumAcronymCasingAsync(string originalName, string expectedName)
+    {
+        var model = root.AddEnum(new CodeEnum
+        {
+            Name = originalName,
+        }).First();
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.Java }, root, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(expectedName, model.Name);
+    }
     [Fact]
     public async Task AddsMethodsOverloadsAsync()
     {


### PR DESCRIPTION
## Summary

Fixes #7654 — Java class name / file name casing mismatch for acronyms causes compilation failure.

## Root Cause

When OpenAPI metadata changes the casing of acronyms in type names (e.g. `ComplianceDlpApplicationsAuditRecord` → `ComplianceDLPApplicationsAuditRecord`), the generated Java class declaration uses the new casing, but **git does not recognize case-only file name changes** when `core.ignorecase=true` (the default on Windows and often inherited by repos initialized there). This means:

1. The generation pipeline (running on `ubuntu-latest`) produces a file named `ComplianceDLPApplicationsAuditRecord.java` with `public class ComplianceDLPApplicationsAuditRecord` inside.
2. `git add` with `core.ignorecase=true` treats the new file as a modification to the old-cased path `ComplianceDlpApplicationsAuditRecord.java`, preserving the **old file name** in the index.
3. The committed file has old-cased name but new-cased class → Java compilation error on CI (`class X is public, should be declared in a file named X.java`).

This caused **19 compilation errors** in [microsoftgraph/msgraph-beta-sdk-java#1309](https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1309).

## Fix

Normalize consecutive uppercase acronyms in model class and enum names during Java refinement so the output is **deterministic regardless of upstream acronym casing changes**:

| Before | After |
|---|---|
| `ComplianceDLPApplicationsAuditRecord` | `ComplianceDlpApplicationsAuditRecord` |
| `PowerBIAuditRecord` | `PowerBiAuditRecord` |
| `OnPremisesSharePointScannerDLPAuditRecord` | `OnPremisesSharePointScannerDlpAuditRecord` |

Whether the metadata says `DLP` or `Dlp`, the generated Java code always produces `Dlp` — matching Java PascalCase conventions for acronyms.

## Changes

- **`StringExtensions.cs`**: Added `NormalizePascalCaseAcronyms()` extension method
- **`JavaRefiner.cs`**: Added a `CorrectNames` pass using the normalizer (runs after the existing underscore-to-PascalCase pass)
- **Tests**: Added unit tests for the string extension and Java refiner integration tests for both classes and enums
