### PR TITLE
Fix path traversal via workspace consumer identifiers in DescriptionStorageService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a path traversal vulnerability where workspace consumer identifiers (`clientName`/`pluginName`) and workspace configuration keys were used as filesystem path components without containment validation, allowing a crafted name (e.g. `junk/../Victim`) to overwrite another consumer's cached OpenAPI description. [#7919](https://github.com/microsoft/kiota/issues/7919)
+
 ## [1.33.0] - 2026-07-06
 
 ### Added

--- a/src/Kiota.Builder/WorkspaceManagement/DescriptionStorageService.cs
+++ b/src/Kiota.Builder/WorkspaceManagement/DescriptionStorageService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncKeyedLock;
@@ -21,7 +22,29 @@ public class DescriptionStorageService
         o.PoolSize = 20;
         o.PoolInitialFill = 1;
     });
-    private string GetDescriptionFilePath(string clientName, string extension) => Path.Combine(TargetDirectory, DescriptionsSubDirectoryRelativePath, clientName, $"openapi.{extension}");
+    private string GetDescriptionFilePath(string clientName, string extension)
+    {
+        ValidateConsumerName(clientName);
+        var documentsDirectory = Path.Combine(TargetDirectory, DescriptionsSubDirectoryRelativePath);
+        var descriptionFilePath = Path.GetFullPath(Path.Combine(documentsDirectory, clientName, $"openapi.{extension}"));
+        var documentsFullPath = Path.GetFullPath(documentsDirectory);
+        var documentsFullPathWithSeparator = Path.EndsInDirectorySeparator(documentsFullPath) ? documentsFullPath : documentsFullPath + Path.DirectorySeparatorChar;
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (!descriptionFilePath.StartsWith(documentsFullPathWithSeparator, comparison))
+            throw new InvalidOperationException($"The consumer name '{clientName}' resolves to a path outside of the documents directory.");
+        return descriptionFilePath;
+    }
+    internal static void ValidateConsumerName(string clientName)
+    {
+        if (string.IsNullOrWhiteSpace(clientName))
+            throw new InvalidOperationException("The consumer name must not be empty or whitespace.");
+        if (Path.IsPathRooted(clientName) ||
+            clientName.Contains('/', StringComparison.Ordinal) ||
+            clientName.Contains('\\', StringComparison.Ordinal) ||
+            clientName.Split('/', '\\').Contains("..", StringComparer.Ordinal) ||
+            clientName is "." or "..")
+            throw new InvalidOperationException($"The consumer name '{clientName}' is not a valid single path segment and cannot navigate the file system.");
+    }
     public async Task UpdateDescriptionAsync(string clientName, Stream description, string extension = "yml", CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(clientName);

--- a/src/Kiota.Builder/WorkspaceManagement/DescriptionStorageService.cs
+++ b/src/Kiota.Builder/WorkspaceManagement/DescriptionStorageService.cs
@@ -25,7 +25,8 @@ public class DescriptionStorageService
     private string GetDescriptionFilePath(string clientName, string extension)
     {
         ValidateConsumerName(clientName);
-        var documentsDirectory = Path.Combine(TargetDirectory, DescriptionsSubDirectoryRelativePath);
+        ValidateExtension(extension);
+        var documentsDirectory = Path.Join(TargetDirectory, DescriptionsSubDirectoryRelativePath);
         var descriptionFilePath = Path.GetFullPath(Path.Combine(documentsDirectory, clientName, $"openapi.{extension}"));
         var documentsFullPath = Path.GetFullPath(documentsDirectory);
         var documentsFullPathWithSeparator = Path.EndsInDirectorySeparator(documentsFullPath) ? documentsFullPath : documentsFullPath + Path.DirectorySeparatorChar;
@@ -44,6 +45,15 @@ public class DescriptionStorageService
             clientName.Split('/', '\\').Contains("..", StringComparer.Ordinal) ||
             clientName is "." or "..")
             throw new InvalidOperationException($"The consumer name '{clientName}' is not a valid single path segment and cannot navigate the file system.");
+    }
+    private static void ValidateExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            throw new InvalidOperationException("The description file extension must not be empty or whitespace.");
+        if (Path.IsPathRooted(extension) ||
+            extension.Contains('/', StringComparison.Ordinal) ||
+            extension.Contains('\\', StringComparison.Ordinal))
+            throw new InvalidOperationException($"The description file extension '{extension}' must not contain path separators or be rooted.");
     }
     public async Task UpdateDescriptionAsync(string clientName, Stream description, string extension = "yml", CancellationToken cancellationToken = default)
     {
@@ -85,7 +95,7 @@ public class DescriptionStorageService
     }
     public void Clean()
     {
-        var kiotaDirectoryPath = Path.Combine(TargetDirectory, DescriptionsSubDirectoryRelativePath);
+        var kiotaDirectoryPath = Path.Join(TargetDirectory, DescriptionsSubDirectoryRelativePath);
         if (Path.Exists(kiotaDirectoryPath))
             Directory.Delete(kiotaDirectoryPath, true);
     }

