### PR TITLE
custom: enforce OpenAPI required field constraints in generated C# SDK

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeProperty.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeProperty.cs
@@ -122,6 +122,13 @@ public class CodeProperty : CodeTerminalWithKind<CodePropertyKind>, IDocumentedE
     {
         get; set;
     }
+    /// <summary>
+    /// Indicates if the property is marked as required in the OpenAPI schema.
+    /// </summary>
+    public bool IsRequired
+    {
+        get; init;
+    }
 
     public object Clone()
     {
@@ -143,6 +150,7 @@ public class CodeProperty : CodeTerminalWithKind<CodePropertyKind>, IDocumentedE
             OriginalPropertyFromBaseType = OriginalPropertyFromBaseType?.Clone() as CodeProperty,
             Deprecation = Deprecation,
             IsPrimaryErrorMessage = IsPrimaryErrorMessage,
+            IsRequired = IsRequired,
         };
         return property;
     }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1174,7 +1174,7 @@ public partial class KiotaBuilder
     }
     private static readonly StructuralPropertiesReservedNameProvider structuralPropertiesReservedNameProvider = new();
 
-    private CodeProperty? CreateProperty(string childIdentifier, string childType, IOpenApiSchema? propertySchema = null, CodeTypeBase? existingType = null, CodePropertyKind kind = CodePropertyKind.Custom)
+    private CodeProperty? CreateProperty(string childIdentifier, string childType, IOpenApiSchema? propertySchema = null, CodeTypeBase? existingType = null, CodePropertyKind kind = CodePropertyKind.Custom, bool isRequired = false)
     {
         var propertyName = childIdentifier.CleanupSymbolName();
         if (structuralPropertiesReservedNameProvider.ReservedNames.Contains(propertyName))
@@ -1200,7 +1200,8 @@ public partial class KiotaBuilder
                                         propertySchema is { Extensions: not null } &&
                                         propertySchema.Extensions.TryGetValue(OpenApiPrimaryErrorMessageExtension.Name, out var openApiExtension) &&
                                         openApiExtension is OpenApiPrimaryErrorMessageExtension primaryErrorMessageExtension &&
-                                        primaryErrorMessageExtension.IsPrimaryErrorMessage
+                                        primaryErrorMessageExtension.IsPrimaryErrorMessage,
+            IsRequired = isRequired,
         };
         if (prop.IsOfKind(CodePropertyKind.Custom, CodePropertyKind.QueryParameter) &&
             !propertyName.Equals(childIdentifier, StringComparison.Ordinal))
@@ -2426,7 +2427,7 @@ public partial class KiotaBuilder
                             LogOmittedPropertyInvalidSchema(x.Key, model.Name, currentNode.Path);
                             return null;
                         }
-                        return CreateProperty(x.Key, definition.Name, propertySchema: propertySchema, existingType: definition);
+                        return CreateProperty(x.Key, definition.Name, propertySchema: propertySchema, existingType: definition, isRequired: schema.Required?.Contains(x.Key) ?? false);
                     })
                     .OfType<CodeProperty>()
                     .ToArray() ?? [];

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -190,6 +190,8 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
         new (static x => x is CodeMethod @method && @method.IsOfKind(CodeMethodKind.RequestExecutor) && (method.ReturnType.Name.Equals(KiotaBuilder.UntypedNodeName, StringComparison.OrdinalIgnoreCase) ||
                                                                                                         method.Parameters.Any(x => x.Kind is CodeParameterKind.RequestBody && x.Type.Name.Equals(KiotaBuilder.UntypedNodeName, StringComparison.OrdinalIgnoreCase))),
             SerializationNamespaceName, KiotaBuilder.UntypedNodeName),
