### PR TITLE
Return void from HEAD executors instead of Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ruby: a model sharing its name with a sibling namespace had the disambiguation suffix applied once per reference to it rather than once, so generation failed with `The element to rename was not found available_phone_number_countryModelModelModelModel`. The reference pass was removed: `CodeType.Name` already delegates to the type definition, so references follow the rename on their own. Un-suppresses the Twilio integration and idempotency tests. [kiota-abstractions-ruby#66](https://github.com/microsoft/kiota-abstractions-ruby/issues/66)
 - C#: create property "EqualsEscaped" instead of "Equals" for model properties "equals" to avoid a compiler warning [#8133](https://github.com/microsoft/kiota/issues/8133)
+- A HEAD operation with no response schema generated an executor returning a `Stream`. The default return type was picked from the response codes alone, so a HEAD declaring only a `200` fell through to binary, while one that happened to list `304` returned void by accident. The request method is now checked first, so a HEAD that falls through to the default returns void. [#4245](https://github.com/microsoft/kiota/issues/4245)
 
 ## [1.35.0] - 2026-09-01
 

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -1460,19 +1460,21 @@ public partial class KiotaBuilder
             }
             else if (modelType is null)
             {
-                return (GetExecutorMethodDefaultReturnType(operation), null);
+                return (GetExecutorMethodDefaultReturnType(operation, operationType), null);
             }
             return (modelType, null);
         }
         else
         {
-            return (GetExecutorMethodDefaultReturnType(operation), null);
+            return (GetExecutorMethodDefaultReturnType(operation, operationType), null);
         }
     }
-    private static CodeType GetExecutorMethodDefaultReturnType(OpenApiOperation operation)
+    private static CodeType GetExecutorMethodDefaultReturnType(OpenApiOperation operation, NetHttpMethod operationType)
     {
         string returnType;
-        if (operation.Responses?.Any(static x => (x.Value.Content?.ContainsKey(RequestBodyOctetStreamContentType) ?? false) && redirectStatusCodes.Contains(x.Key)) is true)
+        if (operationType == NetHttpMethod.Head)
+            returnType = VoidType;
+        else if (operation.Responses?.Any(static x => (x.Value.Content?.ContainsKey(RequestBodyOctetStreamContentType) ?? false) && redirectStatusCodes.Contains(x.Key)) is true)
             returnType = "binary";
         else if (operation.Responses?.Any(static x => noContentStatusCodes.Contains(x.Key)) is true)
             returnType = VoidType;

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -6685,6 +6685,44 @@ components:
         Assert.NotNull(executor);
         Assert.Equal("void", executor.ReturnType.Name);
     }
+    [InlineData(new[] { 200 })]
+    [InlineData(new[] { 200, 304, 400 })]
+    [Theory]
+    public void GeneratesVoidReturnTypeForHeadRequests(int[] statusCodes)
+    {
+        var responses = new OpenApiResponses();
+        foreach (var statusCode in statusCodes)
+            responses[statusCode.ToString()] = new OpenApiResponse();
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["answer"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [NetHttpMethod.Head] = new OpenApiOperation
+                        {
+                            Responses = responses
+                        }
+                    }
+                }
+            },
+        };
+        document.SetReferenceHostDocument();
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "TestClient", ClientNamespaceName = "TestSdk", ApiRootUrl = "https://localhost" }, _httpClient);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+        var rbNS = codeModel.FindNamespaceByName("TestSdk.Answer");
+        Assert.NotNull(rbNS);
+        var rbClass = rbNS.Classes.FirstOrDefault(x => x.IsOfKind(CodeClassKind.RequestBuilder));
+        Assert.NotNull(rbClass);
+        Assert.Single(rbClass.Methods, x => x.IsOfKind(CodeMethodKind.RequestExecutor));
+        var executor = rbClass.Methods.FirstOrDefault(x => x.IsOfKind(CodeMethodKind.RequestExecutor));
+        Assert.NotNull(executor);
+        Assert.Equal("void", executor.ReturnType.Name);
+    }
     [InlineData(new[] { "microsoft.graph.user", "microsoft.graph.termstore.term" }, "microsoft.graph")]
     [InlineData(new[] { "microsoft.graph.user", "odata.errors.error" }, "")]
     [InlineData(new string[] { }, "")]


### PR DESCRIPTION
Fixes #4245

A HEAD operation that declares no response content generates an executor returning a `Stream`. Smallest repro:

```yaml
openapi: 3.0.4
info:
  title: head test
  version: 1.0.0
servers:
  - url: https://localhost
paths:
  /answer:
    head:
      responses:
        '200':
          description: ok
```

That generates `Task<Stream>`. Add a `304` to the same operation and it flips to `void`, which is why this looks fixed from one description and still broken from another.

## Cause

`GetExecutorMethodDefaultReturnType` only ever inspected `operation.Responses`. With no octet stream redirect, nothing in `noContentStatusCodes` and no plain text success code, it falls through its last `else` to `binary`. It never sees the HTTP method, so a HEAD landing there is only ever right by accident.

## Fix

`GetExecutorMethodReturnType` already has the `NetHttpMethod` in scope, it just wasn't passing it down. I thread it into the helper and check it first. The HEAD branch goes first, so every other operation takes exactly the path it took before.

One scope note, since it's the first thing I'd ask. This covers the default path, which is the one the issue hits. If a HEAD response declares a schema under a structured content type, a model type is built earlier and the executor still returns that model. I left that alone deliberately: returning `void` there would strand the generated model class with nothing pointing at it. Happy to extend it if you'd rather HEAD were unconditional.

## Tests

New theory `GeneratesVoidReturnTypeForHeadRequests`, next to the existing `GeneratesVoidReturnTypeForNoContent`. It covers both shapes from the issue: `200` alone, and `200` plus `304` plus `400`.

With only the source reverted to main and the test kept:

```
GeneratesVoidReturnTypeForHeadRequests(statusCodes: [200]) [FAIL]
  Expected: "void"
  Actual:   "binary"
```

The `200` plus `304` plus `400` case passes either way, which is the reporter's actual complaint: the `304` was making that one right by coincidence while `200` alone stayed wrong.

With the fix: `Kiota.Builder.Tests` 2311 passed, 2 skipped (the existing Go ones), `Kiota.Tests` 18 passed. `dotnet format --verify-no-changes` clean on both projects.

## Generated output

I couldn't run the integration and idempotency jobs here, so I checked what they'd generate differently instead. Every description in `it/config.json`, the four under `tests/Kiota.Builder.IntegrationTests`, and the Graph beta description used by the surface area job: none contains a HEAD operation. The 80 `head` keys in the GitHub description are all schema properties, not path items. So that output should be byte identical, not merely still compiling.
