### PR TITLE
fix(php): call parent constructor only if it exists in parent class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a bug that generares an empty model when allOf inheritance schema is reached via a composed type [#7791](https://github.com/microsoft/kiota/issues/7791)
+- Fixed a bug in PHP generation where `parent::__construct()` was generated for parent classes without a constructor [#7809](https://github.com/microsoft/kiota/issues/7809) [#7810](https://github.com/microsoft/kiota/pull/7810) 
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Fixed a bug that generares an empty model when allOf inheritance schema is reached via a composed type [#7791](https://github.com/microsoft/kiota/issues/7791)
 
 ## [1.32.2] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that generares an empty model when allOf inheritance schema is reached via a composed type [#7791](https://github.com/microsoft/kiota/issues/7791)
 - Fixed a bug in PHP generation where `parent::__construct()` was generated for parent classes without a constructor [#7809](https://github.com/microsoft/kiota/issues/7809) [#7810](https://github.com/microsoft/kiota/pull/7810) 
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-- Fixed a bug that generares an empty model when allOf inheritance schema is reached via a composed type [#7791](https://github.com/microsoft/kiota/issues/7791)
 
 ## [1.32.2] - 2026-06-05
 

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -122,8 +122,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         var requestHeadersParameter = currentMethod.Parameters.OfKind(CodeParameterKind.Headers);
         var pathParametersProperty = parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.PathParameters);
         var urlTemplateProperty = parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.UrlTemplate);
-        var hasConstructor = parentClass.Methods.Any(static x => x.IsOfKind(CodeMethodKind.Constructor));
-
+        var baseClass = parentClass.StartBlock.Inherits?.TypeDefinition as CodeClass;
+        var hasConstructor = baseClass?.Methods.Any(static x => x.IsOfKind(CodeMethodKind.Constructor)) ?? false;
         if (parentClass.IsOfKind(CodeClassKind.RequestBuilder))
         {
             writer.WriteLine($"parent::__construct(${(requestAdapterParameter?.Name ?? "requestAdapter")}, {(pathParametersProperty?.DefaultValue ?? "[]")}, {(urlTemplateProperty?.DefaultValue.ReplaceDoubleQuoteWithSingleQuote() ?? "")});");

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -122,6 +122,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         var requestHeadersParameter = currentMethod.Parameters.OfKind(CodeParameterKind.Headers);
         var pathParametersProperty = parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.PathParameters);
         var urlTemplateProperty = parentClass.Properties.FirstOrDefaultOfKind(CodePropertyKind.UrlTemplate);
+        var hasConstructor = parentClass.Methods.Any(static x => x.IsOfKind(CodeMethodKind.Constructor));
 
         if (parentClass.IsOfKind(CodeClassKind.RequestBuilder))
         {
@@ -129,9 +130,8 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         }
         else if (parentClass.IsOfKind(CodeClassKind.RequestConfiguration))
             writer.WriteLine($"parent::__construct(${(requestHeadersParameter?.Name ?? "headers")} ?? [], ${(requestOptionParameter?.Name ?? "options")} ?? []);");
-        else
+        else if (hasConstructor)
             writer.WriteLine("parent::__construct();");
-
     }
 
     private static string? GetDefaultValue(string defaultValue, CodeType propertyType, out bool checkParsedValue)

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1292,6 +1292,36 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("$this->setPropWithDefaultNullValue(null)", result);
         Assert.Contains("$this->setPropWithDefaultBoolValue(true)", result);
     }
+
+    [Fact]
+    public async Task DoesNotWriteParentConstructorCallWhenParentHasNoConstructorAsync()
+    {
+        setup();
+        parentClass.Kind = CodeClassKind.Model;
+        var constructor = new CodeMethod
+        {
+            Name = "constructor",
+            Access = AccessModifier.Public,
+            ReturnType = new CodeType { Name = "void" },
+            Kind = CodeMethodKind.Constructor
+        };
+        parentClass.AddMethod(constructor);
+        var baseClass = root.AddClass(new CodeClass
+        {
+            Name = "BaseClass",
+            Kind = CodeClassKind.Model
+        }).First();
+        parentClass.StartBlock.Inherits = new CodeType
+        {
+            Name = "BaseClass",
+            TypeDefinition = baseClass
+        };
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root, cancellationToken: TestContext.Current.CancellationToken);
+        _codeMethodWriter.WriteCodeElement(constructor, languageWriter);
+        var result = stringWriter.ToString();
+        Assert.Contains("public function __construct", result);
+        Assert.DoesNotContain("parent::__construct()", result);
+    }
     [Fact]
     public async Task EscapesStringDefaultsInConstructorAsync()
     {

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1292,12 +1292,12 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("$this->setPropWithDefaultNullValue(null)", result);
         Assert.Contains("$this->setPropWithDefaultBoolValue(true)", result);
     }
-
     [Fact]
     public async Task DoesNotWriteParentConstructorCallWhenParentHasNoConstructorAsync()
     {
         setup();
         parentClass.Kind = CodeClassKind.Model;
+
         var constructor = new CodeMethod
         {
             Name = "constructor",
@@ -1306,19 +1306,22 @@ public sealed class CodeMethodWriterTests : IDisposable
             Kind = CodeMethodKind.Constructor
         };
         parentClass.AddMethod(constructor);
+
         var baseClass = root.AddClass(new CodeClass
         {
             Name = "BaseClass",
             Kind = CodeClassKind.Model
         }).First();
+
         parentClass.StartBlock.Inherits = new CodeType
         {
             Name = "BaseClass",
             TypeDefinition = baseClass
         };
-        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root, cancellationToken: TestContext.Current.CancellationToken);
+
         _codeMethodWriter.WriteCodeElement(constructor, languageWriter);
         var result = stringWriter.ToString();
+
         Assert.Contains("public function __construct", result);
         Assert.DoesNotContain("parent::__construct()", result);
     }


### PR DESCRIPTION
### Description
Fixes a bug where `parent::__construct();` is generated even if the parent class has no constructor, causing runtime crashes in PHP.

### Changes
- Added a check using `parentClass.Methods.Any(...)` before writing the constructor parent call.