### PR TITLE
Preserve empty string enum values during generation

### DIFF
--- a/src/Kiota.Builder/CodeDOM/CodeEnumOption.cs
+++ b/src/Kiota.Builder/CodeDOM/CodeEnumOption.cs
@@ -5,18 +5,30 @@ namespace Kiota.Builder.CodeDOM;
 public class CodeEnumOption : CodeElement, IDocumentedElement, ITypeDefinition, IAlternativeName
 {
     /// <inheritdoc/>
-    public string SerializationName { get; set; } = string.Empty;
+    public string SerializationName
+    {
+        get => serializationName;
+        set
+        {
+            serializationName = value ?? string.Empty;
+            hasSerializationName = true;
+        }
+    }
+    private string serializationName = string.Empty;
+    private bool hasSerializationName;
     public CodeDocumentation Documentation { get; set; } = new();
     /// <inheritdoc/>
     public bool IsNameEscaped
     {
-        get => !string.IsNullOrEmpty(SerializationName);
+        get => hasSerializationName;
     }
     /// <inheritdoc/>
     public string WireName => IsNameEscaped ? SerializationName : Name;
     /// <inheritdoc/>
     public string SymbolName
     {
-        get => IsNameEscaped ? SerializationName.CleanupSymbolName() : Name;
+        get => IsNameEscaped && !string.IsNullOrEmpty(SerializationName) ?
+            SerializationName.CleanupSymbolName() :
+            Name;
     }
 }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2192,6 +2192,7 @@ public partial class KiotaBuilder
         OpenApiEnumValuesDescriptionExtension? extensionInformation = null;
         if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiEnumValuesDescriptionExtension.Name, out var rawExtension) && rawExtension is OpenApiEnumValuesDescriptionExtension localExtInfo)
             extensionInformation = localExtInfo;
+        var optionNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         target.AddOption(schema.Enum?.OfType<JsonValue>()
                         .Where(static x => x.GetValueKind() is JsonValueKind.String or JsonValueKind.Number)
                         .Select(static x => x.GetValueKind() is JsonValueKind.String ? x.GetValue<string>() : x.GetValue<decimal>().ToString(CultureInfo.InvariantCulture))
@@ -2204,7 +2205,7 @@ public partial class KiotaBuilder
                                 string.IsNullOrEmpty(x) ? "Empty" : x;
                             return new CodeEnumOption
                             {
-                                Name = optionName.CleanupSymbolName(),
+                                Name = GetUniqueEnumOptionName(optionName.CleanupSymbolName(), optionNames),
                                 SerializationName = x,
                                 Documentation = new()
                                 {
@@ -2214,6 +2215,16 @@ public partial class KiotaBuilder
                         })
                         .Where(static x => !string.IsNullOrEmpty(x.Name))
                         .ToArray() ?? []);
