### PR TITLE
fix(php): Escape $ in double-quoted string literals to prevent code injection

### DIFF
--- a/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeEnumWriter.cs
@@ -48,7 +48,7 @@ public partial class CodeEnumWriter : BaseElementWriter<CodeEnum, PhpConventionS
         writer.IncreaseIndent();
         foreach (var enumProperty in enumProperties)
         {
-            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = \"{enumProperty.WireName.SanitizeDoubleQuote()}\";");
+            writer.WriteLine($"public const {GetEnumValueName(enumProperty.Name)} = \"{PhpConventionService.SanitizePhpDoubleQuoteLiteral(enumProperty.WireName)}\";");
         }
     }
     [GeneratedRegex(@"([A-Z]{1})", RegexOptions.Singleline, 500)]

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -622,7 +622,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (requestParams.requestBody != null)
         {
             var suffix = requestParams.requestBody.Type.IsCollection ? "Collection" : string.Empty;
-            var sanitizedRequestBodyContentType = codeElement.RequestBodyContentType.SanitizeDoubleQuote();
+            var sanitizedRequestBodyContentType = PhpConventionService.SanitizePhpDoubleQuoteLiteral(codeElement.RequestBodyContentType);
             if (requestParams.requestBody.Type.Name.Equals(conventions.StreamTypeName, StringComparison.OrdinalIgnoreCase))
             {
                 if (requestParams.requestContentType is not null)
@@ -667,7 +667,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
     private void WriteAcceptHeaderDef(CodeMethod codeMethod, LanguageWriter writer)
     {
         if (codeMethod.ShouldAddAcceptHeader)
-            writer.WriteLine($"{RequestInfoVarName}->tryAddHeader('Accept', \"{codeMethod.AcceptHeaderValue.SanitizeDoubleQuote()}\");");
+            writer.WriteLine($"{RequestInfoVarName}->tryAddHeader('Accept', \"{PhpConventionService.SanitizePhpDoubleQuoteLiteral(codeMethod.AcceptHeaderValue)}\");");
     }
     private void WriteDeserializerBody(CodeClass parentClass, LanguageWriter writer, CodeMethod method, bool extendsModelClass = false)
     {
@@ -906,7 +906,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         if (writeDiscriminatorValueRead &&
             codeElement.Parameters.OfKind(CodeParameterKind.ParseNode) is CodeParameter parseNodeParameter)
         {
-            writer.WriteLines($"$mappingValueNode = ${parseNodeParameter.Name.ToFirstCharacterLowerCase()}->getChildNode(\"{parentClass.DiscriminatorInformation.DiscriminatorPropertyName.SanitizeDoubleQuote()}\");",
+            writer.WriteLines($"$mappingValueNode = ${parseNodeParameter.Name.ToFirstCharacterLowerCase()}->getChildNode(\"{PhpConventionService.SanitizePhpDoubleQuoteLiteral(parentClass.DiscriminatorInformation.DiscriminatorPropertyName)}\");",
                 "if ($mappingValueNode !== null) {");
             writer.IncreaseIndent();
             writer.WriteLines($"{DiscriminatorMappingVarName} = $mappingValueNode->getStringValue();");

--- a/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodePropertyWriter.cs
@@ -43,7 +43,7 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, PhpConventionS
         writer.WriteLine(PhpConventionService.DocCommentStart);
         if (codeProperty.IsOfKind(CodePropertyKind.QueryParameter) && codeProperty.IsNameEscaped)
         {
-            writer.WriteLine($"{conventions.DocCommentPrefix}@QueryParameter(\"{codeProperty.SerializationName.SanitizeDoubleQuote()}\")");
+            writer.WriteLine($"{conventions.DocCommentPrefix}@QueryParameter(\"{PhpConventionService.SanitizePhpDoubleQuoteLiteral(codeProperty.SerializationName)}\")");
         }
         writer.WriteLine($"{conventions.DocCommentPrefix}@var {typeString}{(codeProperty.Type.IsNullable ? "|null" : string.Empty)} ${codeProperty.Name.ToFirstCharacterLowerCase()} " +
                             $"{(hasDescription ? propertyDescription : string.Empty)}");

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -12,14 +12,6 @@ public class PhpConventionService : CommonLanguageConventionService
 {
     public override string TempDictionaryVarName => "urlTplParams";
 
-    /// <summary>
-    /// Sanitizes a string for safe inclusion inside a PHP double-quoted string literal.
-    /// In addition to the standard escaping performed by <see cref="StringExtensions.SanitizeDoubleQuote"/>,
-    /// this escapes the '$' character so that PHP does not interpolate variables or expressions
-    /// (for example "$var", "${...}" or "{$...}") embedded in attacker-controlled input such as
-    /// OpenAPI descriptions, enum values or content types. Failing to escape '$' allows arbitrary
-    /// PHP code injection when the generated client is compiled or executed.
-    /// </summary>
     internal static string SanitizePhpDoubleQuoteLiteral(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeDoubleQuote().Replace("$", "\\$", StringComparison.Ordinal);
 

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -12,6 +12,18 @@ public class PhpConventionService : CommonLanguageConventionService
 {
     public override string TempDictionaryVarName => "urlTplParams";
 
+    /// <summary>
+    /// Sanitizes a string for safe inclusion inside a PHP double-quoted string literal.
+    /// In addition to the standard escaping performed by <see cref="StringExtensions.SanitizeDoubleQuote"/>,
+    /// this escapes the '$' character so that PHP does not interpolate variables or expressions
+    /// (for example "$var", "${...}" or "{$...}") embedded in attacker-controlled input such as
+    /// OpenAPI descriptions, enum values or content types. Failing to escape '$' allows arbitrary
+    /// PHP code injection when the generated client is compiled or executed.
+    /// </summary>
+    internal static string SanitizePhpDoubleQuoteLiteral(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.SanitizeDoubleQuote().Replace("$", "\\$", StringComparison.Ordinal);
+
+
     private static readonly CodeUsingDeclarationNameComparer _usingDeclarationNameComparer = new();
 
     public override string GetAccessModifier(AccessModifier access)

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeEnumWriterTests.cs
@@ -71,4 +71,20 @@ public sealed class CodeEnumWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("public const OPTION1 = \"line1\\\"\\nline2\";", result);
     }
+    [Fact]
+    public async Task EscapesDollarSignInEnumWireValuesToPreventPhpInterpolationAsync()
+    {
+        var declaration = currentEnum.Parent as CodeNamespace;
+        currentEnum.AddOption(new CodeEnumOption
+        {
+            Name = "option1",
+            SerializationName = "${env('HOME')}",
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, declaration, cancellationToken: TestContext.Current.CancellationToken);
+        _codeEnumWriter.WriteCodeElement(currentEnum, writer);
+        var result = tw.ToString();
+        // The '$' must be escaped so PHP does not interpolate the expression when the generated client runs.
+        Assert.Contains("public const OPTION1 = \"\\${env('HOME')}\";", result);
+        Assert.DoesNotContain("\"${env('HOME')}\"", result);
+    }
 }


### PR DESCRIPTION
### Summary

Kiota's PHP writer emits schema-derived strings into PHP **double-quoted** literals using `SanitizeDoubleQuote()`, which escapes `"`, `\`, and control characters but **not `$`**. Because PHP evaluates `$var`, `${...}`, and `{$...}` inside double-quoted strings, an attacker-controlled OpenAPI description (e.g. a media type like `application/json${system('whoami && id')}`) is emitted verbatim into the generated SDK source and executes arbitrary PHP/OS commands when the generated client runs.

This is a regression/coverage gap in the literal-injection hardening pass (#7603), which already added the equivalent `$` escape for the **Dart** writer (Dart interpolates `$` the same way). The PHP surface was missed.

### Root cause

`SanitizeForQuotedLiteral` in `StringExtensions.cs` is language-agnostic and has no `$` case, so `$` falls through unescaped. The 2024 change that switched PHP enum values from single- to double-quotes (`d472aeb2e`) widened the exposure.

### Fix

Add a PHP-specific `SanitizePhpDoubleQuoteLiteral` on `PhpConventionService` that runs the shared `SanitizeDoubleQuote()` and then escapes `$` → `\$`, and route every PHP double-quoted emission site through it. This mirrors the existing `SanitizeDartDoubleQuoteLiteral` on `DartConventionService` exactly (same name pattern, signature, placement, and implementation), satisfying the project's cross-language consistency rule.

```csharp
internal static string SanitizePhpDoubleQuoteLiteral(string? value) =>
    string.IsNullOrEmpty(value) ? string.Empty
        : value.SanitizeDoubleQuote().Replace("$", "\\$", StringComparison.Ordinal);
```
