### PR TITLE
Populate Python API error messages during deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Python client: Populate `APIError.message` while deserializing a property marked with `x-ms-primary-error-message`. [#7542](https://github.com/microsoft/kiota/issues/7542)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Python client: Populate `APIError.message` while deserializing a property marked with `x-ms-primary-error-message`. [#7542](https://github.com/microsoft/kiota/issues/7542)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -568,13 +568,28 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
     private void WriteDeserializerBodyForInheritedModel(bool inherits, CodeMethod codeElement, CodeClass parentClass, LanguageWriter writer)
     {
         _codeUsingWriter.WriteInternalImports(parentClass, writer);
-        writer.StartBlock($"fields: dict[str, Callable[[Any], {NoneKeyword}]] = {{");
-        foreach (var otherProp in parentClass
-                                        .GetPropertiesOfKind(CodePropertyKind.Custom)
-                                        .Where(static x => !x.ExistsInBaseType)
-                                        .OrderBy(static x => x.Name))
+        var customProperties = parentClass
+                                .GetPropertiesOfKind(CodePropertyKind.Custom)
+                                .Where(static x => !x.ExistsInBaseType)
+                                .OrderBy(static x => x.Name)
+                                .ToArray();
+        if (parentClass.IsErrorDefinition)
         {
-            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": lambda n : setattr(self, '{otherProp.Name}', n.{GetDeserializationMethodName(otherProp.Type, codeElement, parentClass)}),");
+            foreach (var primaryErrorMessageProperty in customProperties.Where(static x => x.IsPrimaryErrorMessage))
+            {
+                writer.StartBlock($"def deserialize_{primaryErrorMessageProperty.Name}(n: ParseNode) -> None:");
+                writer.WriteLine($"self.{primaryErrorMessageProperty.Name} = n.{GetDeserializationMethodName(primaryErrorMessageProperty.Type, codeElement, parentClass)}");
+                writer.WriteLine($"self.message = '' if self.{primaryErrorMessageProperty.Name} is None else str(self.{primaryErrorMessageProperty.Name})");
+                writer.CloseBlock(string.Empty);
+            }
+        }
+        writer.StartBlock($"fields: dict[str, Callable[[Any], {NoneKeyword}]] = {{");
+        foreach (var otherProp in customProperties)
+        {
+            var deserializer = parentClass.IsErrorDefinition && otherProp.IsPrimaryErrorMessage ?
+                $"deserialize_{otherProp.Name}" :
+                $"lambda n : setattr(self, '{otherProp.Name.SanitizeSingleQuote()}', n.{GetDeserializationMethodName(otherProp.Type, codeElement, parentClass)})";
+            writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": {deserializer},");
         }
         writer.CloseBlock();
         if (inherits)

--- a/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs
@@ -577,9 +577,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         {
             foreach (var primaryErrorMessageProperty in customProperties.Where(static x => x.IsPrimaryErrorMessage))
             {
-                writer.StartBlock($"def deserialize_{primaryErrorMessageProperty.Name}(n: ParseNode) -> None:");
-                writer.WriteLine($"self.{primaryErrorMessageProperty.Name} = n.{GetDeserializationMethodName(primaryErrorMessageProperty.Type, codeElement, parentClass)}");
-                writer.WriteLine($"self.message = '' if self.{primaryErrorMessageProperty.Name} is None else str(self.{primaryErrorMessageProperty.Name})");
+                var deserializerName = $"deserialize_{primaryErrorMessageProperty.Name.CleanupSymbolName()}";
+                writer.StartBlock($"def {deserializerName}(n: ParseNode) -> None:");
+                writer.WriteLine($"value = n.{GetDeserializationMethodName(primaryErrorMessageProperty.Type, codeElement, parentClass)}");
+                writer.WriteLine($"setattr(self, '{primaryErrorMessageProperty.Name.SanitizeSingleQuote()}', value)");
+                writer.WriteLine("self.message = '' if value is None else str(value)");
                 writer.CloseBlock(string.Empty);
             }
         }
@@ -587,7 +589,7 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PythonConventionSe
         foreach (var otherProp in customProperties)
         {
             var deserializer = parentClass.IsErrorDefinition && otherProp.IsPrimaryErrorMessage ?
-                $"deserialize_{otherProp.Name}" :
+                $"deserialize_{otherProp.Name.CleanupSymbolName()}" :
                 $"lambda n : setattr(self, '{otherProp.Name.SanitizeSingleQuote()}', n.{GetDeserializationMethodName(otherProp.Type, codeElement, parentClass)})";
             writer.WriteLine($"\"{otherProp.WireName.SanitizeDoubleQuote()}\": {deserializer},");
         }

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -929,9 +929,38 @@ public sealed class CodeMethodWriterTests : IDisposable
         var result = tw.ToString();
 
         Assert.Contains("def deserialize_detail(n: ParseNode) -> None:", result);
