### PR TITLE
ci: add DOM-surface regression integration test

### DIFF
--- a/.github/workflows/surface-area-tests.yml
+++ b/.github/workflows/surface-area-tests.yml
@@ -1,0 +1,137 @@
+name: surface-area-tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      baselineVersion:
+        description: "Specific Microsoft.OpenApi.Kiota version to use as the baseline (defaults to latest stable release)."
+        required: false
+        default: ""
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-surface-area-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - name: Restore dependencies
+        run: dotnet restore kiota.slnx
+      - name: Build
+        run: dotnet publish ./src/kiota/kiota.csproj -c Release -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./publish -f net10.0
+      - uses: actions/upload-artifact@v7
+        with:
+          name: generator
+          path: publish
+
+  surface-diff:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - csharp
+          - java
+        description:
+          - "https://github.com/microsoftgraph/msgraph-metadata/raw/refs/heads/master/openapi/beta/openapi.yaml"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - uses: actions/download-artifact@v8
+        with:
+          name: generator
+          path: publish
+      - run: chmod a+x ./publish/kiota
+
+      - name: Generate baseline & current DOM exports and diff
+        id: compare
+        shell: pwsh
+        timeout-minutes: 30
+        run: |
+          $patchPath = Join-Path -Path (Get-Location) -ChildPath "${{ matrix.language }}-dom-export.patch"
+          ./it/compare-dom-export.ps1 `
+            -descriptionUrl "${{ matrix.description }}" `
+            -language "${{ matrix.language }}" `
+            -patchPath $patchPath `
+            -baselineVersion "${{ github.event.inputs.baselineVersion }}"
+          $hasPatch = (Test-Path $patchPath) -and ((Get-Item $patchPath).Length -gt 0)
+          Write-Output "patchFilePath=$patchPath" >> $Env:GITHUB_OUTPUT
+          Write-Output "hasPatch=$($hasPatch.ToString().ToLowerInvariant())" >> $Env:GITHUB_OUTPUT
+
+      - name: Analyze DOM export diff for breaking changes
+        id: diff
+        if: ${{ steps.compare.outputs.hasPatch == 'true' }}
+        # Pinned to a commit SHA for supply-chain safety. This tool is owned by the
+        # Microsoft Graph Developer Experience team.
+        uses: microsoftgraph/kiota-dom-export-diff-tool/tool@e32a993776c40f03dce8c55ff7a607ed21011945
+        with:
+          path: ${{ steps.compare.outputs.patchFilePath }}
+          fail-on-removal: true
+
+      - name: Comment on the pull request
+        if: ${{ always() && steps.compare.outputs.hasPatch == 'true' && steps.diff.outputs.hasExplanations != '' && github.event_name == 'pull_request' }}
+        continue-on-error: true
+        uses: microsoftgraph/kiota-dom-export-diff-tool/comment@e32a993776c40f03dce8c55ff7a607ed21011945
+        with:
+          comment: ${{ steps.diff.outputs.explanationsFilePath }}
+          prNumber: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload patch file as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: surface-area-patch-${{ matrix.language }}
+          path: "*.patch"
+
+      - name: Upload explanations file as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: surface-area-explanations-${{ matrix.language }}
+          path: "explanations.txt"
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: surface-diff
+    if: always()
+    steps:
+      - uses: jimschubert/delete-artifacts-action@v1
+        with:
+          artifact_name: "generator"
+          min_bytes: "0"
+
+  # Aggregates result of the surface area tests for use in branch policy
+  check-surface-area-tests:
+    runs-on: ubuntu-latest
+    needs: surface-diff
+    if: always()
+    steps:
+      - name: All build matrix options are successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: One or more build matrix options failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a DOM-surface regression integration test that diffs the kiota public API export between the published NuGet generator and the current changeset to catch breaking changes in generated SDKs. [#7858](https://github.com/microsoft/kiota/issues/7858)
+
 ### Changed
 
 ## [1.32.3] - 2026-06-24

--- a/it/Readme.md
+++ b/it/Readme.md
@@ -20,6 +20,46 @@ And finally run the test:
 ./it/exec-cmd.ps1 -descriptionUrl ${FILE/URL} -language ${LANG}
 ```
 
+# Surface area / DOM diff test
+
+The surface area test guards against **binary/source breaking changes** that a change to
+kiota's generation logic could introduce into downstream SDKs (notably the Microsoft Graph
+SDKs). It compares the public-API surface (`kiota-dom-export.txt`) produced by the currently
+published `Microsoft.OpenApi.Kiota` NuGet tool (baseline) against the surface produced by a
+locally built kiota (current changeset).
+
+In CI this runs via `.github/workflows/surface-area-tests.yml` and feeds the resulting patch
+to the [`microsoftgraph/kiota-dom-export-diff-tool`](https://github.com/microsoftgraph/kiota-dom-export-diff-tool)
+`tool` action with `fail-on-removal: true`: any removed surface line fails the check.
+
+To run it locally, first publish a development build of `kiota`:
+
+```bash
+dotnet publish ./src/kiota/kiota.csproj -c Release -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./publish -f net10.0
+```
+
+Then generate the baseline/current exports and a diff patch:
+
+```bash
+./it/compare-dom-export.ps1 -descriptionUrl ${FILE/URL} -language ${LANG}
+```
+
+Useful options:
+
+* `-baselineVersion` — pin a specific published `Microsoft.OpenApi.Kiota` version (defaults to latest stable).
+* `-patchPath` — where to write the unified diff (defaults to `./<language>-dom-export.patch`).
+* `-kiotaExec` — path to the locally built kiota (defaults to `./publish/kiota`).
+* `-additionalArguments` — extra arguments forwarded to both `kiota generate` invocations.
+
+**Interpreting results:** removed lines (`-`) in the patch indicate API removed/changed since
+the baseline release — i.e. potential breaking changes. Added lines (`+`) are additive and do
+not fail the check. Because the baseline is the last published release, the diff reflects every
+change since that release, not just the current changeset.
+
+**Intended breaking changes:** review the explanations produced by the diff tool. If a breaking
+change is deliberate, it must be acknowledged through normal PR review (and, where configured, a
+required-check override) before merging.
+
 # MockServer tests
 
 The OpenAPI description can be published to a mock server, and you can execute tests that call this API.

--- a/it/compare-dom-export.ps1
+++ b/it/compare-dom-export.ps1
@@ -1,0 +1,230 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Compares the kiota public-API DOM export produced by the currently published
+    `Microsoft.OpenApi.Kiota` NuGet tool (baseline) against the export produced by a
+    locally built kiota (current changeset) and emits a unified diff (patch).
+
+.DESCRIPTION
+    This is the orchestrator behind the "surface area" regression check. It detects
+    binary/source breaking changes that a change to kiota's generation logic could
+    introduce into downstream SDKs (e.g. the Microsoft Graph SDKs).
+
+    Steps:
+      1. Resolve / download the OpenAPI description to a single local file (used by both
+         generators for determinism).
+      2. Install the published Microsoft.OpenApi.Kiota tool and generate the BASELINE export.
+      3. Use the locally built kiota to generate the CURRENT export.
+      4. Produce a unified diff (patch) between baseline and current exports.
+
+    The patch is intended to be fed to the
+    `microsoftgraph/kiota-dom-export-diff-tool/tool` action (with fail-on-removal: true)
+    which decides pass/fail. For local runs this script also prints a summary of added /
+    removed surface lines.
+
+    NOTE (accumulation caveat): the baseline is the last published release, so the diff
+    reflects EVERY change since that release, not only the current changeset.
+
+.PARAMETER descriptionUrl
+    OpenAPI description: an http(s) URL, a local path, or a kiota search key.
+
+.PARAMETER language
+    Target generation language (e.g. csharp, java).
+
+.PARAMETER patchPath
+    Path of the unified diff file to write. Defaults to ./<language>-dom-export.patch.
+
+.PARAMETER baselineVersion
+    Optional specific version of Microsoft.OpenApi.Kiota to use as baseline.
+    Defaults to the latest stable release.
+
+.PARAMETER kiotaExec
+    Path to the locally built kiota executable (current changeset). Defaults to ./publish/kiota.
+
+.PARAMETER additionalArguments
+    Optional extra arguments forwarded verbatim to both `kiota generate` invocations.
+
+.PARAMETER workingDirectory
+    Directory used for intermediate artifacts (spec, tool install, exports). Defaults to a temp dir.
+#>
+
+param(
+    [Parameter(Mandatory = $true)][string]$descriptionUrl,
+    [Parameter(Mandatory = $true)][string]$language,
+    [Parameter(Mandatory = $false)][string]$patchPath,
+    [Parameter(Mandatory = $false)][string]$baselineVersion,
+    [Parameter(Mandatory = $false)][string]$kiotaExec,
+    [Parameter(Mandatory = $false)][string]$additionalArguments = "",
+    [Parameter(Mandatory = $false)][string]$workingDirectory
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrEmpty($descriptionUrl)) {
+    Write-Error "Description URL is empty"
+    exit 1
+}
+if ([string]::IsNullOrEmpty($language)) {
+    Write-Error "Language is empty"
+    exit 1
+}
+
+$rootPath = Join-Path -Path $PSScriptRoot -ChildPath ".."
+$executableName = "kiota"
+if ($IsWindows) {
+    $executableName = "kiota.exe"
+}
+
+# Resolve the locally built (current changeset) kiota executable.
+if ([string]::IsNullOrEmpty($kiotaExec)) {
+    $kiotaExec = Join-Path -Path $rootPath -ChildPath "publish" -AdditionalChildPath $executableName
+}
+if (-not (Test-Path $kiotaExec)) {
+    Write-Error "Locally built kiota not found at '$kiotaExec'. Publish it first, e.g. `dotnet publish ./src/kiota/kiota.csproj -c Release -o ./publish -f net10.0`."
+    exit 1
+}
+
+# Working directory for intermediate artifacts.
+if ([string]::IsNullOrEmpty($workingDirectory)) {
+    $workingDirectory = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+}
+New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+Write-Output "Working directory: $workingDirectory"
+
+if ([string]::IsNullOrEmpty($patchPath)) {
+    $patchPath = Join-Path -Path (Get-Location) -ChildPath "$language-dom-export.patch"
+}
+
+$Env:KIOTA_TUTORIAL_ENABLED = "false"
+
+# --- 1. Resolve the OpenAPI description to a single local file -----------------------------
+if ($descriptionUrl.ToLower().EndsWith(".json")) {
+    $targetOpenapiPath = Join-Path -Path $workingDirectory -ChildPath "openapi.json"
+}
+else {
+    $targetOpenapiPath = Join-Path -Path $workingDirectory -ChildPath "openapi.yaml"
+}
+
+if ($descriptionUrl.StartsWith("./") -or $descriptionUrl.StartsWith(".\") -or
+    ($descriptionUrl.Length -gt 1 -and ($descriptionUrl.Substring(1).StartsWith(":\") -or $descriptionUrl.Substring(1).StartsWith(":/"))) -or
+    $descriptionUrl.StartsWith("\") -or $descriptionUrl.StartsWith("/")) {
+    Copy-Item -Path $descriptionUrl -Destination $targetOpenapiPath -Force
+}
+elseif ($descriptionUrl.StartsWith("http")) {
+    Invoke-WebRequest -Uri $descriptionUrl -OutFile $targetOpenapiPath
+}
+else {
+    $downloadProcess = Start-Process "$kiotaExec" -ArgumentList "download ${descriptionUrl} --clean-output --output `"$targetOpenapiPath`"" -Wait -NoNewWindow -PassThru
+    if ($downloadProcess.ExitCode -ne 0) {
+        Write-Error "Failed to download the openapi description"
+        exit 1
+    }
+}
+Write-Output "Using OpenAPI description: $targetOpenapiPath"
+
+# --- 2. Install the published baseline tool ------------------------------------------------
+$toolPath = Join-Path -Path $workingDirectory -ChildPath "baseline-tool"
+$installArgs = @("tool", "install", "Microsoft.OpenApi.Kiota", "--tool-path", $toolPath)
+if (-not [string]::IsNullOrEmpty($baselineVersion)) {
+    $installArgs += @("--version", $baselineVersion)
+}
+Write-Output "Installing baseline tool: dotnet $($installArgs -join ' ')"
+& dotnet @installArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install the baseline Microsoft.OpenApi.Kiota tool"
+    exit 1
+}
+$baselineKiotaExec = Join-Path -Path $toolPath -ChildPath $executableName
+if (-not (Test-Path $baselineKiotaExec)) {
+    Write-Error "Baseline kiota executable not found at '$baselineKiotaExec'"
+    exit 1
+}
+
+# Report the resolved baseline version for traceability.
+$resolvedBaseline = & $baselineKiotaExec --version 2>$null | Select-Object -First 1
+Write-Output "Baseline kiota version: $resolvedBaseline"
+
+# --- 3. Generate baseline and current exports ----------------------------------------------
+$generateScript = Join-Path -Path $PSScriptRoot -ChildPath "generate-dom-export.ps1"
+$baselineOutput = Join-Path -Path $workingDirectory -ChildPath "baseline"
+$currentOutput = Join-Path -Path $workingDirectory -ChildPath "current"
+
+Write-Output "Generating baseline DOM export..."
+& $generateScript -kiotaExec $baselineKiotaExec -openapiPath $targetOpenapiPath -language $language -outputPath $baselineOutput -additionalArguments $additionalArguments | Out-Null
+$baselineExport = Join-Path -Path $baselineOutput -ChildPath "kiota-dom-export.txt"
+
+Write-Output "Generating current DOM export..."
+& $generateScript -kiotaExec $kiotaExec -openapiPath $targetOpenapiPath -language $language -outputPath $currentOutput -additionalArguments $additionalArguments | Out-Null
+$currentExport = Join-Path -Path $currentOutput -ChildPath "kiota-dom-export.txt"
+
+if (-not (Test-Path $baselineExport)) {
+    Write-Error "Baseline export missing at '$baselineExport'"
+    exit 1
+}
+if (-not (Test-Path $currentExport)) {
+    Write-Error "Current export missing at '$currentExport'"
+    exit 1
+}
+
+# --- 4. Produce a unified diff (patch) -----------------------------------------------------
+# The patch is consumed by microsoftgraph/kiota-dom-export-diff-tool, which expects a
+# `git format-patch` style patch: zero context (-U0) so every body line is a + or - line,
+# and a trailing "-- " signature footer (DOM export lines contain "-->" for inheritance, so
+# the tool's footer detection relies on that trailing signature). We therefore build the
+# patch the same way that tool's own export action does: commit the baseline then the current
+# export into a throwaway git repository and run `git format-patch -1 HEAD --minimal -U0 -w`.
+
+# Ensure the destination directory exists and remove any stale patch.
+$patchDir = Split-Path -Parent $patchPath
+if (-not [string]::IsNullOrEmpty($patchDir) -and -not (Test-Path $patchDir)) {
+    New-Item -ItemType Directory -Path $patchDir -Force | Out-Null
+}
+if (Test-Path $patchPath) {
+    Remove-Item -Force $patchPath
+}
+
+$baselineContent = Get-Content -Raw -Path $baselineExport
+$currentContent = Get-Content -Raw -Path $currentExport
+
+if ($baselineContent -ceq $currentContent) {
+    Write-Output "No differences detected in the DOM export for '$language'. The public API surface is unchanged."
+    # Emit an empty patch file so downstream steps can branch on its size.
+    New-Item -ItemType File -Path $patchPath -Force | Out-Null
+    return $patchPath
+}
+
+$patchRepo = Join-Path -Path $workingDirectory -ChildPath "patch-repo"
+New-Item -ItemType Directory -Path $patchRepo -Force | Out-Null
+$repoExport = Join-Path -Path $patchRepo -ChildPath "kiota-dom-export.txt"
+
+# Inline identity + disabled signing so this works on CI runners with no global git config.
+$gitConfig = @("-c", "user.email=kiota@microsoft.com", "-c", "user.name=kiota", "-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main")
+
+& git @gitConfig init $patchRepo | Out-Null
+Copy-Item -Path $baselineExport -Destination $repoExport -Force
+& git @gitConfig -C $patchRepo add kiota-dom-export.txt | Out-Null
+& git @gitConfig -C $patchRepo commit -m "baseline" --quiet | Out-Null
+Copy-Item -Path $currentExport -Destination $repoExport -Force
+& git @gitConfig -C $patchRepo add kiota-dom-export.txt | Out-Null
+& git @gitConfig -C $patchRepo commit -m "current" --quiet | Out-Null
+
+$patchOutDir = Join-Path -Path $workingDirectory -ChildPath "patch-out"
+New-Item -ItemType Directory -Path $patchOutDir -Force | Out-Null
+& git @gitConfig -C $patchRepo format-patch -1 HEAD --minimal -U0 -w -o $patchOutDir | Out-Null
+
+$generatedPatch = Get-ChildItem -Path $patchOutDir -Filter "*.patch" | Select-Object -First 1
+if ($null -eq $generatedPatch) {
+    Write-Error "Failed to generate a patch file with git format-patch"
+    exit 1
+}
+Copy-Item -Path $generatedPatch.FullName -Destination $patchPath -Force
+
+$patchLines = Get-Content -Path $patchPath
+$removed = ($patchLines | Where-Object { $_.StartsWith("-") -and -not $_.StartsWith("---") }).Count
+$added = ($patchLines | Where-Object { $_.StartsWith("+") -and -not $_.StartsWith("+++") }).Count
+Write-Output "DOM export differs for '$language': $removed removed line(s), $added added line(s)."
+Write-Output "Removed lines indicate potential source/binary breaking changes."
+Write-Output "Patch written to: $patchPath"
+
+return $patchPath

