### PR TITLE
fix: make the dart error model additionalData constructor parameter optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dart: an error model's constructor declared the named `additionalData` parameter as `required`, but the generated callers never pass it — inherited error models call a bare `super()` and `createFromDiscriminatorValue` instantiates the class without arguments — so a document with a discriminated error hierarchy generated a client that did not compile. The parameter is now optional and defaults to an empty map in the initializer list.
+
 - Name correction now walks the code model in a fixed order. Where two names correct to the same value only the element reached first can take it, and the walk followed a dictionary whose order varies between runs, so the winner, and with it the generated output, differed from one run to the next. This removes one source of the non-reproducible generation tracked in [#7997](https://github.com/microsoft/kiota/issues/7997); other sources remain, so the descriptions suppressed for it stay suppressed.
 
 - Ruby: a model sharing its name with a sibling namespace had the disambiguation suffix applied once per reference to it rather than once, so generation failed with `The element to rename was not found available_phone_number_countryModelModelModelModel`. The reference pass was removed: `CodeType.Name` already delegates to the type definition, so references follow the rename on their own. Un-suppresses the Twilio integration and idempotency tests. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)

--- a/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
+++ b/src/Kiota.Builder/Writers/Dart/CodeMethodWriter.cs
@@ -44,9 +44,17 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
             }
             else if (isConstructor && parentClass.IsErrorDefinition)
             {
-                if (parentClass.Properties.Where(static x => x.IsOfKind(CodePropertyKind.AdditionalData)).Any() && parentClass.Properties.Where(static x => x.IsOfKind(CodePropertyKind.BackingStore)).Any())
+                if (parentClass.Properties.FirstOrDefault(static x => x.IsOfKind(CodePropertyKind.AdditionalData)) is CodeProperty additionalDataProperty)
                 {
-                    writer.CloseBlock("}) {additionalData = {};}");
+                    if (parentClass.Properties.Where(static x => x.IsOfKind(CodePropertyKind.BackingStore)).Any())
+                    {
+                        writer.CloseBlock($"}}) {{{additionalDataProperty.Name} = {{}};}}");
+                    }
+                    else
+                    {
+                        // additionalData is an optional named parameter so that subclasses and factory methods can call the constructor without arguments.
+                        writer.CloseBlock($"}}) : {additionalDataProperty.Name} = {additionalDataProperty.Name} ?? {{}};");
+                    }
                 }
                 else
                 {
@@ -411,10 +419,16 @@ public class CodeMethodWriter : BaseElementWriter<CodeMethod, DartConventionServ
         {
             foreach (CodeProperty prop in parentClass.GetPropertiesOfKind(CodePropertyKind.Custom, CodePropertyKind.AdditionalData))
             {
-                var required = prop.Type.IsNullable ? "" : "required ";
-
-                if (!conventions.ErrorClassPropertyExistsInSuperClass(prop))
+                if (conventions.ErrorClassPropertyExistsInSuperClass(prop))
+                    continue;
+                if (prop.IsOfKind(CodePropertyKind.AdditionalData))
                 {
+                    // Optional parameter defaulted in the initializer list so that subclasses and factory methods can call the constructor without arguments.
+                    writer.WriteLine($"{conventions.TranslateType(prop.Type)}? {prop.Name},");
+                }
+                else
+                {
+                    var required = prop.Type.IsNullable ? "" : "required ";
                     writer.WriteLine($"{required}this.{prop.Name},");
                 }
             }

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeMethodWriterTests.cs
@@ -2080,4 +2080,84 @@ public sealed class CodeMethodWriterTests : IDisposable
         Assert.Contains("requestInfo.headers.put('Accept', 'application/json; profile=\\'Cam\\$el\\'\\nCase')", result);
         Assert.Contains("'application/json; profile=\\'Cam\\$el\\'\\nCase'", result);
     }
+    private void SetupErrorClassWithAdditionalData()
+    {
+        parentClass.Kind = CodeClassKind.Model;
+        parentClass.IsErrorDefinition = true;
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "additionalData",
+            Kind = CodePropertyKind.AdditionalData,
+            Type = new CodeType
+            {
+                Name = "Map<String, Object?>",
+                IsNullable = false,
+            },
+        });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "type_",
+            Kind = CodePropertyKind.Custom,
+            Type = new CodeType
+            {
+                Name = "String",
+                IsNullable = true,
+            },
+        });
+    }
+    [Fact]
+    public void WritesErrorClassConstructorWithOptionalAdditionalData()
+    {
+        setup();
+        SetupErrorClassWithAdditionalData();
+        method.Kind = CodeMethodKind.Constructor;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("super.message,", result);
+        Assert.Contains("Map<String, Object?>? additionalData,", result);
+        Assert.Contains("this.type_,", result);
+        Assert.Contains("}) : additionalData = additionalData ?? {};", result);
+        // a required parameter would break the bare super() calls of inherited error models and the createFromDiscriminatorValue factories
+        Assert.DoesNotContain("required this.additionalData", result);
+    }
+    [Fact]
+    public void WritesErrorClassConstructorWithBackingStore()
+    {
+        setup();
+        SetupErrorClassWithAdditionalData();
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "backingStore",
+            Kind = CodePropertyKind.BackingStore,
+            Type = new CodeType
+            {
+                Name = "BackingStore",
+            },
+        });
+        method.Kind = CodeMethodKind.Constructor;
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("}) {additionalData = {};}", result);
+        Assert.DoesNotContain("required this.additionalData", result);
+    }
+    [Fact]
+    public void WritesErrorClassFactoryBodyCallableWithoutArguments()
+    {
+        setup();
+        SetupErrorClassWithAdditionalData();
+        method.Kind = CodeMethodKind.Factory;
+        method.IsStatic = true;
+        method.AddParameter(new CodeParameter
+        {
+            Name = "parseNode",
+            Kind = CodeParameterKind.ParseNode,
+            Type = new CodeType
+            {
+                Name = "ParseNode",
+            },
+        });
+        writer.Write(method);
+        var result = tw.ToString();
+        Assert.Contains("return ParentClass(additionalData: {});", result);
+    }
 }


