### PR TITLE
fix(ruby): escape interpolation markers in generated string literals

### DIFF
--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -90,13 +90,13 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
         if (writeDiscriminatorValueRead)
         {
-            writer.WriteLine($"{NodeVarName} = {parseNodeParameter.Name.ToSnakeCase()}.get_child_node(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\")");
+            writer.WriteLine($"{NodeVarName} = {parseNodeParameter.Name.ToSnakeCase()}.get_child_node(\"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(parentClass.DiscriminatorInformation.DiscriminatorPropertyName)}\")");
             writer.StartBlock($"unless {NodeVarName}.nil? then");
             writer.WriteLine($"{DiscriminatorMappingVarName} = {NodeVarName}.get_string_value");
             writer.StartBlock($"case {DiscriminatorMappingVarName}");
             foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings.OrderBy(static x => x.Key))
             {
-                writer.StartBlock($"when \"{mappedType.Key.SanitizeDoubleQuote()}\"");
+                writer.StartBlock($"when \"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(mappedType.Key)}\"");
                 writer.WriteLine($"return {mappedType.Value.AllTypes.First().Name.ToFirstCharacterUpperCase()}.new");
                 writer.DecreaseIndent();
             }
@@ -124,7 +124,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         foreach (var escapedProperty in escapedProperties)
         {
             writer.StartBlock($"when \"{escapedProperty.Name}\"");
-            writer.WriteLine($"return \"{escapedProperty.SerializationName.SanitizeDoubleQuote()}\"");
+            writer.WriteLine($"return \"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(escapedProperty.SerializationName)}\"");
             writer.DecreaseIndent();
         }
         writer.StartBlock("else");
@@ -172,7 +172,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                 parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.UrlTemplate) is CodeProperty urlTemplateProperty &&
                 !string.IsNullOrEmpty(urlTemplateProperty.DefaultValue))
             {
-                var sanitizedUrlTemplate = urlTemplateProperty.DefaultValue.SanitizeQuotedStringLiteral();
+                var sanitizedUrlTemplate = RubyConventionService.SanitizeRubyDoubleQuoteLiteral(urlTemplateProperty.DefaultValue);
                 if (currentMethod.Parameters.OfKind(CodeParameterKind.PathParameters) is CodeParameter pathParametersParameter)
                     writer.WriteLine($"super({pathParametersParameter.Name.ToSnakeCase()}, {requestAdapterParameter.Name.ToSnakeCase()}, {sanitizedUrlTemplate})");
                 else
@@ -185,7 +185,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                         .Where(static x => !string.IsNullOrEmpty(x.DefaultValue))
                                         .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {propWithDefault.DefaultValue.SanitizeQuotedStringLiteral()}");
+            writer.WriteLine($"@{propWithDefault.NamePrefix}{propWithDefault.Name.ToSnakeCase()} = {RubyConventionService.SanitizeRubyDoubleQuoteLiteral(propWithDefault.DefaultValue)}");
         }
         foreach (var propWithDefault in parentClass.GetPropertiesOfKind(CodePropertyKind.AdditionalData,
                                                                         CodePropertyKind.Custom) //additional data and custom properties rely on accessors
@@ -194,7 +194,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                         .Where(static x => x.Type is not CodeType propType || propType.TypeDefinition is not CodeClass propertyClass || propertyClass.OriginalComposedType is null)
                                         .OrderBy(static x => x.Name))
         {
-            string defaultValue = propWithDefault.DefaultValue.SanitizeQuotedStringLiteral();
+            string defaultValue = RubyConventionService.SanitizeRubyDoubleQuoteLiteral(propWithDefault.DefaultValue);
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {
                 // generates "Rootnamespace::Subnamespace::EnumType[:DefaultValue]"
@@ -235,7 +235,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
         if (parentClass.GetPropertyOfKind(CodePropertyKind.PathParameters) is CodeProperty pathParametersProperty &&
             codeElement.OriginalIndexer != null)
             writer.WriteLines($"{conventions.TempDictionaryVarName} = @{pathParametersProperty.NamePrefix}{pathParametersProperty.Name.ToSnakeCase()}.clone",
-                            $"{conventions.TempDictionaryVarName}[\"{codeElement.OriginalIndexer.IndexParameter.SerializationName.SanitizeDoubleQuote()}\"] = {codeElement.OriginalIndexer.IndexParameter.Name.ToSnakeCase()}");
+                            $"{conventions.TempDictionaryVarName}[\"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(codeElement.OriginalIndexer.IndexParameter.SerializationName)}\"] = {codeElement.OriginalIndexer.IndexParameter.Name.ToSnakeCase()}");
         conventions.AddRequestBuilderBody(parentClass, returnType, writer, conventions.TempDictionaryVarName, $"return {prefix}");
     }
     private void WriteDeserializerBody(CodeClass parentClass, LanguageWriter writer)
