### PR TITLE
Harden IsSafeFileReference against NUL, deep-encoding, and Unicode homoglyph traversal

### DIFF
--- a/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
+++ b/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Kiota.Builder.Extensions;
@@ -435,12 +436,9 @@ public class ExtensionResponseSemanticsStaticTemplate
 
         // Reject control characters (e.g. an embedded NUL from %00) which can truncate the path in downstream
         // consumers and defeat the parent-directory segment check below.
-        foreach (var ch in decoded)
+        if (decoded.Any(char.IsControl))
         {
-            if (char.IsControl(ch))
-            {
-                return false;
-            }
+            return false;
         }
 
         // The manifest schema requires a relative file path; reject absolute URIs such as http(s):// or file://.

--- a/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
+++ b/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
@@ -386,8 +386,13 @@ public class ExtensionResponseSemanticsStaticTemplate
     // Inlined cards (no "file" property) are always considered safe.
     public bool HasUnsafeFileReference => File is not null && !IsSafeFileReference(File);
 
+    // Upper bound on percent-decode passes; enough to defeat multi-level (double) encoding without unbounded looping.
+    private const int MaxPercentDecodePasses = 5;
+
     // Validates that a static_template file reference is a relative path that cannot point outside the manifest
     // package: rejects absolute URIs, POSIX/UNC rooted paths, Windows drive paths, and '..' traversal (CWE-22/CWE-829).
+    // The reference is percent-decoded first so encoded traversal sequences (e.g. %2e%2e for '..', %2f for '/',
+    // %3a for ':') cannot bypass the checks below; decoding is repeated to defeat multi-level encoding.
     public static bool IsSafeFileReference(string? file)
     {
         if (string.IsNullOrWhiteSpace(file))
@@ -395,14 +400,32 @@ public class ExtensionResponseSemanticsStaticTemplate
             return false;
         }
 
+        // Percent-decode repeatedly until the value is stable so encoded (and double-encoded) traversal payloads
+        // are normalized back to their literal form before validation.
+        var decoded = file;
+        for (var pass = 0; pass < MaxPercentDecodePasses; pass++)
+        {
+            var next = Uri.UnescapeDataString(decoded);
+            if (string.Equals(next, decoded, StringComparison.Ordinal))
+            {
+                break;
+            }
+            decoded = next;
+        }
+
+        if (string.IsNullOrWhiteSpace(decoded))
+        {
+            return false;
+        }
+
         // The manifest schema requires a relative file path; reject absolute URIs such as http(s):// or file://.
-        if (Uri.TryCreate(file, UriKind.Absolute, out _))
+        if (Uri.TryCreate(decoded, UriKind.Absolute, out _))
         {
             return false;
         }
 
         // Normalize separators so the checks below are OS-independent (the manifest is consumed on any platform).
-        var normalized = file.Replace('\\', '/');
+        var normalized = decoded.Replace('\\', '/');
 
         // Reject POSIX-absolute and UNC-style rooted paths (e.g. /etc/passwd, //server/share).
         if (normalized.StartsWith('/'))

--- a/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
+++ b/src/Kiota.Builder/OpenApiExtensions/OpenApiAiCapabilitiesExtension.cs
@@ -392,7 +392,9 @@ public class ExtensionResponseSemanticsStaticTemplate
     // Validates that a static_template file reference is a relative path that cannot point outside the manifest
     // package: rejects absolute URIs, POSIX/UNC rooted paths, Windows drive paths, and '..' traversal (CWE-22/CWE-829).
     // The reference is percent-decoded first so encoded traversal sequences (e.g. %2e%2e for '..', %2f for '/',
