### PR TITLE
Handle inline arrays on trailing-slash paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed client generation for trailing-slash paths that return arrays of inline objects. [#7876](https://github.com/microsoft/kiota/issues/7876)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed client generation for trailing-slash paths that return arrays of inline objects. [#7876](https://github.com/microsoft/kiota/issues/7876)
 - C#, Java, Go, PHP, Dart, TypeScript, Python and Ruby client: default value initialization in model classes for DateTime/Date/Time/UUID properties did not compile [#7404](https://github.com/microsoft/kiota/issues/7404)
 - All languages: default value initialization in model classes for numeric/boolean properties was missing [#7404](https://github.com/microsoft/kiota/issues/7404)
 - Fixed a bug where required query parameters from one HTTP operation were leaking into the path-item-level URL template, making them appear required for sibling operations on the same path. [#7292](https://github.com/microsoft/kiota/issues/7292)

--- a/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
+++ b/src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs
@@ -93,10 +93,10 @@ public static partial class OpenApiUrlTreeNodeExtensions
     ///<summary>
     /// Returns the class name for the node with more or less precision depending on the provided arguments
     ///</summary>
-    internal static string GetClassName(this OpenApiUrlTreeNode currentNode, StructuredMimeTypesCollection structuredMimeTypes, string? suffix = default, string? prefix = default, OpenApiOperation? operation = default, IOpenApiResponse? response = default, IOpenApiSchema? schema = default, bool requestBody = false)
+    internal static string GetClassName(this OpenApiUrlTreeNode currentNode, StructuredMimeTypesCollection structuredMimeTypes, string? suffix = default, string? prefix = default, OpenApiOperation? operation = default, IOpenApiResponse? response = default, IOpenApiSchema? schema = default, bool requestBody = false, string? placeholder = null)
     {
         ArgumentNullException.ThrowIfNull(currentNode);
-        return currentNode.GetSegmentName(structuredMimeTypes, suffix, prefix, operation, response, schema, requestBody, static x => x.LastOrDefault() ?? string.Empty);
+        return currentNode.GetSegmentName(structuredMimeTypes, suffix, prefix, operation, response, schema, requestBody, static x => x.LastOrDefault() ?? string.Empty, placeholder: placeholder);
     }
     internal static string GetNavigationPropertyName(this OpenApiUrlTreeNode currentNode, StructuredMimeTypesCollection structuredMimeTypes, string? suffix = default, string? prefix = default, OpenApiOperation? operation = default, OpenApiResponse? response = default, OpenApiSchema? schema = default, bool requestBody = false, string? placeholder = null)
     {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1766,7 +1766,7 @@ public partial class KiotaBuilder
         _dynamicScope.Value!.Push(schema);
         try
         {
-            var className = string.IsNullOrEmpty(typeNameForInlineSchema) ? currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, response: response, schema: schema, requestBody: isRequestBody).CleanupSymbolName() : typeNameForInlineSchema;
+            var className = string.IsNullOrEmpty(typeNameForInlineSchema) ? currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, response: response, schema: schema, requestBody: isRequestBody, placeholder: TrailingSlashPlaceholder).CleanupSymbolName() : typeNameForInlineSchema;
             var codeDeclaration = AddModelDeclarationIfDoesntExist(currentNode, operation, schema, className, codeNamespace);
             return new CodeType { TypeDefinition = codeDeclaration };
         }
@@ -1807,7 +1807,7 @@ public partial class KiotaBuilder
                 cName :
                 (!string.IsNullOrEmpty(typeNameForInlineSchema) ?
                     typeNameForInlineSchema :
-                    currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, schema: schema, requestBody: isRequestBody)))
+                    currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: classNameSuffix, schema: schema, requestBody: isRequestBody, placeholder: TrailingSlashPlaceholder)))
             .CleanupSymbolName();
         var codeDeclaration = (rootSchemaHasProperties, inlineSchemas, referencedSchemas, isViaDiscriminator) switch
         {
@@ -1867,7 +1867,7 @@ public partial class KiotaBuilder
     }
     private CodeTypeBase CreateComposedModelDeclaration(OpenApiUrlTreeNode currentNode, IOpenApiSchema schema, OpenApiOperation? operation, string suffixForInlineSchema, CodeNamespace codeNamespace, bool isRequestBody, string typeNameForInlineSchema)
     {
-        var typeName = string.IsNullOrEmpty(typeNameForInlineSchema) ? currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: suffixForInlineSchema, schema: schema, requestBody: isRequestBody).CleanupSymbolName() : typeNameForInlineSchema;
+        var typeName = string.IsNullOrEmpty(typeNameForInlineSchema) ? currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: suffixForInlineSchema, schema: schema, requestBody: isRequestBody, placeholder: TrailingSlashPlaceholder).CleanupSymbolName() : typeNameForInlineSchema;
         var typesCount = schema.AnyOf?.Count ?? schema.OneOf?.Count ?? 0;
         if ((typesCount == 1 && (schema.Type & JsonSchemaType.Null) is JsonSchemaType.Null && schema.IsInclusiveUnion() || // nullable on the root schema outside of anyOf
             typesCount == 2 && (schema.AnyOf?.Any(static x => // nullable on a schema in the anyOf

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -5057,6 +5057,55 @@ components:
         Assert.Equal("\"{+baseurl}/api/contracts/{?type*}\"", emptyProperty.DefaultValue);
     }
     [Fact]
+    public void GeneratesInlineObjectArrayResponseForTrailingSlashPath()
+    {
+        var documentJSON =
+    """
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Sample API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/test/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""";
+        var (document, _) = OpenApiDocument.Parse(documentJSON, OpenApiConstants.Json);
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", ApiRootUrl = "https://localhost" }, _httpClient);
+        var node = builder.CreateUriSpace(document);
+
+        var codeModel = builder.CreateSourceModel(node);
+
+        var requestBuilder = codeModel.FindChildByName<CodeClass>("EmptyPathSegmentRequestBuilder");
+        Assert.NotNull(requestBuilder);
+        var executor = requestBuilder.Methods.Single(static x => x.Kind is CodeMethodKind.RequestExecutor);
+        var returnType = Assert.IsType<CodeType>(executor.ReturnType);
+        Assert.Equal(CodeTypeBase.CodeTypeCollectionKind.Complex, returnType.CollectionKind);
+        var responseModel = Assert.IsType<CodeClass>(returnType.TypeDefinition);
+        Assert.Equal(KiotaBuilder.TrailingSlashPlaceholder, responseModel.Name);
+    }
+    [Fact]
     public void MapsArrayOfTypesAsUnionType()
     {
         var document = new OpenApiDocument


### PR DESCRIPTION
## Summary

Fixes #7876.

Uses the existing `EmptyPathSegment` placeholder when naming inline response models on trailing-slash paths. Without a fallback name, arrays of inline objects reached `FindChildByName` with an empty declaration name and aborted generation.

## Changes

- Allow `GetClassName` callers to provide a fallback for empty path segments.
- Apply the trailing-slash placeholder to regular, inherited, and composed inline model declarations.
- Add a regression test for an inline object array returned from `/test/`.
- Add a changelog entry.

## Testing

- Generated the issue's Go client from the provided OpenAPI shape.
- `go test ./...` on the generated client with Go 1.26.5.
- `dotnet format whitespace kiota.slnx --no-restore --verify-no-changes --include src/Kiota.Builder/Extensions/OpenApiUrlTreeNodeExtensions.cs src/Kiota.Builder/KiotaBuilder.cs tests/Kiota.Builder.Tests/KiotaBuilderTests.cs`
- `dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore` (2,191 passed, 2 skipped)
