### PR TITLE
 - bumps version for release of 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.34.0] - 2026-07-08
+
+### Added
+
+### Changed
+
 - Fixed a path traversal vulnerability where workspace consumer identifiers (`clientName`/`pluginName`) and workspace configuration keys were used as filesystem path components without containment validation, allowing a crafted name (e.g. `junk/../Victim`) to overwrite another consumer's cached OpenAPI description. [#7919](https://github.com/microsoft/kiota/issues/7919)
 
 ## [1.33.0] - 2026-07-06


### PR DESCRIPTION
Bumps version for release of 1.34.0.

## Changes
- Cut the `[Unreleased]` CHANGELOG section into `## [1.34.0] - 2026-07-08`.

The csproj `VersionPrefix` was already set to `1.34.0` by the prerelease PR (#7903), so per the established release convention this PR only updates `CHANGELOG.md`.

## Release notes (1.34.0)
- Fixed a path traversal vulnerability where workspace consumer identifiers (`clientName`/`pluginName`) and workspace configuration keys were used as filesystem path components without containment validation, allowing a crafted name (e.g. `junk/../Victim`) to overwrite another consumer''s cached OpenAPI description. [#7919](https://github.com/microsoft/kiota/issues/7919)
