### PR TITLE
Shorten oversized namespace segments for TypeScript generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed TypeScript generation failing with a file-system error when an API endpoint produces a namespace segment longer than the per-component name limit (e.g. NTFS 255 chars). Oversized TypeScript namespace segments are now shortened (directories only; type names are preserved). [#7901](https://github.com/microsoft/kiota/pull/7901)
+
 ## [1.32.5] - 2026-07-03
 
 ### Added

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1626,7 +1626,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     /// <summary>
     /// Shortens overly-long namespace segments and class names in the CodeDOM to avoid exceeding
     /// file system path limits. Uses truncation + hash suffix for human readability and uniqueness.
-    /// Should be called from refiners for languages where package/namespace must match directory structure (Java, Python, PHP).
+    /// Should be called from refiners for languages where package/namespace must match directory structure (Java, Python, PHP, TypeScript).
     /// </summary>
     protected static void ShortenOversizedNamespaceSegments(CodeElement currentElement, int maxSegmentLength = 64)
     {

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -1628,7 +1628,14 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
     /// file system path limits. Uses truncation + hash suffix for human readability and uniqueness.
     /// Should be called from refiners for languages where package/namespace must match directory structure (Java, Python, PHP, TypeScript).
     /// </summary>
-    protected static void ShortenOversizedNamespaceSegments(CodeElement currentElement, int maxSegmentLength = 64)
+    /// <param name="currentElement">The element to process recursively.</param>
+    /// <param name="maxSegmentLength">The maximum allowed length for a namespace segment or type name.</param>
+    /// <param name="shortenTypeNames">
+    /// When true, class/enum/interface names are also shortened. Set to false for languages (e.g. TypeScript)
+    /// that map only namespaces to directories and group types into barrel files, where renaming types would
+    /// break downstream name-based generation without any file-system benefit.
+    /// </param>
+    protected static void ShortenOversizedNamespaceSegments(CodeElement currentElement, int maxSegmentLength = 64, bool shortenTypeNames = true)
     {
         if (currentElement is CodeNamespace codeNamespace && !string.IsNullOrEmpty(codeNamespace.Name))
         {
@@ -1653,20 +1660,23 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
 
             // Shorten class, enum, and interface names and enrich their doc comments
             // Materialize with ToArray() since RenameChildElement modifies the dictionary
-            foreach (var codeClass in codeNamespace.GetChildElements(true).OfType<CodeClass>().ToArray())
+            if (shortenTypeNames)
             {
-                ShortenCodeElementNameIfOversized(codeNamespace, codeClass, codeClass.Documentation, maxSegmentLength);
-            }
-            foreach (var codeEnum in codeNamespace.GetChildElements(true).OfType<CodeEnum>().ToArray())
-            {
-                ShortenCodeElementNameIfOversized(codeNamespace, codeEnum, codeEnum.Documentation, maxSegmentLength);
-            }
-            foreach (var codeInterface in codeNamespace.GetChildElements(true).OfType<CodeInterface>().ToArray())
-            {
-                ShortenCodeElementNameIfOversized(codeNamespace, codeInterface, codeInterface.Documentation, maxSegmentLength);
+                foreach (var codeClass in codeNamespace.GetChildElements(true).OfType<CodeClass>().ToArray())
+                {
+                    ShortenCodeElementNameIfOversized(codeNamespace, codeClass, codeClass.Documentation, maxSegmentLength);
+                }
+                foreach (var codeEnum in codeNamespace.GetChildElements(true).OfType<CodeEnum>().ToArray())
+                {
+                    ShortenCodeElementNameIfOversized(codeNamespace, codeEnum, codeEnum.Documentation, maxSegmentLength);
+                }
+                foreach (var codeInterface in codeNamespace.GetChildElements(true).OfType<CodeInterface>().ToArray())
+                {
+                    ShortenCodeElementNameIfOversized(codeNamespace, codeInterface, codeInterface.Documentation, maxSegmentLength);
+                }
             }
         }
-        CrawlTree(currentElement, x => ShortenOversizedNamespaceSegments(x, maxSegmentLength));
+        CrawlTree(currentElement, x => ShortenOversizedNamespaceSegments(x, maxSegmentLength, shortenTypeNames));
     }
     private static void ShortenCodeElementNameIfOversized(CodeNamespace parentNamespace, CodeElement codeElement, CodeDocumentation? documentation, int maxSegmentLength)
     {

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -54,9 +54,10 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             RemoveCancellationParameter(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
-            // TypeScript maps namespace segments to directories, so overly-long segments must be shortened
-            // to avoid exceeding the file system's per-component name limit (e.g. NTFS 255 chars).
-            ShortenOversizedNamespaceSegments(generatedCode);
+            // TypeScript maps namespace segments to directories (files are grouped into index.ts barrels),
+            // so only namespace segments must be shortened to avoid exceeding the file system's per-component
+            // name limit (e.g. NTFS 255 chars). Type names are left intact to preserve downstream generation.
+            ShortenOversizedNamespaceSegments(generatedCode, shortenTypeNames: false);
             cancellationToken.ThrowIfCancellationRequested();
             RemoveRequestConfigurationClasses(generatedCode,
                 new CodeUsing

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -54,6 +54,9 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             RemoveCancellationParameter(generatedCode);
             CorrectCoreType(generatedCode, CorrectMethodType, CorrectPropertyType, CorrectImplements);
             CorrectCoreTypesForBackingStore(generatedCode, "BackingStoreFactorySingleton.instance.createBackingStore()");
+            // TypeScript maps namespace segments to directories, so overly-long segments must be shortened
+            // to avoid exceeding the file system's per-component name limit (e.g. NTFS 255 chars).
+            ShortenOversizedNamespaceSegments(generatedCode);
             cancellationToken.ThrowIfCancellationRequested();
             RemoveRequestConfigurationClasses(generatedCode,
                 new CodeUsing

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -116,14 +116,16 @@ public sealed class TypeScriptLanguageRefinerTests : IDisposable
         });
         await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
 
-        // Namespace segment should be shortened so it stays within the file system per-component name limit
+        // Namespace segment should be shortened so it stays within the file system per-component name limit.
+        // TypeScript maps namespaces (not type names) to directories, so only segments are shortened.
         foreach (var segment in childNs.Name.Split('.'))
         {
             Assert.True(segment.Length <= 64, $"Segment '{segment}' exceeds 64 chars (length: {segment.Length})");
         }
 
-        // Class name should be shortened
-        Assert.True(requestBuilderClass.Name.Length <= 64, $"Class name '{requestBuilderClass.Name}' exceeds 64 chars");
+        // Type names must be left intact: TypeScript groups types into index.ts barrels and relies on
+        // name-based generation, so only namespaces (directories) are shortened, never the class name.
+        Assert.Equal($"{longSegment}RequestBuilder", requestBuilderClass.Name);
     }
     [Fact]
     public async Task AddsExceptionImplementsOnErrorClassesAsync()

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -91,6 +91,41 @@ public sealed class TypeScriptLanguageRefinerTests : IDisposable
         Assert.Contains(deserializerFunction.Usings, x => x.Declaration?.TypeDefinition == propertyFactoryMethod);
     }
     [Fact]
+    public async Task ShortensOversizedNamespaceSegmentsAsync()
+    {
+        var longSegment = "MicrosoftGraphNetworkaccessDeviceReportWithStartDateTimeWithEndDateTimeDiscoveredApplicationSegmentIdDiscoveredApplicationSegmentIdApplicationIdApplicationId";
+        var childNs = root.AddNamespace($"ApiSdk.NetworkAccess.Reports.{longSegment}");
+        var requestBuilderClass = childNs.AddClass(new CodeClass
+        {
+            Name = $"{longSegment}RequestBuilder",
+            Kind = CodeClassKind.RequestBuilder,
+            Documentation = new()
+            {
+                DescriptionTemplate = "Test request builder",
+            },
+        }).First();
+        requestBuilderClass.AddProperty(new CodeProperty
+        {
+            Kind = CodePropertyKind.UrlTemplate,
+            Name = "urlTemplate",
+            DefaultValue = "{baseurl+}",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.TypeScript }, root, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Namespace segment should be shortened so it stays within the file system per-component name limit
+        foreach (var segment in childNs.Name.Split('.'))
+        {
+            Assert.True(segment.Length <= 64, $"Segment '{segment}' exceeds 64 chars (length: {segment.Length})");
+        }
+
+        // Class name should be shortened
+        Assert.True(requestBuilderClass.Name.Length <= 64, $"Class name '{requestBuilderClass.Name}' exceeds 64 chars");
+    }
+    [Fact]
     public async Task AddsExceptionImplementsOnErrorClassesAsync()
     {
         var apiErrorClassName = "ApiError";


### PR DESCRIPTION
### Overview

TypeScript maps namespace segments to directories, but `TypeScriptRefiner` never called `ShortenOversizedNamespaceSegments` — unlike the Java, PHP, and Python refiners (which map package/namespace to directory structure and already call it).

As a result, endpoints that produce very long segments generate directory names that exceed the **NTFS 255-char per-component limit**, failing generation on Windows with Win32 error 123 (`ERROR_INVALID_NAME`):

> error generating the client: The filename, directory name, or volume label syntax is incorrect.

### Repro (real case)

The beta function `microsoft.graph.networkaccess.deviceReport` is bound to `networkaccess.reports`, returns `Collection(networkaccess.device)`, and takes **8 parameters** (2 required + 6 optional: `discoveredApplicationSegmentId`, `applicationId`, `aiAgentId`, `aiAgentName`, `cloudApplicationName`, `destinationUrl`). kiota concatenates these into a single request-builder namespace segment **265 characters** long:

```
networkAccess/reports/microsoftGraphNetworkaccessDeviceReportWithStartDateTimeWithEndDateTimediscoveredApplicationSegmentIdDiscoveredApplicationSegmentIdApplicationIdApplicationIdAiAgentIdAiAgentIdAiAgentNameAiAgentNameCloudApplicationNameCloudApplicationNameDestinationUrlDestinationUrl/
```

This is a single path **component** > 255 chars, so `LongPathsEnabled` / `\\?\` / a shorter `-o` output dir do **not** help (those address the 260-char total-path limit) — the name itself must be shortened.

### Fix

Call `ShortenOversizedNamespaceSegments(generatedCode, shortenTypeNames: false)` from `TypeScriptRefiner` (placed right after `CorrectCoreTypesForBackingStore`, mirroring the Python refiner). Long **namespace** segments are truncated + suffixed with a deterministic 8-hex hash (threshold 64), consistent with the other directory-structured languages. **Type names are left intact** (see below). The helper gains a `shortenTypeNames` flag (default `true`, preserving Java/PHP/Python behavior) that TypeScript sets to `false`.

### Why not the C#/Go path-segmenter approach?

C# and Go solve the same problem in their **path segmenter** by hashing the on-disk name (`ShortenFileName`), leaving the CodeDOM untouched. That works because **C#/Go imports resolve by declared namespace/package**, not by physical file/folder name — you can scramble a directory to a hash on disk and the code still compiles.

TypeScript can't do this: its imports are **relative file paths** (`import { x } from "./reports/deviceReport.../index.js"`), and those paths are computed from the **CodeDOM namespace names** in `TypescriptRelativeImportManager` — *not* from the path segmenter. If we hashed only the on-disk directory (C#/Go style), the folder and the generated `import` string would derive from two different places and desync:

```
on disk:   .../reports/3f9a1c...e8b2/index.ts               ← hashed folder
import in:  "./reports/microsoftGraphNetworkaccess.../index.js"  ← still the long name
            => TS2307: Cannot find module
```

Shortening the **namespace in the CodeDOM** (the refiner approach) renames it once, so the directory *and* every relative import derive from the same shortened value and stay consistent. This is why TypeScript follows the Java/Python/PHP refiner model, not the C#/Go segmenter model.

### Why `shortenTypeNames: false` (unlike Java/Python/PHP)?

Java/Python/PHP emit **one type per file named after the type**, so a 265-char class name also overflows the *file* name — they must shorten type names too, and it's safe for them.

TypeScript groups many types into a single **`index.ts` barrel** per namespace; the file is always named `index`, never the type. So:

- The FS limit is only ever hit by the **directory** (namespace) — shortening namespaces is sufficient.
- Shortening type names buys **zero** FS benefit and actively breaks TypeScript's composed-type factory generation, which then emits an invalid `return object;` instead of the deserializer function. (This surfaced as a Stripe integration-test compile failure on the first iteration of this PR.)

### Consumer impact

Same trade-off already accepted for PHP/Python: fluent navigation (`client.x.y().get()`) is unaffected; only consumers that **directly import** one of the few long, function-style request builders see a directory rename. Type names are unchanged, so imported symbols keep their names. Bounded and source-breaking only for that niche.

### Tests

- Added `ShortensOversizedNamespaceSegmentsAsync` in `TypeScriptLanguageRefinerTests` using the exact `deviceReport` case, asserting every namespace segment stays <= 64 chars.
- Regenerated the Stripe TypeScript SDK (the previously failing integration case) and confirmed `tsc --noEmit` compiles clean — no `object` errors.
- Full `Kiota.Builder.Tests` suite passes.
