### PR TITLE
fix(java,php): neutralize doc-comment delimiters instead of deleting them

### DIFF
--- a/src/Kiota.Builder/Extensions/StringExtensions.cs
+++ b/src/Kiota.Builder/Extensions/StringExtensions.cs
@@ -365,6 +365,20 @@ public static partial class StringExtensions
         => SecurityElement.Escape(original) ?? string.Empty;
 
     /// <summary>
+    /// Neutralizes block comment delimiters (<c>/*</c> and <c>*/</c>) in schema-derived text so it
+    /// cannot break out of a generated block/doc comment. The delimiters are <b>replaced</b> (not
+    /// deleted): deleting a two-character sequence lets the surrounding characters join back into a
+    /// new delimiter (e.g. <c>**//</c> collapses to <c>*/</c>). Replacing with a spaced variant
+    /// guarantees no residual <c>*/</c> can re-form.
+    /// </summary>
+    /// <param name="original">The original string.</param>
+    /// <returns>The string with block comment delimiters neutralized.</returns>
+    public static string NeutralizeBlockCommentDelimiters(this string? original)
+        => string.IsNullOrEmpty(original) ? string.Empty :
+            original.Replace("/*", "//*", StringComparison.Ordinal)
+                .Replace("*/", "* /", StringComparison.Ordinal);
+
+    /// <summary>
     /// Checks if 2 strings are equal, case insensitive
     /// </summary>
     /// <param name="a">The first or current string</param>

--- a/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
+++ b/src/Kiota.Builder/Writers/Java/JavaConventionService.cs
@@ -154,7 +154,7 @@ public partial class JavaConventionService : CommonLanguageConventionService
     internal static string RemoveInvalidDescriptionCharacters(string originalDescription) =>
         string.IsNullOrEmpty(originalDescription) ?
             originalDescription :
-            nonAsciiReplaceRegex().Replace(originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).Replace("*/", string.Empty, StringComparison.OrdinalIgnoreCase), string.Empty).CleanupXMLString();
+            nonAsciiReplaceRegex().Replace(originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase), string.Empty).NeutralizeBlockCommentDelimiters().CleanupXMLString();
 #pragma warning disable CA1822 // Method should be static
     internal void AddRequestBuilderBody(CodeClass parentClass, string returnType, LanguageWriter writer, string? urlTemplateVarName = default, IEnumerable<CodeParameter>? pathParameters = default)
     {

--- a/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
+++ b/src/Kiota.Builder/Writers/Php/PhpConventionService.cs
@@ -140,7 +140,7 @@ public class PhpConventionService : CommonLanguageConventionService
         return codeParameter.Optional ? $"{doc}|null" : doc;
     }
 
-    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).Replace("*/", string.Empty, StringComparison.OrdinalIgnoreCase);
+    internal static string RemoveInvalidDescriptionCharacters(string originalDescription) => originalDescription.Replace("\\", "/", StringComparison.OrdinalIgnoreCase).NeutralizeBlockCommentDelimiters();
     public override bool WriteShortDescription(IDocumentedElement element, LanguageWriter writer, string prefix = "", string suffix = "")
     {
         ArgumentNullException.ThrowIfNull(writer);

--- a/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/CodeMethodWriterTests.cs
@@ -1658,7 +1658,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(method);
         var result = tw.ToString();
         Assert.DoesNotContain("see */ more", result);
-        Assert.Contains("see  more", result);
+        Assert.Contains("see * / more", result);
         Assert.Contains("@see <a href=", result);
     }
     [Fact]

--- a/tests/Kiota.Builder.Tests/Writers/Java/JavaWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Java/JavaWriterTests.cs
@@ -17,4 +17,18 @@ public class JavaWriterTests
         Assert.Throws<ArgumentNullException>(() => new JavaWriter(null, "graph"));
         Assert.Throws<ArgumentNullException>(() => new JavaWriter("./", null));
     }