@@ -249,7 +249,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                             .Where(static x => !x.ExistsInBaseType)
                                             .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\" => lambda {{|n| @{otherProp.NamePrefix}{otherProp.Name.ToSnakeCase()} = n.{GetDeserializationMethodName(otherProp.Type)} }},");
+            writer.WriteLine($"\"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(otherProp.WireName)}\" => lambda {{|n| @{otherProp.NamePrefix}{otherProp.Name.ToSnakeCase()} = n.{GetDeserializationMethodName(otherProp.Type)} }},");
         }
         writer.DecreaseIndent();
         if (parentClass.StartBlock.Inherits != null)
@@ -356,7 +356,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
                                             .Where(static x => !x.ExistsInBaseType && !x.ReadOnly)
                                             .OrderBy(static x => x.Name))
         {
-            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{otherProp.WireName.SanitizeDoubleQuote()}\", @{otherProp.Name.ToSnakeCase()})");
+            writer.WriteLine($"writer.{GetSerializationMethodName(otherProp.Type)}(\"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(otherProp.WireName)}\", @{otherProp.Name.ToSnakeCase()})");
         }
         if (additionalDataProperty != null)
             writer.WriteLine($"writer.write_additional_data(@{additionalDataProperty.NamePrefix}{additionalDataProperty.Name.ToSnakeCase()})");

--- a/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
+++ b/src/Kiota.Builder/Writers/Ruby/RubyConventionService.cs
@@ -17,6 +17,21 @@ public class RubyConventionService : CommonLanguageConventionService
     internal string DocCommentStart = "## ";
     internal string DocCommentEnd = "## ";
     public override string TempDictionaryVarName => "url_tpl_params";
