### PR TITLE
ci: skip coverage uploads off default branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
         run: cat ./reports/coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
       - name: Upload coverage report
         uses: actions/upload-code-coverage@v1
-        if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
+        if: github.event_name != 'merge_group' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') || (github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch))
         with:
           file: ./reports/coverage/Cobertura.xml
           language: CSharp


### PR DESCRIPTION
## Summary
- only upload code coverage on pull requests from this repository
- only upload branch coverage when the run targets the repository default branch
- skip workflow_dispatch and other non-PR uploads off default branch to avoid post-merge coverage upload failures