### PR TITLE
ci: make release publish jobs idempotent on re-run

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -826,11 +826,22 @@ extends:
                       Write-Host "Publishing $packagePath"
                       if ($Env:isPrerelease -eq "true") {
                         Write-Host "Publishing $packagePath as a pre-release"
-                        vsce publish --pat "$aadToken" --packagePath $packagePath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release
+                        $publishOutput = vsce publish --pat "$aadToken" --packagePath $packagePath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release 2>&1
                       }
                       else {
                         Write-Host "Publishing $packagePath as a release"
-                        vsce publish --pat "$aadToken" --packagePath $packagePath --manifestPath $manifestPath --signaturePath $signaturePath
+                        $publishOutput = vsce publish --pat "$aadToken" --packagePath $packagePath --manifestPath $manifestPath --signaturePath $signaturePath 2>&1
+                      }
+                      $publishExit = $LASTEXITCODE
+                      Write-Host $publishOutput
+                      # Idempotency: a re-run for an already-published vsix version should not fail.
+                      if ($publishExit -ne 0) {
+                        if ("$publishOutput" -match "already exists") {
+                          Write-Host "Extension version for $packagePath already published; skipping (idempotent re-run)."
+                        }
+                        else {
+                          throw "vsce publish failed for $packagePath with exit code $publishExit"
+                        }
                       }
                     }
                 env:
@@ -881,8 +892,31 @@ extends:
                     - pwsh: $(Pipeline.Workspace)/scripts/get-release-notes.ps1 -version Unreleased -createNotes -changelogPath "$(Pipeline.Workspace)/changelog/CHANGELOG.md"
                       condition: eq(variables['isPrerelease'], 'true')
                       displayName: "Get release notes from CHANGELOG.md"
+                    # Idempotency: if the pipeline is re-triggered for a tag whose GitHub
+                    # release already exists, skip creating it (create fails with a 422 on
+                    # an existing tag) and leave the existing release untouched so
+                    # downstream publish jobs can still run. The lookup is anonymous
+                    # because microsoft/kiota is a public repository.
+                    - pwsh: |
+                        $tag = if ($env:ISPRERELEASE -eq 'true') { "v$(artifactVersion)$(versionSuffix)" } else { "v$(artifactVersion)" }
+                        $uri = "https://api.github.com/repos/microsoft/kiota/releases/tags/$tag"
+                        try {
+                          Invoke-RestMethod -Uri $uri -Headers @{ 'User-Agent' = 'kiota-azdo-pipeline'; 'Accept' = 'application/vnd.github+json' } | Out-Null
+                          Write-Host "Release '$tag' already exists; skipping GitHub release creation (idempotent re-run)."
+                          Write-Host "##vso[task.setvariable variable=releaseExists]true"
+                        } catch {
+                          if ($_.Exception.Response.StatusCode.value__ -eq 404) {
+                            Write-Host "Release '$tag' does not exist; GitHub release will be created."
+                            Write-Host "##vso[task.setvariable variable=releaseExists]false"
+                          } else {
+                            throw
+                          }
+                        }
+                      displayName: "Check whether GitHub release already exists (idempotent)"
+                      env:
+                        ISPRERELEASE: $(isPrerelease)
                     - task: GitHubRelease@1
-                      condition: eq(variables['isPrerelease'], 'false')
+                      condition: and(eq(variables['isPrerelease'], 'false'), ne(variables['releaseExists'], 'true'))
                       inputs:
                         gitHubConnection: "microsoftkiota"
                         tagSource: userSpecifiedTag
