### PR TITLE
Fix PHP numeric deserializer keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- PHP: generated deserializers with numeric property names now satisfy static return-type analysis. [#7830](https://github.com/microsoft/kiota/issues/7830)
 - golang: generated code now always uses LF line endings, so `gofmt` no longer reports formatting differences when generating on Windows.
 - golang: make sure all generated code adheres to golangs coding standards
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)

--- a/it/config.json
+++ b/it/config.json
@@ -162,18 +162,7 @@
         "Rationale": "Compilation fails only on linux systems (CI) with api from 2026-06-22 - https://github.com/microsoft/kiota/issues/7828"
       }
     ],
-    "ExcludePatterns": [
-      {
-        "Language": "php",
-        "Pattern": "/organizations/{organizationId}/apiRequests/overview",
-        "Rationale": "Fails for php with api dated 2026-06-24 - https://github.com/microsoft/kiota/issues/7830"
-      },
-      {
-        "Language": "php",
-        "Pattern": "/networks/{networkId}/clients/{clientId}/splashAuthorizationStatus",
-        "Rationale": "Fails for php with api dated 2026-06-24 (GET and PUT) - https://github.com/microsoft/kiota/issues/7830"
-      }
-    ]
+    "ExcludePatterns": []
   },
   "https://raw.githubusercontent.com/docusign/OpenAPI-Specifications/refs/heads/master/esignature.rest.swagger-v2.1.json": {
     "Suppressions": [

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
@@ -680,22 +681,30 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
     }
     private void WriteDeserializerBodyForInheritedModel(CodeMethod method, CodeClass parentClass, LanguageWriter writer, bool extendsModelClass = false)
     {
-        var codeProperties = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom).ToArray();
+        var codeProperties = parentClass.GetPropertiesOfKind(CodePropertyKind.Custom)
+            .Where(static x => !x.ExistsInBaseType && x.Setter != null)
+            .OrderBy(static x => x.Name)
+            .ToArray();
+        var hasNumericPropertyName = codeProperties.Any(static x => IsNumericArrayKey(x.WireName));
         writer.WriteLine("$o = $this;");
+        if (hasNumericPropertyName)
+            writer.WriteLine("/** @var array<string, callable(ParseNode): void> $deserializers */");
         writer.WriteLines(
-            $"return {((extendsModelClass) ? $"array_merge(parent::{method.Name.ToFirstCharacterLowerCase()}(), [" : " [")}");
+            $"{(hasNumericPropertyName ? "$deserializers =" : "return")} {((extendsModelClass) ? $"array_merge(parent::{method.Name.ToFirstCharacterLowerCase()}(), [" : " [")}");
         writer.IncreaseIndent();
         if (codeProperties.Length != 0)
-        {
             codeProperties
-                .Where(static x => !x.ExistsInBaseType && x.Setter != null)
-                .OrderBy(static x => x.Name)
                 .ToList()
                 .ForEach(x => WriteDeserializerPropertyCallback(x, method, writer));
-        }
         writer.DecreaseIndent();
         writer.WriteLine(extendsModelClass ? "]);" : "];");
+        if (hasNumericPropertyName)
+            writer.WriteLine("return $deserializers;");
     }
+
+    private static bool IsNumericArrayKey(string key) =>
+        long.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) &&
+        value.ToString(CultureInfo.InvariantCulture).Equals(key, StringComparison.Ordinal);
 
     private void WriteDeserializerPropertyCallback(CodeProperty property, CodeMethod method, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs
@@ -689,8 +689,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, PhpConventionServi
         writer.WriteLine("$o = $this;");
         if (hasNumericPropertyName)
             writer.WriteLine("/** @var array<string, callable(ParseNode): void> $deserializers */");
+        var deserializers = extendsModelClass ?
+            $"{(hasNumericPropertyName ? "array_replace" : "array_merge")}(parent::{method.Name.ToFirstCharacterLowerCase()}(), [" :
+            " [";
         writer.WriteLines(
-            $"{(hasNumericPropertyName ? "$deserializers =" : "return")} {((extendsModelClass) ? $"array_merge(parent::{method.Name.ToFirstCharacterLowerCase()}(), [" : " [")}");
+            $"{(hasNumericPropertyName ? "$deserializers =" : "return")} {deserializers}");
         writer.IncreaseIndent();
         if (codeProperties.Length != 0)
             codeProperties

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -963,6 +963,14 @@ public sealed class CodeMethodWriterTests : IDisposable
         },
         new object[]
         {
+            new CodeProperty { Name = "fiveHundred", Type = new CodeType { Name = "int32" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom, SerializationName = "500" },
+            "/** @var array<string, callable(ParseNode): void> $deserializers */",
+            "$deserializers =",
+            "'500' => fn(ParseNode $n) => $o->setFiveHundred($n->getIntegerValue()),",
+            "return $deserializers;"
+        },
+        new object[]
+        {
             new CodeProperty { Name = "story", Type = new CodeType { Name = "binary" }, Access = AccessModifier.Private, Kind = CodePropertyKind.Custom },
             "'story' => fn(ParseNode $n) => $o->setStory($n->getBinaryContent()),"
         },

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -1227,6 +1227,41 @@ public sealed class CodeMethodWriterTests : IDisposable
     }
 
     [Fact]
+    public async Task WriteDeserializerPreservesNumericKeysWhenHasParentAsync()
+    {
+        setup(true);
+        parentClass.Kind = CodeClassKind.Model;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "fiveHundred",
+            SerializationName = "500",
+            Access = AccessModifier.Private,
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType { Name = "int32" }
+        });
+        var deserializerMethod = new CodeMethod
+        {
+            Name = "getFieldDeserializers",
+            Kind = CodeMethodKind.Deserializer,
+            ReturnType = new CodeType
+            {
+                IsNullable = false,
+                CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
+                Name = "array"
+            }
+        };
+        parentClass.AddMethod(deserializerMethod);
+
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.PHP }, root, cancellationToken: TestContext.Current.CancellationToken);
+        languageWriter.Write(deserializerMethod);
+        var result = stringWriter.ToString();
+
+        Assert.Contains("$deserializers = array_replace(parent::getFieldDeserializers(), [", result);
+        Assert.Contains("'500' => fn(ParseNode $n) => $o->setFiveHundred($n->getIntegerValue()),", result);
+        Assert.DoesNotContain("array_merge", result);
+    }
+
+    [Fact]
     public async Task WriteConstructorBodyAsync()
     {
         setup();


### PR DESCRIPTION
## Summary

Fixes #7830.

PHP treats canonical numeric string array keys as integers. Generated deserializer maps now retain the required static-analysis annotation without losing numeric keys when a model inherits deserializers from its parent.

## Changes

- Detect canonical numeric serialized property names.
- Emit an annotated local `$deserializers` array for affected models.
- Use `array_replace` instead of `array_merge` for affected inherited models so numeric keys are preserved.
- Keep the existing direct return and `array_merge` output for unaffected models.
- Add regression coverage for standalone and inherited numeric keys.
- Remove the two obsolete #7830 integration-test exclusions.
- Add a changelog entry.

## Testing

- Focused PHP writer tests (12 passed)
- `dotnet test tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj --no-restore --filter FullyQualifiedName!~KiotaSearcherTests` (2,188 passed, 2 skipped)
- `dotnet format kiota.slnx --include src/Kiota.Builder/Writers/Php/CodeMethodWriter.cs tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs --no-restore --verify-no-changes`
- `jq empty it/config.json`