### PR TITLE
Fix: Adding additional check to boolean and numeric values in code writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - golang: make sure all generated code adheres to golangs coding standards
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 - TypeScript: fixed generation for primitive binary unions by handling `ArrayBuffer` as a primitive type, and deduplicated redundant serialization/deserialization branches when multiple union members map to the same runtime type (e.g. `binary` and `base64`).
+- Dotnet: Fixed primitive default-value handling during code generation.
 
 ## [1.34.1] - 2026-07-09
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1269,7 +1269,12 @@ public partial class KiotaBuilder
             stringDefaultJsonValue.TryGetValue<string>(out var stringDefaultValue) &&
             !string.IsNullOrEmpty(stringDefaultValue) &&
             !"null".Equals(stringDefaultValue, StringComparison.OrdinalIgnoreCase))
-            prop.DefaultValue = $"\"{stringDefaultValue}\"";
+        {
+            if (TryNormalizeStringDefaultValue(resultType, stringDefaultValue, out var normalizedDefaultValue))
+                prop.DefaultValue = normalizedDefaultValue;
+            else
+                LogInvalidDefaultValue(propertyName, resultType.Name);
+        }
         else if (kind == CodePropertyKind.Custom &&
             propertySchema?.Default is JsonValue stringDefaultJsonValue2 &&
             !stringDefaultJsonValue2.IsJsonNullSentinel() &&
@@ -1285,6 +1290,28 @@ public partial class KiotaBuilder
             LogCreatingProperty(prop.Name, prop.Type.Name);
         }
         return prop;
+    }
+    private static readonly HashSet<string> primitiveNumericTypeNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "byte", "decimal", "double", "float", "int", "int64", "integer", "sbyte"
+    };
+    private static bool TryNormalizeStringDefaultValue(CodeTypeBase propertyType, string defaultValue, out string normalizedDefaultValue)
+    {
+        if (propertyType.Name.Equals("boolean", StringComparison.OrdinalIgnoreCase))
+        {
+            if (bool.TryParse(defaultValue, out var booleanDefaultValue))
+            {
+                normalizedDefaultValue = booleanDefaultValue ? "true" : "false";
+                return true;
+            }
+            normalizedDefaultValue = string.Empty;
+            return false;
+        }
+        if (primitiveNumericTypeNames.Contains(propertyType.Name))
+            return PrimitiveDefaultValueUtils.TryNormalizeNumericLiteral(defaultValue, propertyType.Name, out normalizedDefaultValue);
+
+        normalizedDefaultValue = $"\"{defaultValue}\"";
+        return true;
     }
     private static readonly HashSet<JsonSchemaType> typeNamesToSkip = [JsonSchemaType.Object, JsonSchemaType.Array, JsonSchemaType.Object | JsonSchemaType.Null, JsonSchemaType.Array | JsonSchemaType.Null];
     internal static readonly HashSet<string> numericFormats = new(StringComparer.OrdinalIgnoreCase) { "int8", "uint8", "int16", "uint16", "int32", "int64", "float", "double", "decimal" };
@@ -3016,6 +3043,8 @@ public partial class KiotaBuilder
     private partial void LogCreatingIndexer(string name);
     [LoggerMessage(Level = LogLevel.Trace, Message = "Creating property {Name} of {Type}")]
     private partial void LogCreatingProperty(string name, string type);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Ignoring the default value for property {PropertyName} because it is incompatible with type {TypeName}.")]
+    private partial void LogInvalidDefaultValue(string propertyName, string typeName);
     [LoggerMessage(Level = LogLevel.Warning, Message = "Could not create error type for {Error} in {Operation}")]
     private partial void LogCouldNotCreateErrorType(string error, string? operation);
     [LoggerMessage(Level = LogLevel.Warning, Message = "No paths were found matching the provided patterns. Check your configuration.")]

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.CodeDOM;

--- a/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeMethodWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kiota.Builder.CodeDOM;
@@ -246,18 +246,43 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             foreach (var serializationClassName in serializationClassNames)
                 writer.WriteLine($"ApiClientBuilder.{methodName}<{serializationClassName}>();");
     }
