### PR TITLE
fix(go): emit LF line endings for generated Go code

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -205,6 +205,13 @@ extends:
                 inputs:
                   version: 10.0.x
 
+              # Pinned to match the version used by the CI pipeline (.github/workflows/dotnet.yml),
+              # required so the integration tests can run gofmt against the generated Go code.
+              - task: GoTool@0
+                displayName: "Use Go 1.26.5"
+                inputs:
+                  version: "1.26.5"
+
               # Install the nuget tool.
               - task: NuGetToolInstaller@1
                 displayName: "Use NuGet >=6.11.0"

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -205,8 +205,8 @@ extends:
                 inputs:
                   version: 10.0.x
 
-              # Pinned to match the version used by the CI pipeline (.github/workflows/dotnet.yml),
-              # required so the integration tests can run gofmt against the generated Go code.
+              # Pinned to a specific Go version for deterministic tool availability and formatting,
+              # so the integration tests can run gofmt against the generated Go code.
               - task: GoTool@0
                 displayName: "Use Go 1.26.5"
                 inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- golang: generated code now always uses LF line endings, so `gofmt` no longer reports formatting differences when generating on Windows.
 - golang: make sure all generated code adheres to golangs coding standards
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 

--- a/src/Kiota.Builder/Writers/Go/GoWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/GoWriter.cs
@@ -4,6 +4,9 @@ namespace Kiota.Builder.Writers.Go;
 
 public class GoWriter : LanguageWriter
 {
+    // gofmt (and Go tooling in general) requires LF line endings, so Go output always uses LF
+    // regardless of the host OS newline.
+    protected override string LineSeparator => "\n";
     public GoWriter(string rootPath, string clientNamespaceName, bool excludeBackwardCompatible = false) : base("\t", 1)
     {
         PathSegmenter = new GoPathSegmenter(rootPath, clientNamespaceName);

--- a/src/Kiota.Builder/Writers/LanguageWriter.cs
+++ b/src/Kiota.Builder/Writers/LanguageWriter.cs
@@ -33,8 +33,16 @@ public abstract class LanguageWriter(string indentationChar = " ", int indentati
     /// By making this a separate step, we can instantiate the LanguageWriter, then get the suffix, then create the writer.</remarks>
     public void SetTextWriter(TextWriter writer)
     {
+        ArgumentNullException.ThrowIfNull(writer);
+        writer.NewLine = LineSeparator;
         this.writer = writer;
     }
+    /// <summary>
+    /// The line ending used to terminate the lines written to the output.
+    /// Defaults to the host OS newline; languages whose tooling mandates a specific
+    /// line ending (e.g. Go, whose gofmt requires LF) override this.
+    /// </summary>
+    protected virtual string LineSeparator => Environment.NewLine;
     public IPathSegmenter? PathSegmenter
     {
         get; protected set;

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeClassDeclarationWriterTests.cs
@@ -92,7 +92,7 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
         // gofmt: exactly one blank line between top-level declarations
         codeElementWriter.WriteCodeElement(parentClass.StartBlock, writer);
         var result = tw.ToString();
-        Assert.Contains($"package {Environment.NewLine}{Environment.NewLine}type ParentClass struct {{", result);
+        Assert.Contains($"package {GoTestConstants.LineFeed}{GoTestConstants.LineFeed}type ParentClass struct {{", result);
     }
     [Fact]
     public void AlignsCommentLessFieldsIntoColumns()
@@ -141,7 +141,7 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
         });
         codeElementWriter.WriteCodeElement(parentClass.StartBlock, writer);
         var result = tw.ToString();
-        Assert.Contains($"\t// The displayName property{Environment.NewLine}\tdisplayName *string", result);
-        Assert.Contains($"\t// The id property{Environment.NewLine}\tid *string", result);
+        Assert.Contains($"\t// The displayName property{GoTestConstants.LineFeed}\tdisplayName *string", result);
+        Assert.Contains($"\t// The id property{GoTestConstants.LineFeed}\tid *string", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -164,7 +164,7 @@ public sealed class CodeEnumWriterTests : IDisposable
         writer.Write(currentEnum);
         var result = tw.ToString();
         Assert.Contains(GoTestConstants.LineFeed, result);
-        var firstline = result[0..^result.IndexOf(GoTestConstants.LineFeed, StringComparison.Ordinal)];
+        var firstline = result[0..result.IndexOf(GoTestConstants.LineFeed, StringComparison.Ordinal)];
         Assert.Contains("DO NOT EDIT", firstline);
     }
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -127,9 +127,9 @@ public sealed class CodeEnumWriterTests : IDisposable
         currentEnum.AddOption(new CodeEnumOption { Name = "option1" });
         writer.Write(currentEnum);
         var result = tw.ToString();
-        Assert.DoesNotContain($"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", result);
-        Assert.Contains($"){Environment.NewLine}{Environment.NewLine}func (i SomeEnum) String() string {{", result);
-        Assert.EndsWith($"}}{Environment.NewLine}", result);
+        Assert.DoesNotContain($"{GoTestConstants.LineFeed}{GoTestConstants.LineFeed}{GoTestConstants.LineFeed}", result);
+        Assert.Contains($"){GoTestConstants.LineFeed}{GoTestConstants.LineFeed}func (i SomeEnum) String() string {{", result);
+        Assert.EndsWith($"}}{GoTestConstants.LineFeed}", result);
     }
     [Fact]
     public void DoesntWriteAnythingOnNoOption()
