### PR TITLE
(fix) Sub class property could not be linked to base class property

### DIFF
--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -589,6 +589,8 @@ public partial class KiotaBuilder
         {
             stopwatch.Start();
             CreateRequestBuilderClass(codeNamespace, root, root);
+            // Check for subclass properties that are not properly linked to base class properties
+            FixInheritedProperties(codeNamespace);
             StopLogAndReset(stopwatch, nameof(CreateRequestBuilderClass));
             stopwatch.Start();
             CreateWebhookModels();
@@ -3024,6 +3026,69 @@ public partial class KiotaBuilder
         paramType.CollectionKind = schema.IsArray() ? CodeTypeBase.CodeTypeCollectionKind.Array : default;
         return paramType;
     }
+
+    /// <summary>
+    /// Workaround for https://github.com/microsoft/kiota/issues/8139: if a class has a property whose type is one of its own subclasses
+    /// and both the current class and the subclass have another property with the same name, the sub class property might not be linked
+    /// to the base class property due to the order of class/property processing. This method tries to find such cases and
+    /// link the properties.
+    /// </summary>
+    /// <param name="codeNamespace"></param>
+    private static void FixInheritedProperties(CodeNamespace codeNamespace)
+    {
+        foreach (CodeNamespace codeSubNamespace in codeNamespace.Namespaces)
+        {
+            FixInheritedProperties(codeSubNamespace);
+        }
+
+        foreach (CodeClass codeClass in codeNamespace.Classes)
+        {
+            // Check only classes that have a base class:
+            if (codeClass.BaseClass != null)
+            {
+                foreach (CodeProperty property in codeClass.Properties)
+                {
+                    //Check only properties that are not already linked to a base class property:
+                    if (property.OriginalPropertyFromBaseType == null)
+                    {
+                        // Is this property also contained in any base class?
+                        CodeProperty? propertyInBaseClass = FindPropertyInBaseClass(codeClass.BaseClass, property);
+                        if (propertyInBaseClass != null)
+                        {
+                            property.OriginalPropertyFromBaseType = propertyInBaseClass;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Searches a property of a sub class in a base class. Recurses into the full class hierarchy.
+    /// </summary>
+    /// <param name="baseClass"></param>
+    /// <param name="propertyToSearch"></param>
+    /// <returns>Found parent class property or null.</returns>
+    private static CodeProperty? FindPropertyInBaseClass(CodeClass baseClass, CodeProperty propertyToSearch)
+    {
+        // Check properties of current class:
+        foreach (CodeProperty propertyOfBaseClass in baseClass.Properties)
+        {
+            if (propertyOfBaseClass.Name == propertyToSearch.Name)
+            {
+                return propertyOfBaseClass;
+            }
+        }
+
+        // Not found: check base class:
+        if (baseClass.BaseClass != null)
+        {
+            return FindPropertyInBaseClass(baseClass.BaseClass, propertyToSearch);
+        }
+
+        return null;
+    }
+
 
     private void CleanUpInternalState()
     {

--- a/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
+++ b/tests/Kiota.Builder.Tests/KiotaBuilderTests.cs
@@ -12333,4 +12333,95 @@ components:
         Assert.NotNull(patchGenerator);
         Assert.False(patchGenerator.HasUrlTemplateOverride);
     }
+
+    /// <summary>
+    /// Test for the fix of https://github.com/microsoft/kiota/issues/8139: the graph beta SDK from 09/2026 defined a base class
+    /// and a child class, which both had a property "@odata.type". Additionally, the base class had a property of subclass type.
+    /// This property was defined before the "@odata.type" property.
+    /// In this situation, Kiota did not link the subclass property "@odata.type" to the base class property, thus creating it twice.
+    /// And this resulted in a compilation warning "'PlannerTeamsPublicationInfo.OdataType' hides inherited member 'PlannerTaskCreation.OdataType'" for C# clients.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task BaseClassHasPropertyOfChildClassTypeAndAnotherPropertyOnBothClasses()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        await using var fs = await GetDocumentStreamAsync(
+    """
+openapi: 3.0.4
+info:
+  title: OData Service for namespace microsoft.graph
+  description: This OData service is located at https://graph.microsoft.com/beta
+  version: beta
+servers:
+  - url: https://graph.microsoft.com/beta
+paths:
+  /doSomething:
+    description: a dummy operation
+    get:
+      summary: fetches data
+      responses:
+        2XX:
+          description: some response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/microsoft.graph.plannerTaskCreation"
+components:
+  schemas:
+    microsoft.graph.plannerTaskCreation:
+      title: plannerTaskCreation
+      required:
+        - '@odata.type'
+      type: object
+      properties:
+        creationSourceKind:
+          type: string
+          description: 'Specifies what kind of creation source the task is created with. The possible values are: external, publication and unknownFutureValue.'
+        teamsPublicationInfo:
+          anyOf:
+            - $ref: '#/components/schemas/microsoft.graph.plannerTeamsPublicationInfo'
+            - type: object
+              nullable: true
+          description: Information about the publication process that created this task. This field is deprecated and clients should move to using the new inheritance model.
+        '@odata.type':
+          type: string
+      discriminator:
+        propertyName: '@odata.type'
+        mapping:
+          '#microsoft.graph.plannerTeamsPublicationInfo': '#/components/schemas/microsoft.graph.plannerTeamsPublicationInfo'
+    microsoft.graph.plannerTeamsPublicationInfo:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.plannerTaskCreation'
+        - title: plannerTeamsPublicationInfo
+          required:
+            - '@odata.type'
+          type: object
+          properties:
+            publicationId:
+              type: string
+              description: The identifier of the publication. Read-only.
+              nullable: true
+            '@odata.type':
+              type: string
+              default: '#microsoft.graph.plannerTeamsPublicationInfo'
+""");
+        var mockLogger = new Mock<ILogger<KiotaBuilder>>();
+        var builder = new KiotaBuilder(mockLogger.Object, new GenerationConfiguration { ClientClassName = "Graph", OpenAPIFilePath = tempFilePath }, _httpClient);
+        var document = await builder.CreateOpenApiDocumentAsync(fs, cancellationToken: TestContext.Current.CancellationToken);
+        var node = builder.CreateUriSpace(document);
+        var codeModel = builder.CreateSourceModel(node);
+
+        var baseClass = codeModel.FindChildByName<CodeClass>("PlannerTaskCreation");
+        Assert.NotNull(baseClass);
+        var baseProperty = baseClass.FindChildByName<CodeProperty>("OdataType", false);
+        Assert.NotNull(baseProperty);
+
+        var childClass = codeModel.FindChildByName<CodeClass>("PlannerTeamsPublicationInfo");
+        Assert.NotNull(childClass);
+        var childProperty = childClass.FindChildByName<CodeProperty>("OdataType", false);
+        Assert.NotNull(childProperty);
+        Assert.True(childProperty.ExistsInBaseType, "Child class property is not linked to base class property");
+        Assert.Equal(childProperty.OriginalPropertyFromBaseType, baseProperty);
+    }
 }


### PR DESCRIPTION
This is an attempt to fix #8139 (which is hopefully the last warning the blocks me from sending a pull request to enable `TreatWarningsAsErrors` in the integration tests): the Graph beta SDK api description contains a class definition where both parent and child class contain the same property `@odata.type`. Normally, this is detected while the model is built, but some kind of circular reference breaks it for this single property.
For full analysis, see #8139.

This pull request fixes the problem for me. Writing a test case is still on my todo list, but I first wanted to get your feedback whether my approach is reasonable at all. So this is actually a "draft" request.

The workaround code, which sets `CodeProperty.OriginalPropertyFromBaseType` for the child property, is called only once, and this is the `OdataType` property. So, no other properties are affected from this change.

### Implementation details
In `KiotaBuilder.CreateSourceModel` I added code after `CreateRequestBuilderClass` that loops over all classes and checks for each property that has no `OriginalPropertyFromBaseType` whether a base class contains a property with the same `CodeProperty.Name`. If it finds one, it sets the `OriginalPropertyFromBaseType`. This is done recursively, though for fixing the Graph API, it would require only level of one base class search.

### Generated code with fixed version
Here is the full generated code of the two classes from #8139. Note that the child class `PlannerTeamsPublicationInfo` has no more property `OdataType`, but the constructor still assigns the default value:


```c#
    public partial class PlannerTaskCreation : IAdditionalDataHolder, IParsable
    {
        /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
        public IDictionary<string, object> AdditionalData { get; set; }
        /// <summary>Specifies what kind of creation source the task is created with. The possible values are: external, publication and unknownFutureValue.</summary>
        public global::My.GraphClient.Models.PlannerCreationSourceKind? CreationSourceKind { get; set; }
        /// <summary>The OdataType property</summary>
        public string? OdataType { get; set; }
        /// <summary>Information about the publication process that created this task. This field is deprecated and clients should move to using the new inheritance model.</summary>
        public global::My.GraphClient.Models.PlannerTeamsPublicationInfo? TeamsPublicationInfo { get; set; }
        /// <summary>
        /// Instantiates a new <see cref="global::My.GraphClient.Models.PlannerTaskCreation"/> and sets the default values.
        /// </summary>
        public PlannerTaskCreation()
        {
            AdditionalData = new Dictionary<string, object>();
        }
        /// <summary>
        /// Creates a new instance of the appropriate class based on discriminator value
        /// </summary>
        /// <returns>A <see cref="global::My.GraphClient.Models.PlannerTaskCreation"/></returns>
        /// <param name="parseNode">The parse node to use to read the discriminator value and create the object</param>
        public static global::My.GraphClient.Models.PlannerTaskCreation CreateFromDiscriminatorValue(IParseNode parseNode)
        {
            if(ReferenceEquals(parseNode, null)) throw new ArgumentNullException(nameof(parseNode));
            var mappingValue = parseNode.GetChildNode("@odata.type")?.GetStringValue();
            return mappingValue switch
            {
                "#microsoft.graph.plannerExternalTaskSource" => new global::My.GraphClient.Models.PlannerExternalTaskSource(),
                "#microsoft.graph.plannerTeamsPublicationInfo" => new global::My.GraphClient.Models.PlannerTeamsPublicationInfo(),
                _ => new global::My.GraphClient.Models.PlannerTaskCreation(),
            };
        }
        /// <summary>
        /// The deserialization information for the current model
        /// </summary>
        /// <returns>A IDictionary&lt;string, Action&lt;IParseNode&gt;&gt;</returns>
        public virtual IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
        {
            return new Dictionary<string, Action<IParseNode>>
            {
                { "creationSourceKind", n => { CreationSourceKind = n.GetEnumValue<global::My.GraphClient.Models.PlannerCreationSourceKind>(); } },
                { "@odata.type", n => { OdataType = n.GetStringValue(); } },
                { "teamsPublicationInfo", n => { TeamsPublicationInfo = n.GetObjectValue<global::My.GraphClient.Models.PlannerTeamsPublicationInfo>(global::My.GraphClient.Models.PlannerTeamsPublicationInfo.CreateFromDiscriminatorValue); } },
            };
        }
        /// <summary>
        /// Serializes information the current object
        /// </summary>
        /// <param name="writer">Serialization writer to use to serialize this model</param>
        public virtual void Serialize(ISerializationWriter writer)
        {
            if(ReferenceEquals(writer, null)) throw new ArgumentNullException(nameof(writer));
            writer.WriteEnumValue<global::My.GraphClient.Models.PlannerCreationSourceKind>("creationSourceKind", CreationSourceKind);
            writer.WriteStringValue("@odata.type", OdataType);
            writer.WriteObjectValue<global::My.GraphClient.Models.PlannerTeamsPublicationInfo>("teamsPublicationInfo", TeamsPublicationInfo);
            writer.WriteAdditionalData(AdditionalData);
        }
    }
    
    
    public partial class PlannerTeamsPublicationInfo : global::My.GraphClient.Models.PlannerTaskCreation, IParsable
    {
        /// <summary>The date and time when this task was last modified by the publication process. Read-only.</summary>
        public DateTimeOffset? LastModifiedDateTime { get; set; }
        /// <summary>The identifier of the publication. Read-only.</summary>
        public string? PublicationId { get; set; }
        /// <summary>The name of the published task list. Read-only.</summary>
        public string? PublicationName { get; set; }
        /// <summary>The identifier of the plannerPlan this task was originally placed in. Read-only.</summary>
        public string? PublishedToPlanId { get; set; }
        /// <summary>The identifier of the team that initiated the publication process. Read-only.</summary>
        public string? PublishingTeamId { get; set; }
        /// <summary>The display name of the team that initiated the publication process. This display name is for reference only, and might not represent the most up-to-date name of the team. Read-only.</summary>
        public string? PublishingTeamName { get; set; }
        /// <summary>
        /// Instantiates a new <see cref="global::My.GraphClient.Models.PlannerTeamsPublicationInfo"/> and sets the default values.
        /// </summary>
        public PlannerTeamsPublicationInfo() : base()
        {
            OdataType = "#microsoft.graph.plannerTeamsPublicationInfo";
        }
        /// <summary>
        /// Creates a new instance of the appropriate class based on discriminator value
        /// </summary>
        /// <returns>A <see cref="global::My.GraphClient.Models.PlannerTeamsPublicationInfo"/></returns>
        /// <param name="parseNode">The parse node to use to read the discriminator value and create the object</param>
        public static new global::My.GraphClient.Models.PlannerTeamsPublicationInfo CreateFromDiscriminatorValue(IParseNode parseNode)
        {
            if(ReferenceEquals(parseNode, null)) throw new ArgumentNullException(nameof(parseNode));
            return new global::My.GraphClient.Models.PlannerTeamsPublicationInfo();
        }
        /// <summary>
        /// The deserialization information for the current model
        /// </summary>
        /// <returns>A IDictionary&lt;string, Action&lt;IParseNode&gt;&gt;</returns>
        public override IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
        {
            return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
            {
                { "lastModifiedDateTime", n => { LastModifiedDateTime = n.GetDateTimeOffsetValue(); } },
                { "publicationId", n => { PublicationId = n.GetStringValue(); } },
                { "publicationName", n => { PublicationName = n.GetStringValue(); } },
                { "publishedToPlanId", n => { PublishedToPlanId = n.GetStringValue(); } },
                { "publishingTeamId", n => { PublishingTeamId = n.GetStringValue(); } },
                { "publishingTeamName", n => { PublishingTeamName = n.GetStringValue(); } },
            };
        }
        /// <summary>
        /// Serializes information the current object
        /// </summary>
        /// <param name="writer">Serialization writer to use to serialize this model</param>
        public override void Serialize(ISerializationWriter writer)
        {
            if(ReferenceEquals(writer, null)) throw new ArgumentNullException(nameof(writer));
            base.Serialize(writer);
            writer.WriteDateTimeOffsetValue("lastModifiedDateTime", LastModifiedDateTime);
            writer.WriteStringValue("publicationId", PublicationId);
            writer.WriteStringValue("publicationName", PublicationName);
            writer.WriteStringValue("publishedToPlanId", PublishedToPlanId);
            writer.WriteStringValue("publishingTeamId", PublishingTeamId);
            writer.WriteStringValue("publishingTeamName", PublishingTeamName);
        }
    }

```