### PR TITLE
Enable API Explorer filter during regeneration path editing

### DIFF
--- a/vscode/packages/microsoft-kiota/CHANGELOG.md
+++ b/vscode/packages/microsoft-kiota/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Fixed a bug where the filter button in the API Explorer was disabled when selecting an existing client or plugin for regeneration. [#6099](https://github.com/microsoft/kiota/issues/6099)
 - Fixed a bug in the VS Code extension deeplink with the API Center extension [#6004](https://github.com/microsoft/kiota/issues/6004)
 - Use a subdirectory in the output path when generating clients [#5977](https://github.com/microsoft/kiota/issues/5977)
 

--- a/vscode/packages/microsoft-kiota/package.json
+++ b/vscode/packages/microsoft-kiota/package.json
@@ -409,7 +409,7 @@
         "command": "kiota.openApiExplorer.filterDescription",
         "category": "Kiota",
         "title": "%kiota.openApiExplorer.filterDescription.title%",
-        "enablement": "kiota.openApiExplorer.showIcons",
+        "enablement": "kiota.openApiExplorer.showIcons || kiota.openApiExplorer.showRegenerateIcon",
         "icon": "$(filter)"
       },
       {


### PR DESCRIPTION
## Summary

When selecting an existing client or plugin to regenerate, the filter button in the API Explorer toolbar was disabled and could not be used.

## Root Cause

The filterDescription command is declared with enablement: kiota.openApiExplorer.showIcons

When the user clicks Edit Paths on a workspace item, EditPathsCommand calls updateTreeViewIcons(treeViewId, false, true), which sets showIcons=false (disabling generate and filter buttons) and showRegenerateIcon=true (enabling the regenerate button).

This left the filter disabled precisely when it is most needed, since the user is selecting paths from a potentially large API surface.

## Change

Updated the enablement expression for kiota.openApiExplorer.filterDescription in package.json to:
kiota.openApiExplorer.showIcons || kiota.openApiExplorer.showRegenerateIcon

The filter is now enabled in both states where the API Explorer has content loaded.

## Files Changed

- vscode/packages/microsoft-kiota/package.json: updated enablement for filterDescription command
- vscode/packages/microsoft-kiota/CHANGELOG.md: unreleased entry

Closes #6099