### PR DESCRIPTION
## Description

A dart client generated from a document that declares a discriminated error hierarchy does not
compile. The error base class is generated with a required named `additionalData` parameter:

```dart
// models/srs_error.dart
SrsError( {
    super.message,
    super.statusCode,
    super.responseHeaders,
    super.innerExceptions,
    required this.additionalData,
    this.type_,
});
```

but none of the generated callers pass it — every inherited error model calls a bare `super()`
and the discriminator factory instantiates the base class without arguments:

```dart
// models/validation_error.dart
ValidationError() : super() ;

// models/srs_error.dart
_ => SrsError(),
```

`dart analyze` reports `missing_required_argument` once per subclass, factory arm and fallback
(17 times for the document this was found in), and since every request builder imports its error
mapping types, no operation in the client is usable. Likely one of the compile-error families behind the dart reports in
#7807 (the Notion description shows `additionalData` initialization errors of the same shape).

## Root cause

`CodeMethodWriter.WriteErrorClassConstructor` marks any non-nullable constructor parameter of an
error model as `required`, which always hits the `additionalData` property (`Map<String, Object?>`,
not nullable). The code the writer generates elsewhere never satisfies that contract:

- `GetBaseSuffix` emits `: super()` for every inherited model constructor, error subclasses included;
- `WriteFactoryMethodBodyForInheritedModel` emits `SubType()` for each discriminator mapping and
  `BaseType()` for the fallback arm;
- an error model inheriting another error model has no `additionalData` of its own, so its
  constructor ends with an implicit zero-argument super call.

## Changes Made

- `additionalData` is now an optional named parameter, defaulted in the constructor initializer
  list, keeping the field non-nullable:

  ```dart
  SrsError( {
      super.message,
      ...
      Map<String, Object?>? additionalData,
      this.type_,
  }) : additionalData = additionalData ?? {};
  ```

  All existing call shapes stay valid: bare `super()`, the factory arms, the
  `additionalData: {}` factory for non-inherited error models, `copyWith`, and callers that pass
  `additionalData` explicitly. The backing-store variant (`}) {additionalData = {};}`) is untouched.
- New tests `WritesErrorClassConstructorWithOptionalAdditionalData`,
  `WritesErrorClassConstructorWithBackingStore` and
  `WritesErrorClassFactoryBodyCallableWithoutArguments` in the dart `CodeMethodWriterTests`.
- CHANGELOG entry under Unreleased/Changed.

## Testing

- The dart writer test suite passes: `dotnet test --filter "FullyQualifiedName~Writers.Dart"`,
  75 passed, 0 failed, and the full `Kiota.Builder.Tests` suite passes: 2307 passed, 0 failed, 2 skipped.
- **Reproduction, before/after.** A production document of ≈100 operations declaring a
  16-subclass discriminated error hierarchy, generated with `-l dart` and analyzed with dart 3.9
  against the pub.dev kiota runtime:

  | | `dart analyze` |
  | --- | --- |
  | before | 21 errors, 17 of them `missing_required_argument` on the error hierarchy |
  | after | all 17 `missing_required_argument` errors gone (the remaining 4 are an unrelated file-name collision, fixed separately in #8151) |

---

Generated with Claude Code