-    // %3a for ':') cannot bypass the checks below; decoding is repeated to defeat multi-level encoding.
+    // %3a for ':') cannot bypass the checks below; decoding is repeated to defeat multi-level encoding, residual
+    // encoding beyond the decode budget fails closed, embedded control/NUL characters are rejected, and Unicode
+    // compatibility forms are folded so full-width homoglyph traversal cannot slip through.
     public static bool IsSafeFileReference(string? file)
     {
         if (string.IsNullOrWhiteSpace(file))
@@ -416,6 +418,29 @@ public class ExtensionResponseSemanticsStaticTemplate
         if (string.IsNullOrWhiteSpace(decoded))
         {
             return false;
+        }
+
+        // Fail closed if percent-encoding remains after the decode budget is exhausted: undecoded residue
+        // (e.g. more encoding levels than MaxPercentDecodePasses) could still be decoded by the downstream
+        // consumer into a traversal sequence, so treat it as unsafe rather than accepting it verbatim.
+        if (!string.Equals(Uri.UnescapeDataString(decoded), decoded, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Fold Unicode compatibility forms (e.g. full-width '．'/'／') to their canonical ASCII equivalents so
+        // homoglyph traversal payloads are normalized before the checks below. Validation only; the original
+        // reference is still emitted verbatim.
+        decoded = decoded.Normalize(System.Text.NormalizationForm.FormKC);
+
+        // Reject control characters (e.g. an embedded NUL from %00) which can truncate the path in downstream
+        // consumers and defeat the parent-directory segment check below.
+        foreach (var ch in decoded)
+        {
+            if (char.IsControl(ch))
+            {
+                return false;
+            }
         }
 
         // The manifest schema requires a relative file path; reject absolute URIs such as http(s):// or file://.

--- a/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
@@ -269,6 +269,18 @@ components:
     [InlineData("http://attacker.example/exfil", false)]
     [InlineData("https://attacker.example/card.json", false)]
     [InlineData("file:///etc/passwd", false)]
+    // Percent-encoded traversal / URIs must be decoded before validation (CWE-22 / CWE-829).
+    [InlineData("%2e%2e/card.json", false)]
+    [InlineData("..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd", false)]
+    [InlineData("file%3A%2F%2F%2Fetc%2Fpasswd", false)]
+    [InlineData("%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd", false)]
+    // Encoding hardening variants.
+    [InlineData("%2E%2E/card.json", false)]
+    [InlineData("..%5c..%5csecret.json", false)]
+    [InlineData("https%3A%2F%2Fattacker.example%2Fcard.json", false)]
+    [InlineData("%252e%252e%252fcard.json", false)]
+    // A benign filename containing an encoded space stays safe after decoding.
+    [InlineData("card%20name.json", true)]
     public void StaticTemplateIsSafeFileReferenceValidatesPaths(string file, bool expectedSafe)
     {
         Assert.Equal(expectedSafe, ExtensionResponseSemanticsStaticTemplate.IsSafeFileReference(file));

--- a/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
+++ b/tests/Kiota.Builder.Tests/OpenApiExtensions/OpenApiAiCapabilitiesExtensionTests.cs
@@ -281,6 +281,15 @@ components:
     [InlineData("%252e%252e%252fcard.json", false)]
     // A benign filename containing an encoded space stays safe after decoding.
     [InlineData("card%20name.json", true)]
+    // Encoded NUL / control characters must be rejected (truncation + segment-check evasion).
+    [InlineData("card%00.json", false)]
+    [InlineData("safe.json%00%2e%2e%2fetc%2fpasswd", false)]
+    // Encoding deeper than the decode budget must fail closed rather than pass residual %XX through.
+    [InlineData("%25252525252e%25252525252e%25252525252fx", false)]
+    [InlineData("%2525252525252e%2525252525252e%2525252525252fx", false)]
+    // Unicode full-width homoglyph traversal (literal and percent-encoded UTF-8) is folded and rejected.
+    [InlineData("\uFF0E\uFF0E/card.json", false)]
+    [InlineData("%EF%BC%8E%EF%BC%8E/card.json", false)]
     public void StaticTemplateIsSafeFileReferenceValidatesPaths(string file, bool expectedSafe)
     {
         Assert.Equal(expectedSafe, ExtensionResponseSemanticsStaticTemplate.IsSafeFileReference(file));


### PR DESCRIPTION
Fixes #7912

## Summary

Security-audit follow-up to #7910. Auditing the percent-encoding path-traversal fix against a broader payload matrix surfaced **three residual bypasses** in `ExtensionResponseSemanticsStaticTemplate.IsSafeFileReference`, all confirmed by exercising the real method:

1. **Embedded NUL (`%00`)** — `card%00.json` and `safe.json%00%2e%2e%2fetc%2fpasswd` were accepted. The NUL was not rejected and, when fused with the preceding path segment, defeated the exact-match `..` segment check.
2. **Decode-budget fail-open** — traversal encoded deeper than the 5-pass decode budget (e.g. `%25252525252e...`, 6×+) left `%XX` residue that was accepted verbatim; a consumer decoding further resolves the traversal.
3. **Unicode full-width homoglyph** — `%EF%BC%8E%EF%BC%8E/card.json` (→ `．．/card.json`) was accepted because full-width `．` is not literal `.`.

## Fix

After the bounded percent-decode loop, `IsSafeFileReference` now:
- **Fails closed** if percent-encoding still remains (residual `%XX` after the budget) instead of accepting it.
- **NFKC-folds** the value (validation only — the original reference is still emitted verbatim) so full-width / compatibility homoglyphs normalize before the checks.
- **Rejects control characters** (including NUL), closing the truncation / segment-evasion vector.

## Tests

Extended the `StaticTemplateIsSafeFileReferenceValidatesPaths` `[Theory]` with regression cases for NUL, deep-encoding, and full-width (literal + percent-encoded UTF-8) payloads.

`dotnet test --filter "FullyQualifiedName~OpenApiAiCapabilitiesExtensionTest"` → **38 passed, 0 failed**.

## Out of scope (audited, not vulnerable)

`AllowedExternalOriginsStreamLoader` (#7888): path allow-entries canonicalize encoded `..` before matching, so percent-encoding does not bypass them.
