### PR TITLE
fix: keep the full factory name of a go model ending in able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Go: fixed the factory reference emitted for a model whose name ends in `able` (e.g. `ProviderUnavailable`): the writer trimmed the suffix as if it were the model-interface suffix, referencing a `Create...FromDiscriminatorValue` symbol that is never generated, so the package did not compile. The suffix is now only trimmed when the type resolves to the inserted interface.
 - Fixed defaults primitive default-value handling during code generation for all languages
 - Ruby: added composed type (union/intersection) support to the factory, serializer and deserializer bodies, and stopped emitting composed type wrappers as inner classes. Un-suppresses the Twitter integration test. [kiota-abstractions-ruby#73](https://github.com/microsoft/kiota-abstractions-ruby/issues/73) [#1816](https://github.com/microsoft/kiota/issues/1816)
 - Ruby: `initialize` is now a reserved name. An API member called `initialize` previously generated a second `def initialize`, redefining the constructor; it is now escaped.

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -41,7 +41,13 @@ public class GoConventionService : CommonLanguageConventionService
         var typeString = GetTypeString(code, targetElement, false, false)?.Split(Dot);
         var importSymbol = typeString == null || typeString.Length < 2 ? string.Empty : typeString[0] + Dot;
         var methodName = typeString?.Last().ToFirstCharacterUpperCase();
-        if (!string.IsNullOrEmpty(trimEnd) && (methodName?.EndsWith(trimEnd, StringComparison.OrdinalIgnoreCase) ?? false))
+        // the suffix is only trimmed when the type does not resolve to a model class: a type that
+        // resolves to the model's inserted interface (or to nothing) carries the suffix in its name,
+        // while a model class whose own name happens to end with the suffix (e.g. ProviderUnavailable)
+        // must keep it, otherwise the emitted factory reference does not exist
+        if (!string.IsNullOrEmpty(trimEnd) &&
+            (methodName?.EndsWith(trimEnd, StringComparison.OrdinalIgnoreCase) ?? false) &&
+            code is not CodeType { TypeDefinition: CodeClass })
         {
             methodName = methodName[..^trimEnd.Length];
         }

--- a/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Go/CodeMethodWriterTests.cs
@@ -727,6 +727,51 @@ public sealed class CodeMethodWriterTests : IDisposable
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]
+    public void WritesRequestExecutorBodyForErrorModelNamedWithAbleSuffix()
+    {
+        setup();
+        method.Kind = CodeMethodKind.RequestExecutor;
+        method.HttpMethod = HttpMethod.Get;
+        var providerUnavailable = root.AddClass(new CodeClass
+        {
+            Name = "ProviderUnavailable",
+        }).First();
+        var error5XX = root.AddClass(new CodeClass
+        {
+            Name = "Error5XX",
+        }).First();
+        var error5XXInterface = root.AddInterface(new CodeInterface
+        {
+            Name = "Error5XXable",
+            Kind = CodeInterfaceKind.Model,
+            OriginalClass = error5XX,
+        }).First();
+        method.AddErrorMapping("503", new CodeType { Name = "ProviderUnavailable", TypeDefinition = providerUnavailable });
+        method.AddErrorMapping("5XX", new CodeType { Name = "Error5XXable", TypeDefinition = error5XXInterface });
+        AddRequestBodyParameters();
+        method.AddParameter(new CodeParameter
+        {
+            Name = "ctx",
+            Kind = CodeParameterKind.Cancellation,
+            Type = new CodeType
+            {
+                Name = "context.Context",
+                IsExternal = true,
+                IsNullable = false,
+            },
+            Optional = false,
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        // a model class whose own name ends in "able" must keep its full name: the factory is named
+        // after the class, so trimming would reference a symbol that is never generated
+        Assert.Contains("\"503\": CreateProviderUnavailableFromDiscriminatorValue", result);
+        Assert.DoesNotContain("CreateProviderUnavailFromDiscriminatorValue", result);
+        // a mapping through the model's inserted interface still trims the interface suffix
+        Assert.Contains("\"5XX\": CreateError5XXFromDiscriminatorValue", result);
+        AssertExtensions.CurlyBracesAreClosed(result);
+    }
+    [Fact]
     public void WritesRequestExecutorBodyForEnum()
     {
         setup();


### PR DESCRIPTION
## Description

A go client generated from a document containing a model whose name ends in `able` does not
compile. The model itself is generated correctly:

```go
// models/provider_unavailable.go
func CreateProviderUnavailableFromDiscriminatorValue(parseNode ...) (...) {
```

but every error mapping that references it asks for a different symbol, with the trailing
`able` gone:

```go
errorMapping := i2ae...ErrorMappings {
    "503": i138...CreateProviderUnavailFromDiscriminatorValue,   // <- never defined
}
```

```
items/item_stats_request_builder.go:49:76: undefined:
    i138....CreateProviderUnavailFromDiscriminatorValue
```

One schema name breaks the build of the whole package, so every operation in the client is
unusable, not just the endpoint that maps the error. Any name ending in `able` triggers it —
`ProviderUnavailable`, `Cancelable`, `Immutable`, `Table`, `Available` — and only go is
affected: the same document generates correctly for the other languages.

(This may be the same defect as #2955, closed in 2023 without a recorded root cause — same
symptom, an undefined `Create...FromDiscriminatorValue` in a go request builder.)

## Root cause

The go writer names a model's inserted interface by appending `able` (`Domain` →
`Domainable`), and `GoConventionService.GetImportedStaticMethodName` recovers the factory
name from the rendered type name by trimming that suffix back off. The refiner only rewrites
request executor return types and request bodies to the interfaces
(`CopyModelClassesAsInterfaces`); an **error mapping** (and a property factory) still points
at the model *class*. For those, the rendered name is the model's own name — and when that
name itself ends in `able`, the trim eats part of it: `ProviderUnavailable` cannot be told
apart from the interface of a model called `ProviderUnavail`, and the trim wins.

## Changes Made

- `GetImportedStaticMethodName` only trims the suffix when the type does **not** resolve to
  a model class (`code is not CodeType { TypeDefinition: CodeClass }`). Types that resolve
  to the inserted interface — and unresolved names, preserving today's behavior for them —
  are trimmed exactly as before; a model class keeps its full name.
- New test `WritesRequestExecutorBodyForErrorModelNamedWithAbleSuffix` covering both sides:
  a class named `ProviderUnavailable` keeps its name in the factory reference, and a mapping
  through a model interface (`Error5XXable`) still trims to `CreateError5XX...`.
- CHANGELOG entry under Unreleased/Changed.

## Testing

- The full `Kiota.Builder.Tests` suite passes: 2291 passed, 0 failed.
- **Reproduction, before/after.** A minimal document with an error schema named
  `ProviderUnavailable` referenced from a 503 response, generated with `-l go` and compiled
  with go 1.25:

  | | emitted reference | `go build ./...` |
  | --- | --- | --- |
  | before | `CreateProviderUnavailFromDiscriminatorValue` | `undefined: ...CreateProviderUnavailFromDiscriminatorValue` |
  | after | `CreateProviderUnavailableFromDiscriminatorValue` | builds |

- **A production document** of ≈100 operations (which is where this was found) generated
  with this branch compiles cleanly with `go build ./...`.

---

Generated with Claude Code