@@ -163,8 +163,8 @@ public sealed class CodeEnumWriterTests : IDisposable
         currentEnum.AddOption(option);
         writer.Write(currentEnum);
         var result = tw.ToString();
-        Assert.Contains(Environment.NewLine, result);
-        var firstline = result[0..^result.IndexOf(Environment.NewLine)];
+        Assert.Contains(GoTestConstants.LineFeed, result);
+        var firstline = result[0..^result.IndexOf(GoTestConstants.LineFeed, StringComparison.Ordinal)];
         Assert.Contains("DO NOT EDIT", firstline);
     }
     [Fact]
@@ -200,7 +200,7 @@ public sealed class CodeEnumWriterTests : IDisposable
         var result = tw.ToString();
 
         Assert.Contains("// Some optioninjected", result);
-        Assert.DoesNotContain($"{Environment.NewLine}injected", result);
+        Assert.DoesNotContain($"{GoTestConstants.LineFeed}injected", result);
     }
     [Fact]
     public void DoesNotWriteImportOnEmptyImports()

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -1789,7 +1789,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.Contains("[see more]: ", result);
-        Assert.DoesNotContain($"{Environment.NewLine}more", result);
+        Assert.DoesNotContain($"{GoTestConstants.LineFeed}more", result);
     }
     [Fact]
     public void Defensive()
@@ -2560,10 +2560,10 @@ public sealed class CodeMethodWriterTests : IDisposable
     public void SanitizesDeprecationVersionInComments()
     {
         setup();
-        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z"), DateTimeOffset.Parse("2021-01-01T00:00:00Z"), $"v2.0{Environment.NewLine}VERSION_MARKER");
+        method.Deprecation = new("This method is deprecated", DateTimeOffset.Parse("2020-01-01T00:00:00Z"), DateTimeOffset.Parse("2021-01-01T00:00:00Z"), $"v2.0{GoTestConstants.LineFeed}VERSION_MARKER");
         writer.Write(method);
         var result = tw.ToString();
-        Assert.DoesNotContain($"as of v2.0{Environment.NewLine}VERSION_MARKER", result);
+        Assert.DoesNotContain($"as of v2.0{GoTestConstants.LineFeed}VERSION_MARKER", result);
         Assert.Contains("as of v2.0VERSION_MARKER", result);
     }
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Go/GoConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/GoConventionServiceTests.cs
@@ -37,6 +37,6 @@ public class GoConventionServiceTests
         var result = textWriter.ToString();
 
         Assert.Contains("// line1line2 line3", result);
-        Assert.DoesNotContain($"{Environment.NewLine}line2", result);
+        Assert.DoesNotContain($"{GoTestConstants.LineFeed}line2", result);
     }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Go/GoTestConstants.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/GoTestConstants.cs
@@ -1,4 +1,4 @@
-namespace Kiota.Builder.Tests.Writers.Go;
+﻿namespace Kiota.Builder.Tests.Writers.Go;
 
 internal static class GoTestConstants
 {

--- a/tests/Kiota.Builder.Tests/Writers/Go/GoTestConstants.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/GoTestConstants.cs
@@ -1,0 +1,10 @@
+namespace Kiota.Builder.Tests.Writers.Go;
+
+internal static class GoTestConstants
+{
+    /// <summary>
+    /// The line feed character that Go tooling (e.g. gofmt) mandates for line endings.
+    /// Go output always uses this regardless of the host OS newline, so tests assert against it directly.
+    /// </summary>
+    internal const string LineFeed = "\n";
+}


### PR DESCRIPTION
## Problem

`gofmt` requires LF line endings, but kiota wrote generated files using the host OS newline (`Environment.NewLine`), which is CRLF on Windows. As a result, every generated Go file was flagged by `gofmt -l` purely on line endings, causing the `GeneratedGoCodeIsFormattedAsync` integration tests — and the ADO release pipeline (`Kiota generator publish`, which runs on `windows-latest`) — to fail regardless of Go version.

## Fix

- Introduce a `protected virtual string LineSeparator` on `LanguageWriter` (defaulting to `Environment.NewLine`) and wire it into `SetTextWriter` via `writer.NewLine = LineSeparator`. This is the single choke point covering both file rendering and unit tests.
- Override `LineSeparator => "\n"` in `GoWriter`, so Go output always uses LF regardless of host OS. Other languages keep the OS-native newline (unchanged behavior).
- Pin the ADO release pipeline (`.azure-pipelines/ci-build.yml`) to Go 1.26.5 via `GoTool@0` for deterministic formatting.

## Tests

- Updated the Go writer test assertions to expect LF, introducing a shared `GoTestConstants.LineFeed` const rather than repeating literals.
- `Kiota.Builder.Tests`: 2188 passed, 2 skipped, 0 failed.
- Go formatting integration tests (`GeneratedGoCodeIsFormattedAsync`): 9/9 passed on Windows.
- Non-Go languages and their tests are untouched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>