### PR TITLE
Fix TypeScript UUID response factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed TypeScript request metadata to use string response factories for UUID values and collections.
+
 - Fixed the generation of a schema used in two roles at once: as the schema of an error response and as an `allOf` child in the discriminator mapping of another error schema. The error refiner replaced its `allOf` base class with the language error base class while the parent's factory method still returned it as a derived type, so the generated C# and Java clients did not compile (`CS0029` / `incompatible types`). Such a schema now keeps its base class and inherits the error base class through its parent, like every other mapped child.
 
 - Dart: an error model's constructor declared the named `additionalData` parameter as `required`, but the generated callers never pass it — inherited error models call a bare `super()` and `createFromDiscriminatorValue` instantiates the class without arguments — so a document with a discriminated error hierarchy generated a client that did not compile. The parameter is now optional and defaults to an empty map in the initializer list.

--- a/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeConstantWriter.cs
@@ -170,9 +170,9 @@ public class CodeConstantWriter : BaseElementWriter<CodeConstant, TypeScriptConv
     {
         if (isVoid) return string.Empty;
         var typeName = conventions.TranslateType(codeElement.ReturnType);
-        if (isStream || IsPrimitiveType(typeName) || IsKiotaPrimitive(typeName)) return $" \"{typeName}\"";
         if (GetPrimitiveAlias(typeName) is { } alias && !string.IsNullOrEmpty(alias))
             return $" \"{alias}\"";
+        if (isStream || IsPrimitiveType(typeName) || IsKiotaPrimitive(typeName)) return $" \"{typeName}\"";
         return $" {GetFactoryMethodName(codeElement.ReturnType, codeElement, writer)}";
     }
     private string GetReturnTypeWithoutCollectionSymbol(CodeMethod codeElement, string fullTypeName)

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeConstantWriterTests.cs
@@ -290,14 +290,20 @@ public sealed class CodeConstantWriterTests : IDisposable
         Assert.Contains("enumObject: " + EnumName.ToFirstCharacterUpperCase(), result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
-    [Fact]
-    public void WritesRequestExecutorForPrimitive()
+    [Theory]
+    [InlineData("string", "string")]
+    [InlineData("Guid", "string")]
+    [InlineData("Date", "Date")]
+    [InlineData("DateOnly", "DateOnly")]
+    [InlineData("TimeOnly", "TimeOnly")]
+    [InlineData("Duration", "Duration")]
+    public void WritesRequestExecutorForPrimitive(string typeName, string responseType)
     {
         method.Kind = CodeMethodKind.RequestExecutor;
         method.HttpMethod = HttpMethod.Get;
         method.ReturnType = new CodeType
         {
-            Name = "string",
+            Name = typeName,
         };
         AddRequestBodyParameters();
         var constant = CodeConstant.FromRequestBuilderToRequestsMetadata(parentClass);
@@ -311,16 +317,23 @@ public sealed class CodeConstantWriterTests : IDisposable
         writer.Write(constant);
         var result = tw.ToString();
         Assert.Contains("sendPrimitive", result);
+        Assert.Contains($"responseBodyFactory:  \"{responseType}\"", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
-    [Fact]
-    public void WritesRequestExecutorForPrimitiveCollection()
+    [Theory]
+    [InlineData("string", "string")]
+    [InlineData("Guid", "string")]
+    [InlineData("Date", "Date")]
+    [InlineData("DateOnly", "DateOnly")]
+    [InlineData("TimeOnly", "TimeOnly")]
+    [InlineData("Duration", "Duration")]
+    public void WritesRequestExecutorForPrimitiveCollection(string typeName, string responseType)
     {
         method.Kind = CodeMethodKind.RequestExecutor;
         method.HttpMethod = HttpMethod.Get;
         method.ReturnType = new CodeType
         {
-            Name = "string",
+            Name = typeName,
             CollectionKind = CodeTypeBase.CodeTypeCollectionKind.Array,
         };
         AddRequestBodyParameters();
@@ -335,6 +348,7 @@ public sealed class CodeConstantWriterTests : IDisposable
         writer.Write(constant);
         var result = tw.ToString();
         Assert.Contains("sendCollectionOfPrimitive", result);
+        Assert.Contains($"responseBodyFactory:  \"{responseType}\"", result);
         AssertExtensions.CurlyBracesAreClosed(result);
     }
     [Fact]


### PR DESCRIPTION
Fixes #8157.

Resolve primitive aliases before classifying the response factory. UUID responses now emit `"string"` instead of the unsupported `"Guid"`, while retaining Guid types in the generated API.

Expanded the existing scalar and collection tests to cover UUIDs, strings, and date/time primitives. Both UUID cases fail before the fix.

Validation:
- Full builder suite: 2,332 passed, 2 existing skips.
- CLI build: passed for .NET 8, 9, and 10 with no warnings.
- Generated the reported client plus a UUID-array endpoint and compiled it with TypeScript 5.8.2 and Kiota libraries preview.106. Restoring the old `"Guid"` factories reproduces TS2322.
