### PR TITLE
Add PHP QueryParameter import after property renaming

### DIFF
--- a/src/Kiota.Builder/Refiners/PhpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/PhpRefiner.cs
@@ -139,6 +139,7 @@ public class PhpRefiner : CommonLanguageRefiner
                     CodePropertyKind.QueryParameter,
                 },
                 static s => s.ToCamelCase(UnderscoreArray));
+            AddDefaultImports(generatedCode, queryParameterUsingEvaluators);
         }, cancellationToken);
     }
     private static readonly Dictionary<string, (string, CodeUsing?)> DateTypesReplacements = new(StringComparer.OrdinalIgnoreCase)
@@ -212,12 +213,18 @@ public class PhpRefiner : CommonLanguageRefiner
         new(static x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTime", StringComparison.OrdinalIgnoreCase), "", "\\DateTime"),
         new(static x => x is CodeProperty {Type.Name: {}} property && property.Type.Name.Equals("DateTimeOffset", StringComparison.OrdinalIgnoreCase), "", "\\DateTime"),
         new(static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.ClientConstructor), AbstractionsNamespaceName, "ApiClientBuilder"),
-        new(static x => x is CodeProperty property && property.IsOfKind(CodePropertyKind.QueryParameter) && !string.IsNullOrEmpty(property.SerializationName), AbstractionsNamespaceName, "QueryParameter"),
         new(static x => x is CodeClass codeClass && codeClass.IsOfKind(CodeClassKind.RequestConfiguration), AbstractionsNamespaceName, "RequestOption"),
         new (static x => x is CodeClass { OriginalComposedType: CodeIntersectionType intersectionType } && intersectionType.Types.Any(static y => !y.IsExternal),
             $@"{AbstractionsNamespaceName}\Serialization", "ParseNodeHelper"),
         new (static x => x is CodeMethod method && method.IsOfKind(CodeMethodKind.RequestExecutor, CodeMethodKind.RequestGenerator) && method.Parameters.Any(static y => y.IsOfKind(CodeParameterKind.RequestBody) && y.Type.Name.Equals(MultipartBodyClassName, StringComparison.OrdinalIgnoreCase)),
             AbstractionsNamespaceName, MultipartBodyClassName)
+    };
+    private static readonly AdditionalUsingEvaluator[] queryParameterUsingEvaluators = {
+        new(static x => x is CodeProperty property &&
+            property.IsOfKind(CodePropertyKind.QueryParameter) &&
+            !string.IsNullOrEmpty(property.SerializationName),
+            AbstractionsNamespaceName,
+            "QueryParameter"),
     };
 
     private const string MultipartBodyClassName = "MultiPartBody";
@@ -473,4 +480,3 @@ public class PhpRefiner : CommonLanguageRefiner
         CrawlTree(codeElement, AddQueryParameterFactoryMethod);
     }
 }
-

--- a/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/PhpLanguageRefinerTests.cs
@@ -112,6 +112,33 @@ public class PhpLanguageRefinerTests
     }
 
     [Fact]
+    public async Task AddsQueryParameterImportAfterRenamingAsync()
+    {
+        var queryParameters = root.AddClass(new CodeClass
+        {
+            Name = "ThingsRequestBuilderGetQueryParameters",
+            Kind = CodeClassKind.QueryParameters,
+        }).First();
+        var property = queryParameters.AddProperty(new CodeProperty
+        {
+            Name = "category_id",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType { Name = "string" },
+        }).First();
+
+        await ILanguageRefiner.RefineAsync(
+            new GenerationConfiguration { Language = GenerationLanguage.PHP },
+            root,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("categoryId", property.Name);
+        Assert.Equal("category_id", property.SerializationName);
+        Assert.Contains(queryParameters.StartBlock.Usings, static x =>
+            x.Name.Equals("QueryParameter", System.StringComparison.Ordinal) &&
+            x.Declaration?.Name.Equals(@"Microsoft\Kiota\Abstractions", System.StringComparison.Ordinal) is true);
+    }
+
+    [Fact]
     public async Task AddsExceptionInheritanceOnErrorClassesAsync()
     {
         var model = root.AddClass(new CodeClass


### PR DESCRIPTION
## Summary

Evaluates the PHP `QueryParameter` import after query property names are normalized. Adds regression coverage for snake_case query parameters that become camelCase while retaining their serialization name.

The import evaluator previously ran before `ReplacePropertyNames` populated `SerializationName`, so generated annotations could be emitted without the corresponding import.

## Validation

`dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --nologo --filter 'FullyQualifiedName~Refiners.PhpLanguageRefinerTests'` (14 passed)

Fixes #7602