### PR TITLE
Required query params from one operation should not affect sibling operations on the same path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)
 - Fixed a potential NullReferenceException in union model discriminator factory methods when a discriminator mapping key is null or empty across C#, Dart, Go, Java, PHP, and Python writers. [#7641](https://github.com/microsoft/kiota/pull/7641)
 - Fixed `kiota download` returning exit code 0 (success) when no results are found or multiple ambiguous matches exist. [#7643](https://github.com/microsoft/kiota/pull/7643)
 - Fixed incorrect command hints and telemetry in `kiota plugin generate` handler referencing "client" instead of "plugin". [#7642](https://github.com/microsoft/kiota/pull/7642)

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -254,6 +254,51 @@ public static partial class OpenApiUrlTreeNodeExtensions
                 SanitizePathParameterNamesForUrlTemplate(currentNode.Path.Replace('\\', '/'), pathReservedPathParametersIds) +
                 queryStringParameters;
     }
+    /// <summary>
+    /// Gets the URL template for a path item by selecting the most representative template across all operations.
+    /// This prevents required query parameters from one operation leaking into the path-item-level template
+    /// and appearing as required for operations that do not need them.
+    /// </summary>
+    /// <param name="currentNode">The URL tree node to generate a template for.</param>
+    /// <returns>
+    /// A URL template that best represents the path item:
+    /// <list type="bullet">
+    ///   <item>If all operations share the same template, that template is returned.</item>
+    ///   <item>If templates differ, the template shared by the most operations is returned.</item>
+    ///   <item>If every operation has a unique template, an empty string is returned so each operation uses its own URL template override.</item>
+    /// </list>
+    /// </returns>
+    public static string GetUrlTemplateForPathItem(this OpenApiUrlTreeNode currentNode)
+    {
+        ArgumentNullException.ThrowIfNull(currentNode);
+        if (!currentNode.HasOperations(Constants.DefaultOpenApiLabel))
+            return currentNode.GetUrlTemplate();
+
+        var pathItem = currentNode.PathItems[Constants.DefaultOpenApiLabel];
+        if (pathItem.Operations is not { Count: > 0 })
+            return currentNode.GetUrlTemplate();
+
+        var operationTemplates = pathItem.Operations.Keys
+            .Select(operationType => currentNode.GetUrlTemplate(operationType))
+            .ToArray();
+
+        var groups = operationTemplates
+            .GroupBy(static template => template, StringComparer.Ordinal)
+            .OrderByDescending(static g => g.Count())
+            .ToArray();
+
+        // All operations share the same template — use it directly as the path item template
+        if (groups.Length == 1)
+            return groups[0].Key;
+
+        // Every operation has a unique template — use empty so each operation gets its own override
+        if (groups.Length == operationTemplates.Length)
+            return string.Empty;
+
+        // Multiple groups exist — use the template shared by the greatest number of operations
+        return groups[0].Key;
+    }
+
     public static IEnumerable<KeyValuePair<string, HashSet<string>>> GetRequestInfo(this OpenApiUrlTreeNode currentNode)
     {
         ArgumentNullException.ThrowIfNull(currentNode);

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -875,7 +875,7 @@ public partial class KiotaBuilder
         {
             Access = AccessModifier.Private,
             Name = "urlTemplate",
-            DefaultValue = $"\"{currentNode.GetUrlTemplate()}\"",
+            DefaultValue = $"\"{currentNode.GetUrlTemplateForPathItem()}\"",
             ReadOnly = true,
             Documentation = new()
             {
@@ -1473,7 +1473,10 @@ public partial class KiotaBuilder
             var operationUrlTemplate = currentNode.GetUrlTemplate(operationType);
             if (!operationUrlTemplate.Equals(parentClass.Properties.FirstOrDefault(static x => x.Kind is CodePropertyKind.UrlTemplate)?.DefaultValue?.Trim('"'), StringComparison.Ordinal)
                 && currentNode.HasRequiredQueryParametersAcrossOperations())// no need to generate extra strings/templates as optional parameters will have no effect on resolved url.
+            {
                 generatorMethod.UrlTemplateOverride = operationUrlTemplate;
+                executorMethod.UrlTemplateOverride = operationUrlTemplate;
+            }
 
             var mediaTypes = (schema, operation.Responses is null) switch
             {

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -1110,6 +1110,144 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
             return GetChildNodeByPath(currentNode, string.Join('/', pathSegments.Skip(1)));
         return null;
     }
+
+    // Tests for GetUrlTemplateForPathItem (issue #7292)
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_ReturnsCommonTemplate_WhenAllOperationsShareSameTemplate()
+    {
+        // GET /resource?$select={$select} and POST /resource?$select={$select} share the same template
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                {
+                    HttpMethod.Get, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                },
+                {
+                    HttpMethod.Post, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        // Both operations share the same template → return it directly
+        Assert.Equal(childNode.GetUrlTemplate(HttpMethod.Get), childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_ReturnsEmptyString_WhenAllOperationsHaveUniqueTemplates()
+    {
+        // Issue #7292: GET /resource (no required params) + DELETE /resource?confirm={confirm} (required)
+        // → path item template must be empty so each operation provides its own override
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                {
+                    HttpMethod.Delete, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "confirm",
+                                In = ParameterLocation.Query,
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.Boolean },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        // All templates are unique → return empty string
+        Assert.Equal(string.Empty, childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_ReturnsHighestCardinalityTemplate_WhenMultipleGroupsExist()
+    {
+        // GET and POST share no-param template (cardinality 2)
+        // DELETE has required confirm param (cardinality 1)
+        // Highest cardinality group is GET/POST → return their template
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                { HttpMethod.Post, new() },
+                {
+                    HttpMethod.Delete, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "confirm",
+                                In = ParameterLocation.Query,
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.Boolean },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        // GET and POST share the no-param template; DELETE has its own → highest cardinality wins
+        var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Get);
+        Assert.Equal(expectedTemplate, childNode.GetUrlTemplateForPathItem());
+        Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Delete), childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_FallsBackToDefaultTemplate_WhenNoOperations()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem());
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        Assert.Equal(childNode.GetUrlTemplate(), childNode.GetUrlTemplateForPathItem());
+    }
+
     public void Dispose()
     {
         _httpClient.Dispose();

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -11061,4 +11061,100 @@ components:
         var replyWithQuoteRb = replyWithQuoteNs.FindChildByName<CodeClass>("ReplyWithQuoteRequestBuilder", false);
         Assert.NotNull(replyWithQuoteRb);
     }
+
+    /// <summary>
+    /// Regression test for https://github.com/microsoft/kiota/issues/7292
+    /// Required query parameters on one operation must not leak into the path-item URL template
+    /// and must not be visible as required for sibling operations on the same path.
+    /// Both the request-generator and request-executor methods must carry the per-operation URL template override.
+    /// </summary>
+    [Fact]
+    public async Task PerOperationUrlTemplateOverrideSetOnBothGeneratorAndExecutorMethodsAsync()
+    {
+        await using var fs = await GetDocumentStreamAsync(
+            """
+            openapi: 3.0.1
+            info:
+              title: Test
+              version: '1.0'
+            servers:
+              - url: https://graph.microsoft.com/v1.0
+            paths:
+              /resource:
+                get:
+                  description: Gets the resource
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                delete:
+                  description: Deletes the resource (requires confirm)
+                  parameters:
+                    - name: confirm
+                      in: query
+                      required: true
+                      schema:
+                        type: boolean
+                  responses:
+                    '204':
+                      description: No content
+            """);
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(
+            mockLogger.Object,
+            new GenerationConfiguration
+            {
+                ClientClassName = "Graph",
+                OpenAPIFilePath = "https://localhost",
+                ClientNamespaceName = "GraphSdk",
+            },
+            _httpClient);
+
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        // Locate the ResourceRequestBuilder class
+        var resourceNs = codeModel.FindNamespaceByName("GraphSdk.Resource");
+        Assert.NotNull(resourceNs);
+        var resourceRb = resourceNs.FindChildByName<CodeClass>("ResourceRequestBuilder", false);
+        Assert.NotNull(resourceRb);
+
+        // The path-item URL template property must be empty because GET and DELETE have unique templates
+        var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
+        Assert.NotNull(urlTemplateProperty);
+        Assert.Equal("\"\"", urlTemplateProperty.DefaultValue);
+
+        // GET executor method must carry a URL template override (no required params)
+        var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
+        Assert.NotNull(getExecutor);
+        Assert.True(getExecutor.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource", getExecutor.UrlTemplateOverride);
+
+        // GET generator method must also carry the same URL template override
+        var getGenerator = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
+        Assert.NotNull(getGenerator);
+        Assert.True(getGenerator.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource", getGenerator.UrlTemplateOverride);
+
+        // DELETE executor must carry an override with the required confirm parameter
+        var deleteExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Delete);
+        Assert.NotNull(deleteExecutor);
+        Assert.True(deleteExecutor.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource?confirm={confirm}", deleteExecutor.UrlTemplateOverride);
+
+        // DELETE generator must also carry the override
+        var deleteGenerator = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Delete);
+        Assert.NotNull(deleteGenerator);
+        Assert.True(deleteGenerator.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource?confirm={confirm}", deleteGenerator.UrlTemplateOverride);
+    }
 }


### PR DESCRIPTION
Fixes #7292

When a path has operations with different required query parameters (e.g. `GET /resource` with no required params and `DELETE /resource?confirm={confirm}` with a required param), kiota was generating a single path-item-level URL template that included the required params from all operations. This caused `confirm` to appear required even for `GET`.

There were two separate problems:

**Problem 1 - path-item template includes params from all operations**

`GetUrlTemplate()` with no `operationType` calls `GetParameters(null)`, which merges query parameters from every HTTP method on the path. For a path with GET (no params) and DELETE (required `confirm`), this produces `{+baseurl}/resource?confirm={confirm}` as the path-item template, which is wrong.

**Problem 2 - TypeScript executor method was missing the per-operation override**

In `CreateOperationMethods()`, the per-operation `UrlTemplateOverride` was only assigned to `generatorMethod` (RequestGenerator kind). TypeScript's `CodeConstantWriter.WriteRequestsMetadataConstant()` reads `executorMethod.HasUrlTemplateOverride`, so the override was never picked up for TypeScript. All other languages read from the generator method and were unaffected.

**Fix 1 - new `GetUrlTemplateForPathItem()` method**

Generates a per-operation URL template for each HTTP method on the path, then groups them by value:
- Single group (all operations share the same template): use it
- All templates are unique: return empty string so every operation uses its own override
- Multiple groups: return the template used by the most operations

This follows the approach outlined in the issue comments.

**Fix 2 - set override on executor method as well**

Inside the existing override block in `CreateOperationMethods()`, `executorMethod.UrlTemplateOverride` is now set alongside `generatorMethod.UrlTemplateOverride`.

**Tests**

Four unit tests cover all branches of `GetUrlTemplateForPathItem()`. An integration test in `KiotaBuilderTests` verifies that for a GET + DELETE path, both the generator and executor methods on each operation carry the correct per-operation override, and that the path-item template property is empty when all operation templates are unique.