### PR TITLE
Fix URL template override regressions for sibling operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a regression where operations with only optional query-parameter differences could lose their URL template override, yielding empty or incomplete request builder URL templates after the #7292 fix. [#7754](https://github.com/microsoft/kiota/issues/7754) [#7755](https://github.com/microsoft/kiota/issues/7755)
+
 ## [1.32.0] - 2026-06-02
 
 ### Added
@@ -1737,6 +1739,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
-
 
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1478,9 +1478,9 @@ public partial class KiotaBuilder
                 Parent = parentClass,
                 Deprecation = deprecationInformation,
             };
+            var pathItemUrlTemplate = currentNode.GetUrlTemplateForPathItem();
             var operationUrlTemplate = currentNode.GetUrlTemplate(operationType);
-            if (!operationUrlTemplate.Equals(parentClass.Properties.FirstOrDefault(static x => x.Kind is CodePropertyKind.UrlTemplate)?.DefaultValue?.Trim('"'), StringComparison.Ordinal)
-                && currentNode.HasRequiredQueryParametersAcrossOperations())// no need to generate extra strings/templates as optional parameters will have no effect on resolved url.
+            if (!operationUrlTemplate.Equals(pathItemUrlTemplate, StringComparison.Ordinal))
             {
                 generatorMethod.UrlTemplateOverride = operationUrlTemplate;
                 executorMethod.UrlTemplateOverride = operationUrlTemplate;

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -1198,6 +1198,38 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
     }
 
     [Fact]
+    public void GetUrlTemplateForPathItem_ReturnsEmptyString_WhenAllOperationsHaveUniqueOptionalOnlyTemplates()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                {
+                    HttpMethod.Get, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                },
+                { HttpMethod.Post, new() }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        Assert.Equal(string.Empty, childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
     public void GetUrlTemplateForPathItem_ReturnsHighestCardinalityTemplate_WhenMultipleGroupsExist()
     {
         // GET and POST share no-param template (cardinality 2)
@@ -1235,6 +1267,41 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Get);
         Assert.Equal(expectedTemplate, childNode.GetUrlTemplateForPathItem());
         Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Delete), childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_ReturnsHighestCardinalityTemplate_WhenOptionalOnlyOutlierExists()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                { HttpMethod.Post, new() },
+                {
+                    HttpMethod.Patch, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "$filter",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Get);
+        Assert.Equal(expectedTemplate, childNode.GetUrlTemplateForPathItem());
+        Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Patch), childNode.GetUrlTemplateForPathItem());
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -11157,4 +11157,177 @@ components:
         Assert.True(deleteGenerator.HasUrlTemplateOverride);
         Assert.Equal("{+baseurl}/resource?confirm={confirm}", deleteGenerator.UrlTemplateOverride);
     }
+
+    [Fact]
+    public async Task PerOperationUrlTemplateOverrideSetWhenAllTemplatesAreUniqueWithOptionalQueryParametersAsync()
+    {
+        await using var fs = await GetDocumentStreamAsync(
+            """
+            openapi: 3.0.1
+            info:
+              title: Test
+              version: '1.0'
+            servers:
+              - url: https://graph.microsoft.com/v1.0
+            paths:
+              /resource:
+                get:
+                  description: Gets the resource
+                  parameters:
+                    - name: $select
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                post:
+                  description: Creates the resource
+                  responses:
+                    '201':
+                      description: Created
+            """);
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(
+            mockLogger.Object,
+            new GenerationConfiguration
+            {
+                ClientClassName = "Graph",
+                OpenAPIFilePath = "https://localhost",
+                ClientNamespaceName = "GraphSdk",
+            },
+            _httpClient);
+
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var resourceNs = codeModel.FindNamespaceByName("GraphSdk.Resource");
+        Assert.NotNull(resourceNs);
+        var resourceRb = resourceNs.FindChildByName<CodeClass>("ResourceRequestBuilder", false);
+        Assert.NotNull(resourceRb);
+
+        var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
+        Assert.NotNull(urlTemplateProperty);
+        Assert.Equal("\"\"", urlTemplateProperty.DefaultValue);
+
+        var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
+        Assert.NotNull(getExecutor);
+        Assert.True(getExecutor.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource{?%24select*}", getExecutor.UrlTemplateOverride);
+
+        var getGenerator = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
+        Assert.NotNull(getGenerator);
+        Assert.True(getGenerator.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource{?%24select*}", getGenerator.UrlTemplateOverride);
+
+        var postExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Post);
+        Assert.NotNull(postExecutor);
+        Assert.True(postExecutor.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource", postExecutor.UrlTemplateOverride);
+
+        var postGenerator = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Post);
+        Assert.NotNull(postGenerator);
+        Assert.True(postGenerator.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource", postGenerator.UrlTemplateOverride);
+    }
+
+    [Fact]
+    public async Task PerOperationUrlTemplateOverrideSetForOptionalQueryOutlierAgainstHighestCardinalityTemplateAsync()
+    {
+        await using var fs = await GetDocumentStreamAsync(
+            """
+            openapi: 3.0.1
+            info:
+              title: Test
+              version: '1.0'
+            servers:
+              - url: https://graph.microsoft.com/v1.0
+            paths:
+              /resource:
+                get:
+                  description: Gets the resource
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+                post:
+                  description: Creates the resource
+                  responses:
+                    '201':
+                      description: Created
+                patch:
+                  description: Updates the resource
+                  parameters:
+                    - name: $filter
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+            """);
+
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(
+            mockLogger.Object,
+            new GenerationConfiguration
+            {
+                ClientClassName = "Graph",
+                OpenAPIFilePath = "https://localhost",
+                ClientNamespaceName = "GraphSdk",
+            },
+            _httpClient);
+
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var resourceNs = codeModel.FindNamespaceByName("GraphSdk.Resource");
+        Assert.NotNull(resourceNs);
+        var resourceRb = resourceNs.FindChildByName<CodeClass>("ResourceRequestBuilder", false);
+        Assert.NotNull(resourceRb);
+
+        var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
+        Assert.NotNull(urlTemplateProperty);
+        Assert.Equal("\"{+baseurl}/resource\"", urlTemplateProperty.DefaultValue);
+
+        var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
+        Assert.NotNull(getExecutor);
+        Assert.False(getExecutor.HasUrlTemplateOverride);
+
+        var postExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Post);
+        Assert.NotNull(postExecutor);
+        Assert.False(postExecutor.HasUrlTemplateOverride);
+
+        var patchExecutor = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Patch);
+        Assert.NotNull(patchExecutor);
+        Assert.True(patchExecutor.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource{?%24filter*}", patchExecutor.UrlTemplateOverride);
+
+        var patchGenerator = resourceRb.Methods.FirstOrDefault(static m =>
+            m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Patch);
+        Assert.NotNull(patchGenerator);
+        Assert.True(patchGenerator.HasUrlTemplateOverride);
+        Assert.Equal("{+baseurl}/resource{?%24filter*}", patchGenerator.UrlTemplateOverride);
+    }
 }


### PR DESCRIPTION
## Summary
- restore per-operation URL template overrides whenever an operation template differs from the selected path-item template
- add regression coverage for optional-query unique-template and highest-cardinality cases
- document the regression fix in the changelog

Fixes #7754
Refs #7755
