### PR TITLE
chore(tests): replace obsolete property OpenApiSchema.Example

### DIFF
--- a/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/tests/Kiota.Builder.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using Kiota.Builder.Extensions;
 using Microsoft.OpenApi;
 using Xunit;
@@ -477,7 +478,9 @@ public class OpenApiSchemaExtensionsTests
             Description = "unique identifier",
             Type = JsonSchemaType.String,
             Pattern = "^[1-9][0-9]*$",
-            Example = "1323232",
+            Examples = [
+                 (JsonNode) "1323232"
+                ]
         };
         var tmpDocument = new OpenApiDocument();
         tmpDocument.AddComponent("UserId", userIdSchema);


### PR DESCRIPTION
The test `OpenApiSchemaExtensionsTests.IsIntersection` used the now obsolete property `OpenApiSchema.Example`.

Hope I properly changed it to `Examples` and an array.

It became obsolete in [Microsoft.OpenApi 3.10](https://github.com/microsoft/OpenAPI.NET/releases#release-v3.10.0), introduced by https://www.github.com/microsoft/OpenAPI.NET/issues/2972