--- a/it/generate-dom-export.ps1
+++ b/it/generate-dom-export.ps1
@@ -1,0 +1,89 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Generates the kiota public-API DOM export (kiota-dom-export.txt) for a single
+    generator executable, OpenAPI description and language.
+
+.DESCRIPTION
+    Enables the public API export feature (Generation:ExportPublicApi) through the
+    KIOTA_ prefixed environment variable and runs `kiota generate`. The resulting
+    "kiota-dom-export.txt" surface file is written to the output directory.
+
+    The same flags must be used for the baseline (published) and current (changeset)
+    generators so that any difference in the export reflects a real change in the
+    generated public API surface rather than a difference in invocation.
+
+.PARAMETER kiotaExec
+    Path to the kiota executable to run.
+
+.PARAMETER openapiPath
+    Path to the local OpenAPI description file.
+
+.PARAMETER language
+    Target generation language (e.g. csharp, java).
+
+.PARAMETER outputPath
+    Directory where the generated code and kiota-dom-export.txt are written.
+
+.PARAMETER additionalArguments
+    Optional extra arguments forwarded verbatim to `kiota generate` (e.g. exclude patterns).
+
+.OUTPUTS
+    The full path to the generated kiota-dom-export.txt file.
+#>
+
+param(
+    [Parameter(Mandatory = $true)][string]$kiotaExec,
+    [Parameter(Mandatory = $true)][string]$openapiPath,
+    [Parameter(Mandatory = $true)][string]$language,
+    [Parameter(Mandatory = $true)][string]$outputPath,
+    [Parameter(Mandatory = $false)][string]$additionalArguments = ""
+)
+
+if ([string]::IsNullOrEmpty($kiotaExec)) {
+    Write-Error "kiota executable path is empty"
+    exit 1
+}
+if (-not (Test-Path $kiotaExec)) {
+    Write-Error "kiota executable not found at '$kiotaExec'"
+    exit 1
+}
+if ([string]::IsNullOrEmpty($openapiPath) -or -not (Test-Path $openapiPath)) {
+    Write-Error "OpenAPI description not found at '$openapiPath'"
+    exit 1
+}
+if ([string]::IsNullOrEmpty($language)) {
+    Write-Error "Language is empty"
+    exit 1
+}
+if ([string]::IsNullOrEmpty($outputPath)) {
+    Write-Error "Output path is empty"
+    exit 1
+}
+
+# Disable update checks / tutorials so they do not pollute the run.
+$Env:KIOTA_TUTORIAL_ENABLED = "false"
+$Env:KIOTA_OFFLINE_ENABLED = "true"
+# Enable the public API (DOM) export. Config key is Generation:ExportPublicApi and the
+# host binds environment variables with the KIOTA_ prefix, using __ as the section separator.
+$Env:KIOTA_Generation__ExportPublicApi = "true"
+
+$generateArguments = "generate --exclude-backward-compatible --clean-output --language ${language} --openapi `"${openapiPath}`" --output `"${outputPath}`"${additionalArguments}"
+
+Write-Output "Generating DOM export: $kiotaExec $generateArguments"
+$generationProcess = Start-Process "$kiotaExec" -ArgumentList $generateArguments -Wait -NoNewWindow -PassThru
+
+if ($generationProcess.ExitCode -ne 0) {
+    Write-Error "Failed to generate the code/DOM export for '${language}' (exit code $($generationProcess.ExitCode))"
+    exit 1
+}
+
+$domExportPath = Join-Path -Path $outputPath -ChildPath "kiota-dom-export.txt"
+if (-not (Test-Path $domExportPath)) {
+    Write-Error "DOM export file was not produced at '$domExportPath'. Ensure the generator supports the public API export feature."
+    exit 1
+}
+
+Write-Output "DOM export written to $domExportPath"
+return $domExportPath


