### PR TITLE
Fix non-idempotent model class descriptions for shared component schemas (#7927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - golang: make sure all generated code adheres to golangs coding standards
+- Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 
 ## [1.34.1] - 2026-07-09
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1790,7 +1790,7 @@ public partial class KiotaBuilder
         };
         if (codeDeclaration is not CodeClass currentClass) throw new InvalidOperationException("Inheritance is only supported for classes");
         if (!currentClass.Documentation.DescriptionAvailable &&
-            new string[] { schema.Description ?? string.Empty }
+            new string[] { GetModelClassDescription(schema) }
                         .Union(schema.AllOf?
                                     .OfType<OpenApiSchema>()
                                     .Select(static x => x.Description) ?? [])
@@ -2106,6 +2106,20 @@ public partial class KiotaBuilder
         }
         return currentNamespace;
     }
+    private static string GetModelClassDescription(IOpenApiSchema schema)
+    {
+        // The class description must be derived from the schema definition, never from a $ref site's
+        // own (sibling) description. A reference object's Description overrides the target's, and since
+        // the same component can be referenced from multiple properties with different descriptions
+        // (built by parallel tasks), using it makes generation non-deterministic (see issue #7927).
+        // The reference-level description is only relevant to the property, which is handled in CreateProperty.
+        var descriptionSource = schema is OpenApiSchemaReference schemaReference ? schemaReference.Target : schema;
+        if (descriptionSource is null)
+            return string.Empty;
+        return (string.IsNullOrEmpty(descriptionSource.Description) ?
+                    descriptionSource.AllOf?.FirstOrDefault(static x => !x.IsReferencedSchema() && !string.IsNullOrEmpty(x.Description))?.Description :
+                    descriptionSource.Description) ?? string.Empty;
+    }
     private CodeClass AddModelClass(OpenApiUrlTreeNode currentNode, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, OpenApiOperation? currentOperation, CodeClass? inheritsFrom = null)
     {
         if (inheritsFrom == null && schema.AllOf?.OfType<OpenApiSchemaReference>().ToArray() is { Length: 1 } referencedSchemas)
@@ -2122,7 +2136,7 @@ public partial class KiotaBuilder
             {
                 DocumentationLabel = schema.ExternalDocs?.Description ?? string.Empty,
                 DocumentationLink = schema.ExternalDocs?.Url,
-                DescriptionTemplate = (string.IsNullOrEmpty(schema.Description) ? schema.AllOf?.FirstOrDefault(static x => !x.IsReferencedSchema() && !string.IsNullOrEmpty(x.Description))?.Description : schema.Description).CleanupDescription(),
+                DescriptionTemplate = GetModelClassDescription(schema).CleanupDescription(),
             },
             Deprecation = schema.GetDeprecationInformation(),
         };

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -7784,6 +7784,152 @@ components:
         Assert.Equal("sub2", codeModel.FindChildByName<CodeClass>("sub2").Documentation.DescriptionTemplate);
     }
     [Fact]