+    [Theory]
+    [InlineData("**//", "** //")] // deletion would re-form "*/"; replacement must not
+    [InlineData("**\\/", "** //")] // backslash normalization must not re-form "*/"
+    [InlineData("*\u00e9/", "* /")] // non-ASCII strip must run before delimiter neutralization
+    [InlineData("*/", "* /")]
+    [InlineData("/*", "//*")]
+    [InlineData("normal description", "normal description")]
+    [InlineData("", "")]
+    public void RemoveInvalidDescriptionCharactersNeutralizesCommentBreakout(string input, string expected)
+    {
+        var result = JavaConventionService.RemoveInvalidDescriptionCharacters(input);
+        Assert.Equal(expected, result);
+        Assert.DoesNotContain("*/", result, StringComparison.Ordinal);
+    }
 }

--- a/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/CodeMethodWriterTests.cs
@@ -289,7 +289,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("public function post(): Promise", result);
         Assert.Contains("$requestInfo = $this->createPostRequestInformation();", result);
         Assert.DoesNotContain("@link https://learn.microsoft.com/ Learning */ docs", result);
-        Assert.Contains("@link https://learn.microsoft.com/ Learning  docs", result);
+        Assert.Contains("@link https://learn.microsoft.com/ Learning * / docs", result);
         Assert.Contains("'401' => [Error401::class, 'createFromDiscriminatorValue']", result);
         Assert.Contains("$result = $this->requestAdapter->sendPrimitiveAsync($requestInfo, StreamInterface::class, $errorMappings);", result);
         Assert.Contains("return $result;", result);

--- a/tests/Kiota.Builder.Tests/Writers/Php/PhpWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Php/PhpWriterTests.cs
@@ -32,6 +32,19 @@ public sealed class PhpWriterTests : IDisposable
         Assert.Throws<ArgumentNullException>(() => new PhpWriter(null, "graph"));
         Assert.Throws<ArgumentNullException>(() => new PhpWriter("./", null));
     }
+    [Theory]
+    [InlineData("**//", "** //")] // deletion would re-form "*/"; replacement must not
+    [InlineData("**\\/", "** //")] // backslash normalization must not re-form "*/"
+    [InlineData("*/", "* /")]
+    [InlineData("/*", "//*")]
+    [InlineData("legit /* nested */ text", "legit //* nested * / text")]
+    [InlineData("normal description", "normal description")]
+    public void RemoveInvalidDescriptionCharactersNeutralizesCommentBreakout(string input, string expected)
+    {
+        var result = PhpConventionService.RemoveInvalidDescriptionCharacters(input);
+        Assert.Equal(expected, result);
+        Assert.DoesNotContain("*/", result, StringComparison.Ordinal);
+    }
     public void Dispose()
     {
         tw?.Dispose();


### PR DESCRIPTION
## Summary

Fixes doc-comment breakout / code-injection in the **Java** and **PHP** generators. Both sanitizers *deleted* the `*/` terminator, which is unsafe: deleting a two-character sequence lets the surrounding characters rejoin into a new delimiter (`**//` → `*/`). A hostile OpenAPI `description`/`summary`/`externalDocs` value could therefore close the generated doc comment and inject executable code into the generated client.

This mirrors the already-fixed C# CVE-2026-59860 class and reuses the non-re-forming, replace-based approach already present in `TypeScriptConventionService` (`/*`→`//*`, `*/`→`* /`).

## Reports addressed
Three internal reports map onto **two** underlying code sinks:
- **PHP + Java delete-based re-formation** (`**//` → `*/`) — reported twice; same root cause, same fix.
- **Java ordering bug** — the `*/` strip ran *before* the non-ASCII strip, so `*é/` re-formed `*/` after the non-ASCII char was removed.

A single Java change fixes both Java reports (reorders the passes **and** switches delete→replace).

## Changes
- New shared `StringExtensions.NeutralizeBlockCommentDelimiters()` — replaces (never deletes) `/*` and `*/`.
- **PHP** `RemoveInvalidDescriptionCharacters`: `\\`→`/`, then neutralize.
- **Java** `RemoveInvalidDescriptionCharacters`: `\\`→`/` → non-ASCII strip → neutralize → `CleanupXMLString()` (neutralization now runs *after* the non-ASCII strip).
- Regression tests for `**//`, `**\/`, `*é/`, `*/`, `/*` asserting exact output and no residual `*/`.
- Updated 2 pre-existing tests that asserted the old delete output.

## Validation
- 359/359 Java + PHP + TypeScript + common convention-service writer tests pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>