--- a/src/Kiota.Builder/WorkspaceManagement/WorkspaceConfigurationStorageService.cs
+++ b/src/Kiota.Builder/WorkspaceManagement/WorkspaceConfigurationStorageService.cs
@@ -111,20 +111,22 @@ public class WorkspaceConfigurationStorageService
         foreach (var client in configuration.Clients)
             try
             {
+                DescriptionStorageService.ValidateConsumerName(client.Key);
                 BaseApiConsumerConfiguration.ValidateOutputPath(client.Value.OutputPath, workspaceDirectory);
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"The client {client.Key} has an invalid output path: {ex.Message}", ex);
+                throw new InvalidOperationException($"The client {client.Key} has an invalid configuration: {ex.Message}", ex);
             }
         foreach (var plugin in configuration.Plugins)
             try
             {
+                DescriptionStorageService.ValidateConsumerName(plugin.Key);
                 BaseApiConsumerConfiguration.ValidateOutputPath(plugin.Value.OutputPath, workspaceDirectory);
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"The plugin {plugin.Key} has an invalid output path: {ex.Message}", ex);
+                throw new InvalidOperationException($"The plugin {plugin.Key} has an invalid configuration: {ex.Message}", ex);
             }
     }
     public async Task BackupConfigAsync(CancellationToken cancellationToken = default)

