### PR TITLE
Collapse oneOf nullable reference types to the target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - golang: generated code now always uses LF line endings, so `gofmt` no longer reports formatting differences when generating on Windows.
 - golang: make sure all generated code adheres to golangs coding standards
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
+- Fixed generation of a spurious union type/wrapper for `oneOf` nullable reference types (e.g. `oneOf: [$ref, {type: null}]` as emitted by ASP.NET Core 10's OpenAPI 3.1 generator); these now collapse to the nullable target type, matching the existing `anyOf` behavior. [#6776](https://github.com/microsoft/kiota/issues/6776)
 - TypeScript: fixed generation for primitive binary unions by handling `ArrayBuffer` as a primitive type, and deduplicated redundant serialization/deserialization branches when multiple union members map to the same runtime type (e.g. `binary` and `base64`).
 - Dotnet: Fixed primitive default-value handling during code generation.
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1924,8 +1924,7 @@ public partial class KiotaBuilder
         // meaningful entry plus a { "type": "null" } branch. Both patterns must be squished to the target
         // type so we don't create an unnecessary union type/wrapper for what is just a nullable reference.
         var unionEntries = schema.AnyOf is { Count: > 0 } ? schema.AnyOf : schema.OneOf;
-        if ((typesCount == 1 && (schema.Type & JsonSchemaType.Null) is JsonSchemaType.Null && schema.IsInclusiveUnion() || // nullable on the root schema outside of anyOf/oneOf
-            typesCount == 2 && (unionEntries?.Any(static x => // nullable on a schema in the anyOf/oneOf
+        if (typesCount == 2 && (unionEntries?.Any(static x => // nullable on a schema in the anyOf/oneOf
                                                         (x.Type & JsonSchemaType.Null) is JsonSchemaType.Null &&
                                                         !x.HasAnyProperty() &&
                                                         !x.IsExclusiveUnion() &&
@@ -1933,7 +1932,7 @@ public partial class KiotaBuilder
                                                         !x.IsInherited() &&
                                                         !x.IsIntersection() &&
                                                         !x.IsArray() &&
-                                                        !x.IsReferencedSchema()) ?? false)) &&
+                                                        !x.IsReferencedSchema()) ?? false) &&
             unionEntries?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.GetSchemaName())) is { } targetSchema)
         {
             var className = targetSchema.GetSchemaName().CleanupSymbolName();

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1920,8 +1920,12 @@ public partial class KiotaBuilder
     {
         var typeName = string.IsNullOrEmpty(typeNameForInlineSchema) ? currentNode.GetClassName(config.StructuredMimeTypes, operation: operation, suffix: suffixForInlineSchema, schema: schema, requestBody: isRequestBody).CleanupSymbolName() : typeNameForInlineSchema;
         var typesCount = schema.AnyOf?.Count ?? schema.OneOf?.Count ?? 0;
-        if ((typesCount == 1 && (schema.Type & JsonSchemaType.Null) is JsonSchemaType.Null && schema.IsInclusiveUnion() || // nullable on the root schema outside of anyOf
-            typesCount == 2 && (schema.AnyOf?.Any(static x => // nullable on a schema in the anyOf
+        // ASP.NET Core 10 emits nullable reference types as either an anyOf or a oneOf with a single
+        // meaningful entry plus a { "type": "null" } branch. Both patterns must be squished to the target
+        // type so we don't create an unnecessary union type/wrapper for what is just a nullable reference.
+        var unionEntries = schema.AnyOf is { Count: > 0 } ? schema.AnyOf : schema.OneOf;
+        if ((typesCount == 1 && (schema.Type & JsonSchemaType.Null) is JsonSchemaType.Null && schema.IsInclusiveUnion() || // nullable on the root schema outside of anyOf/oneOf
+            typesCount == 2 && (unionEntries?.Any(static x => // nullable on a schema in the anyOf/oneOf
                                                         (x.Type & JsonSchemaType.Null) is JsonSchemaType.Null &&
                                                         !x.HasAnyProperty() &&
                                                         !x.IsExclusiveUnion() &&
@@ -1930,7 +1934,7 @@ public partial class KiotaBuilder
                                                         !x.IsIntersection() &&
                                                         !x.IsArray() &&
                                                         !x.IsReferencedSchema()) ?? false)) &&
-            schema.AnyOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.GetSchemaName())) is { } targetSchema)
+            unionEntries?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.GetSchemaName())) is { } targetSchema)
         {
             var className = targetSchema.GetSchemaName().CleanupSymbolName();
             var shortestNamespace = GetShortestNamespace(codeNamespace, targetSchema);

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -3256,6 +3256,282 @@ paths:
     }
 
     [Fact]
+    public void SquishesNullableOneOfReferenceProperty()
+    {
+        // ASP.NET Core 10 emits nullable reference types as a oneOf with the target type and a { type: null } branch.
+        var childSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                { "id", new OpenApiSchema { Type = JsonSchemaType.String } }
+            },
+        };
+        var parentSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                {
+                    "child", new OpenApiSchema {
+                        OneOf = [
+                            new OpenApiSchemaReference("child"),
+                            new OpenApiSchema { Type = JsonSchemaType.Null }
+                        ]
+                    }
+                }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["thing"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchemaReference("parent")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("child", childSchema);
+        document.AddComponent("parent", parentSchema);
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        builder.SetOpenApiDocument(document);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var parentClass = codeModel.FindChildByName<CodeClass>("parent");
+        Assert.NotNull(parentClass);
+        var childProperty = parentClass.FindChildByName<CodeProperty>("child", false);
+        Assert.NotNull(childProperty);
+        // the oneOf nullable wrapper must be squished to the plain target type, not a union/composed wrapper
+        Assert.False(childProperty.Type is CodeComposedTypeBase);
+        Assert.Equal("child", childProperty.Type.Name, StringComparer.OrdinalIgnoreCase);
+        // no spurious composed-type wrapper or null-branch member class should be generated
+        Assert.Null(codeModel.FindChildByName<CodeClass>("parent_child"));
+        Assert.Null(codeModel.FindChildByName<CodeClass>("parent_childMember1"));
+    }
+
+    [Fact]
+    public void SquishesNullableOneOfReferencePropertyNullBranchFirst()
+    {
+        // Branch order independence: the { type: null } branch appears before the target reference.
+        var childSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                { "id", new OpenApiSchema { Type = JsonSchemaType.String } }
+            },
+        };
+        var parentSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                {
+                    "child", new OpenApiSchema {
+                        OneOf = [
+                            new OpenApiSchema { Type = JsonSchemaType.Null },
+                            new OpenApiSchemaReference("child")
+                        ]
+                    }
+                }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["thing"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchemaReference("parent")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("child", childSchema);
+        document.AddComponent("parent", parentSchema);
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        builder.SetOpenApiDocument(document);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var parentClass = codeModel.FindChildByName<CodeClass>("parent");
+        Assert.NotNull(parentClass);
+        var childProperty = parentClass.FindChildByName<CodeProperty>("child", false);
+        Assert.NotNull(childProperty);
+        Assert.False(childProperty.Type is CodeComposedTypeBase);
+        Assert.Equal("child", childProperty.Type.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.Null(codeModel.FindChildByName<CodeClass>("parent_childMember1"));
+    }
+
+    [Fact]
+    public void SquishesLonelyNullablesOneOf()
+    {
+        // Response-level oneOf nullable wrapper should collapse to the target type, not a union return type.
+        var uploadSessionSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            AdditionalPropertiesAllowed = false,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                { "date", new OpenApiSchema { Type = JsonSchemaType.String, Format = "date-time" } },
+                { "temperature", new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int32" } }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["createUploadSession"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchema
+                                            {
+                                                OneOf = new List<IOpenApiSchema> {
+                                                    new OpenApiSchemaReference("microsoft.graph.uploadSession"),
+                                                    new OpenApiSchema { Type = JsonSchemaType.Null }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("microsoft.graph.uploadSession", uploadSessionSchema);
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        builder.SetOpenApiDocument(document);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var sessionClass = codeModel.FindChildByName<CodeClass>("UploadSession");
+        Assert.NotNull(sessionClass);
+        var requestBuilderClass = codeModel.FindChildByName<CodeClass>("createUploadSessionRequestBuilder");
+        Assert.NotNull(requestBuilderClass);
+        var executorMethod = requestBuilderClass.Methods.FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
+        Assert.NotNull(executorMethod);
+        Assert.True(executorMethod.ReturnType is CodeType); // not union
+        Assert.Null(codeModel.FindChildByName<CodeClass>("createUploadSessionResponseMember1"));
+    }
+
+    [Fact]
+    public void PreservesMultiMemberOneOfWithNull()
+    {
+        // A genuine multi-branch oneOf that also includes null must remain a union type (no accidental collapse).
+        var oneOfSchema = new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            AdditionalPropertiesAllowed = false,
+            Properties = new Dictionary<string, IOpenApiSchema> {
+                {
+                    "date", new OpenApiSchema {
+                        OneOf = [
+                            new OpenApiSchema { Type = JsonSchemaType.String },
+                            new OpenApiSchema { Type = JsonSchemaType.Number, Format = "int64" },
+                            new OpenApiSchema { Type = JsonSchemaType.Null }
+                        ]
+                    }
+                }
+            },
+        };
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["createUploadSession"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchemaReference("oneOfNullable")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        document.AddComponent("oneOfNullable", oneOfSchema);
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", ApiRootUrl = "https://localhost" }, _httpClient);
+        builder.SetOpenApiDocument(document);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var oneOfClass = codeModel.FindChildByName<CodeClass>("oneOfNullable");
+        Assert.NotNull(oneOfClass);
+        var dateProperty = oneOfClass.FindChildByName<CodeProperty>("date", false);
+        Assert.NotNull(dateProperty);
+        if (dateProperty.Type is not CodeUnionType unionType)
+            Assert.Fail("Date property type is not a union type");
+        else
+        {
+            // the union must be preserved (not collapsed) and still expose the real branches
+            Assert.Contains(unionType.Types, x => x.Name.Equals("string", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(unionType.Types, x => x.Name.Equals("int64", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Fact]
     public void AddsDiscriminatorMappings()
     {
         var entitySchema = new OpenApiSchema


### PR DESCRIPTION
ASP.NET Core 10's OpenAPI 3.1 generator emits nullable reference types as a two-branch `oneOf` (the real type + a `{ "type": "null" }` branch). Kiota only "squished" the equivalent `anyOf` pattern, so `oneOf` nullables were treated as genuine unions — producing a composed-type wrapper (`IComposedTypeWrapper`) and an empty null-branch member class instead of a plain nullable reference.

```yaml
child:
  oneOf:
    - $ref: '#/components/schemas/Child'
    - type: 'null'
```

Before: `Parent_child` wrapper + empty `Parent_childMember1`. After: `public Child? Child { get; set; }`.

### Changes

- **`CreateComposedModelDeclaration` (`src/Kiota.Builder/KiotaBuilder.cs`)**: the nullable-squish block now derives its branch list from whichever of `AnyOf`/`OneOf` is populated (new `unionEntries` local) rather than hard-coding `schema.AnyOf`. Both the null-branch detection predicate and the target-schema selection use it, making `oneOf` and `anyOf` handling symmetric. The existing `typesCount == 2` guard is retained, so multi-branch unions (`oneOf: [A, B, null]`) still generate a union type. Reuses the existing `IsInherited`/`IsIntersection` re-routing path.
- **Tests (`tests/Kiota.Builder.Tests/KiotaBuilderTests.cs`)**: added regression coverage for the property-level `oneOf` nullable, reversed branch order, response/return-type level, and a control test asserting genuine multi-member `oneOf` unions are preserved.
- **`CHANGELOG.md`**: added a bug-fix entry.

Scoped to composed-type/nullable resolution; no writer/refiner changes and no changes to `IsExclusiveUnion`/`IsInclusiveUnion`/`IsSemanticallyMeaningful`.

Fixes: #6776


We tested this with our APIs and this yields exactly the required results.