### PR TITLE
fix: correct names in a fixed order so generation is reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Name correction now walks the code model in a fixed order. Where two names correct to the same value only the element reached first can take it, and the walk followed a dictionary whose order varies between runs, so the winner, and with it the generated output, differed from one run to the next. This removes one source of the non-reproducible generation tracked in [#7997](https://github.com/microsoft/kiota/issues/7997); other sources remain, so the descriptions suppressed for it stay suppressed.
+
 - Ruby: a model sharing its name with a sibling namespace had the disambiguation suffix applied once per reference to it rather than once, so generation failed with `The element to rename was not found available_phone_number_countryModelModelModelModel`. The reference pass was removed: `CodeType.Name` already delegates to the type definition, so references follow the rename on their own. Un-suppresses the Twilio integration and idempotency tests. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)
 
 ## [1.35.0] - 2026-09-01

--- a/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
+++ b/src/Kiota.Builder/Refiners/CommonLanguageRefiner.cs
@@ -117,6 +117,7 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         bool enumNames = true)
     {
         ArgumentNullException.ThrowIfNull(refineName);
+        ArgumentNullException.ThrowIfNull(current);
         if (current is CodeClass currentClass && classNames &&
             refineName(currentClass.Name) is string refinedClassName &&
             !currentClass.Name.Equals(refinedClassName, StringComparison.Ordinal) &&
@@ -134,7 +135,15 @@ public abstract class CommonLanguageRefiner : ILanguageRefiner
         {
             parentBlock2.RenameChildElement(currentEnum.Name, refinedEnumName);
         }
-        CrawlTree(current, x => CorrectNames(x, refineName));
+        // Renaming mutates the tree that later elements are checked against, so when two names
+        // refine to the same value only the element reached first can take it. Children are stored
+        // in a dictionary whose enumeration order varies between runs, which made the winner, and
+        // therefore the generated output, differ from one run to the next (kiota#7997). Ordering
+        // the walk keeps it reproducible.
+        // classNames and enumNames are deliberately left to their defaults below the root, as
+        // callers rely on that: Ruby passes classNames false yet expects its models pascal-cased.
+        foreach (var childElement in current.GetChildElements(true).OrderBy(static x => x.Name, StringComparer.Ordinal))
+            CorrectNames(childElement, refineName);
     }
     protected static void ReplacePropertyNames(CodeElement current, HashSet<CodePropertyKind> propertyKindsToReplace, Func<string, string> refineAccessorName)
     {

--- a/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
+++ b/tests/Kiota.Builder.Tests/Refiners/RubyLanguageRefinerTests.cs
@@ -186,6 +186,36 @@ public class RubyLanguageRefinerTests
         // the references track the rename through the type definition, so they must agree
         Assert.Equal(collidingModel.Name, holder.Properties.First(static x => x.Name.Equals("country", StringComparison.OrdinalIgnoreCase)).Type.Name);
     }
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CorrectsNamesDeterministicallyWhenTwoRefineToTheSameNameAsync(bool doubledFirst)
+    {
+        // Both names pascal-case to FooBar and they differ by more than case, so they coexist in
+        // the child dictionary. Only one can take the refined name. The walk followed the
+        // dictionary's own order, so the winner depended on insertion order and generation was not
+        // reproducible (kiota#7997). Whichever order they are added, the ordinally first name wins.
+        var localRoot = CodeNamespace.InitRootNamespace();
+        var config = new GenerationConfiguration { Language = GenerationLanguage.Ruby };
+        var modelsNS = localRoot.AddNamespace(config.ModelsNamespaceName);
+        CodeClass doubled, single;
+        if (doubledFirst)
+        {
+            doubled = modelsNS.AddClass(new CodeClass { Name = "foo__bar", Kind = CodeClassKind.Model }).First();
+            single = modelsNS.AddClass(new CodeClass { Name = "foo_bar", Kind = CodeClassKind.Model }).First();
+        }
+        else
+        {
+            single = modelsNS.AddClass(new CodeClass { Name = "foo_bar", Kind = CodeClassKind.Model }).First();
+            doubled = modelsNS.AddClass(new CodeClass { Name = "foo__bar", Kind = CodeClassKind.Model }).First();
+        }
+
+        await ILanguageRefiner.RefineAsync(config, localRoot, cancellationToken: TestContext.Current.CancellationToken);
+
+        // "foo__bar" sorts before "foo_bar" ordinally ('_' is below 'b'), so it takes the refined name
+        Assert.Equal("FooBar", doubled.Name);
+        Assert.Equal("foo_bar", single.Name);
+    }
     [Fact]
     public async Task ConvertEnumsToPascalCaseAsync()
     {


### PR DESCRIPTION
- two names correcting to the same value raced, and the dictionary order decided the winner
- removes one source of #7997 ; others remain, so its suppressions stay