### PR TITLE
fix: keep the base class of an error schema deriving from another error schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed the generation of a schema used in two roles at once: as the schema of an error response and as an `allOf` child in the discriminator mapping of another error schema. The error refiner replaced its `allOf` base class with the language error base class while the parent's factory method still returned it as a derived type, so the generated C# and Java clients did not compile (`CS0029` / `incompatible types`). Such a schema now keeps its base class and inherits the error base class through its parent, like every other mapped child.
+
 - Dart: an error model's constructor declared the named `additionalData` parameter as `required`, but the generated callers never pass it — inherited error models call a bare `super()` and `createFromDiscriminatorValue` instantiates the class without arguments — so a document with a discriminated error hierarchy generated a client that did not compile. The parameter is now optional and defaults to an empty map in the initializer list.
 
 - Name correction now walks the code model in a fixed order. Where two names correct to the same value only the element reached first can take it, and the walk followed a dictionary whose order varies between runs, so the winner, and with it the generated output, differed from one run to the next. This removes one source of the non-reproducible generation tracked in [#7997](https://github.com/microsoft/kiota/issues/7997); other sources remain, so the descriptions suppressed for it stay suppressed.

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -594,6 +594,9 @@ public partial class KiotaBuilder
             CreateWebhookModels();
             StopLogAndReset(stopwatch, nameof(CreateWebhookModels));
             stopwatch.Start();
+            UnmarkDerivedErrorDefinitions();
+            StopLogAndReset(stopwatch, nameof(UnmarkDerivedErrorDefinitions));
+            stopwatch.Start();
             MapTypeDefinitions(codeNamespace);
             StopLogAndReset(stopwatch, nameof(MapTypeDefinitions));
             stopwatch.Start();
@@ -1409,6 +1412,21 @@ public partial class KiotaBuilder
             else
                 LogCouldNotCreateErrorType(errorCode, operation.OperationId);
         }
+    }
+    /// <summary>
+    /// Unmarks error definitions that derive from another error definition so they keep their inheritance hierarchy.
+    /// A schema can be used both as the schema of an error response and as a child of another discriminated error schema.
+    /// Since such a class already derives from the error base class through its parent, replacing its base class would
+    /// break the discriminator factory method of the parent which returns the derived types.
+    /// </summary>
+    private void UnmarkDerivedErrorDefinitions()
+    {
+        if (rootNamespace is null) return;
+        foreach (var derivedErrorDefinition in GetAllModels(rootNamespace)
+                                                .OfType<CodeClass>()
+                                                .Where(static x => x.IsErrorDefinition && x.GetInheritanceTree(false, false).Any(static y => y.IsErrorDefinition))
+                                                .ToArray())
+            derivedErrorDefinition.IsErrorDefinition = false;
     }
     private (CodeTypeBase?, CodeTypeBase?) GetExecutorMethodReturnType(OpenApiUrlTreeNode currentNode, IOpenApiSchema? schema, OpenApiOperation operation, CodeClass parentClass, NetHttpMethod operationType)
     {

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1424,7 +1424,7 @@ public partial class KiotaBuilder
         if (rootNamespace is null) return;
         foreach (var derivedErrorDefinition in GetAllModels(rootNamespace)
                                                 .OfType<CodeClass>()
-                                                .Where(static x => x.IsErrorDefinition && x.GetInheritanceTree(false, false).Any(static y => y.IsErrorDefinition))
+                                                .Where(static x => x.IsErrorDefinition && x.BaseClass is { } baseClass && baseClass.GetInheritanceTree().Any(static y => y.IsErrorDefinition))
                                                 .ToArray())
             derivedErrorDefinition.IsErrorDefinition = false;
     }

--- a/src/Kiota.Builder/Writers/Python/CodeUsingWriter.cs
+++ b/src/Kiota.Builder/Writers/Python/CodeUsingWriter.cs
@@ -55,7 +55,7 @@ public class CodeUsingWriter
         var parentNameSpace = parentClass.GetImmediateParentOfType<CodeNamespace>();
         var internalErrorMappingImportSymbolsAndPaths = parentClass.Usings
                                                         .Where(static x => !x.IsExternal)
