### PR TITLE
fix(ruby): resolve enum default values by wire name instead of raw value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `Microsoft.OpenApi` and `Microsoft.OpenApi.YamlReader` to 3.10.0.
 - Numeric scalar unions with a format (e.g. `type: ["integer", "string"]` with `format: int32`, as emitted by ASP.NET Core's OpenAPI 3.1 generator under System.Text.Json's default `JsonNumberHandling.AllowReadingFromString`) now map to the numeric type instead of degrading to `UntypedNode`. [#6541](https://github.com/microsoft/kiota/issues/6541)
 - Ruby: removed `then` from multiline `unless` and skipped empty `case` blocks in factory methods to fix RuboCop and SyntaxError offenses. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66) [#7856](https://github.com/microsoft/kiota/issues/7856)
+- Ruby: fixed enum default values with numeric wire names (e.g. `2.0`) to use the enum option name instead of the raw value as a Ruby symbol. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)
 - Ruby: fixed `case/when` indentation and added empty line after `attr_accessor` to resolve RuboCop offenses in generated code. [kiota-abstractions-ruby#59](https://github.com/microsoft/kiota-abstractions-ruby/issues/59)
 - golang: generated code now always uses LF line endings, so `gofmt` no longer reports formatting differences when generating on Windows.
 - golang: make sure all generated code adheres to golangs coding standards

--- a/it/config.json
+++ b/it/config.json
@@ -65,13 +65,6 @@
   "https://raw.githubusercontent.com/googlemaps/openapi-specification/refs/tags/v1.22.5/dist/google-maps-platform-openapi3.yml": {
   },
   "https://developers.pipedrive.com/docs/api/v1/openapi.yaml": {
-    "Suppressions": [
-      {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota-abstractions-ruby/issues/66"
-      }
-    ],
-    "IdempotencySuppressions": [],
     "ExcludePatterns": [
       {
         "Language": "typescript",
@@ -127,10 +120,6 @@
   },
   "https://raw.githubusercontent.com/meraki/openapi/refs/heads/master/openapi/spec3.json": {
     "Suppressions": [
-      {
-        "Language": "ruby",
-        "Rationale": "https://github.com/microsoft/kiota-abstractions-ruby/issues/66"
-      },
       {
         "Language": "dart",
         "Rationale": "Compilation fails with api from 2026-06-22 - https://github.com/microsoft/kiota/issues/7822"

--- a/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Ruby/CodeMethodWriter.cs
@@ -200,8 +200,10 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, RubyConventionServ
             string defaultValue = RubyConventionService.SanitizeRubyDoubleQuoteLiteral(propWithDefault.DefaultValue);
             if (propWithDefault.Type is CodeType propertyType && propertyType.TypeDefinition is CodeEnum enumDefinition)
             {
-                // generates "Rootnamespace::Subnamespace::EnumType[:DefaultValue]"
-                defaultValue = $"{conventions.GetNormalizedNamespacePrefixForType(propWithDefault.Type)}{conventions.GetTypeString(propWithDefault.Type, currentMethod)}[:{defaultValue.TrimQuotes().ToFirstCharacterUpperCase()}]";
+                var trimmedDefault = defaultValue.TrimQuotes();
+                var matchingOption = enumDefinition.Options.FirstOrDefault(x => x.WireName.Equals(trimmedDefault, StringComparison.OrdinalIgnoreCase));
+                var optionName = (matchingOption?.Name ?? trimmedDefault).CleanupSymbolName().ToFirstCharacterUpperCase();
+                defaultValue = $"{conventions.GetNormalizedNamespacePrefixForType(propWithDefault.Type)}{conventions.GetTypeString(propWithDefault.Type, currentMethod)}[:{optionName}]";
             }
             else
             {

--- a/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Ruby/CodeMethodWriterTests.cs
@@ -1080,6 +1080,30 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains($"@{timePropName.ToSnakeCase()} = Time.parse({defaultValueTime})", result);
     }
     [Fact]
+    public void WritesConstructorWithEnumDefaultValueByWireName()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        var enumDef = root.AddEnum(new CodeEnum { Name = "TestEnum" }).First();
+        enumDef.AddOption(new CodeEnumOption { Name = "OneZero", SerializationName = "1.0" });
+        enumDef.AddOption(new CodeEnumOption { Name = "TwoZero", SerializationName = "2.0" });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "version",
+            DefaultValue = "2.0",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "TestEnum",
+                TypeDefinition = enumDef,
+            }
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("[:TwoZero]", result);
+        Assert.DoesNotContain("[:2.0]", result);
+    }
+    [Fact]
     public void WritesWithUrl()
     {
         setup();


### PR DESCRIPTION
When an enum option has a numeric wire name (e.g. "2.0"), the default value lookup now matches against the option's WireName and uses its CodeDOM Name (e.g. "TwoZero") for the Ruby symbol, instead of using the raw value which produces invalid Ruby syntax like [:2.0].

Un-suppresses Pipedrive and Meraki integration tests.

Fixes [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)