### PR DESCRIPTION
## Description

Adds a DOM-surface regression integration test to catch **binary/source breaking changes** that a change to kiota''s generation logic could introduce into downstream SDKs (notably the Microsoft Graph SDKs), mirroring the surface-area validation the Graph SDK repos already run on spec changes.

### How it works

Per language, the new workflow:
1. Downloads a single OpenAPI description (Microsoft Graph **beta**, already in the IT matrix).
2. Generates a **baseline** DOM export (`kiota-dom-export.txt`) using the published `Microsoft.OpenApi.Kiota` NuGet tool.
3. Generates a **current** DOM export using the locally built kiota.
4. Produces a `git format-patch` style patch between the two.
5. Feeds the patch to [`microsoftgraph/kiota-dom-export-diff-tool/tool`](https://github.com/microsoftgraph/kiota-dom-export-diff-tool) with `fail-on-removal: true` (pinned to a commit SHA); on PRs it posts the explanations as a comment.

No generator code change is required — the export is enabled via the existing `Generation:ExportPublicApi` flag (env var `KIOTA_Generation__ExportPublicApi=true`).

### Files

- `it/generate-dom-export.ps1` — emit the DOM export for one generator/language/spec.
- `it/compare-dom-export.ps1` — install the baseline tool, build baseline + current exports, emit the patch.
- `.github/workflows/surface-area-tests.yml` — `csharp` + `java` × Graph beta matrix, analyze + comment + artifacts + branch-policy aggregator.
- `it/Readme.md`, `CHANGELOG.md` — docs.

### Initial scope

`csharp` and `java` against Graph beta, designed to expand to more languages/specs later.

### Notes / caveats

- The baseline is the last published release, so the diff reflects every change since that release, not only this PR''s delta. Acceptable for catching regressions; a base-branch comparison mode can be added later.
- The patch is built with `git format-patch -1 HEAD --minimal -U0 -w` (not `git diff --no-index`) because the diff tool''s parser requires zero-context bodies and a trailing `-- ` signature footer (DOM exports contain `-->` inheritance markers). Validated against the tool''s actual cleanup/parse algorithm.

### Validation

Validated locally end-to-end: the env var enables the export, the published baseline tool installs and runs, both exports generate, and the produced patch parses cleanly through the diff tool''s algorithm with zero crash-inducing lines.

Closes #7858