### PR TITLE
chore(C#): use helper methods for CS1591 pragma

### DIFF
--- a/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodeEnumWriter.cs
@@ -37,9 +37,9 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, CSharpConventionServic
         if (codeElement.Flags)
             writer.WriteLine("[Flags]");
         conventions.WriteDeprecationAttribute(codeElement, writer);
-        if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
+        if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
         writer.WriteLine($"{conventions.GetAccessModifier(codeElement.Access)} enum {codeElement.Name.ToFirstCharacterUpperCase()}");
-        if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
+        if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
         writer.StartBlock();
         var idx = 0;
         foreach (var option in codeElement.Options)
@@ -50,9 +50,9 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, CSharpConventionServic
             {
                 writer.WriteLine($"[EnumMember(Value = \"{option.SerializationName.SanitizeDoubleQuote()}\")]");
             }
-            if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
+            if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
             writer.WriteLine($"{option.Name.ToFirstCharacterUpperCase()}{(codeElement.Flags ? " = " + GetEnumFlag(idx) : string.Empty)},");
-            if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
+            if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
             idx++;
         }
         if (codeNamespace != null)

--- a/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
+++ b/src/Kiota.Builder/Writers/CSharp/CodePropertyWriter.cs
@@ -22,15 +22,15 @@ public class CodePropertyWriter : BaseElementWriter<CodeProperty, CSharpConventi
         if (isNullableReferenceType)
         {
             CSharpConventionService.WriteNullableOpening(writer);
-            if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
+            if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
             WritePropertyInternal(codeElement, writer, $"{propertyType}?");
-            if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
+            if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
             CSharpConventionService.WriteNullableMiddle(writer);
         }
 
-        if (!hasDescription) writer.WriteLine("#pragma warning disable CS1591");
+        if (!hasDescription) conventions.WritePragmaDisable(writer, CSharpConventionService.CS1591);
         WritePropertyInternal(codeElement, writer, propertyType);// Always write the normal way
-        if (!hasDescription) writer.WriteLine("#pragma warning restore CS1591");
+        if (!hasDescription) conventions.WritePragmaRestore(writer, CSharpConventionService.CS1591);
 
         if (isNullableReferenceType)
             CSharpConventionService.WriteNullableClosing(writer);


### PR DESCRIPTION
This is a followup to #8096: for writing `#pragma warning disable CS1591`, there exists a helper method.

It was also not used in old `CodeEnumWriter`

