### PR TITLE
ci(dependabot): add cooldown default delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,160 +1,160 @@
 version: 2
 updates:
-- package-ecosystem: nuget
-  directory: /
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - generator
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-    OpenTelemetry:
-      patterns:
-      - OpenTelemetry.*
-      - Azure.Monitor.OpenTelemetry.Exporter
-    MicrosoftExtensions:
-      patterns:
-      - Microsoft.Extensions.*
-    coverlet:
-      patterns:
-      - coverlet.*
-  cooldown:
-    default-days: 7
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  cooldown:
-    default-days: 7
-- package-ecosystem: nuget
-  directories:
-  - /it/csharp
-  - /it/csharp/basic
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: gomod
-  directories:
-  - /it/go
-  - /it/go/basic
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: composer
-  directories:
-  - /it/php
-  - /it/php/basic
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: pip
-  directory: /it/python
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-    pytest:
-      patterns:
-      - astroid*
-      - isort*
-      - pylint*
-      - pytest*
-  cooldown:
-    default-days: 7
-- package-ecosystem: bundler
-  directory: /it/ruby
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: maven
-  directories:
-  - /it/java
-  - /it/java/basic
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: pub
-  directory: /it/dart
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: npm
-  directory: /it/typescript
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-      - '*kiota*'
-    eslint:
-      patterns:
-      - '*eslint*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: npm
-  directory: /vscode
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  groups:
-    eslint:
-      patterns:
-      - '*eslint*'
-  cooldown:
-    default-days: 7
-- package-ecosystem: dotnet-sdk
-  directory: /
-  schedule:
-    interval: weekly
-    day: wednesday
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-    - version-update:semver-minor
-  cooldown:
-    default-days: 7
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - generator
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+      OpenTelemetry:
+        patterns:
+          - OpenTelemetry.*
+          - Azure.Monitor.OpenTelemetry.Exporter
+      MicrosoftExtensions:
+        patterns:
+          - Microsoft.Extensions.*
+      coverlet:
+        patterns:
+          - coverlet.*
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+  - package-ecosystem: nuget
+    directories:
+      - /it/csharp
+      - /it/csharp/basic
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: gomod
+    directories:
+      - /it/go
+      - /it/go/basic
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: composer
+    directories:
+      - /it/php
+      - /it/php/basic
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: pip
+    directory: /it/python
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+      pytest:
+        patterns:
+          - astroid*
+          - isort*
+          - pylint*
+          - pytest*
+    cooldown:
+      default-days: 7
+  - package-ecosystem: bundler
+    directory: /it/ruby
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: maven
+    directories:
+      - /it/java
+      - /it/java/basic
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: pub
+    directory: /it/dart
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: npm
+    directory: /it/typescript
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      kiota-dependencies:
+        patterns:
+          - '*kiota*'
+      eslint:
+        patterns:
+          - '*eslint*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: npm
+    directory: /vscode
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      eslint:
+        patterns:
+          - '*eslint*'
+    cooldown:
+      default-days: 7
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,136 +1,160 @@
 version: 2
 updates:
-  - package-ecosystem: nuget
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - generator
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-      OpenTelemetry:
-        patterns:
-          - "OpenTelemetry.*"
-          - "Azure.Monitor.OpenTelemetry.Exporter"
-      MicrosoftExtensions:
-        patterns:
-          - "Microsoft.Extensions.*"
-      coverlet:
-        patterns:
-          - "coverlet.*"
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: nuget
-    directories:
-      - "/it/csharp"
-      - "/it/csharp/basic"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: gomod
-    directories:
-      - "/it/go"
-      - "/it/go/basic"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: composer
-    directories:
-      - "/it/php"
-      - "/it/php/basic"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: pip
-    directory: "/it/python"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-      pytest:
-        patterns:
-          - "astroid*"
-          - "isort*"
-          - "pylint*"
-          - "pytest*"
-  - package-ecosystem: bundler
-    directory: "/it/ruby"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: maven
-    directories:
-      - "/it/java"
-      - "/it/java/basic"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: pub
-    directory: "/it/dart"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-  - package-ecosystem: npm
-    directory: "/it/typescript"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      kiota-dependencies:
-        patterns:
-          - "*kiota*"
-      eslint:
-        patterns:
-          - "*eslint*"
-  - package-ecosystem: npm
-    directory: "/vscode"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    groups:
-      eslint:
-        patterns:
-          - "*eslint*"
-  - package-ecosystem: dotnet-sdk
-    directory: /
-    schedule:
-      interval: weekly
-      day: wednesday
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
+- package-ecosystem: nuget
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - generator
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+    OpenTelemetry:
+      patterns:
+      - OpenTelemetry.*
+      - Azure.Monitor.OpenTelemetry.Exporter
+    MicrosoftExtensions:
+      patterns:
+      - Microsoft.Extensions.*
+    coverlet:
+      patterns:
+      - coverlet.*
+  cooldown:
+    default-days: 7
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+- package-ecosystem: nuget
+  directories:
+  - /it/csharp
+  - /it/csharp/basic
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: gomod
+  directories:
+  - /it/go
+  - /it/go/basic
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: composer
+  directories:
+  - /it/php
+  - /it/php/basic
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: pip
+  directory: /it/python
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+    pytest:
+      patterns:
+      - astroid*
+      - isort*
+      - pylint*
+      - pytest*
+  cooldown:
+    default-days: 7
+- package-ecosystem: bundler
+  directory: /it/ruby
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: maven
+  directories:
+  - /it/java
+  - /it/java/basic
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: pub
+  directory: /it/dart
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: npm
+  directory: /it/typescript
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+      - '*kiota*'
+    eslint:
+      patterns:
+      - '*eslint*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: npm
+  directory: /vscode
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    eslint:
+      patterns:
+      - '*eslint*'
+  cooldown:
+    default-days: 7
+- package-ecosystem: dotnet-sdk
+  directory: /
+  schedule:
+    interval: weekly
+    day: wednesday
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Adds a 7-day default Dependabot cooldown so CIF deployment has time to complete before dependency update PRs are opened.

This helps avoid getting ahead with versions before they are fully available through deployment.