### PR TITLE
bump version for release 1.32.0 with dependency and changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `kiota download` returning exit code 0 (success) when no results are found or multiple ambiguous matches exist. [#7643](https://github.com/microsoft/kiota/pull/7643)
 - Fixed incorrect command hints and telemetry in `kiota plugin generate` handler referencing "client" instead of "plugin". [#7642](https://github.com/microsoft/kiota/pull/7642)
 - Fixed Ruby `isStream` always evaluating to false in `CodeMethodWriter`, causing stream/binary responses to never use `send_primitive_async`. [#7639](https://github.com/microsoft/kiota/pull/7639)
+- Fixed a code injection vulnerability in Python generation by sanitizing `x-ms-enum` descriptions before emitting comments/docstrings. [#7735](https://github.com/microsoft/kiota/pull/7735)
+- Fixed a code injection vulnerability in Ruby generation by escaping interpolation markers in generated double-quoted string literals. [#7746](https://github.com/microsoft/kiota/pull/7746)
 
 ## [1.31.1] - 2026-04-13
 
@@ -1735,7 +1737,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
-
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.32.0] - 2026-06-02
+
+### Added
+
+### Changed
+
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)
@@ -1729,6 +1735,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
+
 
 
 

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota.Builder</Title>
     <PackageId>Microsoft.OpenApi.Kiota.Builder</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.31.1</VersionPrefix>
+    <VersionPrefix>1.32.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -15,7 +15,7 @@
     <Title>Microsoft.OpenApi.Kiota</Title>
     <PackageId>Microsoft.OpenApi.Kiota</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>1.31.1</VersionPrefix>
+    <VersionPrefix>1.32.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <PackageReleaseNotes>
       https://github.com/microsoft/kiota/releases
@@ -64,7 +64,7 @@
     <PackageReference Include="StreamJsonRpc" Version="2.24.92" />
     <!-- StreamJsonRpc 2.24.92 uses a vulnerable version of MessagePack. https://github.com/advisories/GHSA-92vj-hp7m-gwcj
     TODO: Replace with a non-vulnerable version once available and delete the explicit transitive reference of Nerdbank.MessagePack. -->
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" /> 
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
     <PackageReference Include="System.CommandLine" Version="2.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -61,10 +61,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Spectre.Console" Version="0.55.2" />
-    <PackageReference Include="StreamJsonRpc" Version="2.24.92" />
-    <!-- StreamJsonRpc 2.24.92 uses a vulnerable version of MessagePack. https://github.com/advisories/GHSA-92vj-hp7m-gwcj
-    TODO: Replace with a non-vulnerable version once available and delete the explicit transitive reference of Nerdbank.MessagePack. -->
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.25" />
     <PackageReference Include="System.CommandLine" Version="2.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
Prepares the 1.32.0 release by updating version metadata and incorporating follow-up release adjustments requested during review.

## Changes Made

- Bumped `src/kiota/kiota.csproj` `VersionPrefix` to `1.32.0`.
- Updated `StreamJsonRpc` from `2.24.92` to `2.25.25`.
- Removed the temporary explicit `Nerdbank.MessagePack` reference and related workaround comment from `src/kiota/kiota.csproj`.
- Added missing 1.32.0 changelog visibility entries for recent security fixes:
  - `#7735` (Python code injection hardening)
  - `#7746` (Ruby interpolation escaping hardening)

## Validation

- `dotnet build src/kiota/kiota.csproj`
- `dotnet test tests/Kiota.Tests/Kiota.Tests.csproj`