### PR TITLE
Use Microsoft.Testing.Platform instead of VSTest, required by xunit v4

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
 name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
@@ -350,7 +350,7 @@ extends:
                 inputs:
                   command: test
                   projects: '$(Build.SourcesDirectory)\kiota.slnx'
-                  arguments: '--configuration $(BuildConfiguration) --no-build --collect:"XPlat Code Coverage"'
+                  arguments: '--configuration $(BuildConfiguration) --no-build --coverlet --coverlet-output-format cobertura'
 
               - pwsh: dotnet tool install --global dotnet-reportgenerator-globaltool --configfile "$(Build.SourcesDirectory)/nuget.config"
                 condition: succeededOrFailed()

--- a/global.json
+++ b/global.json
@@ -1,7 +1,10 @@
-{
+﻿{
   "sdk": {
     "version": "10.0.400",
     "rollForward": "latestMajor",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="18.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -7,19 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="18.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Kiota.Builder.Tests/Helpers/RetryTestCase.cs
+++ b/tests/Kiota.Builder.Tests/Helpers/RetryTestCase.cs
@@ -64,7 +64,10 @@ public class RetryTestCase : XunitTestCase, ISelfExecutingXunitTestCase
         IMessageBus messageBus,
         object[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationTokenSource cancellationTokenSource,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager methodFixtureMappings)
     {
         var delay = delayMilliseconds;
         RunSummary lastSummary = default;
@@ -79,9 +82,12 @@ public class RetryTestCase : XunitTestCase, ISelfExecutingXunitTestCase
                 this,
                 replayBus,
                 cancellationTokenSource,
+                parallelMode,
+                scheduler,
                 attemptAggregator,
                 explicitOption,
-                constructorArguments).ConfigureAwait(false);
+                constructorArguments,
+                methodFixtureMappings).ConfigureAwait(false);
 
             var hasFailures = summary.Failed > 0 || attemptAggregator.HasExceptions;
             if (!hasFailures || attempt == maxRetries)

--- a/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
+++ b/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
+++ b/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
@@ -13,19 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="10.0.1" />
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Kiota.Tests/Kiota.Tests.csproj
+++ b/tests/Kiota.Tests/Kiota.Tests.csproj
@@ -10,17 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Kiota.Tests/Kiota.Tests.csproj
+++ b/tests/Kiota.Tests/Kiota.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This is what I had to do in my project to support xunit v4.  Hope this helps.
* Replace `coverlet.collector` and `coverlet.msbuild` with `coverlet.MTP`.
* Set test.runner in `global.json`.
* New dotnet test arguments in the yaml pipeline.