### PR TITLE
Enable merge queue on main and drop strict status checks

### DIFF
--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -24,6 +24,8 @@ configuration:
       requiresConversationResolution: true
       # Are merge commits prohibited from being pushed to this branch. boolean
       requiresLinearHistory: false
+      # Indicates whether "Require merge queue" ("Use merge queue") is enabled for this branch. boolean
+      requiresMergeQueue: true
       # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
       requiredStatusChecks:
         - license/cla
@@ -33,7 +35,7 @@ configuration:
         - check-integration-tests
         - build_extension
       # Require branches to be up to date before merging
-      requiresStrictStatusChecks: true
+      requiresStrictStatusChecks: false
       # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
       restrictsPushes: false
       # Restrict who can dismiss pull request reviews. boolean

--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -24,8 +24,6 @@ configuration:
       requiresConversationResolution: true
       # Are merge commits prohibited from being pushed to this branch. boolean
       requiresLinearHistory: false
-      # Indicates whether "Require merge queue" ("Use merge queue") is enabled for this branch. boolean
-      requiresMergeQueue: true
       # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
       requiredStatusChecks:
         - license/cla


### PR DESCRIPTION
## What

- **Repository ruleset (created via API, not in this repo's files):** `merge-queue-default-branch` — enables the merge queue on the default branch with `merge_method: SQUASH`, active enforcement.
- **`.github/policies/branch-protection.yml`:** sets `requiresStrictStatusChecks: false`, dropping "Require branches to be up to date before merging" (now redundant under the merge queue).

## Why

The "Use merge queue" setting kept disappearing from `main`'s branch protection. Root cause: the **GitOps Policy Service** reconciles `main`'s protection to match `branch-protection.yml`. An initial attempt to declare `requiresMergeQueue: true` in that file **failed schema validation** — the Policy Service's `BranchProtection` type has no merge-queue property, and a survey of 80+ Microsoft/Azure `.github/policies` files confirms none can express merge queue or rulesets.

Merge queue is therefore only configurable as a **repository ruleset** via the GitHub Rulesets API. That ruleset has been created directly on the repo (it lives in repo settings, not in these files). With the queue active, strict status checks are no longer needed, so `requiresStrictStatusChecks` is turned off here.

## Notes

- The merge-queue ruleset is repo settings, not source-controlled — there's no Policy-Service-managed home for it in this repo.
- Squash is enforced via the ruleset's `merge_method: SQUASH`, so all queued merges squash.