### PR TITLE
feat: map confirmation isNonConsequential in AI capabilities extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for the `isNonConsequential` confirmation property in the AI capabilities extension (`x-ai-capabilities`) and mapped it to the generated plugin manifest confirmation object (plugin manifest 2.4).
+- Added support for the `isNonConsequential` confirmation property in the AI capabilities extension (`x-ai-capabilities`) and mapped it to the generated plugin manifest confirmation object (plugin manifest 2.4). [#7857](https://github.com/microsoft/kiota/pull/7857)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for the `isNonConsequential` confirmation property in the AI capabilities extension (`x-ai-capabilities`) and mapped it to the generated plugin manifest confirmation object (plugin manifest 2.4).
+
 ### Changed
 
 ## [1.32.3] - 2026-06-24

--- a/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
+++ b/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
@@ -91,6 +91,13 @@ public class OpenApiAiCapabilitiesExtension : IOpenApiExtension
         {
             confirmation.Body = bodyStrValue;
         }
+        if (source.TryGetPropertyValue(nameof(Confirmation.IsNonConsequential).ToFirstCharacterLowerCase(), out var isNonConsequential) &&
+            isNonConsequential is JsonValue isNonConsequentialValue &&
+            isNonConsequentialValue.GetValueKind() is JsonValueKind.True or JsonValueKind.False &&
+            isNonConsequentialValue.TryGetValue<bool>(out var isNonConsequentialBoolValue))
+        {
+            confirmation.IsNonConsequential = isNonConsequentialBoolValue;
+        }
 
         return confirmation;
     }
@@ -115,6 +122,12 @@ public class OpenApiAiCapabilitiesExtension : IOpenApiExtension
         {
             writer.WritePropertyName(nameof(Confirmation.Body).ToFirstCharacterLowerCase());
             writer.WriteValue(confirmation.Body);
+        }
+
+        if (confirmation.IsNonConsequential.HasValue)
+        {
+            writer.WritePropertyName(nameof(Confirmation.IsNonConsequential).ToFirstCharacterLowerCase());
+            writer.WriteValue(confirmation.IsNonConsequential.Value);
         }
 
         writer.WriteEndObject();
@@ -329,6 +342,10 @@ public class ExtensionConfirmation
         get; set;
     }
     public string? Body
+    {
+        get; set;
+    }
+    public bool? IsNonConsequential
     {
         get; set;
     }

--- a/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
+++ b/src/Kiota.Builder/Plugins/PluginsGenerationService.cs
@@ -1220,6 +1220,7 @@ public partial class PluginsGenerationService
                     Type = capabilities.Confirmation.Type,
                     Title = capabilities.Confirmation.Title,
                     Body = capabilities.Confirmation.Body,
+                    IsNonConsequential = capabilities.Confirmation.IsNonConsequential,
                 };
                 functionCapabilities.Confirmation = confirmation;
             }

--- a/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
@@ -235,7 +235,7 @@ components:
         Assert.Contains("Confirm action", result);
         Assert.Contains("body", result);
         Assert.Contains("Do you want to proceed?", result);
-        Assert.Contains("isNonConsequential", result);
+        Assert.Contains("\"isNonConsequential\":true", result);
         Assert.Contains("\"security_info\":", result);
         Assert.Contains("data_handling", result);
         Assert.Contains("some data handling", result);

--- a/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
@@ -51,7 +51,8 @@ public sealed class OpenApiAiCapabilitiesExtensionTest : IDisposable
             "confirmation": {
                 "type": "modal",
                 "title": "Confirm action",
-                "body": "Do you want to proceed?"
+                "body": "Do you want to proceed?",
+                "isNonConsequential": true
             },
             "security_info": {
                 "data_handling": ["some data handling"]
@@ -89,6 +90,7 @@ public sealed class OpenApiAiCapabilitiesExtensionTest : IDisposable
         Assert.Equal("modal", confirmation.Type);
         Assert.Equal("Confirm action", confirmation.Title);
         Assert.Equal("Do you want to proceed?", confirmation.Body);
+        Assert.True(confirmation.IsNonConsequential);
 
         Assert.Equal("some data handling", securityInfo.DataHandling[0]);
     }