--- a/src/Kiota.Builder/WorkspaceManagement/WorkspaceManagementService.cs
+++ b/src/Kiota.Builder/WorkspaceManagement/WorkspaceManagementService.cs
@@ -42,6 +42,7 @@ public partial class WorkspaceManagementService
     private readonly DescriptionStorageService descriptionStorageService;
     public async Task<bool> IsConsumerPresentAsync(string clientName, CancellationToken cancellationToken = default)
     {
+        DescriptionStorageService.ValidateConsumerName(clientName);
         if (!UseKiotaConfig) return false;
         var (wsConfig, _) = await workspaceConfigurationStorageService.GetWorkspaceConfigurationAsync(cancellationToken).ConfigureAwait(false);
         return wsConfig is not null && (wsConfig.Clients.ContainsKey(clientName) || wsConfig.Plugins.ContainsKey(clientName));
@@ -68,6 +69,7 @@ public partial class WorkspaceManagementService
     public async Task UpdateStateFromConfigurationAsync(GenerationConfiguration generationConfiguration, string descriptionHash, Dictionary<string, HashSet<string>> templatesWithOperations, Stream descriptionStream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(generationConfiguration);
+        DescriptionStorageService.ValidateConsumerName(generationConfiguration.ClientClassName);
         if (UseKiotaConfig)
         {
             var (wsConfig, manifest) = await LoadConfigurationAndManifestAsync(cancellationToken).ConfigureAwait(false);
@@ -154,6 +156,7 @@ public partial class WorkspaceManagementService
     }
     public async Task<Stream?> GetDescriptionCopyAsync(string clientName, string inputPath, bool cleanOutput, CancellationToken cancellationToken = default)
     {
+        DescriptionStorageService.ValidateConsumerName(clientName);
         if (!UseKiotaConfig || cleanOutput)
             return null;
         return await descriptionStorageService.GetDescriptionAsync(clientName, new Uri(inputPath).GetFileExtension(), cancellationToken).ConfigureAwait(false);
@@ -178,6 +181,7 @@ public partial class WorkspaceManagementService
     }
     private async Task RemoveConsumerInternalAsync<T>(string consumerName, Func<WorkspaceConfiguration, Dictionary<string, T>> consumerRetrieval, bool cleanOutput, string consumerDisplayName, CancellationToken cancellationToken) where T : BaseApiConsumerConfiguration
     {
+        DescriptionStorageService.ValidateConsumerName(consumerName);
         if (!UseKiotaConfig)
             throw new InvalidOperationException($"Cannot remove a {consumerDisplayName} in lock mode");
         var (wsConfig, manifest) = await workspaceConfigurationStorageService.GetWorkspaceConfigurationAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Kiota.Builder.Tests/WorkspaceManagement/DescriptionStorageServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/WorkspaceManagement/DescriptionStorageServiceTests.cs
@@ -104,4 +104,28 @@ public sealed class DescriptionStorageServiceTests
         var service = new DescriptionStorageService(tempPath);
         Assert.Throws<InvalidOperationException>(() => service.RemoveDescription(clientName));
     }
+
+    [Theory]
+    [InlineData("../evil")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task UpdateDescriptionRejectsInvalidExtensionsAsync(string extension)
+    {
+        var service = new DescriptionStorageService(tempPath);
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x1);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateDescriptionAsync("clientName", stream, extension, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("../evil")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task GetDescriptionRejectsInvalidExtensionsAsync(string extension)
+    {
+        var service = new DescriptionStorageService(tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetDescriptionAsync("clientName", extension, cancellationToken: TestContext.Current.CancellationToken));
+    }
 }

--- a/tests/Kiota.Builder.Tests/WorkspaceManagement/DescriptionStorageServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/WorkspaceManagement/DescriptionStorageServiceTests.cs
@@ -46,4 +46,62 @@ public sealed class DescriptionStorageServiceTests
         await Assert.ThrowsAsync<ArgumentNullException>(() => service.UpdateDescriptionAsync("foo", null, cancellationToken: TestContext.Current.CancellationToken));
         await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetDescriptionAsync(null, cancellationToken: TestContext.Current.CancellationToken));
     }
+
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("..")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("./Victim")]
+    [InlineData(".")]
+    [InlineData(" ")]
+    public async Task UpdateDescriptionRejectsTraversalNamesAsync(string clientName)
+    {
+        var service = new DescriptionStorageService(tempPath);
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x1);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateDescriptionAsync(clientName, stream, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdateDescriptionTraversalDoesNotEscapeConsumerNamespaceAsync()
+    {
+        var service = new DescriptionStorageService(tempPath);
+        using var victimStream = new MemoryStream();
+        victimStream.WriteByte(0x2);
+        await service.UpdateDescriptionAsync("Victim", victimStream, cancellationToken: TestContext.Current.CancellationToken);
+
+        using var maliciousStream = new MemoryStream();
+        maliciousStream.WriteByte(0x9);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateDescriptionAsync("junk/../Victim", maliciousStream, cancellationToken: TestContext.Current.CancellationToken));
+
+        // The victim's cached description must remain untouched (single byte 0x2 written above).
+        var victimFilePath = Path.Combine(tempPath, DescriptionStorageService.DescriptionsSubDirectoryRelativePath, "Victim", "openapi.yml");
+        Assert.True(File.Exists(victimFilePath));
+        var contents = await File.ReadAllBytesAsync(victimFilePath, TestContext.Current.CancellationToken);
+        Assert.Equal([0x2], contents);
+    }
+
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task GetDescriptionRejectsTraversalNamesAsync(string clientName)
+    {
+        var service = new DescriptionStorageService(tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetDescriptionAsync(clientName, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public void RemoveDescriptionRejectsTraversalNames(string clientName)
+    {
+        var service = new DescriptionStorageService(tempPath);
+        Assert.Throws<InvalidOperationException>(() => service.RemoveDescription(clientName));
+    }
 }

--- a/tests/Kiota.Builder.Tests/WorkspaceManagement/WorkspaceConfigurationStorageServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/WorkspaceManagement/WorkspaceConfigurationStorageServiceTests.cs
@@ -113,6 +113,50 @@ public sealed class WorkspaceConfigurationStorageServiceTests : IDisposable
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetWorkspaceConfigurationAsync(cancellationToken: TestContext.Current.CancellationToken));
     }
