### PR TITLE
C#: don't create xml doc links to arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic model class descriptions when a component schema is referenced from multiple properties with differing reference-level descriptions. [#7927](https://github.com/microsoft/kiota/issues/7927)
 - Fixed generation of a spurious union type/wrapper for `oneOf` nullable reference types (e.g. `oneOf: [$ref, {type: null}]` as emitted by ASP.NET Core 10's OpenAPI 3.1 generator); these now collapse to the nullable target type, matching the existing `anyOf` behavior. [#6776](https://github.com/microsoft/kiota/issues/6776)
 - TypeScript: fixed generation for primitive binary unions by handling `ArrayBuffer` as a primitive type, and deduplicated redundant serialization/deserialization branches when multiple union members map to the same runtime type (e.g. `binary` and `base64`).
-- C#: write "#pragma" to disable CS1591 for properties without description. [#8095](https://github.com/microsoft/kiota/issues/8095)
+- C#: write `#pragma` to disable CS1591 for properties without description. [#8095](https://github.com/microsoft/kiota/issues/8095)
+- C#: don't create `<see cref="byte[]"/>` xml doc comments [#8099](https://github.com/microsoft/kiota/issues/8099)
 
 ## [1.34.1] - 2026-07-09
 

--- a/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CSharpConventionService.cs
@@ -190,6 +190,13 @@ public class CSharpConventionService : CommonLanguageConventionService
         var typeString = GetTypeString(code, targetElement, true, false);// dont include nullable markers
         if (typeString.EndsWith('>'))
             return typeString.CleanupXMLString(); // don't generate cref links for generic types as concrete types generate invalid links
+        if (typeString.EndsWith("[]", StringComparison.Ordinal))
+        {
+            // Array type: "<see cref="byte[]"/>" is invalid.
+            // Convert it to "<see cref="byte"/> array", which is hopefully human readable.
+            var rawTypeString = typeString.Substring(0, typeString.Length - "[]".Length);
+            return $"{ReferenceTypePrefix}{rawTypeString.CleanupXMLString()}{ReferenceTypeSuffix} array";
+        }
 
         return $"{ReferenceTypePrefix}{typeString.CleanupXMLString()}{ReferenceTypeSuffix}";
     }

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpConventionServiceTests.cs
@@ -11,12 +11,11 @@ namespace Kiota.Builder.Tests.Writers.CSharp
     {
         private readonly CSharpConventionService instance = new();
 
-
         [Fact]
         public void WritesSeeDoc()
         {
             // Tests that "<see cref=" documentation tags are written properly
-            
+
             CodeElement targetElement = new CodeClass();
 
             // Reference to any class:

--- a/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpConventionServiceTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/CSharp/CSharpConventionServiceTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Kiota.Builder.CodeDOM;
+using Kiota.Builder.Writers.CSharp;
+using Xunit;
+
+namespace Kiota.Builder.Tests.Writers.CSharp
+{
+    public class CSharpConventionServiceTests
+    {
+        private readonly CSharpConventionService instance = new();
+
+
+        [Fact]
+        public void WritesSeeDoc()
+        {
+            // Tests that "<see cref=" documentation tags are written properly
+            
+            CodeElement targetElement = new CodeClass();
+
+            // Reference to any class:
+            CodeType codeType = new CodeType()
+            {
+                Name = "SomeClass"
+            };
+
+            var see = instance.GetTypeStringForDocumentation(codeType, targetElement);
+
+            Assert.Equal("<see cref=\"SomeClass\"/>", see);
+
+            // Reference to byte[]:
+            codeType = new CodeType()
+            {
+                Name = "base64"
+            };
+
+            see = instance.GetTypeStringForDocumentation(codeType, targetElement);
+
+            // Brackets are stripped, the word "array" is added.
+            Assert.Equal("<see cref=\"byte\"/> array", see);
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to resolve #8099: xml doc "see" tags could point to array types: `<see cref="byte[]"/>`, which resulted in xml doc warnings.

This pull request changes the comments to `<see cref="byte[]"/> array` (note the additional word "array" to make it human readable). 
If found also the [suggestion](https://stackoverflow.com/questions/2367493/how-to-refer-to-array-types-in-documentation-comments/45711689#45711689) to write the square brackets after the see tag (`<see cref="byte[]"/>[]`), but this might look wrong in a VB.NET environment.

There was no test class for `CSharpConventionService`, but as I found a test `GoConventionServiceTests`. I added a similar test class. Hope this is OK.


The sample class from #8099 now looks like this:

```c#
        /// <summary>
        /// Composed type wrapper for classes <see cref="byte"/> array, <see cref="byte"/> array
        /// </summary>
        [global::System.CodeDom.Compiler.GeneratedCode("Kiota", "1.0.0")]
        public partial class AppendMediaUploadRequest_media : IComposedTypeWrapper, IParsable
        {
            /// <summary>Composed type representation for type <see cref="byte"/> array</summary>
#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
#nullable enable
            public byte[]? Base64 { get; set; }
#nullable restore
#else
            public byte[] Base64 { get; set; }
#endif
            /// <summary>Composed type representation for type <see cref="byte"/> array</summary>
#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
#nullable enable
            public byte[]? Binary { get; set; }
#nullable restore
#else
            public byte[] Binary { get; set; }
#endif
```