### PR TITLE
[C#] Suppress warning CS1591 for properties without description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 - Fixed generation of a spurious union type/wrapper for `oneOf` nullable reference types (e.g. `oneOf: [$ref, {type: null}]` as emitted by ASP.NET Core 10's OpenAPI 3.1 generator); these now collapse to the nullable target type, matching the existing `anyOf` behavior. [#6776](https://github.com/microsoft/kiota/issues/6776)
 - TypeScript: fixed generation for primitive binary unions by handling `ArrayBuffer` as a primitive type, and deduplicated redundant serialization/deserialization branches when multiple union members map to the same runtime type (e.g. `binary` and `base64`).
+- C#: write empty xml doc tags if an element has no description to avoid warning CS1591. [#8095](https://github.com/microsoft/kiota/issues/8095)
 
 ## [1.34.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 - Fixed generation of a spurious union type/wrapper for `oneOf` nullable reference types (e.g. `oneOf: [$ref, {type: null}]` as emitted by ASP.NET Core 10's OpenAPI 3.1 generator); these now collapse to the nullable target type, matching the existing `anyOf` behavior. [#6776](https://github.com/microsoft/kiota/issues/6776)
 - TypeScript: fixed generation for primitive binary unions by handling `ArrayBuffer` as a primitive type, and deduplicated redundant serialization/deserialization branches when multiple union members map to the same runtime type (e.g. `binary` and `base64`).
-- C#: write empty xml doc tags if an element has no description to avoid warning CS1591. [#8095](https://github.com/microsoft/kiota/issues/8095)
+- C#: write "#pragma" to disable CS1591 for properties without description. [#8095](https://github.com/microsoft/kiota/issues/8095)
 
 ## [1.34.1] - 2026-07-09
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -61,7 +61,7 @@ public class CSharpConventionService : CommonLanguageConventionService
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(element);
         if (element is not CodeElement codeElement) return false;
-        if (!element.Documentation.DescriptionAvailable) return false;
+        // Write documentation tag also for empty descriptions (#8095)
         var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => RemoveInvalidDescriptionCharacters(x.CleanupXMLString()));
         writer.WriteLine($"{DocCommentPrefix}{prefix}{description}{suffix}");
         return true;

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -61,7 +61,7 @@ public class CSharpConventionService : CommonLanguageConventionService
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(element);
         if (element is not CodeElement codeElement) return false;
-        // Write documentation tag also for empty descriptions (#8095)
+        if (!element.Documentation.DescriptionAvailable) return false;
         var description = element.Documentation.GetDescription(type => GetTypeStringForDocumentation(type, codeElement), normalizationFunc: static x => RemoveInvalidDescriptionCharacters(x.CleanupXMLString()));
         writer.WriteLine($"{DocCommentPrefix}{prefix}{description}{suffix}");
         return true;

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -17,16 +17,20 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
                                       && codeElement.IsOfKind(
                                             CodePropertyKind.Custom,
                                             CodePropertyKind.QueryParameter);// Other property types are appropriately constructor initialized
-        conventions.WriteShortDescription(codeElement, writer);
+        bool hasDescription = conventions.WriteShortDescription(codeElement, writer);
         conventions.WriteDeprecationAttribute(codeElement, writer);
         if (isNullableReferenceType)
         {
             CSharpConventionService.WriteNullableOpening(writer);
+            if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
             WritePropertyInternal(codeElement, writer, $"{propertyType}?");
+            if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
             CSharpConventionService.WriteNullableMiddle(writer);
         }
 
+        if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
         WritePropertyInternal(codeElement, writer, propertyType);// Always write the normal way
+        if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
 
         if (isNullableReferenceType)
             CSharpConventionService.WriteNullableClosing(writer);

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -305,12 +305,15 @@ public sealed class CodePropertyWriterTests : IDisposable
 
         // Assert: description tag is written
         Assert.Contains("/// <summary>Description</summary>", result);
+        // No "#pragma" is written.
+        Assert.DoesNotContain("#pragma", result);
 
         writer.Write(prop2);
         result = tw.ToString();
 
-        // Assert: empty description tag is written
-        Assert.Contains("/// <summary></summary>", result);
+        // Assert: the warning is suppressed
+        Assert.Contains("#pragma warning disable CS1591", result);
+        Assert.Contains("#pragma warning restore CS1591", result);
     }
 }
 

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CodePropertyWriterTests.cs
@@ -271,5 +271,46 @@ public sealed class CodePropertyWriterTests : IDisposable
         // Then
         Assert.Contains("public override string Message { get => Prop1 ?? string.Empty; }", result);
     }
+    [Fact]
+    public void WritesPropertyDescription()
+    {
+        // Tests that the XML doc for a property description is written, whether it is empty or not.
+
+        // Create two properties, one with description and one without.
+        var prop1 = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "prop1",
+            Kind = CodePropertyKind.Custom,
+            Documentation = new CodeDocumentation
+            {
+                DescriptionTemplate = "Description",
+            },
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        }).First();
+        var prop2 = parentClass.AddProperty(new CodeProperty
+        {
+            Name = "prop2",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "string",
+            },
+        }).First();
+
+        writer.Write(prop1);
+        var result = tw.ToString();
+
+        // Assert: description tag is written
+        Assert.Contains("/// <summary>Description</summary>", result);
+
+        writer.Write(prop2);
+        result = tw.ToString();
+
+        // Assert: empty description tag is written
+        Assert.Contains("/// <summary></summary>", result);
+    }
 }
 


### PR DESCRIPTION
This is an attempt to resolve #8095: if a property has no description, suppress the warning CS1591, as is done e.g. for classes.


My first attempt was to write an empty xml doc, but then I noticed that for empty class doc, the warning is suppressed, so I made another commit to do the same for properties.

Probably, I should have closed the first pull request and create a new one, sorry!

For completeness, here is the old initial comment, hidden in a "details" section.

<details><summary>Irrelevant first attempt to resolve this.</summary>
<p>
This is an attempt to resolve #8095: if a property or some other element in the api description has no description, write an empty xml doc tag.

This avoids the warning "CS1591" if `GenerateDocumentationFile` is set to `true` in the target project.

This change just removes a check to suppress empty descriptions, and it adds a test case.

It is a request for comment - do you think this is reasonable?

The problem started with recent twitter api 2.167, and I hope they fix it in the future. So the change might become unnecessary again. But currently, it is annoying 😠 


</p>
</details> 