### PR TITLE
Fix: template override sensibility

### DIFF
--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -217,7 +217,7 @@ public static partial class OpenApiUrlTreeNodeExtensions
                         .ToArray() ?? [];
     }
 
-    public static string GetUrlTemplate(this OpenApiUrlTreeNode currentNode, HttpMethod? operationType = null, bool includeQueryParameters = true, bool includeBaseUrl = true)
+    public static string GetUrlTemplate(this OpenApiUrlTreeNode currentNode, HttpMethod? operationType = null, bool includeQueryParameters = true, bool includeBaseUrl = true, bool excludeOperationSpecificRequiredQueryParameters = false)
     {
         ArgumentNullException.ThrowIfNull(currentNode);
         var queryStringParameters = string.Empty;
@@ -229,7 +229,14 @@ public static partial class OpenApiUrlTreeNodeExtensions
             var parameters = pathItem.GetParameters(operationType);
             if (parameters.Length != 0)
             {
-                var requiredParameters = string.Join("&", parameters.Where(static x => x.Required)
+                IEnumerable<IOpenApiParameter> requiredParams = parameters.Where(static x => x.Required);
+                if (excludeOperationSpecificRequiredQueryParameters)
+                {
+                    var operationSpecificNames = GetOperationSpecificRequiredQueryParameterNames(pathItem);
+                    if (operationSpecificNames.Count > 0)
+                        requiredParams = requiredParams.Where(x => !operationSpecificNames.Contains(x.Name!));
+                }
+                var requiredParameters = string.Join("&", requiredParams
                                                 .Select(static x =>
                                                             $"{x.Name}={{{x.Name?.SanitizeParameterNameForUrlTemplate()}}}"));
                 var optionalParameters = string.Join(",", parameters.Where(static x => !x.Required)
@@ -255,19 +262,13 @@ public static partial class OpenApiUrlTreeNodeExtensions
                 queryStringParameters;
     }
     /// <summary>
-    /// Gets the URL template for a path item by selecting the most representative template across all operations.
-    /// This prevents required query parameters from one operation leaking into the path-item-level template
-    /// and appearing as required for operations that do not need them.
+    /// Gets the URL template for a path item that is safe to use as the class-level default.
+    /// Includes the union of all optional query parameters across operations and any required
+    /// query parameters that are common to every operation (path-item-level or universally required).
+    /// Operation-specific required query parameters are excluded to prevent leakage.
     /// </summary>
     /// <param name="currentNode">The URL tree node to generate a template for.</param>
-    /// <returns>
-    /// A URL template that best represents the path item:
-    /// <list type="bullet">
-    ///   <item>If all operations share the same template, that template is returned.</item>
-    ///   <item>If templates differ, the template shared by the most operations is returned.</item>
-    ///   <item>If every operation has a unique template, an empty string is returned so each operation uses its own URL template override.</item>
-    /// </list>
-    /// </returns>
+    /// <returns>A URL template suitable for the class-level UrlTemplate property.</returns>
     public static string GetUrlTemplateForPathItem(this OpenApiUrlTreeNode currentNode)
     {
         ArgumentNullException.ThrowIfNull(currentNode);
@@ -278,25 +279,66 @@ public static partial class OpenApiUrlTreeNodeExtensions
         if (pathItem.Operations is not { Count: > 0 })
             return currentNode.GetUrlTemplate();
 
-        var operationTemplates = pathItem.Operations.Keys
-            .Select(operationType => currentNode.GetUrlTemplate(operationType))
+        return currentNode.GetUrlTemplate(operationType: null, includeQueryParameters: true, includeBaseUrl: true, excludeOperationSpecificRequiredQueryParameters: true);
+    }
+    /// <summary>
+    /// Determines whether an operation has required query parameters that are not shared by all
+    /// sibling operations on the same path item (i.e., operation-specific required parameters).
+    /// When true, the operation needs a per-method URL template override to include those parameters.
+    /// </summary>
+    public static bool HasOperationSpecificRequiredQueryParameters(this OpenApiUrlTreeNode currentNode, HttpMethod operationType)
+    {
+        ArgumentNullException.ThrowIfNull(currentNode);
+        if (!currentNode.HasOperations(Constants.DefaultOpenApiLabel))
+            return false;
+
+        var pathItem = currentNode.PathItems[Constants.DefaultOpenApiLabel];
+        var operationSpecificRequiredNames = GetOperationSpecificRequiredQueryParameterNames(pathItem);
+        if (operationSpecificRequiredNames.Count == 0)
+            return false;
+
+        var operationParams = pathItem.GetParameters(operationType);
+        return operationParams.Any(p => p.Required && operationSpecificRequiredNames.Contains(p.Name!));
+    }
+    /// <summary>
+    /// Returns the names of required query parameters that are NOT common to all operations on the path item.
+    /// A required parameter is "common" if it is required by every operation (or is defined at the path-item level).
+    /// </summary>
+    private static HashSet<string> GetOperationSpecificRequiredQueryParameterNames(IOpenApiPathItem pathItem)
+    {
+        if (pathItem.Operations is not { Count: > 0 })
+            return [];
+
+        // Path-item-level required query parameters are always common
+        var pathItemRequiredNames = (pathItem.Parameters ?? Enumerable.Empty<IOpenApiParameter>())
+            .Where(static x => x.In == ParameterLocation.Query && x.Required && x.Name is not null)
+            .Select(static x => x.Name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Collect required query param names per operation
+        var perOperationRequired = pathItem.Operations
+            .Select(op =>
+            {
+                var opParams = (op.Value.Parameters ?? Enumerable.Empty<IOpenApiParameter>())
+                    .Where(static x => x.In == ParameterLocation.Query && x.Required && x.Name is not null)
+                    .Select(static x => x.Name!);
+                // Union with path-item-level params (they apply to every operation)
+                return opParams.Union(pathItemRequiredNames, StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
+            })
             .ToArray();
 
-        var groups = operationTemplates
-            .GroupBy(static template => template, StringComparer.Ordinal)
-            .OrderByDescending(static g => g.Count())
-            .ToArray();
+        // All required params across all operations (computed first to avoid mutation issues)
+        var allRequired = perOperationRequired
+            .Aggregate(new HashSet<string>(StringComparer.Ordinal), static (acc, next) => { acc.UnionWith(next); return acc; });
 
-        // All operations share the same template — use it directly as the path item template
-        if (groups.Length == 1)
-            return groups[0].Key;
+        // Required params common to ALL operations
+        var commonRequired = perOperationRequired
+            .Skip(1)
+            .Aggregate(new HashSet<string>(perOperationRequired[0], StringComparer.Ordinal), static (acc, next) => { acc.IntersectWith(next); return acc; });
 
-        // Every operation has a unique template — use empty so each operation gets its own override
-        if (groups.Length == operationTemplates.Length)
-            return string.Empty;
-
-        // Multiple groups exist — use the template shared by the greatest number of operations
-        return groups[0].Key;
+        // Operation-specific = all required minus common
+        allRequired.ExceptWith(commonRequired);
+        return allRequired;
     }
 
     public static IEnumerable<KeyValuePair<string, HashSet<string>>> GetRequestInfo(this OpenApiUrlTreeNode currentNode)

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1478,9 +1478,8 @@ public partial class KiotaBuilder
                 Parent = parentClass,
                 Deprecation = deprecationInformation,
             };
-            var pathItemUrlTemplate = currentNode.GetUrlTemplateForPathItem();
             var operationUrlTemplate = currentNode.GetUrlTemplate(operationType);
-            if (!operationUrlTemplate.Equals(pathItemUrlTemplate, StringComparison.Ordinal))
+            if (currentNode.HasOperationSpecificRequiredQueryParameters(operationType))
             {
                 generatorMethod.UrlTemplateOverride = operationUrlTemplate;
                 executorMethod.UrlTemplateOverride = operationUrlTemplate;

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -1162,10 +1162,10 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void GetUrlTemplateForPathItem_ReturnsEmptyString_WhenAllOperationsHaveUniqueTemplates()
+    public void GetUrlTemplateForPathItem_ReturnsBasePathWithoutOperationSpecificRequiredParams_WhenOperationsHaveUniqueTemplates()
     {
         // Issue #7292: GET /resource (no required params) + DELETE /resource?confirm={confirm} (required)
-        // → path item template must be empty so each operation provides its own override
+        // → path item template excludes operation-specific required params (confirm) but is still a valid template
         var doc = new OpenApiDocument { Paths = [] };
         doc.Paths.Add("resource", new OpenApiPathItem
         {
@@ -1193,12 +1193,14 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var node = OpenApiUrlTreeNode.Create(doc, Label);
         var childNode = node.Children.First().Value;
 
-        // All templates are unique → return empty string
-        Assert.Equal(string.Empty, childNode.GetUrlTemplateForPathItem());
+        // confirm is operation-specific required → excluded from class template
+        // Result is the base path without query params (same as GET's template)
+        Assert.Equal(childNode.GetUrlTemplate(HttpMethod.Get), childNode.GetUrlTemplateForPathItem());
+        Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Delete), childNode.GetUrlTemplateForPathItem());
     }
 
     [Fact]
-    public void GetUrlTemplateForPathItem_ReturnsEmptyString_WhenAllOperationsHaveUniqueOptionalOnlyTemplates()
+    public void GetUrlTemplateForPathItem_ReturnsUnionOfOptionalParams_WhenOperationsHaveUniqueOptionalOnlyTemplates()
     {
         var doc = new OpenApiDocument { Paths = [] };
         doc.Paths.Add("resource", new OpenApiPathItem
@@ -1226,15 +1228,16 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var node = OpenApiUrlTreeNode.Create(doc, Label);
         var childNode = node.Children.First().Value;
 
-        Assert.Equal(string.Empty, childNode.GetUrlTemplateForPathItem());
+        // No required params at all → class template includes the union of all optional params
+        // GET's $select is optional → included in class template
+        Assert.Equal(childNode.GetUrlTemplate(HttpMethod.Get), childNode.GetUrlTemplateForPathItem());
     }
 
     [Fact]
-    public void GetUrlTemplateForPathItem_ReturnsHighestCardinalityTemplate_WhenMultipleGroupsExist()
+    public void GetUrlTemplateForPathItem_ExcludesOperationSpecificRequiredParams_WhenMultipleGroupsExist()
     {
-        // GET and POST share no-param template (cardinality 2)
-        // DELETE has required confirm param (cardinality 1)
-        // Highest cardinality group is GET/POST → return their template
+        // GET and POST have no params, DELETE has required confirm param
+        // confirm is operation-specific → excluded from class template
         var doc = new OpenApiDocument { Paths = [] };
         doc.Paths.Add("resource", new OpenApiPathItem
         {
@@ -1263,15 +1266,17 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var node = OpenApiUrlTreeNode.Create(doc, Label);
         var childNode = node.Children.First().Value;
 
-        // GET and POST share the no-param template; DELETE has its own → highest cardinality wins
+        // Class template = base path (same as GET/POST template since confirm is excluded)
         var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Get);
         Assert.Equal(expectedTemplate, childNode.GetUrlTemplateForPathItem());
         Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Delete), childNode.GetUrlTemplateForPathItem());
     }
 
     [Fact]
-    public void GetUrlTemplateForPathItem_ReturnsHighestCardinalityTemplate_WhenOptionalOnlyOutlierExists()
+    public void GetUrlTemplateForPathItem_IncludesUnionOfOptionalParams_WhenOptionalOnlyOutlierExists()
     {
+        // GET and POST have no params, PATCH has optional $filter
+        // No required params at all → class template includes the union of all optional params
         var doc = new OpenApiDocument { Paths = [] };
         doc.Paths.Add("resource", new OpenApiPathItem
         {
@@ -1299,9 +1304,9 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var node = OpenApiUrlTreeNode.Create(doc, Label);
         var childNode = node.Children.First().Value;
 
-        var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Get);
+        // Class template includes the union of optional params ($filter) from all operations
+        var expectedTemplate = childNode.GetUrlTemplate(HttpMethod.Patch);
         Assert.Equal(expectedTemplate, childNode.GetUrlTemplateForPathItem());
-        Assert.NotEqual(childNode.GetUrlTemplate(HttpMethod.Patch), childNode.GetUrlTemplateForPathItem());
     }
 
     [Fact]
@@ -1313,6 +1318,187 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         var childNode = node.Children.First().Value;
 
         Assert.Equal(childNode.GetUrlTemplate(), childNode.GetUrlTemplateForPathItem());
+    }
+
+    [Fact]
+    public void GetUrlTemplateForPathItem_IncludesCommonRequiredParams_WhenRequiredByAllOperations()
+    {
+        // api-version is required by all operations → it should appear in the class-level template
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Parameters =
+            [
+                new OpenApiParameter
+                {
+                    Name = "api-version",
+                    In = ParameterLocation.Query,
+                    Required = true,
+                    Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                    Style = ParameterStyle.Simple,
+                }
+            ],
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                { HttpMethod.Post, new() },
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        // api-version is common to all operations → included in class template
+        var pathItemTemplate = childNode.GetUrlTemplateForPathItem();
+        Assert.Contains("api%2Dversion", pathItemTemplate);
+        Assert.Equal(childNode.GetUrlTemplate(HttpMethod.Get), pathItemTemplate);
+    }
+
+    [Fact]
+    public void HasOperationSpecificRequiredQueryParameters_ReturnsFalse_WhenNoRequiredParams()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                {
+                    HttpMethod.Get, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "$select",
+                                In = ParameterLocation.Query,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                },
+                { HttpMethod.Post, new() }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        Assert.False(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Get));
+        Assert.False(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Post));
+    }
+
+    [Fact]
+    public void HasOperationSpecificRequiredQueryParameters_ReturnsTrue_ForOperationWithUniqueRequiredParam()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                {
+                    HttpMethod.Delete, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "confirm",
+                                In = ParameterLocation.Query,
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.Boolean },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        Assert.False(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Get));
+        Assert.True(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Delete));
+    }
+
+    [Fact]
+    public void HasOperationSpecificRequiredQueryParameters_ReturnsFalse_WhenRequiredParamIsCommonToAllOperations()
+    {
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Parameters =
+            [
+                new OpenApiParameter
+                {
+                    Name = "api-version",
+                    In = ParameterLocation.Query,
+                    Required = true,
+                    Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                    Style = ParameterStyle.Simple,
+                }
+            ],
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                { HttpMethod.Get, new() },
+                { HttpMethod.Post, new() },
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        Assert.False(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Get));
+        Assert.False(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Post));
+    }
+
+    [Fact]
+    public void HasOperationSpecificRequiredQueryParameters_DetectsUniqueRequiredParamsOnBothOperations()
+    {
+        // Both operations have unique required params — both must be detected regardless of iteration order
+        var doc = new OpenApiDocument { Paths = [] };
+        doc.Paths.Add("resource", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+            {
+                {
+                    HttpMethod.Get, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "filter",
+                                In = ParameterLocation.Query,
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                },
+                {
+                    HttpMethod.Delete, new()
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "confirm",
+                                In = ParameterLocation.Query,
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.Boolean },
+                                Style = ParameterStyle.Simple,
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        var node = OpenApiUrlTreeNode.Create(doc, Label);
+        var childNode = node.Children.First().Value;
+
+        // Both operations have unique required params — both need overrides
+        Assert.True(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Get));
+        Assert.True(childNode.HasOperationSpecificRequiredQueryParameters(HttpMethod.Delete));
     }
 
     public void Dispose()

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -11124,24 +11124,21 @@ components:
         var resourceRb = resourceNs.FindChildByName<CodeClass>("ResourceRequestBuilder", false);
         Assert.NotNull(resourceRb);
 
-        // The path-item URL template property must be empty because GET and DELETE have unique templates
+        // The path-item URL template excludes operation-specific required params (confirm)
         var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
         Assert.NotNull(urlTemplateProperty);
-        Assert.Equal("\"\"", urlTemplateProperty.DefaultValue);
+        Assert.Equal("\"{+baseurl}/resource\"", urlTemplateProperty.DefaultValue);
 
-        // GET executor method must carry a URL template override (no required params)
+        // GET has no operation-specific required params → no override needed (uses class-level UrlTemplate)
         var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(getExecutor);
-        Assert.True(getExecutor.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource", getExecutor.UrlTemplateOverride);
+        Assert.False(getExecutor.HasUrlTemplateOverride);
 
-        // GET generator method must also carry the same URL template override
         var getGenerator = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(getGenerator);
-        Assert.True(getGenerator.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource", getGenerator.UrlTemplateOverride);
+        Assert.False(getGenerator.HasUrlTemplateOverride);
 
         // DELETE executor must carry an override with the required confirm parameter
         var deleteExecutor = resourceRb.Methods.FirstOrDefault(static m =>
@@ -11214,31 +11211,29 @@ components:
 
         var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
         Assert.NotNull(urlTemplateProperty);
-        Assert.Equal("\"\"", urlTemplateProperty.DefaultValue);
+        // Class-level template includes the union of optional params ($select) — no required params to exclude
+        Assert.Equal("\"{+baseurl}/resource{?%24select*}\"", urlTemplateProperty.DefaultValue);
 
+        // No operation-specific required params → no overrides needed for any operation
         var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(getExecutor);
-        Assert.True(getExecutor.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource{?%24select*}", getExecutor.UrlTemplateOverride);
+        Assert.False(getExecutor.HasUrlTemplateOverride);
 
         var getGenerator = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(getGenerator);
-        Assert.True(getGenerator.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource{?%24select*}", getGenerator.UrlTemplateOverride);
+        Assert.False(getGenerator.HasUrlTemplateOverride);
 
         var postExecutor = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Post);
         Assert.NotNull(postExecutor);
-        Assert.True(postExecutor.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource", postExecutor.UrlTemplateOverride);
+        Assert.False(postExecutor.HasUrlTemplateOverride);
 
         var postGenerator = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Post);
         Assert.NotNull(postGenerator);
-        Assert.True(postGenerator.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource", postGenerator.UrlTemplateOverride);
+        Assert.False(postGenerator.HasUrlTemplateOverride);
     }
 
     [Fact]
@@ -11306,8 +11301,10 @@ components:
 
         var urlTemplateProperty = resourceRb.Properties.FirstOrDefault(static p => p.Kind is CodePropertyKind.UrlTemplate);
         Assert.NotNull(urlTemplateProperty);
-        Assert.Equal("\"{+baseurl}/resource\"", urlTemplateProperty.DefaultValue);
+        // Class-level template includes the union of optional params ($filter) — no required params to exclude
+        Assert.Equal("\"{+baseurl}/resource{?%24filter*}\"", urlTemplateProperty.DefaultValue);
 
+        // No operation-specific required params → no overrides needed for any operation
         var getExecutor = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Get);
         Assert.NotNull(getExecutor);
@@ -11321,13 +11318,11 @@ components:
         var patchExecutor = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestExecutor && m.HttpMethod == Builder.CodeDOM.HttpMethod.Patch);
         Assert.NotNull(patchExecutor);
-        Assert.True(patchExecutor.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource{?%24filter*}", patchExecutor.UrlTemplateOverride);
+        Assert.False(patchExecutor.HasUrlTemplateOverride);
 
         var patchGenerator = resourceRb.Methods.FirstOrDefault(static m =>
             m.Kind is CodeMethodKind.RequestGenerator && m.HttpMethod == Builder.CodeDOM.HttpMethod.Patch);
         Assert.NotNull(patchGenerator);
-        Assert.True(patchGenerator.HasUrlTemplateOverride);
-        Assert.Equal("{+baseurl}/resource{?%24filter*}", patchGenerator.UrlTemplateOverride);
+        Assert.False(patchGenerator.HasUrlTemplateOverride);
     }
 }


### PR DESCRIPTION
# SDK generation issue

## Summary

The latest Kiota code generation update (commit `272007ee94` — `feat(generation): update request builders and models`) introduced a breaking change in how URL templates are handled in generated request builders. This change causes all `ItemWithPath` extension methods to produce incorrect URLs, breaking drive item path-based addressing.

## Affected Tests

All tests in `DriveItemRequestBuilderExtensionsTests` that use `ItemWithPath` are failing:

| Test | Expected URL | Actual URL |
|------|-------------|------------|
| `ItemByPath_BuildRequest` | `.../drives/driveId/root:/item/with/path:` | `.../drives/driveId/items/` |
| `ItemByPath_BuildRequestWithLeadingSlash` | `.../drives/driveId/root:/item/with/path:` | `.../drives/driveId/items/` |
| `ItemByPath_BuildRequestWithNestedPathSlashAndQueryParameters` | `.../drives/driveId/root:/item/with/path:?%24expand=children` | `.../drives/driveId/items/?%24expand=children` |

# Kiota
## Problem

PR #7665 (https://github.com/microsoft/kiota/issues/7665) introduced GetUrlTemplateForPathItem() and per-operation UrlTemplateOverride to prevent required query parameters from one operation leaking into sibling operations on the same path. However, this caused a regression: when an override is set, all language writers emit the URL template as a hardcoded string literal in generated methods (e.g., ToGetRequestInformation()), bypassing the class-level UrlTemplate field entirely.

Downstream SDKs like msgraph-sdk-dotnet rely on overriding the UrlTemplate field at runtime for custom URL construction (e.g., OneDrive path-based addressing via ItemWithPath). The hardcoded templates break this pattern, producing incorrect URLs.

## Root cause

The override condition used string equality between the per-operation template and the path-item template. Since operations commonly differ by optional query parameters (e.g., GET has {?%24select,%24expand} while POST has none), overrides were triggered far too broadly, even though optional parameters are harmless to include at the class level per RFC 6570 (they are omitted from the resolved URL when not provided).

## Fix

The fix narrows the override condition so that per-operation UrlTemplateOverride is only set when an operation has required query parameters not shared by all sibling operations on the same path item. This is the only case where the class-level template would cause incorrect URL resolution.

OpenApiUrlTreeNodeExtensions.cs:

 - Rewrote GetUrlTemplateForPathItem() to build the class-level template as: path + union of all optional query params + required query params common to every operation. This replaces the previous cardinality-based group selection which could return an empty string.
 - Added GetUrlTemplate() parameter excludeOperationSpecificRequiredQueryParameters to filter out operation-specific required params when building the path-item template.
 - Added HasOperationSpecificRequiredQueryParameters() to determine whether a specific operation needs a per-method override.
 - Added GetOperationSpecificRequiredQueryParameterNames() to compute which required params are not shared across all operations.

KiotaBuilder.cs:

 - Changed the override condition from string equality (!operationUrlTemplate.Equals(pathItemUrlTemplate)) to HasOperationSpecificRequiredQueryParameters(operationType).

## Result

 - Operations that differ only by optional query parameters no longer get overrides â generated methods reference the UrlTemplate field, preserving downstream customization.
 - Operations with operation-specific required query parameters still get overrides, preventing parameter leakage.
 - The fix is at the CodeDOM/builder level, no changes needed in any of the 8 language writers.
