### PR TITLE
Fix Python enum members generating tuple values

### DIFF
--- a/src/Kiota.Builder/Writers/Python/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeEnumWriter.cs
@@ -26,7 +26,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, PythonConventionServic
             codeElement.Options.ToList().ForEach(x =>
             {
                 conventions.WriteInLineDescription(x, writer);
-                writer.WriteLine($"{x.Name} = \"{x.WireName.SanitizeDoubleQuote()}\",");
+                writer.WriteLine($"{x.Name} = \"{x.WireName.SanitizeDoubleQuote()}\"");
             });
         }
     }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeEnumWriterTests.cs
@@ -42,7 +42,8 @@ public sealed class CodeEnumWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("from enum import Enum", result);
         Assert.Contains("(str, Enum):", result);
-        Assert.Contains($"Option1 = \"{optionName}\"", result);
+        Assert.Contains($"Option1 = \"{optionName}\"{Environment.NewLine}", result);
+        Assert.DoesNotContain($"Option1 = \"{optionName}\",", result);
         Assert.DoesNotContain("pass", result);
     }
     [Fact]
@@ -64,7 +65,8 @@ public sealed class CodeEnumWriterTests : IDisposable
         });
         writer.Write(currentEnum);
         var result = tw.ToString();
-        Assert.Contains("Option1 = \"line1\\\"\\nline2\",", result);
+        Assert.Contains($"Option1 = \"line1\\\"\\nline2\"{Environment.NewLine}", result);
+        Assert.DoesNotContain("Option1 = \"line1\\\"\\nline2\",", result);
     }
     [Fact]
     public void SanitizesEnumOptionDescriptionWithNewlines()


### PR DESCRIPTION
## Summary

Removes trailing commas from generated Python string enum assignments. Adds enum writer coverage for regular and escaped wire values.

A trailing comma makes a Python expression such as `"red",` a one-element tuple, preventing incoming string values from matching generated enum members during deserialization.

## Validation

`dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --nologo --filter 'FullyQualifiedName~Writers.Python.CodeEnumWriterTests'` (11 passed)

Fixes #7811