### PR TITLE
fix(ci): pin extension dependency to preview version in update-vscode-releases

### DIFF
--- a/scripts/update-vscode-releases.ps1
+++ b/scripts/update-vscode-releases.ps1
@@ -73,6 +73,20 @@ if (Test-Path $runtimePackageJsonFilePath) {
   $runtimePackageJson = Get-Content $runtimePackageJsonFilePath | ConvertFrom-Json
   $runtimePackageJson.version = $version
   Set-Content $runtimePackageJsonFilePath ($runtimePackageJson | ConvertTo-Json -Depth 10)
+
+  # For preview builds the npm-package version becomes a prerelease (e.g. 1.x.y-preview.*).
+  # A caret range such as ^1.x.y does not satisfy a prerelease of a different patch tuple, so
+  # `npm ci` would stop resolving the dependency to the local workspace and instead pull it (plus
+  # its transitive dependencies) from the registry, breaking the committed lockfile's sync check.
+  # Pin the extension's dependency to the exact preview version so npm keeps linking the local
+  # workspace. This is intentionally limited to preview builds to preserve `npm ci` validity for
+  # regular releases, whose plain versions still satisfy the committed caret range.
+  if ($version -like "*-preview.*") {
+    $dependencyName = $runtimePackageJson.name
+    if ($dependencyName -and $packageJson.dependencies -and ($packageJson.dependencies.PSObject.Properties.Name -contains $dependencyName)) {
+      $packageJson.dependencies.$dependencyName = $version
+    }
+  }
 }
 
 if ($online) {


### PR DESCRIPTION
## Problem

The `build_vscode_extension` job fails at `npm ci` on **preview** builds:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: @microsoft/kiota@1.34.1 from lock file
npm error Missing: adm-zip@0.5.18 from lock file
```

## Root cause

`update-vscode-releases.ps1` runs before `npm ci` and, on preview builds, rewrites the `npm-package` workspace `version` to a prerelease (e.g. `1.34.1-preview.<timestamp>`).

Per node-semver rules, the extension's `"@microsoft/kiota": "^1.25.1"` caret range does **not** match a prerelease of a different `major.minor.patch` tuple. npm therefore stops resolving `@microsoft/kiota` to the local workspace and pulls the **published** `1.34.1` from the registry — which transitively depends on `adm-zip@^0.5.18`. Neither is in the committed lockfile, so `npm ci`'s sync check fails.

Release builds use a plain version (`1.34.1`) that `^1.25.1` matches, which is why only preview builds broke.

## Fix

Make `update-vscode-releases.ps1` pin the extension's `@microsoft/kiota` dependency to the **exact preview version** whenever it bumps the workspace to a prerelease. This keeps npm linking the local workspace, so `npm ci` stays in sync.

The change is **intentionally limited to preview builds** (`-preview.*` versions). For regular releases the dependency range is left untouched, preserving `npm ci` validity against the committed caret range — which is the main intent. The dependency name is read from the npm-package's own `name` field rather than hardcoded.

## Validation

- Ran the real script with a preview version: npm-package → `1.34.1-preview.*`, extension dependency → exact preview version, then `npm ci` **passes** (exit 0) and links `@microsoft/kiota -> ./packages/npm-package` (no registry fallback).
- Ran the script with a release version (`1.34.1`): the extension dependency **remains** `^1.25.1` (untouched), so release `npm ci` behavior is unchanged.
- The GitHub Actions `build-vscode-extension.yml` workflow only passes release versions (`--exclude-pre-releases`), so it is unaffected.
- PowerShell script parses cleanly.

_Supersedes the earlier pipeline-reorder approach; the pipeline YAML is left unchanged._