### PR TITLE
C#: rename property 'Equals'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name correction now walks the code model in a fixed order. Where two names correct to the same value only the element reached first can take it, and the walk followed a dictionary whose order varies between runs, so the winner, and with it the generated output, differed from one run to the next. This removes one source of the non-reproducible generation tracked in [#7997](https://github.com/microsoft/kiota/issues/7997); other sources remain, so the descriptions suppressed for it stay suppressed.
 
 - Ruby: a model sharing its name with a sibling namespace had the disambiguation suffix applied once per reference to it rather than once, so generation failed with `The element to rename was not found available_phone_number_countryModelModelModelModel`. The reference pass was removed: `CodeType.Name` already delegates to the type definition, so references follow the rename on their own. Un-suppresses the Twilio integration and idempotency tests. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)
+- C#: create property "EqualsEscaped" instead of "Equals" for model properties "equals" to avoid a compiler warning [#8133](https://github.com/microsoft/kiota/issues/8133)
 
 ## [1.35.0] - 2026-09-01
 

--- a/src/Kiota.Builder/Refiners/CSharpRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CSharpRefiner.cs
@@ -82,6 +82,14 @@ public class CSharpRefiner : CommonLanguageRefiner, ILanguageRefiner
                 new CSharpReservedClassNamesProvider(),
                 x => $"{x.ToFirstCharacterUpperCase()}Escaped"
             );
+            // Check properties for reserved names: https://github.com/microsoft/kiota/issues/8133
+            // Exclude everything besides "CodeProperty" types:
+            ReplaceReservedNames(
+               generatedCode,
+               new CSharpReservedPropertyNamesProvider(),
+               x => $"{x.ToFirstCharacterUpperCase()}Escaped",
+               new HashSet<Type> { typeof(CodeClass), typeof(ClassDeclaration), typeof(CodeUsing), typeof(CodeNamespace), typeof(CodeMethod), typeof(CodeEnum), typeof(CodeEnumOption) }
+            );
             ReplaceReservedExceptionPropertyNames(
                 generatedCode,
                 new CSharpExceptionsReservedNamesProvider(),

--- a/src/Kiota.Builder/Refiners/CSharpReservedPropertyNamesProvider.cs
+++ b/src/Kiota.Builder/Refiners/CSharpReservedPropertyNamesProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kiota.Builder.Refiners;
+
+/// <summary>
+/// Names that are not allowed for properties.
+/// </summary>
+public class CSharpReservedPropertyNamesProvider : IReservedNamesProvider
+{
+    private readonly Lazy<HashSet<string>> _reservedNames = new(static () => new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Equals",  //warning "hides inherited member 'object.Equals(object?)'", https://github.com/microsoft/kiota/issues/8133
+        "GetHashCode",
+        "ToString",
+    });
+    public HashSet<string> ReservedNames => _reservedNames.Value;
+}

--- a/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/CSharpLanguageRefinerTests.cs
@@ -341,6 +341,36 @@ public class CSharpLanguageRefinerTests
         Assert.Contains("TaskNamespace", subNS.Name);
         Assert.Contains("TaskNamespace", itemSubNamespace.Name);
     }
+
+    /// <summary>
+    /// Tests that "forbidden" property names are escaped.
+    /// </summary>
+    [Theory]
+    [InlineData("equals")]
+    [InlineData("gethashcode")]
+    [InlineData("tostring")]
+    public async Task EscapesReservedPropertyNamesAsync(string propertyName)
+    {
+        // Arrange
+        var model = root.AddClass(new CodeClass
+        {
+            Name = "Sample",
+            Kind = CodeClassKind.Model,
+        }).First();
+        var property = model.AddProperty(new CodeProperty
+        {
+            Name = propertyName,
+            Type = new CodeType
+            {
+                Name = "string"
+            }
+        }).First();
+        // Act
+        await ILanguageRefiner.RefineAsync(new GenerationConfiguration { Language = GenerationLanguage.CSharp }, root, cancellationToken: TestContext.Current.CancellationToken);
+        // Assert
+        Assert.Equal(property.Name, $"{propertyName.ToFirstCharacterUpperCase()}Escaped");
+    }
+
     [Fact]
     public async Task ConvertsUnionTypesToWrapperAsync()
     {


### PR DESCRIPTION
This is attempt to resolve #8133

The NOTION.COM api contains model properties `equals` that result in class property `Equals`, which causes a warning.

This commit adds a list of reserved property names (which currently contains only `Equals`). The result looks like this:

```c#
    public partial class CheckboxPropertyFilterMember1 : IAdditionalDataHolder, IParsable
    {
        /// <summary>The equals property</summary>
        public bool? EqualsEscaped { get; set; }
```

Please review it thorougly, maybe my approach to add a class `CSharpReservedPropertyNamesProvider` and another call to `ReplaceReservedNames` in `CSharpRefiner.RefineAsync` could have been done better. If yes, give me feedback 😄 