### PR TITLE
Suppress format warnings for response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed unsupported type-format warnings for response header schemas, which are always emitted as strings. [#4227](https://github.com/microsoft/kiota/issues/4227)
+- Fixed unsupported type-format warnings for response and component header schemas, which are always emitted as strings. [#4227](https://github.com/microsoft/kiota/issues/4227)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed unsupported type-format warnings for response header schemas, which are always emitted as strings. [#4227](https://github.com/microsoft/kiota/issues/4227)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed unsupported type-format warnings for response header schemas, which are always emitted as strings. [#4227](https://github.com/microsoft/kiota/issues/4227)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/src/Kiota.Builder/Validation/InconsistentTypeFormatPair.cs
+++ b/src/Kiota.Builder/Validation/InconsistentTypeFormatPair.cs
@@ -48,7 +48,8 @@ public class InconsistentTypeFormatPair : ValidationRule<IOpenApiSchema>
     ];
     public InconsistentTypeFormatPair() : base(nameof(InconsistentTypeFormatPair), static (context, schema) =>
     {
-        if (schema is null || !schema.Type.HasValue || string.IsNullOrEmpty(schema.Format) || KnownAndNotSupportedFormats.knownAndUnsupportedFormats.Contains(schema.Format) || escapedTypes.Contains(schema.Type.Value))
+        if (KnownAndNotSupportedFormats.IsHeaderSchema(context.PathString) ||
+            schema is null || !schema.Type.HasValue || string.IsNullOrEmpty(schema.Format) || KnownAndNotSupportedFormats.knownAndUnsupportedFormats.Contains(schema.Format) || escapedTypes.Contains(schema.Type.Value))
             return;
         var sanitizedType = schema.Type.Value & ~JsonSchemaType.Null;
         if (!validPairs.TryGetValue(sanitizedType, out var validFormats) || !validFormats.Contains(schema.Format))

--- a/src/Kiota.Builder/Validation/InconsistentTypeFormatPair.cs
+++ b/src/Kiota.Builder/Validation/InconsistentTypeFormatPair.cs
@@ -48,8 +48,8 @@ public class InconsistentTypeFormatPair : ValidationRule<IOpenApiSchema>
     ];
     public InconsistentTypeFormatPair() : base(nameof(InconsistentTypeFormatPair), static (context, schema) =>
     {
-        if (KnownAndNotSupportedFormats.IsHeaderSchema(context.PathString) ||
-            schema is null || !schema.Type.HasValue || string.IsNullOrEmpty(schema.Format) || KnownAndNotSupportedFormats.knownAndUnsupportedFormats.Contains(schema.Format) || escapedTypes.Contains(schema.Type.Value))
+        if (schema is null || !schema.Type.HasValue || string.IsNullOrEmpty(schema.Format) || KnownAndNotSupportedFormats.knownAndUnsupportedFormats.Contains(schema.Format) || escapedTypes.Contains(schema.Type.Value) ||
+            KnownAndNotSupportedFormats.IsHeaderSchema(context.PathString))
             return;
         var sanitizedType = schema.Type.Value & ~JsonSchemaType.Null;
         if (!validPairs.TryGetValue(sanitizedType, out var validFormats) || !validFormats.Contains(schema.Format))

--- a/src/Kiota.Builder/Validation/KnownAndNotSupportedFormats.cs
+++ b/src/Kiota.Builder/Validation/KnownAndNotSupportedFormats.cs
@@ -25,8 +25,9 @@ public class KnownAndNotSupportedFormats : ValidationRule<IOpenApiSchema>
     };
     public KnownAndNotSupportedFormats() : base(nameof(KnownAndNotSupportedFormats), static (context, schema) =>
     {
-        if (!IsHeaderSchema(context.PathString) &&
-            !string.IsNullOrEmpty(schema.Format) && knownAndUnsupportedFormats.Contains(schema.Format))
+        if (!string.IsNullOrEmpty(schema.Format) &&
+            knownAndUnsupportedFormats.Contains(schema.Format) &&
+            !IsHeaderSchema(context.PathString))
             context.CreateWarning(nameof(KnownAndNotSupportedFormats), $"The format {schema.Format} is not supported by Kiota and the string type will be used.");
     })
     {

--- a/src/Kiota.Builder/Validation/KnownAndNotSupportedFormats.cs
+++ b/src/Kiota.Builder/Validation/KnownAndNotSupportedFormats.cs
@@ -25,9 +25,28 @@ public class KnownAndNotSupportedFormats : ValidationRule<IOpenApiSchema>
     };
     public KnownAndNotSupportedFormats() : base(nameof(KnownAndNotSupportedFormats), static (context, schema) =>
     {
-        if (!string.IsNullOrEmpty(schema.Format) && knownAndUnsupportedFormats.Contains(schema.Format))
+        if (!IsHeaderSchema(context.PathString) &&
+            !string.IsNullOrEmpty(schema.Format) && knownAndUnsupportedFormats.Contains(schema.Format))
             context.CreateWarning(nameof(KnownAndNotSupportedFormats), $"The format {schema.Format} is not supported by Kiota and the string type will be used.");
     })
     {
+    }
+
+    internal static bool IsHeaderSchema(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var pathSegments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < pathSegments.Length - 1; i++)
+        {
+            if (pathSegments[i].Equals("components", StringComparison.OrdinalIgnoreCase) &&
+                pathSegments[i + 1].Equals("headers", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (pathSegments[i].Equals("responses", StringComparison.OrdinalIgnoreCase) &&
+                i + 2 < pathSegments.Length &&
+                pathSegments[i + 2].Equals("headers", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 }

--- a/tests/Kiota.Builder.Tests/Validation/InconsistentTypeFormatPairTests.cs
+++ b/tests/Kiota.Builder.Tests/Validation/InconsistentTypeFormatPairTests.cs
@@ -126,6 +126,26 @@ paths:
         var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
         Assert.Empty(diagnostic.Warnings);
     }
+    [Fact]
+    public async Task DoesntAddAWarningForComponentHeaders()
+    {
+        var documentTxt =
+    """
+openapi: 3.0.1
+info:
+  title: Sample API
+  version: 1.0.0
+paths: {}
+components:
+  headers:
+    Location:
+      schema:
+        type: string
+        format: int32
+""";
+        var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
+        Assert.Empty(diagnostic.Warnings);
+    }
     private static async Task<OpenApiDiagnostic> GetDiagnosticFromDocumentAsync(string document)
     {
         var rule = new InconsistentTypeFormatPair();

--- a/tests/Kiota.Builder.Tests/Validation/InconsistentTypeFormatPairTests.cs
+++ b/tests/Kiota.Builder.Tests/Validation/InconsistentTypeFormatPairTests.cs
@@ -102,6 +102,30 @@ paths:
         var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
         Assert.Empty(diagnostic.Warnings);
     }
+    [Fact]
+    public async Task DoesntAddAWarningForResponseHeaders()
+    {
+        var documentTxt =
+    """
+openapi: 3.0.1
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              schema:
+                type: string
+                format: int32
+""";
+        var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
+        Assert.Empty(diagnostic.Warnings);
+    }
     private static async Task<OpenApiDiagnostic> GetDiagnosticFromDocumentAsync(string document)
     {
         var rule = new InconsistentTypeFormatPair();

--- a/tests/Kiota.Builder.Tests/Validation/KnownAndNotSupportedFormatsTests.cs
+++ b/tests/Kiota.Builder.Tests/Validation/KnownAndNotSupportedFormatsTests.cs
@@ -75,6 +75,77 @@ paths:
         var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
         Assert.Empty(diagnostic.Warnings);
     }
+    [Fact]
+    public async Task DoesntAddAWarningForResponseHeaders()
+    {
+        var documentTxt =
+    """
+openapi: 3.0.1
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+""";
+        var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
+        Assert.Empty(diagnostic.Warnings);
+    }
+    [Fact]
+    public async Task DoesntAddAWarningForComponentHeaders()
+    {
+        var documentTxt =
+    """
+openapi: 3.0.1
+info:
+  title: Sample API
+  version: 1.0.0
+paths: {}
+components:
+  headers:
+    Location:
+      schema:
+        type: string
+        format: uri
+""";
+        var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
+        Assert.Empty(diagnostic.Warnings);
+    }
+    [Fact]
+    public async Task AddsAWarningForSchemaPropertyNamedHeaders()
+    {
+        var documentTxt =
+    """
+openapi: 3.0.1
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  headers:
+                    type: string
+                    format: uri
+""";
+        var diagnostic = await GetDiagnosticFromDocumentAsync(documentTxt);
+        Assert.Single(diagnostic.Warnings);
+    }
     private static async Task<OpenApiDiagnostic> GetDiagnosticFromDocumentAsync(string document)
     {
         var rule = new KnownAndNotSupportedFormats();


### PR DESCRIPTION
## Summary

Fixes #4227.

Skips unsupported-format validation for response and component header schemas. Kiota exposes response header values as strings, so validating their OpenAPI formats as generated model types produced warnings that users could not act on.

## Changes

- Ignore direct response/component header schemas in both format validation rules.
- Match structural path segments so a model property named `headers` is still validated.
- Defer structural path checks until the cheaper format checks pass.
- Add regression tests for response headers, component headers, and similarly named model properties.
- Add a changelog entry.

## Testing

- Focused validation tests (12 passed)
- `dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --filter FullyQualifiedName!~KiotaSearcherTests` (2,191 passed, 2 skipped)
- `dotnet format kiota.slnx --include src/Kiota.Builder/Validation/KnownAndNotSupportedFormats.cs src/Kiota.Builder/Validation/InconsistentTypeFormatPair.cs tests/Kiota.Builder.Tests/Validation/InconsistentTypeFormatPairTests.cs --no-restore --verify-no-changes`