### PR TITLE
fix: disambiguate dart file names colliding after snake casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dart: an error model's constructor declared the named `additionalData` parameter as `required`, but the generated callers never pass it — inherited error models call a bare `super()` and `createFromDiscriminatorValue` instantiates the class without arguments — so a document with a discriminated error hierarchy generated a client that did not compile. The parameter is now optional and defaults to an empty map in the initializer list.
+- Dart: models whose names differ only in where a separator falls (e.g. the inline property type `Process_error` and the component schema `ProcessError`) snake-cased to the same file name, so one silently overwrote the other and the client did not compile (`Undefined class 'Process_error'`). Colliding file names are now disambiguated, leaving the generated type names unchanged. Same defect as the one fixed for Ruby, part of [#7821](https://github.com/microsoft/kiota/issues/7821).
 
 - Name correction now walks the code model in a fixed order. Where two names correct to the same value only the element reached first can take it, and the walk followed a dictionary whose order varies between runs, so the winner, and with it the generated output, differed from one run to the next. This removes one source of the non-reproducible generation tracked in [#7997](https://github.com/microsoft/kiota/issues/7997); other sources remain, so the descriptions suppressed for it stay suppressed.
 

--- a/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
+++ b/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
+++ b/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.Extensions;
 using Kiota.Builder.Writers.Go;
@@ -11,10 +14,39 @@ public class DartPathSegmenter(string rootPath, string clientNamespaceName) : Co
 
     public override string NormalizeNamespaceSegment(string segmentName) => segmentName.ToCamelCase();
 
-    public override string NormalizeFileName(CodeElement currentElement) => GetLastFileNameSegment(currentElement).ToSnakeCase();
+    private readonly ConcurrentDictionary<CodeNamespace, Dictionary<string, CodeElement[]>> collidingFileNames = new();
+    /// <summary>
+    /// Snake casing is lossy: names that differ only in where a separator falls, such as
+    /// Process_error (an inline property type) and ProcessError (a component schema), collapse onto
+    /// the same file name. One model then silently overwrote the other, so the surviving file did not
+    /// declare the type the imports asked for and the client did not compile. The second and later
+    /// members of a colliding set get a numeric suffix; the ordering is by ordinal name, which keeps
+    /// the result stable between the import path and the output path.
+    /// </summary>
+    public override string NormalizeFileName(CodeElement currentElement)
+    {
+        var fileName = GetLastFileNameSegment(currentElement).ToSnakeCase();
+        if (currentElement is not (CodeClass or CodeEnum) || currentElement.Parent is not CodeNamespace parentNamespace)
+            return fileName;
+        var collisions = collidingFileNames.GetOrAdd(parentNamespace, static ns =>
+            ns.Classes.Cast<CodeElement>()
+                .Concat(ns.Enums)
+                .GroupBy(static x => GetLastFileNameSegment(x).ToSnakeCase(), StringComparer.OrdinalIgnoreCase)
+                .Where(static x => x.Skip(1).Any())
+                .ToDictionary(static x => x.Key,
+                              static x => x.OrderBy(static y => y.Name, StringComparer.Ordinal).ToArray(),
+                              StringComparer.OrdinalIgnoreCase));
+        if (!collisions.TryGetValue(fileName, out var siblings))
+            return fileName;
+        var index = Array.FindIndex(siblings, x => ReferenceEquals(x, currentElement));
+        return index > 0 ? $"{fileName}_{index + 1}" : fileName;
+    }
 
     internal string GetRelativeFileName(CodeNamespace @namespace, CodeElement element)
     {
-        return NormalizeFileName(element);
+        // the import manager passes the using's CodeType; resolve it to the definition the file is named after
+        return element is CodeType { TypeDefinition: CodeElement typeDefinition } ?
+            NormalizeFileName(typeDefinition) :
+            NormalizeFileName(element);
     }
 }

--- a/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
+++ b/src/Kiota.Builder/PathSegmenters/DartPathSegmenter.cs
@@ -25,14 +25,16 @@ public class DartPathSegmenter(string rootPath, string clientNamespaceName) : Co
     /// </summary>
     public override string NormalizeFileName(CodeElement currentElement)
     {
-        var fileName = GetLastFileNameSegment(currentElement).ToSnakeCase();
+        ArgumentNullException.ThrowIfNull(currentElement);
+        static string NormalizedFileName(CodeElement element) => GetLastFileNameSegment(element).ToSnakeCase();
+        var fileName = NormalizedFileName(currentElement);
         if (currentElement is not (CodeClass or CodeEnum) || currentElement.Parent is not CodeNamespace parentNamespace)
             return fileName;
         var collisions = collidingFileNames.GetOrAdd(parentNamespace, static ns =>
             ns.Classes.Cast<CodeElement>()
                 .Concat(ns.Enums)
-                .GroupBy(static x => GetLastFileNameSegment(x).ToSnakeCase(), StringComparer.OrdinalIgnoreCase)
-                .Where(static x => x.Skip(1).Any())
+                .GroupBy(NormalizedFileName, StringComparer.OrdinalIgnoreCase)
+                .Where(static x => x.Count() > 1)
                 .ToDictionary(static x => x.Key,
                               static x => x.OrderBy(static y => y.Name, StringComparer.Ordinal).ToArray(),
                               StringComparer.OrdinalIgnoreCase));

--- a/tests/Kiota.Builder.Tests/PathSegmenters/DartPathSegmenterTests.cs
+++ b/tests/Kiota.Builder.Tests/PathSegmenters/DartPathSegmenterTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Kiota.Builder.CodeDOM;
 using Kiota.Builder.PathSegmenters;
 using Xunit;

--- a/tests/Kiota.Builder.Tests/PathSegmenters/DartPathSegmenterTests.cs
+++ b/tests/Kiota.Builder.Tests/PathSegmenters/DartPathSegmenterTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using Kiota.Builder.CodeDOM;
+using Kiota.Builder.PathSegmenters;
+using Xunit;
+
+namespace Kiota.Builder.Tests.PathSegmenters
+{
+    public class DartPathSegmenterTests
+    {
+        private readonly DartPathSegmenter segmenter;
+        public DartPathSegmenterTests()
+        {
+            segmenter = new DartPathSegmenter("/tmp/kiota-sample", "client");
+        }
+
+        [Fact]
+        public void DartPathSegmenterGeneratesCorrectFileName()
+        {
+            var rootNamespace = CodeNamespace.InitRootNamespace();
+            var classExample = rootNamespace.AddClass(new CodeClass
+            {
+                Name = "testClass"
+            }).First();
+            Assert.Equal("test_class", segmenter.NormalizeFileName(classExample));
+        }
+
+        [Fact]
+        public void DisambiguatesClassesThatSnakeCaseToTheSameFileName()
+        {
+            // an inline property type keeps its raw Parent_property name when the pascal cased
+            // form is already taken by a component schema; snake casing collapses both onto one
+            // path, so one silently overwrote the other and the imports referenced a type the
+            // surviving file does not declare
+            var rootNamespace = CodeNamespace.InitRootNamespace();
+            var ns = rootNamespace.AddNamespace("client.models");
+            var componentSchema = ns.AddClass(new CodeClass { Name = "ProcessError", Kind = CodeClassKind.Model }).First();
+            var inlineType = ns.AddClass(new CodeClass { Name = "Process_error", Kind = CodeClassKind.Model }).First();
+
+            var first = segmenter.NormalizeFileName(componentSchema);
+            var second = segmenter.NormalizeFileName(inlineType);
+            Assert.NotEqual(first, second);
+            Assert.Equal("process_error", first);
+            Assert.Equal("process_error_2", second);
+        }
+
+        [Fact]
+        public void DisambiguatesAClassAndAnEnumSharingAFileName()
+        {
+            var rootNamespace = CodeNamespace.InitRootNamespace();
+            var ns = rootNamespace.AddNamespace("client.models");
+            var model = ns.AddClass(new CodeClass { Name = "SomeModel", Kind = CodeClassKind.Model }).First();
+            var enumeration = ns.AddEnum(new CodeEnum { Name = "some_model" }).First();
+
+            Assert.NotEqual(segmenter.NormalizeFileName(model), segmenter.NormalizeFileName(enumeration));
+        }
+
+        [Fact]
+        public void KeepsTheFileNameStableWhenThereIsNoCollision()
+        {
+            var rootNamespace = CodeNamespace.InitRootNamespace();
+            var ns = rootNamespace.AddNamespace("client.models");
+            var only = ns.AddClass(new CodeClass { Name = "someModel", Kind = CodeClassKind.Model }).First();
+            ns.AddClass(new CodeClass { Name = "otherModel", Kind = CodeClassKind.Model });
+
+            Assert.Equal("some_model", segmenter.NormalizeFileName(only));
+        }
+
+        [Fact]
+        public void ReturnsTheSameNameForRepeatedCalls()
+        {
+            // the class declaration writer resolves the import path and the file writer resolves
+            // the output path through separate calls, so they have to agree
+            var rootNamespace = CodeNamespace.InitRootNamespace();
+            var ns = rootNamespace.AddNamespace("client.models");
+            ns.AddClass(new CodeClass { Name = "ProcessError", Kind = CodeClassKind.Model });
+            var second = ns.AddClass(new CodeClass { Name = "Process_error", Kind = CodeClassKind.Model }).First();
+
+            Assert.Equal(segmenter.NormalizeFileName(second), segmenter.NormalizeFileName(second));
+        }
+    }
+}

--- a/tests/Kiota.Builder.Tests/Writers/Dart/CodeClassDeclarationWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/Dart/CodeClassDeclarationWriterTests.cs
@@ -92,4 +92,42 @@ public sealed class CodeClassDeclarationWriterTests : IDisposable
         var result = tw.ToString();
         Assert.Contains("import './message.dart';", result);
     }
+    [Fact]
+    public void WritesDistinctImportsForClassesSnakeCasingToTheSameFileName()
+    {
+        var declaration = parentClass.StartBlock;
+        var componentSchema = new CodeClass
+        {
+            Name = "ProcessError",
+            Kind = CodeClassKind.Model,
+        };
+        var inlineType = new CodeClass
+        {
+            Name = "Process_error",
+            Kind = CodeClassKind.Model,
+        };
+        root.AddClass(componentSchema);
+        root.AddClass(inlineType);
+        declaration.AddUsings(new CodeUsing
+        {
+            Name = "project.graph",
+            Declaration = new()
+            {
+                Name = "ProcessError",
+                TypeDefinition = componentSchema
+            }
+        }, new CodeUsing
+        {
+            Name = "project.graph",
+            Declaration = new()
+            {
+                Name = "Process_error",
+                TypeDefinition = inlineType
+            }
+        });
+        codeElementWriter.WriteCodeElement(declaration, writer);
+        var result = tw.ToString();
+        Assert.Contains("import './process_error.dart';", result);
+        Assert.Contains("import './process_error_2.dart';", result);
+    }
 }