@@ -898,7 +932,7 @@ extends:
                           $(Pipeline.Workspace)/*.snupkg
                         addChangeLog: false
                     - task: GitHubRelease@1
-                      condition: eq(variables['isPrerelease'], 'true')
+                      condition: and(eq(variables['isPrerelease'], 'true'), ne(variables['releaseExists'], 'true'))
                       inputs:
                         gitHubConnection: "microsoftkiota"
                         tagSource: userSpecifiedTag
@@ -936,8 +970,32 @@ extends:
                     - pwsh: |
                         Remove-Item "$(Pipeline.Workspace)/Microsoft.OpenApi.Kiota.Builder.*.nupkg" -Verbose
                       displayName: remove other nupkgs to avoid duplication
+                    - pwsh: |
+                        $pkg = Get-ChildItem -Path "$(Pipeline.Workspace)" -Filter "Microsoft.OpenApi.Kiota.*.nupkg" | Where-Object { $_.Name -match '^Microsoft\.OpenApi\.Kiota\.(\d[\w\.\-]*)\.nupkg$' } | Select-Object -First 1
+                        if (-not $pkg) { throw "No Microsoft.OpenApi.Kiota nupkg found to publish." }
+                        $null = $pkg.Name -match '^Microsoft\.OpenApi\.Kiota\.(\d[\w\.\-]*)\.nupkg$'
+                        $version = $Matches[1]
+                        $id = 'microsoft.openapi.kiota'
+                        $uri = "https://api.nuget.org/v3-flatcontainer/$id/index.json"
+                        try {
+                          $resp = Invoke-RestMethod -Uri $uri -Headers @{ 'User-Agent' = 'kiota-azdo-pipeline' }
+                          if ($resp.versions -contains $version) {
+                            Write-Host "NuGet $id $version already published; skipping push (idempotent re-run)."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]true"
+                          } else {
+                            Write-Host "NuGet $id $version not found on nuget.org; will push."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]false"
+                          }
+                        } catch {
+                          if ($_.Exception.Response.StatusCode.value__ -eq 404) {
+                            Write-Host "NuGet $id has no published versions yet; will push."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]false"
+                          } else { throw }
+                        }
+                      displayName: "Check whether NuGet package version already published (idempotent)"
                     - task: 1ES.PublishNuget@1
                       displayName: "NuGet push"
+                      condition: ne(variables['nugetAlreadyPublished'], 'true')
                       inputs:
                         packagesToPush: "$(Pipeline.Workspace)/Microsoft.OpenApi.Kiota.*.nupkg"
                         packageParentPath: "$(Pipeline.Workspace)"
@@ -965,8 +1023,32 @@ extends:
                     - pwsh: |
                         Remove-Item "$(Pipeline.Workspace)/Microsoft.OpenApi.Kiota.*.nupkg" -Verbose -Exclude "*.Builder.*"
                       displayName: remove other nupkgs to avoid duplication
+                    - pwsh: |
+                        $pkg = Get-ChildItem -Path "$(Pipeline.Workspace)" -Filter "Microsoft.OpenApi.Kiota.Builder.*.nupkg" | Where-Object { $_.Name -match '^Microsoft\.OpenApi\.Kiota\.Builder\.(\d[\w\.\-]*)\.nupkg$' } | Select-Object -First 1
+                        if (-not $pkg) { throw "No Microsoft.OpenApi.Kiota.Builder nupkg found to publish." }
+                        $null = $pkg.Name -match '^Microsoft\.OpenApi\.Kiota\.Builder\.(\d[\w\.\-]*)\.nupkg$'
+                        $version = $Matches[1]
+                        $id = 'microsoft.openapi.kiota.builder'
+                        $uri = "https://api.nuget.org/v3-flatcontainer/$id/index.json"
+                        try {
+                          $resp = Invoke-RestMethod -Uri $uri -Headers @{ 'User-Agent' = 'kiota-azdo-pipeline' }
+                          if ($resp.versions -contains $version) {
+                            Write-Host "NuGet $id $version already published; skipping push (idempotent re-run)."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]true"
+                          } else {
+                            Write-Host "NuGet $id $version not found on nuget.org; will push."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]false"
+                          }
+                        } catch {
+                          if ($_.Exception.Response.StatusCode.value__ -eq 404) {
+                            Write-Host "NuGet $id has no published versions yet; will push."
+                            Write-Host "##vso[task.setvariable variable=nugetAlreadyPublished]false"
+                          } else { throw }
+                        }
+                      displayName: "Check whether NuGet package version already published (idempotent)"
                     - task: 1ES.PublishNuget@1
                       displayName: "NuGet push"
+                      condition: ne(variables['nugetAlreadyPublished'], 'true')
                       inputs:
                         packagesToPush: "$(Pipeline.Workspace)/Microsoft.OpenApi.Kiota.Builder.*.nupkg"
                         packageParentPath: "$(Pipeline.Workspace)"
@@ -1093,7 +1175,29 @@ extends:
             dependsOn:
               - github_release
             steps:
+              - task: UseNode@1
+                inputs:
+                  version: "22.x"
+              - pwsh: |
+                  $pkg = Get-ChildItem -Path "$(Pipeline.Workspace)/npm-package" -Filter "*.tgz" | Select-Object -First 1
+                  if (-not $pkg) { throw "No npm .tgz package found to publish." }
+                  if ($pkg.Name -match '^microsoft-kiota-(.+)\.tgz$') {
+                    $version = $Matches[1]
+                  } else {
+                    throw "Could not parse version from $($pkg.Name)."
+                  }
+                  Write-Host "Checking npm registry for @microsoft/kiota@$version ..."
+                  $published = & npm view "@microsoft/kiota@$version" version 2>$null
+                  if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($published)) {
+                    Write-Host "npm @microsoft/kiota@$version already published; skipping ESRP release (idempotent re-run)."
+                    Write-Host "##vso[task.setvariable variable=npmAlreadyPublished]true"
+                  } else {
+                    Write-Host "npm @microsoft/kiota@$version not found; will publish."
+                    Write-Host "##vso[task.setvariable variable=npmAlreadyPublished]false"
+                  }
+                displayName: "Check whether npm version already published (idempotent)"
               - task: EsrpRelease@12
+                condition: ne(variables['npmAlreadyPublished'], 'true')
                 inputs:
                   connectedservicename: "Federated DevX ESRP Managed Identity Connection"
                   usemanagedidentity: false


### PR DESCRIPTION
## Why

Re-triggering the release pipeline for a tag that was already (partially) published previously **failed hard**, making it impossible to recover from a partial release without manual surgery:

- `GitHubRelease@1` returns **422** when the tag/release already exists
- `1ES.PublishNuget@1` returns **409** on a duplicate NuGet version
- `EsrpRelease@12` (npm) and `vsce publish` fail on an already-published version

This blocked recovery scenarios such as a run where every stage succeeded **except** the npm ESRP publish — a plain "Rerun failed jobs" still re-hit the 422/409 walls on the other publish steps.

## What

Each publish job now checks whether its artifact version is already published and **skips** that publish step if so, otherwise publishes exactly as before:

| Job | Idempotency check | Skip when already published |
|-----|-------------------|-----------------------------|
| `github_release` | anonymous GitHub API lookup of the release by tag → `releaseExists` | both `GitHubRelease@1` tasks gated `ne(releaseExists,'true')` |
| `deploy_kiota` / `deploy_builder` | query nuget.org flat container for the version parsed from the `.nupkg` filename → `nugetAlreadyPublished` | `1ES.PublishNuget@1` gated on it |
| `deploy_npm` | add `UseNode@1`; `npm view @microsoft/kiota@<version>` (version from `microsoft-kiota-<version>.tgz`) → `npmAlreadyPublished` | `EsrpRelease@12` gated on it |
| `vs_marketplace` | capture `vsce publish` output; non-zero exit whose output contains `already exists` | treated as an idempotent skip |

`PushDockerImage` is already idempotent (tag overwrite) and is unchanged.

## Notes

- The registry lookups are anonymous/read-only against the public NuGet, npm, and GitHub APIs (microsoft/kiota is a public repo), so no additional credentials/service connections are required.
- The VS Marketplace uses build-derived version numbers (decoupled from the release tag), so `vs_marketplace` relies on vsce's own duplicate detection rather than a tag-version compare: a re-run of the same build republishes an identical vsix version (skipped), while a new build produces a new version (published).

## Validation

- Pipeline YAML parses cleanly (`yaml.safe_load`).
- Verified the checks against the live registries for **v1.32.5**: NuGet `Microsoft.OpenApi.Kiota` / `.Builder` both already at 1.32.5 → would skip; npm `@microsoft/kiota` is only at 1.32.4 (1.32.5 returns 404) → would publish. This matches the real partial-release state.
