### PR TITLE
fix(ruby): fix factory method syntax errors and RuboCop offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Numeric scalar unions with a format (e.g. `type: ["integer", "string"]` with `format: int32`, as emitted by ASP.NET Core's OpenAPI 3.1 generator under System.Text.Json's default `JsonNumberHandling.AllowReadingFromString`) now map to the numeric type instead of degrading to `UntypedNode`. [#6541](https://github.com/microsoft/kiota/issues/6541)
+- Ruby: removed `then` from multiline `unless` and skipped empty `case` blocks in factory methods to fix RuboCop and SyntaxError offenses. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66) [#7856](https://github.com/microsoft/kiota/issues/7856)
 - Ruby: fixed `case/when` indentation and added empty line after `attr_accessor` to resolve RuboCop offenses in generated code. [kiota-abstractions-ruby#59](https://github.com/microsoft/kiota-abstractions-ruby/issues/59)
 - golang: generated code now always uses LF line endings, so `gofmt` no longer reports formatting differences when generating on Windows.
 - golang: make sure all generated code adheres to golangs coding standards

--- a/it/config.json
+++ b/it/config.json
@@ -6,13 +6,7 @@
     "MockServerITFolder": "query-params"
   },
   "./tests/Kiota.Builder.IntegrationTests/DiscriminatorSample.yaml": {
-    "MockServerITFolder": "discriminator",
-    "Suppressions": [
-      {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota-abstractions-ruby/issues/66"
-      }
-    ]
+    "MockServerITFolder": "discriminator"
   },
   "./tests/Kiota.Builder.IntegrationTests/ModelWithDefaultValues.json": {
     "MockServerITFolder": "defaultvalues"
@@ -49,10 +43,6 @@
   "https://developers.notion.com/openapi.json": {
     "Suppressions": [
       {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota-abstractions-ruby/issues/66"
-      },
-      {
         "Language": "typescript",
         "Rationale": "Kiota client generation fails with api from 2026-06-17 - https://github.com/microsoft/kiota/issues/7802"
       },
@@ -73,12 +63,6 @@
     ]
   },
   "https://raw.githubusercontent.com/googlemaps/openapi-specification/refs/tags/v1.22.5/dist/google-maps-platform-openapi3.yml": {
-    "Suppressions": [
-      {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota/issues/7856"
-      }
-    ]
   },
   "https://developers.pipedrive.com/docs/api/v1/openapi.yaml": {
     "Suppressions": [
@@ -170,12 +154,6 @@
     ]
   },
   "https://raw.githubusercontent.com/docusign/OpenAPI-Specifications/refs/heads/master/esignature.rest.swagger-v2.1.json": {
-    "Suppressions": [
-      {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota-abstractions-ruby/issues/59"
-      }
-    ]
   },
   "https://api.twitter.com/2/openapi.json": {
     "Suppressions": [

--- a/it/ruby/.rubocop.yml
+++ b/it/ruby/.rubocop.yml
@@ -122,3 +122,15 @@ Metrics/ModuleLength:
 # Don't raise an error if block is longer than 25 lines. This happens in "spec\defaultvalues\integration_test_defaultvalues.rb"
 Metrics/BlockLength:
   Enabled: false
+
+# Generated property names may contain letter_digit patterns (e.g. heading_1) from the OpenAPI spec
+Naming/VariableNumber:
+  Enabled: false
+
+# Generated factory methods can have many discriminator branches
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+# Generated factory methods may just delegate to super
+Lint/UselessMethodDefinition:
+  Enabled: false

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -90,13 +90,14 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
     {
         var parseNodeParameter = codeElement.Parameters.OfKind(CodeParameterKind.ParseNode) ?? throw new InvalidOperationException("Factory method should have a ParseNode parameter");
         var writeDiscriminatorValueRead = parentClass.DiscriminatorInformation.ShouldWriteParseNodeCheck && !parentClass.DiscriminatorInformation.ShouldWriteDiscriminatorForIntersectionType;
-        if (writeDiscriminatorValueRead)
+        var discriminatorMappings = parentClass.DiscriminatorInformation.DiscriminatorMappings.OrderBy(static x => x.Key).ToArray();
+        if (writeDiscriminatorValueRead && discriminatorMappings.Length > 0)
         {
             writer.WriteLine($"{NodeVarName} = {parseNodeParameter.Name.ToSnakeCase()}.get_child_node(\"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(parentClass.DiscriminatorInformation.DiscriminatorPropertyName)}\")");
-            writer.StartBlock($"unless {NodeVarName}.nil? then");
+            writer.StartBlock($"unless {NodeVarName}.nil?");
             writer.WriteLine($"{DiscriminatorMappingVarName} = {NodeVarName}.get_string_value");
             writer.StartBlock($"case {DiscriminatorMappingVarName}", false);
-            foreach (var mappedType in parentClass.DiscriminatorInformation.DiscriminatorMappings.OrderBy(static x => x.Key))
+            foreach (var mappedType in discriminatorMappings)
             {
                 writer.StartBlock($"when \"{RubyConventionService.SanitizeRubyDoubleQuoteLiteral(mappedType.Key)}\"");
                 writer.WriteLine($"return {mappedType.Value.AllTypes.First().Name.ToFirstCharacterUpperCase()}.new");

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -350,7 +350,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.Contains("mapping_value_node = parse_node.get_child_node(\"@odata.type\")", result);
-        Assert.Contains("unless mapping_value_node.nil? then", result);
+        Assert.Contains("unless mapping_value_node.nil?", result);
         Assert.Contains("mapping_value = mapping_value_node.get_string_value", result);
         Assert.Contains("case mapping_value", result);
         Assert.Contains("when \"ns.childmodel\"", result);
@@ -506,7 +506,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.DoesNotContain("mapping_value_node = parse_node.get_child_node(\"@odata.type\")", result);
-        Assert.DoesNotContain("unless mapping_value_node.nil? then", result);
+        Assert.DoesNotContain("unless mapping_value_node.nil?", result);
         Assert.DoesNotContain("mapping_value = mapping_value_node.get_string_value", result);
         Assert.DoesNotContain("case mapping_value", result);
         Assert.DoesNotContain("when \"ns.childmodel\"", result);
@@ -552,7 +552,7 @@ public sealed class CodeMethodWriterTests : IDisposable
         writer.Write(factoryMethod);
         var result = tw.ToString();
         Assert.DoesNotContain("mapping_value_node = parse_node.get_child_node(\"@odata.type\")", result);
-        Assert.DoesNotContain("unless mapping_value_node.nil? then", result);
+        Assert.DoesNotContain("unless mapping_value_node.nil?", result);
         Assert.DoesNotContain("mapping_value = mapping_value_node.get_string_value", result);
         Assert.DoesNotContain("case mapping_value", result);
         Assert.DoesNotContain("when \"ns.childmodel\"", result);


### PR DESCRIPTION
Fixes three issues in the Ruby code generator that caused integration test failures:

- Remove `then` from multiline `unless` (Style/MultilineIfThen)
- Skip empty `case` blocks when no discriminator mappings exist (SyntaxError)
- Disable Naming/VariableNumber, Metrics/CyclomaticComplexity, and Lint/UselessMethodDefinition in .rubocop.yml for generated code patterns
- Un-suppress discriminator, notion, docusign, and googlemaps integration tests

Fixes [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66), 
fixes [kiota-abstractions-ruby#59](https://github.com/microsoft/kiota-abstractions-ruby/issues/59)
fixes #7856