+        new (static x => x is CodeProperty prop && prop.IsOfKind(CodePropertyKind.Custom) && prop.IsRequired,
+            "System.ComponentModel.DataAnnotations", "RequiredAttribute"),
         new (static x => x is CodeEnum prop && prop.Options.Any(x => x.IsNameEscaped),
             "System.Runtime.Serialization", "EnumMemberAttribute"),
         new (static x => x is IDeprecableElement element && element.Deprecation is not null && element.Deprecation.IsDeprecated,

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -370,7 +370,9 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
                                         .Where(static x => !x.ExistsInBaseType)
                                         .OrderBy(static x => x.Name, StringComparer.Ordinal))
         {
-            writer.WriteLine($"{{ \"{otherProp.WireName.SanitizeDoubleQuote()}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{GetDeserializationMethodName(otherProp.Type, codeElement)}; }} }},");
+            var deserializationCall = GetDeserializationMethodName(otherProp.Type, codeElement);
+            var nullCoalesce = otherProp.IsRequired && conventions.GetTypeString(otherProp.Type, codeElement).EndsWith('?') ? " ?? default" : string.Empty;
+            writer.WriteLine($"{{ \"{otherProp.WireName.SanitizeDoubleQuote()}\", n => {{ {otherProp.Name.ToFirstCharacterUpperCase()} = n.{deserializationCall}{nullCoalesce}; }} }},");
         }
         writer.CloseBlock("};");
     }

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -13,12 +13,17 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
         ArgumentNullException.ThrowIfNull(writer);
         if (codeElement.ExistsInExternalBaseType) return;
         var propertyType = conventions.GetTypeString(codeElement.Type, codeElement);
+        if (codeElement.IsRequired && propertyType.EndsWith('?'))
+            propertyType = propertyType[..^1];
         var isNullableReferenceType = !propertyType.EndsWith('?')
+                                      && !codeElement.IsRequired
                                       && codeElement.IsOfKind(
                                             CodePropertyKind.Custom,
                                             CodePropertyKind.QueryParameter);// Other property types are appropriately constructor initialized
         conventions.WriteShortDescription(codeElement, writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
+        if (codeElement.IsRequired && codeElement.IsOfKind(CodePropertyKind.Custom))
+            writer.WriteLine("[Required]");
         if (isNullableReferenceType)
         {
             CSharpConventionService.WriteNullableOpening(writer);

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -271,5 +271,41 @@ public sealed class CodePropertyWriterTests : IDisposable
         // Then
         Assert.Contains("public override string Message { get => Prop1 ?? string.Empty; }", result);
     }
+    [Fact]
+    public void WritesRequiredAttributeOnRequiredCustomProperty()
+    {
+        var requiredProp = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "requiredProp",
+            Kind = CodePropertyKind.Custom,
+            IsRequired = true,
+            Type = new CodeType { Name = TypeName },
+        }).First();
+        writer.Write(requiredProp);
+        var result = tw.ToString();
+        Assert.Contains("[Required]", result);
+    }
+    [Fact]
+    public void DoesNotWriteRequiredAttributeOnNonRequiredCustomProperty()
+    {
+        property.Kind = CodePropertyKind.Custom;
+        writer.Write(property);
+        var result = tw.ToString();
+        Assert.DoesNotContain("[Required]", result);
+    }
+    [Fact]
+    public void DoesNotWriteRequiredAttributeOnRequiredQueryParameter()
+    {
+        var requiredParam = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "requiredParam",
+            Kind = CodePropertyKind.QueryParameter,
+            IsRequired = true,
+            Type = new CodeType { Name = "string" },
+        }).First();
+        writer.Write(requiredParam);
+        var result = tw.ToString();
+        Assert.DoesNotContain("[Required]", result);
+    }
 }
 


### PR DESCRIPTION
## Why

1. Kiota generates all C# model properties as `T?` regardless of the OpenAPI `required:` array, making required and optional fields indistinguishable at the type level. 
2. When a generated SDK model is re-exposed through another API, the Azure Functions OpenAPI extension relies on `[Required]` to determine which fields are required in the generated spec — without it, the constraint is silently dropped.

## Main changes

| File | Change |
|------|--------|
| `CodeProperty.cs` | Adds `IsRequired` to the Code DOM |
| `KiotaBuilder.cs` | Reads `schema.Required` and sets `IsRequired` per property |
| `CodePropertyWriter.cs` | Strips `?`, skips `#nullable enable`, emits `[Required]` |
| `CSharpRefiner.cs` | Injects `using System.ComponentModel.DataAnnotations;` |
| `CodeMethodWriter.cs` | Appends `?? default` in deserializers for required value types |

## Plan

This is a temporary fork maintained until upstream ships a native fix. Track [microsoft/kiota#3911]
