### PR TITLE
ci: suppress the typescript idempotency test for the github description

### DIFF
--- a/it/config.json
+++ b/it/config.json
@@ -27,6 +27,12 @@
         "Rationale": "Multiple compilation errors with api from 2026-06-25 - https://github.com/microsoft/kiota/issues/7862"
       }
     ],
+    "IdempotencySuppressions": [
+      {
+        "Language": "typescript",
+        "Rationale": "Client generation fails for typescript with the current api - https://github.com/microsoft/kiota/issues/7803"
+      }
+    ],
     "ExcludePatterns": [
       {
         "Language": "typescript",


### PR DESCRIPTION
The typescript idempotency test against the github description started failing for every pull request once the description was refreshed. It is the generation crash from #7803, which is still open: `error generating the client: Function deserializeIntoWithPath not found in namespace ApiSdk.models`. I reproduced it on main at d5f667d24 with no other changes, so it is the description plus the generator, not any one branch.

Integration is already suppressed for typescript on this description, but idempotency is not, so it blocks the merge queue and every open pull request. This adds the matching `IdempotencySuppressions` entry pointing at #7803, the same shape the notion description uses for its sibling issue. Generation for typescript cannot be idempotent while it crashes, so nothing is lost by skipping it until #7803 is fixed.

Related: #7803
