### PR TITLE
ci: validate dependency changes through the central feed

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -277,9 +277,10 @@ extends:
                   version: 6.x
 
               - task: UseDotNet@2
-                displayName: "Use .NET 10"
+                displayName: "Use .NET SDK from global.json"
                 inputs:
-                  version: 10.0.x
+                  useGlobalJson: true
+                  workingDirectory: "$(Build.SourcesDirectory)"
 
               # Pinned to a specific Go version for deterministic tool availability and formatting,
               # so the integration tests can run gofmt against the generated Go code.
@@ -524,9 +525,10 @@ extends:
                     inputs:
                       version: 6.x
                   - task: UseDotNet@2
-                    displayName: "Use .NET 10"
+                    displayName: "Use .NET SDK from global.json"
                     inputs:
-                      version: 10.0.x
+                      useGlobalJson: true
+                      workingDirectory: "$(Build.SourcesDirectory)"
 
                   - task: UseDotNet@2
                     condition: and(succeeded(), eq('${{ distribution.hostArchitecture }}', 'arm64'))

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -31,6 +31,7 @@ schedules:
 variables:
   buildPlatform: "Any CPU"
   buildConfiguration: "Release"
+  nodeVersion: "24.x"
   ProductBinPath: '$(Build.SourcesDirectory)\src\kiota\bin\$(BuildConfiguration)'
   REGISTRY: "msgraphprodregistry.azurecr.io"
   IMAGE_NAME: "public/openapi/kiota"
@@ -765,7 +766,7 @@ extends:
                 displayName: "Remove unused integration-test fixtures (it/)"
               - task: UseNode@1
                 inputs:
-                  version: "22.x"
+                  version: "$(nodeVersion)"
               - pwsh: $(Build.SourcesDirectory)/scripts/get-prerelease-version.ps1 -currentBranch $(Build.SourceBranch) -previewBranch ${{ parameters.previewBranch }}
                 displayName: "Set version suffix"
               - pwsh: $(Build.SourcesDirectory)/scripts/get-version-from-csproj.ps1
@@ -901,7 +902,7 @@ extends:
                 displayName: "Remove unused integration-test fixtures (it/)"
               - task: UseNode@1
                 inputs:
-                  version: "22.x"
+                  version: "$(nodeVersion)"
               - pwsh: $(Build.SourcesDirectory)/scripts/get-prerelease-version.ps1 -currentBranch $(Build.SourceBranch) -previewBranch ${{ parameters.previewBranch }}
                 displayName: "Set version suffix"
               - pwsh: $(Build.SourcesDirectory)/scripts/get-version-from-csproj.ps1
@@ -970,7 +971,7 @@ extends:
             steps:
               - task: UseNode@1
                 inputs:
-                  version: "22.x"
+                  version: "$(nodeVersion)"
               # Route the vsce tool install through the authenticated Azure Artifacts feed
               # (GraphDeveloperExperiences_Public) instead of the public npm registry, so this
               # release job resolves the global tool from the private feed's configured upstreams.
@@ -1406,7 +1407,7 @@ extends:
             steps:
               - task: UseNode@1
                 inputs:
-                  version: "22.x"
+                  version: "$(nodeVersion)"
               - pwsh: |
                   $pkg = Get-ChildItem -Path "$(Pipeline.Workspace)/npm-package" -Filter "*.tgz" | Select-Object -First 1
                   if (-not $pkg) { throw "No npm .tgz package found to publish." }

