### PR TITLE
fix: keep the wire name of an escaped query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Go: fixed the factory reference emitted for a model whose name ends in `able` (e.g. `ProviderUnavailable`): the writer trimmed the suffix as if it were the model-interface suffix, referencing a `Create...FromDiscriminatorValue` symbol that is never generated, so the package did not compile. The suffix is now only trimmed when the type resolves to the inserted interface.
+- Fixed query parameters whose name is escaped (e.g. `export` in TypeScript) being silently dropped from the request: the original name is now kept as the serialization name, so TypeScript emits the `queryParametersMapper` entry mapping the escaped symbol back to its wire name. [kiota-typescript#2111](https://github.com/microsoft/kiota-typescript/issues/2111)
 - Fixed defaults primitive default-value handling during code generation for all languages
 - Ruby: added composed type (union/intersection) support to the factory, serializer and deserializer bodies, and stopped emitting composed type wrappers as inner classes. Un-suppresses the Twitter integration test. [kiota-abstractions-ruby#73](https://github.com/microsoft/kiota-abstractions-ruby/issues/73) [#1816](https://github.com/microsoft/kiota/issues/1816)
 - Ruby: `initialize` is now a reserved name. An API member called `initialize` previously generated a second `def initialize`, redefining the constructor; it is now escaped.

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -345,7 +345,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
             (shouldReplaceCallback?.Invoke(current) ?? true))// re-invoke the callback if present as conditions above may have renamed dependencies.
         {
             if (current is CodeProperty currentProperty &&
-                currentProperty.IsOfKind(CodePropertyKind.Custom) &&
+                currentProperty.IsOfKind(CodePropertyKind.Custom, CodePropertyKind.QueryParameter) &&
                 string.IsNullOrEmpty(currentProperty.SerializationName))
             {
                 currentProperty.SerializationName = currentProperty.Name;

--- a/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/TypeScriptLanguageRefinerTests.cs
@@ -849,6 +849,59 @@ public sealed class TypeScriptLanguageRefinerTests : IDisposable
     }
 
     [Fact]
+    public async Task MapsEscapedQueryParamsBackToTheirWireNameAsync()
+    {
+        var generationConfiguration = new GenerationConfiguration { Language = GenerationLanguage.TypeScript };
+        var testNS = root.FindOrAddNamespace(generationConfiguration.ClientNamespaceName);
+        var requestBuilder = testNS.AddClass(new CodeClass
+        {
+            Name = "requestBuilder",
+            Kind = CodeClassKind.RequestBuilder
+        }).First();
+        requestBuilder.AddProperty(new CodeProperty
+        {
+            Kind = CodePropertyKind.UrlTemplate,
+            Name = "urlTemplate",
+            DefaultValue = "{baseurl+}",
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        });
+
+        var requestConfig = requestBuilder.AddInnerClass(new CodeClass
+        {
+            Name = "requestConfig",
+            Kind = CodeClassKind.RequestConfiguration
+        }).First();
+
+        var queryParam = requestBuilder.AddInnerClass(new CodeClass
+        {
+            Name = "queryParams",
+            Kind = CodeClassKind.QueryParameters
+        }).First();
+
+        queryParam.AddProperty(new CodeProperty
+        {
+            Name = "export",
+            Kind = CodePropertyKind.QueryParameter,
+            Type = new CodeType
+            {
+                Name = "boolean"
+            },
+        });
+
+        requestConfig.AddProperty(new CodeProperty { Name = queryParam.Name, Type = new CodeType { Name = queryParam.Name, TypeDefinition = queryParam } });
+
+        await ILanguageRefiner.RefineAsync(generationConfiguration, root, cancellationToken: TestContext.Current.CancellationToken);
+        var queryParamsInterface = testNS.Interfaces.First(static x => x.Name.Equals("queryParams", StringComparison.OrdinalIgnoreCase));
+        var escapedProperty = queryParamsInterface.Properties.First(static x => x.IsOfKind(CodePropertyKind.QueryParameter));
+        Assert.Equal("exportEscaped", escapedProperty.Name);
+        Assert.Equal("export", escapedProperty.SerializationName);
+        Assert.Single(testNS.Constants, static x => x.IsOfKind(CodeConstantKind.QueryParametersMapper));
+    }
+
+    [Fact]
     public async Task GeneratesCodeFilesAsync()
     {
         var generationConfiguration = new GenerationConfiguration { Language = GenerationLanguage.TypeScript };


### PR DESCRIPTION
## Description

Fixes microsoft/kiota-typescript#2111.

An OpenAPI query parameter named `export` is generated for typescript as `exportEscaped`
(correctly — `export` is a reserved word), but nothing maps that symbol back to the wire
name. A caller who sets it through the generated, type safe interface sends **no** query
parameter at all: `exportEscaped` is not a variable of the uri template, and
std-uritemplate discards unknown variables. No error, no warning.

```ts
await client.items.get({ queryParameters: { exportEscaped: true } });
// GET /items                      <- the parameter is gone

await client.items.get({ queryParameters: { export: true } as any });
// GET /items?export=true          <- what the caller meant, only reachable with a cast
```

The machinery to fix this already exists end to end — `CodeConstant.FromQueryParametersMapping`
builds a `...QueryParametersMapper` constant from every query parameter property that carries a
`SerializationName`, the constant writer emits it and references it from the requests metadata,
and `setQueryStringParametersFromRawObject` renames through it at runtime. It just never fired:
when `ReplaceReservedNames` renames a property it only preserves the original name as the
serialization name for `Custom` properties, so a renamed `QueryParameter` property lost its
wire name and the mapper came out empty.

Every query parameter whose name collides with a typescript reserved word is affected
(`export`, `default`, `new`, `class`, `function`, ...). Response properties are not: those
carry their own serialization mapping.

## Changes

One condition widened in `CommonLanguageRefiner.ReplaceReservedNames`: the original name is
preserved as `SerializationName` for `QueryParameter` properties as well as `Custom` ones
(only when no serialization name is set yet, as before).

Generated typescript for a spec with an `export` query parameter now carries the mapping:

```ts
const ItemsRequestBuilderGetQueryParametersMapper: Record<string, string> = {
    "exportEscaped": "export",
};
// ...
requests metadata: { get: { ..., queryParametersMapper: ItemsRequestBuilderGetQueryParametersMapper } }
```

- CHANGELOG entry added under Unreleased/Changed.
- New refiner test `MapsEscapedQueryParamsBackToTheirWireNameAsync`: a `QueryParameter`
  property named `export` ends up as `exportEscaped` with `SerializationName == "export"`,
  and the `QueryParametersMapper` constant is generated.

## Testing

- The full `Kiota.Builder.Tests` suite passes: 2291 passed, 0 failed.
- **Generated output, typescript**: the spec from the issue generated before and after — before,
  no mapper constant and no `queryParametersMapper` in the requests metadata; after, both
  present (snippet above).
- **Runtime, with the released `@microsoft/kiota-abstractions` 1.0.0-preview.103**: feeding
  `setQueryStringParametersFromRawObject({ exportEscaped: true, limit: 10 }, mapper)` the
  mapper the generator now emits builds
  `https://api.example.com/v2/items?export=true&limit=10`; with `undefined` (the status quo)
  the same call builds `...?limit=10` — the silent drop from the issue. No abstractions
  change is needed.
- **Other languages are unchanged**: the same spec generated for csharp and go produces
  identical output before and after — csharp already mapped the name through
  `[QueryParameter("export")]`, go through the `uriparametername:"export"` tag; both derive
  from the wire name, which this change only makes available earlier. Languages where the
  parameter name is not reserved never enter the renamed path at all.

## Notes

The alternative fix — failing loudly in `setQueryStringParametersFromRawObject` for a key the
uri template does not know — would live in `microsoft/kiota-typescript` and would still be a
worthwhile safety net for hand-written raw objects, but the mapper is the actual missing
piece: the other languages all map the name back, typescript was the only one that did not.

---

Generated with Claude Code
