### PR TITLE
Emit TypeScript primitive collection deserialization types

### DIFF
--- a/it/typescript/package-lock.json
+++ b/it/typescript/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
-        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.102",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.102",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.102",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.102",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
+        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.103",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.103",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.103",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.103",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.103",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.103",
         "express": "^5.2.1",
         "node-fetch": "^2.7.0"
       },
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.102.tgz",
-      "integrity": "sha512-WL+S7X+W6zpDO6vFk+FClb5hoUJMV1ZcMHo1H52r2Q49xTuYx9esJqmwh/0EXsftmxKwOOIOoPfO7+Tp5QAddw==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.103.tgz",
+      "integrity": "sha512-om7nKH8nWyEAQ0lgbIdKdrkmznhkdDJdliCnAIo31X/hlUah1aBzvfUx+pbyp67Q040yLK+2J6P7AnvGSoN/qQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -925,65 +925,65 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.102.tgz",
-      "integrity": "sha512-S+TENSTiMNI0KfXZeuuN0bQEpSOYPYviz/KiiiwByx9M96aoF/Oxagj8PoCVebbJRxrVkZrRsVyRuKt0ikfyDw==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.103.tgz",
+      "integrity": "sha512-eggxtsJWLcvaExghUJsOuUhVsJoalyWBGPtBYhlQEgJsUkozJOa1C4Mml8nq88vaQJ7rh+LbS3sTgZI69plIUg==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.102.tgz",
-      "integrity": "sha512-oXfrPOWkIR2/Gs700n00EY3VDc+Qgz6y7ZiA/f8FHJsnwSjZ017xcWFw2PLzJItczVsad0pq/N5DYnoF6Co11Q==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.103.tgz",
+      "integrity": "sha512-DbhGL+pdVjtv2AVvxB4fxvNC/GMzKbYyeQsknaXJXwqnPR/oIClWjaXlIxWL5SBK72DOmrZ18leaWMB2vfWvpw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.102.tgz",
-      "integrity": "sha512-1w70XAA/F4RgbyNbRAaZCjLAOiKQjdiQDYlNZC9x8g7xgd7tNqYqowt/auQS1A9SZOrT626q6+Gr2xKKyW3wOg==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.103.tgz",
+      "integrity": "sha512-AD5Q59Qu61DfhaLLN7Mvgx4Zw0Zmftqx04XAbrRreC+r9hwT1BqTf0EReCraMzEoC4sdrp/8haI2Arm8dWUWuQ==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.102.tgz",
-      "integrity": "sha512-YpIt5pXNX13ND736oJFf0wBYPAafCv+CAE17Fa1HcS1drCdXx8ELPQ5GxGDbQG7J5LIMDgUtBOUmf5R/FrMQ6A==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.103.tgz",
+      "integrity": "sha512-dTr8q6H42TSe+HaCPBXU4Pv6ypo7MjMGRo/r9GRbnCuy8VCWfe+Vh38rnAZJx4r8cmvOUD7Yw74IJ6q4Hjv3mg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.102.tgz",
-      "integrity": "sha512-tjwt0m+8+OqZizZU6gBARTcA8suPYS0onD9IUbhKsvRrAJpBIyp07hnyOTXBgE+gurGGbeT3TTl9AUK2ic6DiA==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.103.tgz",
+      "integrity": "sha512-b3ePXYgFv/2TQtbzFQ8ZY+hzMtCRkz4Cx5y/Pf8vtoQu56KU0/9rYq5kA9wySDdCx/oZxfubQQRV/8QSTxmejw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.102",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.102.tgz",
-      "integrity": "sha512-ZCihyrXKYGfTz/frqNQvwKsD+EgjhjfclB5/XDrSGNXduisL/f1MbyvjsgmrZnLmtCwX8/v+Mc3vlz716KWYbg==",
+      "version": "1.0.0-preview.103",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.103.tgz",
+      "integrity": "sha512-FkiboqpNtT2F40xUC9LETHK9ckHd+WuocLJE70ljI4EYvD59MQDsrTERYAwbmkfPIJ6JRE4OfLXFVh510LG1/Q==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
         "tslib": "^2.6.2"
       }
     },

