### PR TITLE
Fix percent-encoded path traversal in static_template IsSafeFileReference

### DIFF
--- a/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
+++ b/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
@@ -386,8 +386,13 @@ public class ExtensionResponseSemanticsStaticTemplate
     // Inlined cards (no "file" property) are always considered safe.
     public bool HasUnsafeFileReference => File is not null && !IsSafeFileReference(File);
 
+    // Upper bound on percent-decode passes; enough to defeat multi-level (double) encoding without unbounded looping.
+    private const int MaxPercentDecodePasses = 5;
+
     // Validates that a static_template file reference is a relative path that cannot point outside the manifest
     // package: rejects absolute URIs, POSIX/UNC rooted paths, Windows drive paths, and '..' traversal (CWE-22/CWE-829).
+    // The reference is percent-decoded first so encoded traversal sequences (e.g. %2e%2e for '..', %2f for '/',
+    // %3a for ':') cannot bypass the checks below; decoding is repeated to defeat multi-level encoding.
     public static bool IsSafeFileReference(string? file)
     {
         if (string.IsNullOrWhiteSpace(file))
@@ -395,14 +400,32 @@ public class ExtensionResponseSemanticsStaticTemplate
             return false;
         }
 
+        // Percent-decode repeatedly until the value is stable so encoded (and double-encoded) traversal payloads
+        // are normalized back to their literal form before validation.
+        var decoded = file;
+        for (var pass = 0; pass < MaxPercentDecodePasses; pass++)
+        {
+            var next = Uri.UnescapeDataString(decoded);
+            if (string.Equals(next, decoded, StringComparison.Ordinal))
+            {
+                break;
+            }
+            decoded = next;
+        }
+
+        if (string.IsNullOrWhiteSpace(decoded))
+        {
+            return false;
+        }
+
         // The manifest schema requires a relative file path; reject absolute URIs such as http(s):// or file://.
-        if (Uri.TryCreate(file, UriKind.Absolute, out _))
+        if (Uri.TryCreate(decoded, UriKind.Absolute, out _))
         {
             return false;
         }
 
         // Normalize separators so the checks below are OS-independent (the manifest is consumed on any platform).
-        var normalized = file.Replace('\\', '/');
+        var normalized = decoded.Replace('\\', '/');
 
         // Reject POSIX-absolute and UNC-style rooted paths (e.g. /etc/passwd, //server/share).
         if (normalized.StartsWith('/'))

--- a/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
@@ -269,6 +269,18 @@ components:
     [InlineData("http://attacker.example/exfil", false)]
     [InlineData("https://attacker.example/card.json", false)]
     [InlineData("file:///etc/passwd", false)]
+    // Percent-encoded traversal / URIs must be decoded before validation (CWE-22 / CWE-829).
+    [InlineData("%2e%2e/card.json", false)]
+    [InlineData("..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd", false)]
+    [InlineData("file%3A%2F%2F%2Fetc%2Fpasswd", false)]
+    [InlineData("%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd", false)]
+    // Encoding hardening variants.
+    [InlineData("%2E%2E/card.json", false)]
+    [InlineData("..%5c..%5csecret.json", false)]
+    [InlineData("https%3A%2F%2Fattacker.example%2Fcard.json", false)]
+    [InlineData("%252e%252e%252fcard.json", false)]
+    // A benign filename containing an encoded space stays safe after decoding.
+    [InlineData("card%20name.json", true)]
     public void StaticTemplateIsSafeFileReferenceValidatesPaths(string file, bool expectedSafe)
     {
         Assert.Equal(expectedSafe, ExtensionResponseSemanticsStaticTemplate.IsSafeFileReference(file));


### PR DESCRIPTION
Fixes #7911

## Summary  

`ExtensionResponseSemanticsStaticTemplate.IsSafeFileReference` validated the **raw** `static_template.file` reference, so percent-encoded traversal payloads bypassed the absolute-URI, rooted-path, drive-path, and `..`-segment checks and were treated as safe. This allowed a malicious OpenAPI description to make the generated plugin manifest point outside the manifest package (CWE-22 / CWE-829).  The following inputs incorrectly returned `true` (safe):  
| Input | Decodes to | 
|-------|-----------|
| `%2e%2e/card.json` | `../card.json` |
| `..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd` | `../../../../../../etc/passwd` |
| `file%3A%2F%2F%2Fetc%2Fpasswd` | `file:///etc/passwd` |
| `%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd` | `../../../etc/passwd` |

 ## Fix

Percent-decode the reference in a **bounded loop** (`Uri.UnescapeDataString`, max 5 passes) until the value is stable, then run the existing validation against the decoded value. The loop defeats single- and multi-level (double) encoding — e.g. `%252e%252e%252fcard.json` → `%2e%2e%2fcard.json` → `../card.json`.  Enforcement paths (`HasUnsafeFileReference` and the direct call in `PluginsGenerationService`) already route through this method, so no wiring changes were needed.  ## Tests  Extended the `StaticTemplateIsSafeFileReferenceValidatesPaths` `[Theory]` with the four reported payloads plus mixed-case, encoded-backslash, encoded-URI, and double-encoded variants (all `false`), and a benign `card%20name.json` (`true`).  `dotnet test --filter "FullyQualifiedName~OpenApiAiCapabilitiesExtensionTest"` → **32 passed, 0 failed**. 