@@ -190,7 +192,8 @@ components:
             {
                 Type = "modal",
                 Title = "Confirm action",
-                Body = "Do you want to proceed?"
+                Body = "Do you want to proceed?",
+                IsNonConsequential = true
             },
             SecurityInfo = new ExtensionSecurityInfo
             {
@@ -232,6 +235,7 @@ components:
         Assert.Contains("Confirm action", result);
         Assert.Contains("body", result);
         Assert.Contains("Do you want to proceed?", result);
+        Assert.Contains("isNonConsequential", result);
         Assert.Contains("\"security_info\":", result);
         Assert.Contains("data_handling", result);
         Assert.Contains("some data handling", result);

--- a/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Plugins/PluginsGenerationServiceTests.cs
@@ -1531,6 +1531,7 @@ paths:
           type: text
           title: Confirmation Title
           body: Are you sure you want to proceed?
+          isNonConsequential: true
         security_info:
           data_handling:
             - sensitiveData
@@ -1609,6 +1610,7 @@ paths:
         Assert.Equal("text", resultingManifest.Document.Functions[0].Capabilities.Confirmation.Type);
         Assert.Equal("Confirmation Title", resultingManifest.Document.Functions[0].Capabilities.Confirmation.Title);
         Assert.Equal("Are you sure you want to proceed?", resultingManifest.Document.Functions[0].Capabilities.Confirmation.Body);
+        Assert.True(resultingManifest.Document.Functions[0].Capabilities.Confirmation.IsNonConsequential);
 
         // Validate SecurityInfo
         Assert.NotNull(resultingManifest.Document.Functions[0].Capabilities.SecurityInfo);


### PR DESCRIPTION
## Description

The `x-ai-capabilities` confirmation object supports `isNonConsequential` (plugin manifest **2.4**, available in `Microsoft.DeclarativeAgents.Manifest` as `Confirmation.IsNonConsequential`), but Kiota was silently dropping it:

- `ExtensionConfirmation` (the `x-ai-capabilities` parser model) only had `Type`/`Title`/`Body`.
- `ParseConfirmation` / `WriteConfirmation` never read or wrote `isNonConsequential`.
- `PluginsGenerationService.GetFunctionCapabilitiesFromCapabilitiesExtension` mapped only `Type`/`Title`/`Body` onto the generated manifest `Confirmation`.

As a result, a function could never be marked non-consequential in the generated plugin manifest, so the "Always Allow" confirmation option was unavailable.

## Changes

- `OpenApiAiCapabilitiesExtension.cs`: add `IsNonConsequential` to `ExtensionConfirmation`; parse it (boolean) in `ParseConfirmation`; emit it in `WriteConfirmation`.
- `PluginsGenerationService.cs`: map `capabilities.Confirmation.IsNonConsequential` → `Confirmation.IsNonConsequential`.
- Tests: extended the `OpenApiAiCapabilitiesExtension` parse + write round-trip tests and the end-to-end `GeneratesManifestWithAiCapabilitiesExtensionAsync` generation test to cover `isNonConsequential`.

## Example

OpenAPI operation extension:
```yaml
x-ai-capabilities:
  confirmation:
    type: AdaptiveCard
    title: Fill color
    body: Change the cell color?
    isNonConsequential: true
```
now produces in the generated plugin manifest:
```json
"capabilities": {
  "confirmation": { "type": "AdaptiveCard", "title": "Fill color", "body": "Change the cell color?", "isNonConsequential": true }
}
```

## Testing

- `dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --filter "FullyQualifiedName~OpenApiAiCapabilitiesExtension|FullyQualifiedName~PluginsGenerationService"` → **96 passing, 0 failing**.

## Context

Complements the TypeSpec authoring side (`@microsoft/typespec-m365-copilot`) which emits `x-ai-capabilities.confirmation.isNonConsequential` — see microsoft/typespec-copilot-skills#530. The underlying manifest model already supports the property (`Microsoft.DeclarativeAgents.Manifest@5.0.0-rc.2`); this PR wires Kiota's generator to populate it.