--- a/it/typescript/package.json
+++ b/it/typescript/package.json
@@ -32,13 +32,13 @@
   },
   "dependencies": {
     "@azure/identity": "^4.13.1",
-    "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.102",
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
-    "@microsoft/kiota-serialization-form": "^1.0.0-preview.102",
-    "@microsoft/kiota-serialization-json": "^1.0.0-preview.102",
-    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.102",
-    "@microsoft/kiota-serialization-text": "^1.0.0-preview.102",
+    "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.103",
+    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.103",
+    "@microsoft/kiota-serialization-form": "^1.0.0-preview.103",
+    "@microsoft/kiota-serialization-json": "^1.0.0-preview.103",
+    "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.103",
+    "@microsoft/kiota-serialization-text": "^1.0.0-preview.103",
     "express": "^5.2.1",
     "node-fetch": "^2.7.0"
   }

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -370,12 +370,27 @@ public class TypeScriptConventionService : CommonLanguageConventionService
             {
                 (CodeEnum currentEnum, _, _) when currentEnum.CodeEnumObject is not null => $"{(currentEnum.Flags || isCollection ? "getCollectionOfEnumValues" : "getEnumValue")}<{currentEnum.Name.ToFirstCharacterUpperCase()}>({currentEnum.CodeEnumObject.Name.ToFirstCharacterUpperCase()})",
                 (_, _, _) when StreamTypeName.Equals(propertyType, StringComparison.OrdinalIgnoreCase) => "getByteArrayValue()",
-                (_, true, _) when currentType.TypeDefinition is null => $"getCollectionOfPrimitiveValues<{propertyType}>()",
+                (_, true, _) when currentType.TypeDefinition is null && GetPrimitiveCollectionDeserializationType(propertyType) is string primitiveType => $"getCollectionOfPrimitiveValues<{propertyType}>(\"{primitiveType}\")",
                 (_, true, _) => $"getCollectionOfObjectValues<{propertyType.ToFirstCharacterUpperCase()}>({GetFactoryMethodName(_codeType, targetElement)})",
                 _ => GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, targetElement)
             };
         }
         return GetDeserializationMethodNameForPrimitiveOrObject(_codeType, propertyType, targetElement);
+    }
+
+    private static string? GetPrimitiveCollectionDeserializationType(string propertyTypeName)
+    {
+        return propertyTypeName switch
+        {
+            TYPE_LOWERCASE_STRING or TYPE_STRING or TYPE_GUID => TYPE_LOWERCASE_STRING,
+            TYPE_LOWERCASE_BOOLEAN or TYPE_BOOLEAN => TYPE_LOWERCASE_BOOLEAN,
+            TYPE_NUMBER => TYPE_NUMBER,
+            TYPE_DATE => TYPE_DATE,
+            TYPE_DATE_ONLY => TYPE_DATE_ONLY,
+            TYPE_TIME_ONLY => TYPE_TIME_ONLY,
+            TYPE_DURATION => TYPE_DURATION,
+            _ => null,
+        };
     }
 
     private static string GetDeserializationMethodNameForPrimitiveOrObject(CodeTypeBase propType, string propertyTypeName, CodeElement targetElement)

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFunctionWriterTests.cs
@@ -383,6 +383,52 @@ public sealed class CodeFunctionWriterTests : IDisposable
         Assert.Contains("definedInParent", result, StringComparison.OrdinalIgnoreCase);
     }
     [Fact]
+    public async Task WritesDeSerializerBodyForPrimitiveCollectionsAsync()
+    {
+        var parentClass = TestHelper.CreateModelClass(root, "parentClass");
+        foreach (var primitiveType in new[] { "string", "integer", "boolean", "Date", "DateOnly", "TimeOnly", "Duration" })
+        {
+            parentClass.AddProperty(new CodeProperty
+            {
+                Name = $"{primitiveType.ToFirstCharacterLowerCase()}Collection",
+                Kind = CodePropertyKind.Custom,
+                Type = new CodeType
+                {
+                    Name = primitiveType,
+                    CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
+                },
+            });
+        }
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "guidCollection",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "Guid",
+                CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
+            },
+        });
+
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
+        var deserializerFunction = root.FindChildByName<CodeFunction>($"deserializeInto{parentClass.Name.ToFirstCharacterUpperCase()}");
+        Assert.NotNull(deserializerFunction);
+        var parentNS = deserializerFunction.GetImmediateParentOfType<CodeNamespace>();
+        Assert.NotNull(parentNS);
+        parentNS.TryAddCodeFile("foo", deserializerFunction);
+        writer.Write(deserializerFunction);
+        var result = tw.ToString();
+
+        Assert.Contains("n.getCollectionOfPrimitiveValues<string>(\"string\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<number>(\"number\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<boolean>(\"boolean\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<Date>(\"Date\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<DateOnly>(\"DateOnly\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<TimeOnly>(\"TimeOnly\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<Duration>(\"Duration\")", result);
+        Assert.Contains("n.getCollectionOfPrimitiveValues<Guid>(\"string\")", result);
+    }
+    [Fact]
     public async Task WritesDeSerializerBodyWithDefaultValueAsync()
     {
         var parentClass = TestHelper.CreateModelClass(root, "parentClass");


### PR DESCRIPTION
## Summary
- emit the required runtime primitive type argument for generated TypeScript primitive collection deserialization calls
- map TypeScript `Guid` collections to the runtime `"string"` primitive token
- add focused TypeScript deserializer writer coverage for supported primitive collection tokens

## Validation
- `docker run --rm -v "$PWD":/src -v /tmp/nuget-kiota:/root/.nuget/packages -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --filter 'FullyQualifiedName~Kiota.Builder.Tests.Writers.TypeScript.CodeFunctionWriterTests'`

Related to microsoft/kiota-typescript#2039.
