### PR TITLE
Fix empty model when allOf inheritance schema is reached via a composed type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug that generares an empty model when allOf inheritance schema is reached via a composed type [#7791](https://github.com/microsoft/kiota/issues/7791)
+
 ## [1.32.2] - 2026-06-05
 
 ### Added
@@ -1754,6 +1756,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
-
 
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1817,6 +1817,15 @@ public partial class KiotaBuilder
         {
             var className = targetSchema.GetSchemaName().CleanupSymbolName();
             var shortestNamespace = GetShortestNamespace(codeNamespace, targetSchema);
+            // When the unwrapped target is itself an allOf inheritance/intersection schema, route it through
+            // CreateModelDeclarations so the allOf entries get merged. Calling AddModelDeclarationIfDoesntExist
+            // directly with the raw schema would only set the base class (from the single allOf $ref) but drop
+            // the inline allOf member's properties, producing an empty model that then wins the name-based dedup.
+            if ((targetSchema.IsInherited() || targetSchema.IsIntersection()) &&
+                CreateModelDeclarations(currentNode, targetSchema, operation, codeNamespace, suffixForInlineSchema, typeNameForInlineSchema: typeNameForInlineSchema, isRequestBody: isRequestBody) is CodeType inheritedType)
+            {
+                return inheritedType;
+            }
             return new CodeType
             {
                 TypeDefinition = AddModelDeclarationIfDoesntExist(currentNode, operation, targetSchema, className, shortestNamespace),

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -8550,6 +8550,82 @@ components:
         Assert.Equal(4, modelsNamespace.Classes.Count());// only 4 classes for user, member, group and directoryObject
     }
     [Fact]
+    public async Task AllOfInheritanceModelReferencedViaComposedTypeKeepsItsPropertiesAsync()
+    {
+        // Regression test: a model defined as allOf [ $ref base, { inline properties } ] that is also reached
+        // as a member of a composed (anyOf/oneOf) type used to be generated with its base class but WITHOUT the
+        // inline allOf properties. CreateComposedModelDeclaration passed the raw $ref straight to
+        // AddModelDeclarationIfDoesntExist, bypassing the allOf merge, and the resulting empty class then won
+        // the name-based dedup over the correctly-merged one.
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(@"openapi: 3.0.1
+info:
+  title: repro
+  version: 1.0.1
+servers:
+  - url: https://example.com
+paths:
+  /things/{id}:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Offer.jsonld-read'
+components:
+  schemas:
+    ItemBase:
+      type: object
+      required: ['@id', '@type']
+      properties:
+        '@id':
+          type: string
+          readOnly: true
+        '@type':
+          type: string
+          readOnly: true
+    Offer.jsonld-read:
+      allOf:
+        - $ref: '#/components/schemas/ItemBase'
+        - type: object
+          properties:
+            name:
+              type: [string, 'null']
+            amount:
+              type: [integer, 'null']
+            product:
+              anyOf:
+                - $ref: '#/components/schemas/Product.jsonld-read'
+                - type: 'null'
+    Product.jsonld-read:
+      allOf:
+        - $ref: '#/components/schemas/ItemBase'
+        - type: object
+          properties:
+            label:
+              type: [string, 'null']
+            offer:
+              anyOf:
+                - $ref: '#/components/schemas/Offer.jsonld-read'
+                - type: 'null'");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var offerClass = codeModel.FindNamespaceByName("ApiSdk.models.Offer")?.FindChildByName<CodeClass>("JsonldRead", false);
+        Assert.NotNull(offerClass);
+        Assert.NotNull(offerClass.StartBlock.Inherits); // still inherits ItemBase
+        Assert.Equal("ItemBase", offerClass.StartBlock.Inherits!.Name);
+        // the inline allOf properties must be present (regression: they were dropped, leaving an empty class)
+        Assert.Contains(offerClass.Properties, static p => p.Name.Equals("name", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(offerClass.Properties, static p => p.Name.Equals("amount", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(offerClass.Properties, static p => p.Name.Equals("product", StringComparison.OrdinalIgnoreCase));
+    }
+    [Fact]
     public async Task InheritanceWithAllOfWith3Parts3SchemaChildClassAsync()
     {
         var tempFilePath = Path.GetTempFileName();


### PR DESCRIPTION
Fixes #7791

A schema defined as `allOf: [ { $ref base }, { inline properties } ]` could be generated with its base class but without any of the inline allOf properties when it was also reached as the unwrapped target of a nullable anyOf/oneOf (the "anyOf was only used for nullable" optimization in CreateComposedModelDeclaration).

That branch passed the raw $ref straight to AddModelDeclarationIfDoesntExist, bypassing the allOf merge. AddModelClass then set the base class (detected from the single allOf $ref) but built properties from schema.Properties, which is null for an allOf wrapper, producing an empty model. Because the class was now registered by name, the later correctly-merged declaration was discarded by the name-based dedup in AddModelDeclarationIfDoesntExist.

Route inheritance/intersection targets through CreateModelDeclarations so the allOf entries are merged before the class is built.

**Code generated by Claude** : it fixes the issue with my OpenApi file, but I'm not 100% sure the fix resides in the right location, as I'm not really familiar with the code.