### PR TITLE
ci: switches to merge queue for the dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,16 +2,14 @@ name: Auto-merge dependabot updates
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-
   dependabot-merge:
-
     runs-on: ubuntu-latest
 
     if: ${{ github.actor == 'dependabot[bot]' }}
@@ -26,7 +24,7 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         # Only if version bump is not a major version change
         if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --auto --squash -d "$PR_URL"
+        run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
after enabling merge queues for the repository, we forgot to update this automation, which now fails