+    }
+    private static string GetUniqueEnumOptionName(string optionName, HashSet<string> optionNames)
+    {
+        if (string.IsNullOrEmpty(optionName) || optionNames.Add(optionName))
+            return optionName;
+
+        var suffix = 1;
+        while (!optionNames.Add($"{optionName}{suffix}"))
+            suffix++;
+        return $"{optionName}{suffix}";
     }
     private CodeNamespace GetShortestNamespace(CodeNamespace currentNamespace, IOpenApiSchema currentSchema)
     {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2195,16 +2195,16 @@ public partial class KiotaBuilder
         target.AddOption(schema.Enum?.OfType<JsonValue>()
                         .Where(static x => x.GetValueKind() is JsonValueKind.String or JsonValueKind.Number)
                         .Select(static x => x.GetValueKind() is JsonValueKind.String ? x.GetValue<string>() : x.GetValue<decimal>().ToString(CultureInfo.InvariantCulture))
-                        .Where(static x => !string.IsNullOrEmpty(x))
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .Select((x) =>
                         {
                             var optionDescription = extensionInformation?.ValuesDescriptions.Find(y => y.Value.Equals(x, StringComparison.OrdinalIgnoreCase));
+                            var optionName = optionDescription?.Name is string name && !string.IsNullOrEmpty(name) ?
+                                name :
+                                string.IsNullOrEmpty(x) ? "Empty" : x;
                             return new CodeEnumOption
                             {
-                                Name = (optionDescription?.Name is string name && !string.IsNullOrEmpty(name) ?
-                                        name :
-                                        x).CleanupSymbolName(),
+                                Name = optionName.CleanupSymbolName(),
                                 SerializationName = x,
                                 Documentation = new()
                                 {

--- a/tests/Kiota.Builder.Tests/CodeDOM/CodeEnumTests.cs
+++ b/tests/Kiota.Builder.Tests/CodeDOM/CodeEnumTests.cs
@@ -23,4 +23,18 @@ public class CodeEnumTests
         }).First();
         codeEnum.AddOption(new CodeEnumOption { Name = "option1" });
     }
+
+    [Fact]
+    public void PreservesExplicitEmptySerializationName()
+    {
+        var option = new CodeEnumOption
+        {
+            Name = "Empty",
+            SerializationName = string.Empty,
+        };
+
+        Assert.True(option.IsNameEscaped);
+        Assert.Empty(option.WireName);
+        Assert.Equal("Empty", option.SymbolName);
+    }
 }

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -530,6 +530,7 @@ components:
         - Standard_RAGRS
         - Premium_LRS
         - Premium_LRS
+        - Empty
         - ''
       x-ms-enum:
         name: AccountType
@@ -569,9 +570,12 @@ components:
         Assert.Equal("StandardLocalRedundancy", thirdOption.Name);
         Assert.NotEmpty(thirdOption.Documentation.DescriptionTemplate);
         Assert.Single(enumDef.Options, static x => x.Name.Equals("Premium_LRS", StringComparison.OrdinalIgnoreCase));
-        var emptyOption = Assert.Single(enumDef.Options, static x => x.Name.Equals("Empty", StringComparison.OrdinalIgnoreCase));
+        var emptyOption = Assert.Single(enumDef.Options, static x => x.WireName.Length == 0);
+        Assert.Equal("Empty1", emptyOption.Name);
         Assert.Empty(emptyOption.SerializationName);
         Assert.Empty(emptyOption.WireName);
+        var nonEmptyOption = Assert.Single(enumDef.Options, static x => x.WireName.Equals("Empty", StringComparison.Ordinal));
+        Assert.Equal("Empty", nonEmptyOption.Name);
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -530,6 +530,7 @@ components:
         - Standard_RAGRS
         - Premium_LRS
         - Premium_LRS
+        - ''
       x-ms-enum:
         name: AccountType
         modelAsString: false
@@ -568,6 +569,9 @@ components:
         Assert.Equal("StandardLocalRedundancy", thirdOption.Name);
         Assert.NotEmpty(thirdOption.Documentation.DescriptionTemplate);
         Assert.Single(enumDef.Options, static x => x.Name.Equals("Premium_LRS", StringComparison.OrdinalIgnoreCase));
+        var emptyOption = Assert.Single(enumDef.Options, static x => x.Name.Equals("Empty", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(emptyOption.SerializationName);
+        Assert.Empty(emptyOption.WireName);
     }
 
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeEnumWriterTests.cs
@@ -232,4 +232,19 @@ public sealed class CodeEnumWriterTests : IDisposable
         Assert.Contains("return []string{\"line1\\\"\\nline2\"}[i]", result);
         Assert.Contains("case \"line1\\\"\\nline2\":", result);
     }
+
+    [Fact]
+    public void WritesEmptyEnumWireValue()
+    {
+        currentEnum.AddOption(
+            new CodeEnumOption { Name = "option1" },
+            new CodeEnumOption { Name = "empty", SerializationName = string.Empty });
+
+        writer.Write(currentEnum);
+        var result = tw.ToString();
+
+        Assert.Contains("return []string{\"option1\", \"\"}[i]", result);
+        Assert.Contains("case \"\":", result);
+        Assert.Contains("result = EMPTY_SOMEENUM", result);
+    }
 }


### PR DESCRIPTION
## Summary

Retains empty string values when building enum CodeDOM options. Distinguishes an explicitly empty serialization name from an unset one, and verifies the Go writer emits and parses the empty wire value.

This allows schemas with values such as `M`, `F`, `X`, and `""` to generate a valid constant and parser case for the empty value.

## Validation

`dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --nologo --filter 'FullyQualifiedName~CodeDOM.CodeEnumTests|FullyQualifiedName~Writers.Go.CodeEnumWriterTests|Name=ParsesEnumDescriptionsAsync'` (14 passed)

Fixes #4329