+    public async Task ModelClassDescriptionIgnoresReferenceLevelDescriptionAsync()
+    {
+        // Regression test for https://github.com/microsoft/kiota/issues/7927
+        // A component referenced from multiple properties with differing $ref-level descriptions
+        // must not adopt one of those (property-level) descriptions as its class description, as the
+        // winning one is non-deterministic. When the target schema has no description of its own, the
+        // class description must be empty, while each property keeps its own reference-level description.
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(@"openapi: 3.1.0
+info:
+  title: Notion repro
+  version: 1.0.0
+paths:
+  /pages:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pageResponse'
+components:
+  schemas:
+    internalFileResponse:
+      type: object
+      properties:
+        url:
+          type: string
+        expiry_time:
+          type: string
+          format: date-time
+    filePageCoverResponse:
+      type: object
+      properties:
+        cover:
+          $ref: '#/components/schemas/internalFileResponse'
+          description: 'The file URL for the cover.'
+    filePageIconResponse:
+      type: object
+      properties:
+        icon:
+          $ref: '#/components/schemas/internalFileResponse'
+          description: 'The file URL for the icon.'
+    pageResponse:
+      type: object
+      properties:
+        coverInfo:
+          $ref: '#/components/schemas/filePageCoverResponse'
+        iconInfo:
+          $ref: '#/components/schemas/filePageIconResponse'");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Notion", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var internalFileResponseClass = codeModel.FindChildByName<CodeClass>("internalFileResponse");
+        Assert.NotNull(internalFileResponseClass);
+        Assert.Empty(internalFileResponseClass.Documentation.DescriptionTemplate);
+
+        var coverClass = codeModel.FindChildByName<CodeClass>("filePageCoverResponse");
+        Assert.NotNull(coverClass);
+        var coverProperty = coverClass.FindChildByName<CodeProperty>("cover", false);
+        Assert.NotNull(coverProperty);
+        Assert.Equal("The file URL for the cover.", coverProperty.Documentation.DescriptionTemplate);
+
+        var iconClass = codeModel.FindChildByName<CodeClass>("filePageIconResponse");
+        Assert.NotNull(iconClass);
+        var iconProperty = iconClass.FindChildByName<CodeProperty>("icon", false);
+        Assert.NotNull(iconProperty);
+        Assert.Equal("The file URL for the icon.", iconProperty.Documentation.DescriptionTemplate);
+    }
+    [Fact]
+    public async Task ModelClassDescriptionUsesReferenceTargetDescriptionAsync()
+    {
+        // Regression test for https://github.com/microsoft/kiota/issues/7927
+        // When the referenced (target) schema carries its own description, the class description must
+        // use that target description, regardless of any differing $ref-level descriptions, while each
+        // property keeps its own reference-level description.
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(@"openapi: 3.1.0
+info:
+  title: Notion repro
+  version: 1.0.0
+paths:
+  /pages:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pageResponse'
+components:
+  schemas:
+    internalFileResponse:
+      type: object
+      description: 'Details about an internally hosted file.'
+      properties:
+        url:
+          type: string
+        expiry_time:
+          type: string
+          format: date-time
+    filePageCoverResponse:
+      type: object
+      properties:
+        cover:
+          $ref: '#/components/schemas/internalFileResponse'
+          description: 'The file URL for the cover.'
+    filePageIconResponse:
+      type: object
+      properties:
+        icon:
+          $ref: '#/components/schemas/internalFileResponse'
+          description: 'The file URL for the icon.'
+    pageResponse:
+      type: object
+      properties:
+        coverInfo:
+          $ref: '#/components/schemas/filePageCoverResponse'
+        iconInfo:
+          $ref: '#/components/schemas/filePageIconResponse'");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Notion", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var internalFileResponseClass = codeModel.FindChildByName<CodeClass>("internalFileResponse");
+        Assert.NotNull(internalFileResponseClass);
+        Assert.Equal("Details about an internally hosted file.", internalFileResponseClass.Documentation.DescriptionTemplate);
+
+        var coverClass = codeModel.FindChildByName<CodeClass>("filePageCoverResponse");
+        Assert.NotNull(coverClass);
+        var coverProperty = coverClass.FindChildByName<CodeProperty>("cover", false);
+        Assert.NotNull(coverProperty);
+        Assert.Equal("The file URL for the cover.", coverProperty.Documentation.DescriptionTemplate);
+
+        var iconClass = codeModel.FindChildByName<CodeClass>("filePageIconResponse");
+        Assert.NotNull(iconClass);
+        var iconProperty = iconClass.FindChildByName<CodeProperty>("icon", false);
+        Assert.NotNull(iconProperty);
+        Assert.Equal("The file URL for the icon.", iconProperty.Documentation.DescriptionTemplate);
+    }
+    [Fact]
     public async Task CleanupSymbolNameDoesNotCauseNameConflictsAsync()
     {
         var tempFilePath = Path.GetTempFileName();


### PR DESCRIPTION
## Fixes #7927

### Problem
When an OpenAPI component schema is referenced directly as the type of multiple properties, and those `$ref` sites carry different sibling `description`s, Kiota could emit a **different class-level description on each run** (idempotency failure). Reproduced with `notion.com`, where the component `internalFileResponse` is `$ref`'d from several properties, each `$ref` adding its own description (e.g. "The file URL for the cover.", "The file URL for the icon.").

### Root cause
`KiotaBuilder.AddModelClass` sourced the class `DescriptionTemplate` from `schema.Description`. For an `OpenApiSchemaReference`, `.Description` returns the reference object's own (sibling) description first, falling back to the target only when absent. Since models are built by parallel tasks and the same class can be reached from several `$ref` sites, which sibling description "wins" was non-deterministic.

### Fix
Derive the class description from the schema **definition/target** (via a new `GetModelClassDescription` helper): use `schemaRef.Target` for references, otherwise the schema itself, then apply the existing own-description → non-referenced `allOf` fallback. This makes the class description identical regardless of which reference triggers creation. The reference-level (property) description path in `CreateProperty` is unchanged and still describes the property.

This matches the behavior defined by @baywet in the issue:
- Both schema and reference descriptions present → schema description for the class, reference description for the property.
- Only schema description → used for both class and property.
- Only reference-level description → property only; class description left empty.
- `allOf` crawl retained as a fallback.

### Tests
Added two regression tests in `KiotaBuilderTests.cs` covering the shared-component scenario with differing `$ref` descriptions, with and without a target description. Verified they fail against the pre-fix code and pass after. Full `KiotaBuilderTests` (336) and the description/inheritance/allOf suites (164) pass with no new warnings.