-    private static string? GetDefaultValue(string defaultValue, CodeType propertyType)
+    private static readonly HashSet<string> NumericTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
-        return propertyType.Name.ToLowerInvariant() switch
+        "byte", "decimal", "double", "float", "int", "int64", "integer", "sbyte"
+    };
+    private static bool TryGetDefaultValue(string defaultValue, CodeType propertyType, out string? convertedDefaultValue)
+    {
+        convertedDefaultValue = propertyType.Name.ToLowerInvariant() switch
         {
-            "boolean" => defaultValue.TrimQuotes(),
             "date" => $"new Date(DateTimeOffset.Parse({defaultValue}).Date)",
             "datetimeoffset" => $"DateTimeOffset.Parse({defaultValue})",
             "time" => $"new Time(DateTimeOffset.Parse({defaultValue}).DateTime)",
             "guid" => $"Guid.Parse({defaultValue})",
-            "float" => $"{defaultValue}f", //Append "f" to the float value
             _ => null,
         };
+        if (convertedDefaultValue is not null)
+            return true;
+        if (propertyType.Name.Equals("boolean", StringComparison.OrdinalIgnoreCase))
+        {
+            if (bool.TryParse(defaultValue.TrimQuotes(), out var booleanDefaultValue))
+                convertedDefaultValue = booleanDefaultValue ? "true" : "false";
+            return true;
+        }
+        if (NumericTypeNames.Contains(propertyType.Name))
+        {
+            if (PrimitiveDefaultValueUtils.TryNormalizeNumericLiteral(defaultValue.TrimQuotes(), propertyType.Name, out var numericDefaultValue))
+            {
+                convertedDefaultValue = propertyType.Name.ToLowerInvariant() switch
+                {
+                    "decimal" => $"{numericDefaultValue}m",
+                    "float" => $"{numericDefaultValue}f",
+                    "int64" => $"{numericDefaultValue}L",
+                    _ => numericDefaultValue,
+                };
+            }
+            return true;
+        }
+        return false;
     }
     private void WriteConstructorBody(CodeClass parentClass, CodeMethod currentMethod, LanguageWriter writer)
     {
@@ -279,8 +304,11 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, CSharpConventionSe
             { // avoid setting null as a string.
                 defaultValue = NullValueString;
             }
-            else if (propWithDefault.Type is CodeType propertyType && GetDefaultValue(defaultValue.SanitizeQuotedStringLiteral(), propertyType) is string convertedDefaultValue)
+            else if (propWithDefault.Type is CodeType propertyType &&
+                TryGetDefaultValue(defaultValue.SanitizeQuotedStringLiteral(), propertyType, out var convertedDefaultValue))
             {
+                if (convertedDefaultValue is null)
+                    continue;
                 defaultValue = convertedDefaultValue;
             }
             else if (defaultValue.StartsWith('"') && defaultValue.EndsWith('"'))

--- a/src/Kiota.Builder/Writers/PrimitiveDefaultValueUtils.cs
+++ b/src/Kiota.Builder/Writers/PrimitiveDefaultValueUtils.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Text.Json;
+
+namespace Kiota.Builder.Writers;
+
+internal static class PrimitiveDefaultValueUtils
+{
+    internal static bool TryNormalizeNumericLiteral(string defaultValue, string typeName, out string normalizedDefaultValue)
+    {
+        try
+        {
+            using var jsonDocument = JsonDocument.Parse(defaultValue);
+            var value = jsonDocument.RootElement;
+            var isValid = typeName.ToLowerInvariant() switch
+            {
+                "byte" => value.TryGetByte(out _),
+                "decimal" => value.TryGetDecimal(out _),
+                "double" => value.TryGetDouble(out _),
+                "float" => value.TryGetSingle(out _),
+                "int" or "integer" => value.TryGetInt32(out _),
+                "int64" => value.TryGetInt64(out _),
+                "sbyte" => value.TryGetSByte(out _),
+                _ => false,
+            };
+            if (isValid)
+            {
+                normalizedDefaultValue = value.GetRawText();
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+        normalizedDefaultValue = string.Empty;
+        return false;
+    }
+}

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -7651,6 +7651,105 @@ paths:
         Assert.Empty(displayNameProperty?.DefaultValue);
     }
     [Fact]
+    public void NormalizesCompatiblePrimitiveDefaultsAndOmitsInvalidOnes()
+    {
+        var modelSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema>
+            {
+                ["actualBoolean"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Boolean,
+                    Default = JsonValue.Create(false)
+                },
+                ["stringBoolean"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Boolean,
+                    Default = JsonValue.Create("true")
+                },
+                ["hostileBoolean"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Boolean,
+                    Default = JsonValue.Create("'false; Environment.Exit(1)\\\r\n\t$'")
+                },
+                ["stringNumber"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Number,
+                    Format = "double",
+                    Default = JsonValue.Create("1.5")
+                },
+                ["hostileNumber"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Number,
+                    Format = "double",
+                    Default = JsonValue.Create("1; Environment.Exit(1)")
+                },
+                ["fractionalInteger"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Integer,
+                    Format = "int32",
+                    Default = JsonValue.Create("1.5")
+                },
+                ["overflowingByte"] = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Integer,
+                    Format = "uint8",
+                    Default = JsonValue.Create("256")
+                }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["/api"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchemaReference("sample.model")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("sample.model", modelSchema);
+        document.SetReferenceHostDocument();
+        var logger = new CountLogger<KiotaBuilder>();
+        var builder = new KiotaBuilder(logger, new GenerationConfiguration
+        {
+            ClientClassName = "Graph",
+            ApiRootUrl = "https://localhost"
+        }, _httpClient);
+
+        var codeModel = builder.CreateSourceModel(builder.CreateUriSpace(document));
+        var model = codeModel.FindChildByName<CodeClass>("model");
+
+        Assert.NotNull(model);
+        Assert.Equal("false", model.FindChildByName<CodeProperty>("actualBoolean", false)?.DefaultValue);
+        Assert.Equal("true", model.FindChildByName<CodeProperty>("stringBoolean", false)?.DefaultValue);
+        Assert.Empty(model.FindChildByName<CodeProperty>("hostileBoolean", false)?.DefaultValue);
+        Assert.Equal("1.5", model.FindChildByName<CodeProperty>("stringNumber", false)?.DefaultValue);
+        Assert.Empty(model.FindChildByName<CodeProperty>("hostileNumber", false)?.DefaultValue);
+        Assert.Empty(model.FindChildByName<CodeProperty>("fractionalInteger", false)?.DefaultValue);
+        Assert.Empty(model.FindChildByName<CodeProperty>("overflowingByte", false)?.DefaultValue);
+        Assert.Equal(4, logger.Count[LogLevel.Warning]);
+    }
+    [Fact]
     public void DoesNotAddReservedPathParameterSymbol()
     {
         var userSchema = new OpenApiSchema

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodeMethodWriterTests.cs
@@ -2288,6 +2288,72 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains(@"\n", result);
     }
     [Fact]
+    public void DoesNotWriteInvalidPrimitiveDefaultValues()
+    {
+        setup();
+        method.Kind = CodeMethodKind.Constructor;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "hostileBoolean",
+            DefaultValue = "\"'false; Environment.Exit(1)\\\\\r\n\t$'\"",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "boolean"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "hostileFloat",
+            DefaultValue = "1f; Environment.Exit(1);//",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "float"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "fractionalInteger",
+            DefaultValue = "1.5",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "integer"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "decimalValue",
+            DefaultValue = "1.5",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "decimal"
+            }
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "longValue",
+            DefaultValue = "2147483648",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "int64"
+            }
+        });
+
+        writer.Write(method);
+        var result = tw.ToString();
+
+        Assert.DoesNotContain("Environment.Exit", result);
+        Assert.DoesNotContain("HostileBoolean =", result);
+        Assert.DoesNotContain("HostileFloat =", result);
+        Assert.DoesNotContain("FractionalInteger =", result);
+        Assert.Contains("DecimalValue = 1.5m;", result);
+        Assert.Contains("LongValue = 2147483648L;", result);
+    }
+    [Fact]
     public void DoesNotWriteConstructorWithDefaultFromComposedType()
     {
         setup();


### PR DESCRIPTION
Improves primitive default-value handling during code generation.

• Validates and normalizes Boolean and numeric defaults
• Ignores incompatible defaults with a warning
• Emits correct C# numeric suffixes
• Adds regression coverage for invalid values, numeric ranges, and formatting