### PR DESCRIPTION
## Description

A dart client generated from a document where an inline property type and a component schema
snake-case to the same file name does not compile. With a component schema `ProcessError` and a
`Process.error` inline property (raw type name `Process_error`), both models map onto
`models/process_error.dart`; one silently overwrites the other, so the surviving file does not
declare the type the imports ask for:

```
error - lib/models/process.dart:29:5 - Undefined class 'Process_error'. ... - undefined_class
error - lib/models/process.dart:71:74 - The name 'Process_error' isn't a type, ... - non_type_as_type_argument
```

This is one of the dart compile-error families reported in #7821 for the GitHub description
(`codeScanningVariantAnalysis_status` vs `CodeScanningVariantAnalysisStatus` is the same
collision).

## Root cause

The dart refiner pascal-cases model names containing `_`, but `CorrectNames` deliberately backs
off when the target name is already taken — with a component schema `ProcessError` present, the
inline type keeps its raw `Process_error` name. `DartPathSegmenter.NormalizeFileName` then does a
plain `ToSnakeCase()`, which is lossy: `Process_error` and `ProcessError` both become
`process_error`, and `CodeRenderer.RenderCodeNamespaceToFilePerClassAsync` opens each path with
`FileMode.Create`, so whichever class renders last wins the file.