+    internal static string SanitizeRubyDoubleQuoteLiteral(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        if (value.Length > 1)
+        {
+            if (value[0] == '"' && value[^1] == '"')
+                return $"\"{value[1..^1].SanitizeDoubleQuote().Replace("#", "\\#", StringComparison.Ordinal)}\"";
+
+            if (value[0] == '\'' && value[^1] == '\'')
+                return $"'{value[1..^1].SanitizeSingleQuote().Replace("#", "\\#", StringComparison.Ordinal)}'";
+        }
+
+        return value.SanitizeDoubleQuote().Replace("#", "\\#", StringComparison.Ordinal);
+    }
     public override string GetAccessModifier(AccessModifier access)
     {
         return access switch
@@ -30,7 +45,7 @@ public class RubyConventionService : CommonLanguageConventionService
     {
         ArgumentNullException.ThrowIfNull(parameter);
         var defaultValue = parameter.Optional && (targetElement is not CodeMethod currentMethod || !currentMethod.IsOfKind(CodeMethodKind.Setter)) ?
-            $"={(string.IsNullOrEmpty(parameter.DefaultValue) ? "nil" : parameter.DefaultValue.SanitizeQuotedStringLiteral())}" :
+            $"={(string.IsNullOrEmpty(parameter.DefaultValue) ? "nil" : SanitizeRubyDoubleQuoteLiteral(parameter.DefaultValue))}" :
             string.Empty;
         return $"{parameter.Name}{defaultValue}";
     }

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -62,6 +62,9 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Spectre.Console" Version="0.55.2" />
     <PackageReference Include="StreamJsonRpc" Version="2.24.92" />
+    <!-- StreamJsonRpc 2.24.92 uses a vulnerable version of MessagePack. https://github.com/advisories/GHSA-92vj-hp7m-gwcj
+    TODO: Replace with a non-vulnerable version once available and delete the explicit transitive reference of Nerdbank.MessagePack. -->
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" /> 
     <PackageReference Include="System.CommandLine" Version="2.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -720,17 +720,17 @@ public sealed class CodeMethodWriterTests : IDisposable
     {
         setup();
         AddSerializationProperties();
-        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"\nbreak";
+        parentClass.Properties.First(static x => x.Name.Equals("dummyProp", StringComparison.Ordinal)).SerializationName = "line1\"#\nbreak";
         method.Kind = CodeMethodKind.Serializer;
         method.IsAsync = false;
         writer.Write(method);
         var serializerResult = tw.ToString();
-        Assert.Contains("write_string_value(\"line1\\\"\\nbreak\",", serializerResult);
+        Assert.Contains("write_string_value(\"line1\\\"\\#\\nbreak\",", serializerResult);
         tw.GetStringBuilder().Clear();
         method.Kind = CodeMethodKind.Deserializer;
         writer.Write(method);
         var deserializerResult = tw.ToString();
-        Assert.Contains("\"line1\\\"\\nbreak\" => lambda", deserializerResult);
+        Assert.Contains("\"line1\\\"\\#\\nbreak\" => lambda", deserializerResult);
     }
     [Fact]
     public void WritesTranslatedTypesDeSerializerBody()
@@ -986,7 +986,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         parentClass.AddProperty(new CodeProperty
         {
             Name = propName,
-            DefaultValue = "\"line1\nline2\"",
+            DefaultValue = "\"line1#\nline2\"",
             Kind = CodePropertyKind.Custom,
             Type = new CodeType
             {
@@ -995,7 +995,26 @@ public sealed class CodeMethodWriterTests : IDisposable
         });
         writer.Write(method);
         var result = tw.ToString();
-        Assert.Contains($"@{propName.ToSnakeCase()} = \"line1\\nline2\"", result);
+        Assert.Contains($"@{propName.ToSnakeCase()} = \"line1\\#\\nline2\"", result);
+    }
+    [Fact]
+    public void EscapesParameterDefaultsInSignature()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        method.AddParameter(new CodeParameter
+        {
+            Name = "displayName",
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+            Optional = true,
+            DefaultValue = "\"#{`id`}\"",
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("def initialize(display_name=\"\\#{`id`}\")", result);
     }
     [Fact]
     public void WritesConstructorWithDefaultValuesThatRequireParsing()
@@ -1325,7 +1344,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         {
             Name = "filter",
             Kind = CodePropertyKind.QueryParameter,
-            SerializationName = "li\"ne\nbreak",
+            SerializationName = "li\"ne#\nbreak",
             Type = new CodeType
             {
                 Name = "string",
@@ -1343,7 +1362,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("when \"filter\"", result);
-        Assert.Contains("return \"li\\\"ne\\nbreak\"", result);
+        Assert.Contains("return \"li\\\"ne\\#\\nbreak\"", result);
     }
     [Fact]
     public void DoesntWriteReadOnlyPropertiesInSerializerBody()


### PR DESCRIPTION
Prevent Ruby code injection in generated clients by escaping # in schema-derived values emitted into Ruby double-quoted literals.

add a Ruby-specific literal sanitizer for double-quoted output apply it across Ruby writer emission sites (defaults, wire names, discriminator mappings, indexer keys, and query parameter mapping) preserve quoted default-literal behavior while hardening interpolation safety add/adjust Ruby writer regression tests to verify # is escaped in constructor defaults, method parameter defaults, and serializer/deserializer wire names Security impact: blocks runtime interpolation payloads from malicious OpenAPI default and name fields in generated Ruby code.

ref: 31000000601260