### PR TITLE
fix(builder): make model declaration check-and-create atomic

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2123,11 +2123,15 @@ public partial class KiotaBuilder
         return currentNamespace;
     }
     private ConcurrentDictionary<string, ModelClassBuildLifecycle> classLifecycles = new(StringComparer.OrdinalIgnoreCase);
+    // Test-only hook for coordinating callers between the initial lookup and class publication.
+    internal Action? BeforeModelDeclarationCreation { get; set; }
+    internal Action? BeforeModelClassPublication { get; set; }
     private static readonly ThreadLocal<HashSet<string>> schemasBeingProcessedForDiscriminators = new(() => new(StringComparer.OrdinalIgnoreCase));
     private CodeElement AddModelDeclarationIfDoesntExist(OpenApiUrlTreeNode currentNode, OpenApiOperation? currentOperation, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, CodeClass? inheritsFrom = null)
     {
         if (GetExistingDeclaration(currentNamespace, currentNode, declarationName) is not CodeElement existingDeclaration) // we can find it in the components
         {
+            BeforeModelDeclarationCreation?.Invoke();
             if (AddEnumDeclaration(currentNode, schema, declarationName, currentNamespace) is CodeEnum enumDeclaration)
                 return enumDeclaration;
 
@@ -2266,8 +2270,16 @@ public partial class KiotaBuilder
         var includeAdditionalDataProperties = config.IncludeAdditionalData && (schema.AdditionalPropertiesAllowed || schema.AdditionalProperties is not null);
         AddSerializationMembers(newClassStub, includeAdditionalDataProperties, config.UsesBackingStore, static s => s);
 
-        var newClass = currentNamespace.AddClass(newClassStub).First();
         var lifecycle = classLifecycles.GetOrAdd(currentNamespace.Name + "." + declarationName, static n => new());
+        CodeClass newClass;
+        lock (lifecycle)
+        {
+            // Another thread may have added this class while we were creating the stub.
+            if (GetExistingDeclaration(currentNamespace, currentNode, declarationName) is CodeClass existingClass)
+                return existingClass;
+            BeforeModelClassPublication?.Invoke();
+            newClass = currentNamespace.AddClass(newClassStub).First();
+        }
         if (!lifecycle.IsPropertiesBuilt() && !lifecycle.IsPropertiesBuildingInProgress())
         {
             try

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -63,6 +63,83 @@ paths:
         Assert.Equal(OpenApiSpecVersion.OpenApi3_0, diagnostics.SpecificationVersion);
     }
     [Fact]
+    public async Task GeneratesSharedModelWhenConcurrentCallersPassInitialLookup()
+    {
+        var specPath = Path.GetTempFileName();
+        _tempFiles.Add(specPath);
+        var outputPath = Path.Combine(Path.GetTempPath(), $"kiota-shared-model-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(specPath, """
+            openapi: 3.0.3
+            info:
+              title: Shared model API
+              version: 1.0.0
+            servers:
+              - url: https://example.com
+            paths:
+              /first:
+                get:
+                  operationId: getFirst
+                  responses:
+                    '200':
+                      description: User
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/User'
+              /second:
+                get:
+                  operationId: getSecond
+                  responses:
+                    '200':
+                      description: User
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/User'
+            components:
+              schemas:
+                User:
+                  type: object
+                  properties:
+                    displayName:
+                      type: string
+            """, TestContext.Current.CancellationToken);
+
+        using var barrier = new Barrier(2);
+        var arrivals = 0;
+        var publicationAttempts = 0;
+        var builder = new KiotaBuilder(NullLogger<KiotaBuilder>.Instance, new GenerationConfiguration
+        {
+            ClientClassName = "ApiClient",
+            Language = GenerationLanguage.CSharp,
+            OpenAPIFilePath = specPath,
+            OutputPath = outputPath,
+            NoWorkspace = true,
+            MaxDegreeOfParallelism = 2,
+        }, _httpClient);
+        builder.BeforeModelDeclarationCreation = () =>
+        {
+            if (Interlocked.Increment(ref arrivals) <= 2)
+                Assert.True(barrier.SignalAndWait(TimeSpan.FromSeconds(10)));
+        };
+        builder.BeforeModelClassPublication = () => Interlocked.Increment(ref publicationAttempts);
+        try
+        {
+            await builder.GenerateClientAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(2, arrivals);
+            Assert.Equal(1, publicationAttempts);
+            Assert.Single(Directory.EnumerateFiles(outputPath, "User.cs", SearchOption.AllDirectories));
+        }
+        finally
+        {
+            builder.BeforeModelDeclarationCreation = null;
+            builder.BeforeModelClassPublication = null;
+            if (Directory.Exists(outputPath))
+                Directory.Delete(outputPath, true);
+        }
+    }
+    [Fact]
     public async Task SupportsExternalReferences()
     {
         var tempFilePathReferee = Path.GetTempFileName();


### PR DESCRIPTION
## Problem

Intermittent idempotency test failures with the Twitter API spec: two consecutive generations from the same spec sometimes produced different output. CI logs showed model files missing in one run (`Models/Analytics_metrics.cs`) and content differences in others (`Models/Analytics.cs`, `Models/User.cs`, etc.).

## Root cause

`AddModelClass` checked for an existing class implicitly via `AddModelDeclarationIfDoesntExist`'s `GetExistingDeclaration` call, then created and added a class stub via `currentNamespace.AddClass()` — in separate, non-atomic steps. When two parallel threads processing different URL tree nodes both referenced the same component schema, both could pass the check and both create class stubs. The existing `classLifecycles` mechanism prevented duplicate property building but not duplicate class creation.

## Fix

Added a narrow `lock (lifecycle)` inside `AddModelClass`, covering ONLY the `GetExistingDeclaration` re-check and `AddClass` call — not property building. This makes check-and-add atomic per class name.

**Why not lock the entire method?** Property building (`CreatePropertiesForModelClass`) recursively creates dependent models via `AddModelDeclarationIfDoesntExist`. If the lock were held during property building, mutually-referencing models (A → B → A) processed by different threads would deadlock: Thread 1 holds A's lock waiting for B's, Thread 2 holds B's waiting for A's.

The narrow lock avoids this because:
- Lock is held only for microseconds (check + add stub), no recursion inside
- Property building happens outside the lock, coordinated by the existing `classLifecycles` mechanism
- Different classes use different lock objects — no unnecessary contention

## Verification

- **No deadlock:** 10/10 runs on a mutually-referencing fixture (`ModelA.b → ModelB`, `ModelB.a → ModelA`)
- **Reduced race:** 29/30 idempotency iterations pass with the Twitter API spec (was ~20% failure rate before fix)
- **Unit tests:** 2190 passed (2 pre-existing skips)
- **Pre-existing:** race reproduces on `main` (2/10 failures without fix)