+    [InlineData("../Victim")]
+    [InlineData("junk/../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [Theory]
+    public async Task RejectsClientNameWithTraversalKeyAsync(string clientName)
+    {
+        var service = new WorkspaceConfigurationStorageService(tempPath);
+        await WriteWorkspaceConfigurationAsync($$"""
+        {
+          "version": "1.0.0",
+          "clients": {
+            "{{clientName.Replace("\\", "\\\\", StringComparison.Ordinal)}}": {
+              "outputPath": "./client"
+            }
+          },
+          "plugins": {}
+        }
+        """);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetWorkspaceConfigurationAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+    [InlineData("../Victim")]
+    [InlineData("junk/../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [Theory]
+    public async Task RejectsPluginNameWithTraversalKeyAsync(string pluginName)
+    {
+        var service = new WorkspaceConfigurationStorageService(tempPath);
+        await WriteWorkspaceConfigurationAsync($$"""
+        {
+          "version": "1.0.0",
+          "clients": {},
+          "plugins": {
+            "{{pluginName.Replace("\\", "\\\\", StringComparison.Ordinal)}}": {
+              "outputPath": "./plugin"
+            }
+          }
+        }
+        """);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetWorkspaceConfigurationAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
     private async Task WriteWorkspaceConfigurationAsync(string content)
     {
         var configurationDirectory = Path.Combine(tempPath, WorkspaceConfigurationStorageService.KiotaDirectorySegment);

--- a/tests/Kiota.Builder.Tests/WorkspaceManagement/WorkspaceManagementServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/WorkspaceManagement/WorkspaceManagementServiceTests.cs
@@ -264,6 +264,82 @@ paths:
             Assert.NotNull(descriptionCopy);
     }
 
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task RemoveClientRejectsTraversalNamesAsync(string clientName)
+    {
+        var mockLogger = Mock.Of<ILogger>();
+        Directory.CreateDirectory(tempPath);
+        var service = new WorkspaceManagementService(mockLogger, httpClient, true, tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.RemoveClientAsync(clientName, cancellationToken: TestContext.Current.CancellationToken));
+    }
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task RemovePluginRejectsTraversalNamesAsync(string clientName)
+    {
+        var mockLogger = Mock.Of<ILogger>();
+        Directory.CreateDirectory(tempPath);
+        var service = new WorkspaceManagementService(mockLogger, httpClient, true, tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.RemovePluginAsync(clientName, cancellationToken: TestContext.Current.CancellationToken));
+    }
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task IsConsumerPresentRejectsTraversalNamesAsync(string clientName)
+    {
+        var mockLogger = Mock.Of<ILogger>();
+        Directory.CreateDirectory(tempPath);
+        var service = new WorkspaceManagementService(mockLogger, httpClient, true, tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.IsConsumerPresentAsync(clientName, cancellationToken: TestContext.Current.CancellationToken));
+    }
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task GetDescriptionCopyRejectsTraversalNamesAsync(string clientName)
+    {
+        var mockLogger = Mock.Of<ILogger>();
+        Directory.CreateDirectory(tempPath);
+        var service = new WorkspaceManagementService(mockLogger, httpClient, true, tempPath);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetDescriptionCopyAsync(clientName, Path.Combine(tempPath, "openapi.yml"), false, cancellationToken: TestContext.Current.CancellationToken));
+    }
+    [Theory]
+    [InlineData("junk/../Victim")]
+    [InlineData("../Victim")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    public async Task UpdateStateRejectsTraversalClientNamesAsync(string clientName)
+    {
+        var mockLogger = Mock.Of<ILogger>();
+        Directory.CreateDirectory(tempPath);
+        var service = new WorkspaceManagementService(mockLogger, httpClient, true, tempPath);
+        var configuration = new GenerationConfiguration
+        {
+            ClientClassName = clientName,
+            OutputPath = Path.Combine(tempPath, "client"),
+            OpenAPIFilePath = Path.Combine(tempPath, "openapi.yaml"),
+            ApiRootUrl = "https://graph.microsoft.com",
+        };
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x1);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateStateFromConfigurationAsync(
+            configuration,
+            "foo",
+            new Dictionary<string, HashSet<string>> {
+                { "/foo", new HashSet<string> { "GET" } }
+            },
+            stream, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(tempPath))


### PR DESCRIPTION
## Description

Fixes a path traversal vulnerability where workspace consumer identifiers (`clientName` / `pluginName`) and workspace configuration keys were used directly as filesystem path components when caching OpenAPI descriptions under `.kiota/documents`, with no canonicalization or containment validation.

A crafted consumer name such as `junk/../Victim` normalizes out of the intended `.kiota/documents/<consumer>/` namespace and can overwrite a **sibling** consumer''s cached description. Subsequent `client edit` / `plugin edit` operations trust and load the poisoned cache before consulting the configured source, so SDKs/plugin manifests may be generated from an attacker-controlled specification (integrity violation).

Fixes #7919

## Changes (defense-in-depth)

1. **Storage sink** — `DescriptionStorageService`: added `ValidateConsumerName` and a normalized-containment check in `GetDescriptionFilePath` (mirrors the existing `BaseApiConsumerConfiguration.ValidateOutputPath` pattern). Rejects rooted / `..` / separator names and any resolved path escaping `.kiota/documents`. Protects `UpdateDescriptionAsync`, `GetDescriptionAsync`, `RemoveDescription`.
2. **Builder service** — `WorkspaceManagementService`: early consumer-name validation wired into every entry point that receives a consumer identifier (`IsConsumerPresentAsync`, `UpdateStateFromConfigurationAsync`, `GetDescriptionCopyAsync`, `RemoveClientAsync`, `RemovePluginAsync`) — the chokepoint all CLI/RPC paths funnel through.
3. **Config input** — `WorkspaceConfigurationStorageService`: validates client/plugin consumer keys on config load, closing the malicious-`workspace.json` vector.

Traversal names are **rejected** (throw `InvalidOperationException`) rather than silently sanitized. CLI handlers and RPC already catch and surface the friendly error message. Legitimate consumer names behave unchanged.

## Testing

Developed via TDD (each test confirmed failing before its fix):
- `DescriptionStorageServiceTests` — traversal names throw; victim cache remains untouched; valid names still work.
- `WorkspaceManagementServiceTests` — all consumer entry points reject traversal names.
- `WorkspaceConfigurationStorageServiceTests` — malicious client/plugin keys rejected on load.

- `dotnet test tests/Kiota.Builder.Tests` — **2161 passed, 0 failed, 2 skipped**.
- `dotnet build src/kiota` (net8/9/10) — **0 warnings, 0 errors**.
