### PR TITLE
build(deps-dev): bump IT python dev dependencies and pin astroid for pylint compatibility

### DIFF
--- a/it/python/requirements-dev.txt
+++ b/it/python/requirements-dev.txt
@@ -1,6 +1,6 @@
 -i https://pypi.org/simple
 
-astroid==4.1.2 ; python_full_version >= '3.7.2'
+astroid==4.0.4 ; python_full_version >= '3.7.2'
 
 certifi==2026.6.17 ; python_version >= '3.6'
 
@@ -30,7 +30,7 @@ lazy-object-proxy==1.12.0 ; python_version >= '3.7'
 
 mccabe==0.7.0 ; python_version >= '3.6'
 
-mypy==1.19.1
+mypy==2.1.0
 
 mypy-extensions==1.1.0 ; python_version >= '3.5'
 
@@ -46,7 +46,7 @@ pytest==9.1.1
 
 pytest-asyncio==1.4.0
 
-requests==2.32.5 ; python_version >= '3.7'
+requests==2.34.2 ; python_version >= '3.7'
 
 toml==0.10.2
 
@@ -64,13 +64,13 @@ wrapt==2.2.2 ; python_version < '3.11'
 
 yapf==0.43.0
 
-zipp==3.23.1 ; python_version >= '3.7'
+zipp==4.1.0 ; python_version >= '3.7'
 
 aiohttp==3.14.1 ; python_version >= '3.6'
 
 aiosignal==1.4.0 ; python_version >= '3.7'
 
-anyio==4.12.1 ; python_version >= '3.7'
+anyio==4.14.0 ; python_version >= '3.7'
 
 async-timeout==5.0.1 ; python_version >= '3.6'
 
@@ -120,7 +120,7 @@ multidict==6.7.1 ; python_version >= '3.7'
 
 portalocker==3.1.1 ; python_version >= '3.5' and platform_system == 'Windows'
 
-pycparser==2.23
+pycparser==3.0
 
 pyjwt[crypto]==2.13.0 ; python_version >= '3.7'
 


### PR DESCRIPTION
This PR combines the open dependabot bumps for the integration-test Python dependencies into a single change and fixes the ResolutionImpossible error that broke the Execute the IT test step (pytest).

## Dependency bumps included
- #7841 
- #7840 
- #7839 
- #7838
- #7835

## IT test fix
The `Execute the IT test` job failed at the pip install step:
```
The user requested astroid==4.1.2
pylint 4.0.6 depends on astroid<=4.1.dev0 and >=4.0.2
ERROR: ResolutionImpossible
```
`astroid==4.1.2` (introduced on main) is incompatible with `pylint==4.0.6`. This pins `astroid` to `4.0.4` (latest 4.0.x), restoring a resolvable dependency set. Verified locally with `pip install --dry-run -r requirements-dev.txt`.