Go's segmenter already guards against exactly this (the `_` → `_escaped_` replacement in
`GoPathSegmenter`, whose comment cites the `codeScanningVariantAnalysis_status` case), and Ruby
recently fixed it with collision-aware numeric suffixes. This ports the Ruby approach to dart.

## Changes Made

- `DartPathSegmenter.NormalizeFileName` disambiguates classes and enums of a namespace that
  snake-case onto the same file name: the second and later members of a colliding set (ordinal
  order, stable across calls) get a numeric suffix — `ProcessError` keeps `process_error.dart`,
  `Process_error` gets `process_error_2.dart`. Non-colliding names are untouched, and the
  generated type names do not change. Same scheme as `RubyPathSegmenter`.
- `DartPathSegmenter.GetRelativeFileName` (the import path callback) now resolves a using's
  `CodeType` to its type definition before normalizing, so the emitted `import` line and the
  written file always agree.
- New `DartPathSegmenterTests` mirroring the Ruby segmenter tests, and a
  `CodeClassDeclarationWriterTests` case asserting the two imports come out distinct.
- CHANGELOG entry under Unreleased/Changed.

## Testing

- The dart writer + segmenter test suites pass:
  `dotnet test --filter "FullyQualifiedName~Writers.Dart|FullyQualifiedName~DartPathSegmenter"`,
  78 passed, 0 failed, and the full `Kiota.Builder.Tests` suite passes: 2310 passed, 0 failed, 2 skipped.
- **Reproduction, before/after.** A production document of ≈100 operations with a `ProcessError`
  component schema and a `Process.error` inline property, generated with `-l dart` and analyzed
  with dart 3.9 against the pub.dev kiota runtime:

  | | files | `dart analyze` |
  | --- | --- | --- |
  | before | one `process_error.dart` holding only `ProcessError` | 4 errors: `Undefined class 'Process_error'` and its uses |
  | after | `process_error.dart` + `process_error_2.dart`, imports pointing at the right one | all 4 errors gone (the remaining errors in the document are an unrelated error-constructor defect, fixed separately in #8150) |

---

Generated with Claude Code
