### PR TITLE
fix(csharp): strip newlines from doc comment text to prevent code injection

### DIFF
--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -151,7 +151,7 @@ public static partial class OpenApiUrlTreeNodeExtensions
         "yml",
         "txt",
     };
-    [GeneratedRegex(@"[\r\n\t]", RegexOptions.Singleline, 500)]
+    [GeneratedRegex(@"[\r\n\t\u0085\u2028\u2029]", RegexOptions.Singleline, 500)]
     private static partial Regex descriptionCleanupRegex();
     public static string CleanupDescription(this string? description) => string.IsNullOrEmpty(description) ? string.Empty : descriptionCleanupRegex().Replace(description, string.Empty);
     public static string GetPathItemDescription(this OpenApiUrlTreeNode currentNode, string label, string? defaultValue = default)

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -62,7 +62,7 @@ public class CSharpConventionService : CommonLanguageConventionService
         ArgumentNullException.ThrowIfNull(element);
         if (element is not CodeElement codeElement) return false;
         if (!element.Documentation.DescriptionAvailable) return false;
-        var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => x.CleanupXMLString());
+        var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => RemoveInvalidDescriptionCharacters(x.CleanupXMLString()));
         writer.WriteLine($"{DocCommentPrefix}{prefix}{description}{suffix}");
         return true;
     }
@@ -83,13 +83,13 @@ public class CSharpConventionService : CommonLanguageConventionService
             writer.WriteLine($"{DocCommentPrefix}<summary>");
             if (documentation.DescriptionAvailable)
             {
-                var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => x.CleanupXMLString());
+                var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => RemoveInvalidDescriptionCharacters(x.CleanupXMLString()));
                 writer.WriteLine($"{DocCommentPrefix}{description}");
             }
             if (documentation.ExternalDocumentationAvailable)
             {
-                var documentationLabel = documentation.DocumentationLabel.CleanupXMLString();
-                var documentationLink = documentation.DocumentationLink?.ToString().CleanupXMLString();
+                var documentationLabel = RemoveInvalidDescriptionCharacters(documentation.DocumentationLabel.CleanupXMLString());
+                var documentationLink = RemoveInvalidDescriptionCharacters(documentation.DocumentationLink?.ToString().CleanupXMLString() ?? string.Empty);
                 writer.WriteLine($"{DocCommentPrefix}{documentationLabel} <see href=\"{documentationLink}\" />");
             }
             writer.WriteLine($"{DocCommentPrefix}</summary>");
@@ -177,6 +177,11 @@ public class CSharpConventionService : CommonLanguageConventionService
                 yield return childNsSegment;
         }
     }
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
+        string.IsNullOrEmpty(originalDescription) ? string.Empty :
+        originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     public string GetTypeStringForDocumentation(CodeTypeBase code, CodeElement targetElement)
     {
         var typeString = GetTypeString(code, targetElement, true, false);// dont include nullable markers

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -181,6 +181,9 @@ public class CSharpConventionService : CommonLanguageConventionService
         string.IsNullOrEmpty(originalDescription) ? string.Empty :
         originalDescription.Replace("\r", string.Empty, StringComparison.Ordinal)
             .Replace("\n", string.Empty, StringComparison.Ordinal)
+            .Replace("\u0085", string.Empty, StringComparison.Ordinal) // NEXT LINE
+            .Replace("\u2028", string.Empty, StringComparison.Ordinal) // LINE SEPARATOR
+            .Replace("\u2029", string.Empty, StringComparison.Ordinal) // PARAGRAPH SEPARATOR
             .Replace("\t", " ", StringComparison.Ordinal);
     public string GetTypeStringForDocumentation(CodeTypeBase code, CodeElement targetElement)
     {

--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiUrlTreeNodeExtensionsTests.cs
@@ -25,6 +25,18 @@ public sealed class OpenApiUrlTreeNodeExtensionsTests : IDisposable
         Assert.Empty(OpenApiUrlTreeNode.Create().GetPathItemDescription(Label));
     }
     private const string Label = "default";
+    [Theory]
+    [InlineData("a\rb", "ab")]
+    [InlineData("a\nb", "ab")]
+    [InlineData("a\r\nb", "ab")]
+    [InlineData("a\tb", "ab")]
+    [InlineData("a\u0085b", "ab")] // NEXT LINE
+    [InlineData("a\u2028b", "ab")] // LINE SEPARATOR
+    [InlineData("a\u2029b", "ab")] // PARAGRAPH SEPARATOR
+    public void CleanupDescriptionStripsLineTerminators(string input, string expected)
+    {
+        Assert.Equal(expected, input.CleanupDescription());
+    }
     [Fact]
     public void GetsDescription()
     {

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1849,6 +1849,27 @@ public sealed class CodeMethodWriterTests : IDisposable
         foreach (var line in result.Split('\n').Where(static l => l.Contains("KiotaPwn", StringComparison.Ordinal)))
             Assert.StartsWith("///", line.TrimStart());
     }
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\u0085")] // NEXT LINE
+    [InlineData("\u2028")] // LINE SEPARATOR
+    [InlineData("\u2029")] // PARAGRAPH SEPARATOR
+    public void SanitizesMethodDescriptionLinkLabelLineTerminatorInjection(string lineTerminator)
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = $"See the docs.{lineTerminator}class KiotaPwn{{}}//";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        // every C# line terminator (ECMA-334) must be stripped so the payload cannot
+        // break out of the single-line /// doc comment into namespace-level source
+        foreach (var line in result.Split('\n', '\r', '\u0085', '\u2028', '\u2029').Where(static l => l.Contains("KiotaPwn", StringComparison.Ordinal)))
+            Assert.StartsWith("///", line.TrimStart());
+    }
     [Fact]
     public void Defensive()
     {

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -1835,6 +1835,21 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("see &lt;more&gt; <see href=", result);
     }
     [Fact]