-        Assert.Contains("self.detail = n.get_str_value()", result);
-        Assert.Contains("self.message = '' if self.detail is None else str(self.detail)", result);
+        Assert.Contains("value = n.get_str_value()", result);
+        Assert.Contains("setattr(self, 'detail', value)", result);
+        Assert.Contains("self.message = '' if value is None else str(value)", result);
         Assert.Contains("\"detail\": deserialize_detail,", result);
+    }
+    [Fact]
+    public void EscapesPrimaryErrorMessagePropertyName()
+    {
+        setup();
+        parentClass.IsErrorDefinition = true;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "line1'\nline2",
+            SerializationName = "detail",
+            Kind = CodePropertyKind.Custom,
+            IsPrimaryErrorMessage = true,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        method.Kind = CodeMethodKind.Deserializer;
+        method.IsAsync = false;
+
+        writer.Write(method);
+        var result = tw.ToString();
+
+        Assert.Contains("def deserialize_line1Line2(n: ParseNode) -> None:", result);
+        Assert.Contains("value = n.get_str_value()", result);
+        Assert.Contains("setattr(self, 'line1\\'\\nline2', value)", result);
+        Assert.Contains("self.message = '' if value is None else str(value)", result);
+        Assert.Contains("\"detail\": deserialize_line1Line2,", result);
     }
     [Fact]
     public void WritesInheritedSerializerBody()

--- a/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs
@@ -908,6 +908,32 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("defined_in_parent", result, StringComparison.OrdinalIgnoreCase);
     }
     [Fact]
+    public void WritesPrimaryErrorMessageDeserializer()
+    {
+        setup();
+        parentClass.IsErrorDefinition = true;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "detail",
+            Kind = CodePropertyKind.Custom,
+            IsPrimaryErrorMessage = true,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        method.Kind = CodeMethodKind.Deserializer;
+        method.IsAsync = false;
+
+        writer.Write(method);
+        var result = tw.ToString();
+
+        Assert.Contains("def deserialize_detail(n: ParseNode) -> None:", result);
+        Assert.Contains("self.detail = n.get_str_value()", result);
+        Assert.Contains("self.message = '' if self.detail is None else str(self.detail)", result);
+        Assert.Contains("\"detail\": deserialize_detail,", result);
+    }
+    [Fact]
     public void WritesInheritedSerializerBody()
     {
         setup(true);
@@ -1029,6 +1055,28 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var deserializerResult = tw.ToString();
         Assert.Contains("\"line1\\\"\\nline2\": lambda n : setattr(self, 'dummy_string', n.get_str_value())", deserializerResult);
+    }
+    [Fact]
+    public void EscapesPropertyNamesInDeserializerBody()
+    {
+        setup();
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "line1'\nline2",
+            SerializationName = "value",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+        method.Kind = CodeMethodKind.Deserializer;
+        method.IsAsync = false;
+
+        writer.Write(method);
+        var result = tw.ToString();
+
+        Assert.Contains("setattr(self, 'line1\\'\\nline2', n.get_str_value())", result);
     }
     [Fact]
     public void WritesMethodAsyncDescription()


### PR DESCRIPTION
## Summary

Fixes #7542.

Python API errors now populate the inherited `APIError.message` field while deserializing a property marked with `x-ms-primary-error-message`.

## Changes

- Emit a named deserializer for each primary error-message property.
- Assign the parsed value to both the model property and `APIError.message`.
- Keep `message` string-typed with an explicit `None` check and `str(...)` conversion.
- Sanitize generated function identifiers and use escaped `setattr` calls for schema-derived property names.
- Add regression coverage for regular and irregular property names.
- Add a changelog entry.

## Testing

- Focused Python writer tests (3 passed)
- `dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --filter FullyQualifiedName!~KiotaSearcherTests` (2,189 passed, 2 skipped)
- `dotnet format kiota.slnx --include src/Kiota.Builder/Writers/Python/CodeMethodWriter.cs tests/Kiota.Builder.Tests/Writers/Python/CodeMethodWriterTests.cs --no-restore --verify-no-changes`