--- a/.azure-pipelines/ci-private-feed-validation.yml
+++ b/.azure-pipelines/ci-private-feed-validation.yml
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Verifies that changed npm and NuGet dependency graphs can be restored through the
+# authenticated GraphDeveloperExperiences_Public Azure Artifacts feed.
+
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  privateFeedBaseUrl: "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public"
+
+jobs:
+  - job: private_feed_dependency_validation
+    displayName: "private-feed-dependency-validation"
+    condition: ne(variables['System.PullRequest.IsFork'], 'True')
+    steps:
+      - checkout: self
+        fetchDepth: 2
+
+      - pwsh: |
+          $changedFiles = @(git diff --name-only HEAD^1 HEAD)
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to determine which files changed."
+          }
+
+          $vscodeLockfileChanged = $changedFiles -contains "vscode/package-lock.json"
+          $typescriptIntegrationLockfileChanged = $changedFiles -contains "it/typescript/package-lock.json"
+          $npmDependenciesChanged = $vscodeLockfileChanged -or $typescriptIntegrationLockfileChanged
+
+          [xml]$solution = Get-Content "$(Build.SourcesDirectory)/kiota.slnx"
+          $solutionProjects = @(
+            $solution.SelectNodes("//Project") |
+              ForEach-Object { $_.Path.Replace("\", "/") }
+          )
+          $nugetInputs = @("Directory.Packages.props", "kiota.slnx") + $solutionProjects
+          $nugetDependenciesChanged = $null -ne ($changedFiles | Where-Object { $_ -in $nugetInputs } | Select-Object -First 1)
+
+          $variables = @{
+            vscodeLockfileChanged = $vscodeLockfileChanged
+            typescriptIntegrationLockfileChanged = $typescriptIntegrationLockfileChanged
+            npmDependenciesChanged = $npmDependenciesChanged
+            nugetDependenciesChanged = $nugetDependenciesChanged
+          }
+          foreach ($variable in $variables.GetEnumerator()) {
+            $value = $variable.Value.ToString().ToLowerInvariant()
+            Write-Host "$($variable.Key): $value"
+            Write-Host "##vso[task.setvariable variable=$($variable.Key)]$value"
+          }
+        displayName: "Detect dependency changes"
+
+      - task: UseNode@1
+        displayName: "Install Node.js 24.x"
+        condition: and(succeeded(), eq(variables['npmDependenciesChanged'], 'true'))
+        inputs:
+          version: "24.x"
+
+      - pwsh: |
+          @"
+          registry=$(privateFeedBaseUrl)/npm/registry/
+          always-auth=true
+          "@ | Set-Content -Path "$(Agent.TempDirectory)/.npmrc" -Encoding UTF8
+        displayName: "Create central-feed .npmrc"
+        condition: and(succeeded(), eq(variables['npmDependenciesChanged'], 'true'))
+
+      - task: npmAuthenticate@0
+        displayName: "Authenticate npm dependencies"
+        condition: and(succeeded(), eq(variables['npmDependenciesChanged'], 'true'))
+        inputs:
+          workingFile: "$(Agent.TempDirectory)/.npmrc"
+
+      - pwsh: |
+          if ("$(vscodeLockfileChanged)" -eq "true") {
+            Copy-Item "$(Agent.TempDirectory)/.npmrc" "$(Build.SourcesDirectory)/vscode/.npmrc" -Force
+          }
+          if ("$(typescriptIntegrationLockfileChanged)" -eq "true") {
+            Copy-Item "$(Agent.TempDirectory)/.npmrc" "$(Build.SourcesDirectory)/it/typescript/.npmrc" -Force
+          }
+        displayName: "Copy .npmrc to changed projects"
+        condition: and(succeeded(), eq(variables['npmDependenciesChanged'], 'true'))
+
+      - script: npm ci --verbose
+        displayName: "Restore VS Code npm dependencies"
+        condition: and(succeeded(), eq(variables['vscodeLockfileChanged'], 'true'))
+        workingDirectory: "$(Build.SourcesDirectory)/vscode"
+
+      - script: npm ci --verbose
+        displayName: "Restore TypeScript integration npm dependencies"
+        condition: and(succeeded(), eq(variables['typescriptIntegrationLockfileChanged'], 'true'))
+        workingDirectory: "$(Build.SourcesDirectory)/it/typescript"
+
+      - task: UseDotNet@2
+        displayName: "Install .NET SDK from global.json"
+        condition: and(succeeded(), eq(variables['nugetDependenciesChanged'], 'true'))
+        inputs:
+          useGlobalJson: true
+          workingDirectory: "$(Build.SourcesDirectory)"
+
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet dependencies"
+        condition: and(succeeded(), eq(variables['nugetDependenciesChanged'], 'true'))
+
+      - pwsh: |
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="GraphDeveloperExperiences_Public" value="$(privateFeedBaseUrl)/nuget/v3/index.json" />
+            </packageSources>
+          </configuration>
+          "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+        displayName: "Create nuget.config"
+        condition: and(succeeded(), eq(variables['nugetDependenciesChanged'], 'true'))
+
+      - pwsh: dotnet restore kiota.slnx --configfile "$(Build.SourcesDirectory)/nuget.config"
+        displayName: "Restore NuGet dependencies"
+        condition: and(succeeded(), eq(variables['nugetDependenciesChanged'], 'true'))
+        workingDirectory: "$(Build.SourcesDirectory)"

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Use .NET 10
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - id: last_release
         run: |

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           node-version: 24.x
 
-      - name: Use .NET 10
+      - name: Use .NET SDK from global.json
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "10.0.x"
+          global-json-file: global.json
 
       - id: last_release
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Setup Go
         # required so the integration tests can run gofmt against the generated Go code
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -72,7 +72,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore kiota.slnx
       - name: Publish ${{ matrix.os }}

--- a/.github/workflows/idempotency-tests.yml
+++ b/.github/workflows/idempotency-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore kiota.slnx
       - name: Build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -144,7 +144,7 @@ jobs:
         if: matrix.language == 'typescript'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: Setup Ruby
         if: matrix.language == 'ruby'
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore kiota.slnx
       - name: Build
@@ -134,7 +134,7 @@ jobs:
         if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Setup Go
         if: matrix.language == 'go'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Compile the CLI in debug mode
         run: |
           dotnet restore ./src/kiota

--- a/.github/workflows/surface-area-tests.yml
+++ b/.github/workflows/surface-area-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore kiota.slnx
       - name: Build
@@ -56,7 +56,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generator

--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,7 @@ FakesAssemblies/
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 node_modules/
+nuget.config
 
 # Visual Studio 6 build log
 *.plg

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,43 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1507</WarningsNotAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AsyncKeyedLock" Version="8.0.2" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0.0" />
+    <PackageVersion Include="Microsoft.DeclarativeAgents.Manifest" Version="5.0.0-rc.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="3.10.2" />
+    <PackageVersion Include="Microsoft.OpenApi.ApiManifest" Version="3.0.0-preview.1" />
+    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.10.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.57.2" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+</Project>

--- a/it/Directory.Packages.props
+++ b/it/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/it/typescript/.npmrc
+++ b/it/typescript/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+min-release-age=7
+min-release-age-exclude[]=@microsoft/*

--- a/src/Kiota.Builder/Kiota.Builder.csproj
+++ b/src/Kiota.Builder/Kiota.Builder.csproj
@@ -35,16 +35,16 @@
     <NoWarn>$(NoWarn);CS8785;NU5048;NU5104;CA1724;CA1055;CA1848;CA1308;CA1822</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
-    <PackageReference Include="DotNet.Glob" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="3.10.2" />
-    <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="3.0.0-preview.1" />
-    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.10.2" />
-    <PackageReference Include="Microsoft.DeclarativeAgents.Manifest" Version="5.0.0-rc.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="AsyncKeyedLock" />
+    <PackageReference Include="DotNet.Glob" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Kiota.Bundle" />
+    <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi.ApiManifest" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" />
+    <PackageReference Include="Microsoft.DeclarativeAgents.Manifest" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Kiota.Generated/KiotaGenerated.csproj
+++ b/src/Kiota.Generated/KiotaGenerated.csproj
@@ -12,9 +12,9 @@
             Updating this version might cause runtime errors due to unsupported dependencies in older SDK versions.
             Please avoid upgrading this dependency unless the target framework version is changed or until confirmed compatible with .NET 8.
             If Dependabot suggests an upgrade, it should be ignored. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0.0"
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"
       ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"
       ExcludeAssets="runtime" />
   </ItemGroup>
 

--- a/src/kiota/kiota.csproj
+++ b/src/kiota/kiota.csproj
@@ -42,28 +42,28 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.18.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
-    <PackageReference Include="Spectre.Console" Version="0.57.2" />
-    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
-    <PackageReference Include="System.CommandLine" Version="2.0.11" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="StreamJsonRpc" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
+++ b/tests/Kiota.Builder.IntegrationTests/Kiota.Builder.IntegrationTests.csproj
@@ -7,19 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.SDK" Version="18.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.SDK" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
+++ b/tests/Kiota.Builder.Tests/Kiota.Builder.Tests.csproj
@@ -13,19 +13,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DotNet.Glob" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="DotNet.Glob" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="moq" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Kiota.Tests/Kiota.Tests.csproj
+++ b/tests/Kiota.Tests/Kiota.Tests.csproj
@@ -10,21 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vscode/.npmrc
+++ b/vscode/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+min-release-age=7
+min-release-age-exclude[]=@microsoft/*


### PR DESCRIPTION
## Summary
- centralize NuGet versions for the six projects in `kiota.slnx` while keeping integration fixtures independently versioned
- add an ADO PR pipeline that conditionally restores changed npm and NuGet dependency graphs through `GraphDeveloperExperiences_Public`
- add tracked npm release-age policies and move dependency-consuming CI jobs to Node 24
- centralize the official ADO pipeline's Node version and use `global.json` for every pipeline that previously selected a floating .NET 10.x SDK

## Validation
- `dotnet restore kiota.slnx`
- `dotnet build kiota.slnx --no-restore --configuration Debug`
- `dotnet test kiota.slnx --no-build --configuration Debug` (125 passed)
- `npm ci` in `vscode` and `it/typescript`
- VS Code workspace build and lint
- npm package unit tests (18 passed)
- parsed both changed ADO pipeline files as YAML