+    public void SanitizesMethodDescriptionLinkLabelNewlineInjection()
+    {
+        setup();
+        method.Documentation.DescriptionTemplate = MethodDescription;
+        method.Documentation.DocumentationLabel = "See the docs.\nclass KiotaPwn{}//";
+        method.Documentation.DocumentationLink = new("https://foo.org/docs");
+        method.IsAsync = false;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.DoesNotContain("\nclass KiotaPwn", result);
+        Assert.Contains("See the docs.class KiotaPwn{}//", result);
+        foreach (var line in result.Split('\n').Where(static l => l.Contains("KiotaPwn", StringComparison.Ordinal)))
+            Assert.StartsWith("///", line.TrimStart());
+    }
+    [Fact]
     public void Defensive()
     {
         setup();


### PR DESCRIPTION
## Summary

Fixes a generated-source code injection vulnerability (CWE-94) in the C# emitter. An attacker-controlled OpenAPI `externalDocs.description` value was written into a single-line `///` XML doc comment after passing only through `CleanupXMLString` (`SecurityElement.Escape`), which escapes `< > & " '` but **does not strip newline characters**.

A newline in `externalDocs.description` terminates the `///` comment line and places the remainder of the value at namespace-level source position. A crafted spec can therefore inject arbitrary C# (e.g. a `[ModuleInitializer]`) into the generated client, which executes when anyone builds/runs the output - a developer, CI pipeline, or downstream SDK consumer.

## Root cause

- **Sink:** `CSharpConventionService.WriteLongDescription` emitted `DocumentationLabel` / `DocumentationLink` via `CleanupXMLString`, which preserves `\r\n\t`.
- **Source:** `externalDocs.description` is assigned to `DocumentationLabel` **without** `CleanupDescription()` at `KiotaBuilder.cs:1417` (operations) and `:2123` (schemas) Regular descriptions ARE cleaned and were not injectable.
- **C#-only:** Every other emitter (Python, Go, TypeScript, Dart, HTTP, Java, PHP) strips newlines via `RemoveInvalidDescriptionCharacters` or uses block comments. C# was the only single-line `///` emitter lacking newline stripping.

This is a sibling of the previously fixed Python `x-ms-enum` issue (#7735); the `externalDocs.description` field reaches the C# emitter through a different, still-unsanitized path.

## Fix

Sanitize at the **C# emission site** (consistent with the other language writers and the repo's writer-literal-security guidance):

- Added `RemoveInvalidDescriptionCharacters` to `CSharpConventionService` (strips `\r`/`\n`, replaces `\t` with a space).
- Applied it to the description, `documentationLabel`, and `documentationLink` write sites.
- Left `CleanupXMLString` unchanged, since it is also used for plugin JSON manifests where multi-line text is legitimate.

## Testing

- Added `SanitizesMethodDescriptionLinkLabelNewlineInjection` regression test asserting the injected `class KiotaPwn{}` payload stays within the `///` comment and never reaches a code line.
- All 78 `CodeMethodWriterTests` pass.

## Security

- **Severity:** High (CVSS 3.1 7.8 local / 8.1 network variant)
- **CWE:** CWE-94 - Improper Control of Generation of Code