-                                                        .Where(static x => x.Declaration?.TypeDefinition is CodeClass codeClass && codeClass.IsErrorDefinition)
+                                                        .Where(static x => x.Declaration?.TypeDefinition is CodeClass codeClass && (codeClass.IsErrorDefinition || codeClass.GetInheritanceTree(false, false).Any(static y => y.IsErrorDefinition)))
                                                         .Select(x => _relativeImportManager.GetRelativeImportPathForUsing(x, parentNameSpace))
                                                         .GroupBy(static x => x.Item3)
                                                         .Where(static x => !string.IsNullOrEmpty(x.Key))

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -2747,6 +2747,119 @@ paths:
         Assert.Null(codeModel.FindChildByName<CodeClass>("tasks4XXError"));
         Assert.Null(codeModel.FindChildByName<CodeClass>("tasks5XXError"));
     }
+    private const string ErrorSchemaWithDiscriminatedErrorChildDocument = @"openapi: 3.0.3
+info:
+  title: Example API
+  version: 1.0.0
+servers:
+  - url: https://localhost:8080
+paths:
+  /messages:
+    post:
+      responses:
+        '204':
+          description: no content
+        '400':
+          $ref: '#/components/responses/Error400'
+        '500':
+          $ref: '#/components/responses/Error500'
+components:
+  schemas:
+    SrsError:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+        message:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          InvalidMessage: '#/components/schemas/InvalidMessage'
+          InternalSRSError: '#/components/schemas/InternalSRSError'
+    InvalidMessage:
+      allOf:
+        - $ref: '#/components/schemas/SrsError'
+        - type: object
+          properties:
+            veto:
+              type: string
+    InternalSRSError:
+      allOf:
+        - $ref: '#/components/schemas/SrsError'
+        - type: object
+          properties:
+            detail:
+              type: string
+  responses:
+    Error400:
+      description: bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SrsError'
+    Error500:
+      description: internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InternalSRSError'";
+    [Fact]
+    public async Task DoesntMarkErrorDefinitionDerivingFromAnotherErrorDefinitionAsync()
+    {
+        await using var fs = await GetDocumentStreamAsync(ErrorSchemaWithDiscriminatedErrorChildDocument);
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", ApiRootUrl = "https://localhost" }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var parentClass = codeModel.FindChildByName<CodeClass>("SrsError");
+        Assert.NotNull(parentClass);
+        Assert.True(parentClass.IsErrorDefinition);
+        Assert.Contains(parentClass.DiscriminatorInformation.DiscriminatorMappings, static x => "InternalSRSError".Equals(x.Key, StringComparison.OrdinalIgnoreCase));
+        var dualRoleChildClass = codeModel.FindChildByName<CodeClass>("InternalSRSError");
+        Assert.NotNull(dualRoleChildClass);
+        Assert.False(dualRoleChildClass.IsErrorDefinition); // it derives from the error definition through its parent
+        Assert.Equal(parentClass, dualRoleChildClass.StartBlock.Inherits?.TypeDefinition);
+        var singleRoleChildClass = codeModel.FindChildByName<CodeClass>("InvalidMessage");
+        Assert.NotNull(singleRoleChildClass);
+        Assert.False(singleRoleChildClass.IsErrorDefinition);
+        Assert.Equal(parentClass, singleRoleChildClass.StartBlock.Inherits?.TypeDefinition);
+        var executorMethod = codeModel.FindChildByName<CodeMethod>("post");
+        Assert.NotNull(executorMethod);
+        Assert.Equal(parentClass, (executorMethod.ErrorMappings.FirstOrDefault(static x => "400".Equals(x.Key, StringComparison.OrdinalIgnoreCase)).Value as CodeType)?.TypeDefinition);
+        Assert.Equal(dualRoleChildClass, (executorMethod.ErrorMappings.FirstOrDefault(static x => "500".Equals(x.Key, StringComparison.OrdinalIgnoreCase)).Value as CodeType)?.TypeDefinition);
+    }
+    [Theory]
+    [InlineData(GenerationLanguage.CSharp)]
+    [InlineData(GenerationLanguage.Java)]
+    [InlineData(GenerationLanguage.Python)]
+    [InlineData(GenerationLanguage.PHP)]
+    [InlineData(GenerationLanguage.Go)]
+    public async Task KeepsBaseClassOfErrorDefinitionDerivingFromAnotherErrorDefinitionAsync(GenerationLanguage language)
+    {
+        await using var fs = await GetDocumentStreamAsync(ErrorSchemaWithDiscriminatedErrorChildDocument);
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var generationConfiguration = new GenerationConfiguration { ClientClassName = "TestClient", ApiRootUrl = "https://localhost", Language = language };
+        var builder = new KiotaBuilder(mockLogger.Object, generationConfiguration, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        await builder.ApplyLanguageRefinementAsync(generationConfiguration, codeModel, TestContext.Current.CancellationToken);
+        var parentClass = codeModel.FindChildByName<CodeClass>("SrsError");
+        Assert.NotNull(parentClass);
+        Assert.True(parentClass.IsErrorDefinition);
+        Assert.NotNull(parentClass.StartBlock.Inherits);
+        Assert.True(parentClass.StartBlock.Inherits.IsExternal); // the language specific base error class
+        var dualRoleChildClass = codeModel.FindChildByName<CodeClass>("InternalSRSError");
+        Assert.NotNull(dualRoleChildClass);
+        Assert.Equal(parentClass, dualRoleChildClass.StartBlock.Inherits?.TypeDefinition); // and not the language specific base error class
+        var singleRoleChildClass = codeModel.FindChildByName<CodeClass>("InvalidMessage");
+        Assert.NotNull(singleRoleChildClass);
+        Assert.Equal(parentClass, singleRoleChildClass.StartBlock.Inherits?.TypeDefinition);
+    }
     [Fact]
     public void UsesDefaultAs4XXAnd5XXWhenAbsent()
     {

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -2806,6 +2806,64 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/InternalSRSError'";
+    private const string ErrorSchemaDerivingFromNonErrorBaseDocument = @"openapi: 3.0.3
+info:
+  title: Example API
+  version: 1.0.0
+servers:
+  - url: https://localhost:8080
+paths:
+  /messages:
+    post:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Audited'
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationFailure'
+components:
+  schemas:
+    Audited:
+      type: object
+      properties:
+        createdAt:
+          type: string
+    ValidationFailure:
+      allOf:
+        - $ref: '#/components/schemas/Audited'
+        - type: object
+          properties:
+            reason:
+              type: string";
+    [Fact]
+    public async Task KeepsErrorDefinitionDerivingFromANonErrorBaseAsync()
+    {
+        // an error-response schema whose only ancestry is a plain base class must keep its
+        // error role: only deriving from another error definition may unmark it
+        await using var fs = await GetDocumentStreamAsync(ErrorSchemaDerivingFromNonErrorBaseDocument);
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", ApiRootUrl = "https://localhost" }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var baseClass = codeModel.FindChildByName<CodeClass>("Audited");
+        Assert.NotNull(baseClass);
+        Assert.False(baseClass.IsErrorDefinition);
+        var errorClass = codeModel.FindChildByName<CodeClass>("ValidationFailure");
+        Assert.NotNull(errorClass);
+        Assert.True(errorClass.IsErrorDefinition);
+        Assert.Equal(baseClass, errorClass.StartBlock.Inherits?.TypeDefinition);
+        var executorMethod = codeModel.FindChildByName<CodeMethod>("post");
+        Assert.NotNull(executorMethod);
+        Assert.Equal(errorClass, (executorMethod.ErrorMappings.FirstOrDefault(static x => "400".Equals(x.Key, StringComparison.OrdinalIgnoreCase)).Value as CodeType)?.TypeDefinition);
+    }
     [Fact]
     public async Task DoesntMarkErrorDefinitionDerivingFromAnotherErrorDefinitionAsync()
     {


### PR DESCRIPTION
## Description

A schema can be used in two roles at once:

1. as the concrete schema of a reusable error response (`components/responses/Error500` referencing `InternalSRSError` directly), and
2. as an `allOf` child listed in the `discriminator.mapping` of its parent (`SrsError`, itself the schema of the discriminated 400 error response).

For such a dual-role schema the generated C# and Java clients do not compile. The class loses its `allOf` base and is generated straight on the error base class:

```csharp
public partial class InternalSRSError : ApiException, IAdditionalDataHolder, IParsable
```

while the parent's factory method still returns the mapped child types:

```
Models/SrsError.cs(61,39): error CS0029: Cannot implicitly convert type
  'RealtimeRegister.Models.InternalSRSError' to 'RealtimeRegister.Models.SrsError'
models/SrsError.java:[52,49] incompatible types: InternalSRSError cannot be
  converted to SrsError
```

A sibling with the same `allOf` shape that is in the mapping but *not* used as a standalone error response (`InvalidMessage`) generates correctly as `class InvalidMessage : SrsError`. The python/go/php outputs of the same document compile only because their dynamic dispatch never type-checks the factory. Reproduced on 1.34.1 and current main.

## Root cause

`AddErrorMappingToExecutorMethod` marks the schema of every error response as an error definition, both roles included. `CommonLanguageRefiner.AddParentClassToErrorClasses` then replaces the existing base class of every error definition with the language error base class (inlining the parent members). For a class whose parent chain already leads to another error definition this is both unnecessary — the parent itself is rebased onto the error base class, so the child inherits it transitively — and incorrect, because the parent's discriminator factory returns the child as a derived type.

## Changes Made

- `KiotaBuilder.UnmarkDerivedErrorDefinitions`: once the whole url tree has been visited (the marking order between parent and child depends on response traversal order, so this cannot be decided at marking time), an error definition whose inheritance tree contains another error definition is unmarked. It keeps its base class and inherits the error base class through its parent, exactly like a mapped child that is not used as a response schema; a class whose parent chain does not lead to an error definition keeps today's inline-and-rebase behavior. The fix is in the builder, so every language heals together.
- Python `CodeUsingWriter.WriteInternalErrorMappingImports`: the lazy error-mapping imports now also include mapped classes that reach an error definition through their base class, so the `error_mapping` dict entry for such a class keeps its import.
- New tests in `KiotaBuilderTests`: `DoesntMarkErrorDefinitionDerivingFromAnotherErrorDefinitionAsync` (builder model) and `KeepsBaseClassOfErrorDefinitionDerivingFromAnotherErrorDefinitionAsync` (post-refinement, C#/Java/Python/PHP/Go). All six fail without the fix.
- CHANGELOG entry under Unreleased/Changed.

## Testing

- Full `Kiota.Builder.Tests` suite passes: 2313 passed, 0 failed, 2 skipped (pre-existing).
- **Reproduction, before/after.** A production document of ≈100 operations whose 400 response is a discriminated `SrsError` hierarchy and whose 500/502/503 responses reference three of the mapped children directly, generated with this branch and compiled against the released runtimes (C# 1.22.2 packages, Java `microsoft-kiota-bundle` 1.8.5):

  | | before (main, a4b75fd02) | after |
  | --- | --- | --- |
  | C# `dotnet build` | `CS0029` in `Models/SrsError.cs` for each dual-role child | compiles, 0 warnings |
  | Java `mvn compile` | `incompatible types` in `models/SrsError.java` | compiles |

  In both outputs the dual-role children now derive the parent (`class InternalSRSError : SrsError` / `extends SrsError`) and the factory type-checks; the python output regains the `from ...models.internal_s_r_s_error import ...` import next to its `error_mapping` entry.

---

Generated with Claude Code
