### PR TITLE
fix(typescript): value import for runtime primitives in composed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed TypeScript request metadata to use string response factories for UUID values and collections.
 
+- TypeScript: a composed type holding one of the runtime primitives imported from `@microsoft/kiota-abstractions` (`Guid`, `DateOnly`, `TimeOnly`, `Duration`) generated a client that did not compile, with `error TS1361: 'DateOnly' cannot be used as a value because it was imported using 'import type'`. The serializer narrows those types with `instanceof`, which is a value usage, but a value import was only forced for properties carrying a default value. Composed types now force it as well. [#8177](https://github.com/microsoft/kiota/issues/8177)
+
 - Fixed the generation of a schema used in two roles at once: as the schema of an error response and as an `allOf` child in the discriminator mapping of another error schema. The error refiner replaced its `allOf` base class with the language error base class while the parent's factory method still returned it as a derived type, so the generated C# and Java clients did not compile (`CS0029` / `incompatible types`). Such a schema now keeps its base class and inherits the error base class through its parent, like every other mapped child.
 
 - Dart: an error model's constructor declared the named `additionalData` parameter as `required`, but the generated callers never pass it — inherited error models call a bare `super()` and `createFromDiscriminatorValue` instantiates the class without arguments — so a document with a discriminated error hierarchy generated a client that did not compile. The parameter is now optional and defaults to an empty map in the initializer list.

--- a/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
+++ b/src/Kiota.Builder/Refiners/TypeScriptRefiner.cs
@@ -199,13 +199,30 @@ public class TypeScriptRefiner : CommonLanguageRefiner, ILanguageRefiner
             }
             if (!string.IsNullOrEmpty(erasableUsing))
             {
-                //Find all usings for this type (might occur multiple times) and set the using to "Erasable = false":
-                var erasableUsings = currentClass.Usings.Where(currentUsing => currentUsing.Name.Equals(erasableUsing, StringComparison.Ordinal));
-                foreach (var currentUsing in erasableUsings)
-                {
-                    currentUsing.IsErasable = false;
-                }
+                SetUsingNotErasable(currentClass, erasableUsing);
             }
+        }
+
+        //The wrapper class generated for a composed type holds the usings for its branches. Those
+        //branches are narrowed with "instanceof" when the runtime primitives (Guid, Date, DateOnly,
+        //TimeOnly, Duration) are among them, which is a value usage, so the import cannot be
+        //"type DateOnly" there either, even when no default value is set.
+        if (currentClass.OriginalComposedType is { } composedType)
+        {
+            foreach (var type in composedType.Types.Where(static type => TypeScriptConventionService.IsInstanceOfPrimitiveType(type.Name)))
+            {
+                SetUsingNotErasable(currentClass, type.Name);
+            }
+        }
+    }
+
+    private static void SetUsingNotErasable(CodeClass currentClass, string usingName)
+    {
+        //Find all usings for this type (might occur multiple times) and set the using to "Erasable = false":
+        var erasableUsings = currentClass.Usings.Where(currentUsing => currentUsing.Name.Equals(usingName, StringComparison.Ordinal));
+        foreach (var currentUsing in erasableUsings)
+        {
+            currentUsing.IsErasable = false;
         }
     }
 

--- a/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/CodeFunctionWriter.cs
@@ -601,9 +601,6 @@ public class CodeFunctionWriter(TypeScriptConventionService conventionService) :
             ? $"{prefix}if ({valueReference} instanceof {nodeType}) {{"
             : $"{prefix}if (typeof {valueReference} === \"{nodeType}\" ) {{";
     }
-    private static bool IsInstanceOfPrimitiveType(string nodeType) =>
-        nodeType is TYPE_GUID or TYPE_DATE or TYPE_DATE_ONLY or TYPE_TIME_ONLY or TYPE_DURATION;
-
     private static void WriteComposedTypeDefaultClause(CodeComposedTypeBase composedType, LanguageWriter writer, CodeProperty codeProperty, string modelParamName, string defaultValueSuffix, string? serializeName)
     {
         var codePropertyName = codeProperty.Name.ToFirstCharacterLowerCase();

--- a/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
+++ b/src/Kiota.Builder/Writers/TypeScript/TypeScriptConventionService.cs
@@ -258,6 +258,21 @@ public class TypeScriptConventionService : CommonLanguageConventionService
         };
     }
 
+    // Types the generated code narrows with "instanceof" instead of "typeof". "instanceof" is a value
+    // usage, so the imports for these types cannot be erased to "import type".
+    public static bool IsInstanceOfPrimitiveType(string typeName)
+    {
+        return typeName switch
+        {
+            TYPE_GUID or
+            TYPE_DATE or
+            TYPE_DATE_ONLY or
+            TYPE_TIME_ONLY or
+            TYPE_DURATION => true,
+            _ => false,
+        };
+    }
+
     public static string? GetPrimitiveAlias(string typeName)
     {
         return typeName switch

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFileWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFileWriterTests.cs
@@ -86,6 +86,7 @@ public sealed class CodeFileWriterTests : IDisposable
 
         var result = tw.ToString();
         // the composed type is narrowed with "instanceof", which is a value usage, so the imports cannot be erased
+        Assert.Contains("import { DateOnly, Guid, ", result);
         Assert.Contains("instanceof DateOnly", result);
         Assert.Contains("instanceof Guid", result);
         Assert.DoesNotContain("type DateOnly", result);

--- a/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFileWriterTests.cs
+++ b/tests/Kiota.Builder.Tests/Writers/TypeScript/CodeFileWriterTests.cs
@@ -65,4 +65,31 @@ public sealed class CodeFileWriterTests : IDisposable
         Assert.Contains("/* tslint:enable */", result);
     }
 
+    [Fact]
+    public async Task WritesValueImportForRuntimePrimitiveInComposedTypeAsync()
+    {
+        var generationConfiguration = new GenerationConfiguration { Language = GenerationLanguage.TypeScript };
+        var parentClass = TestHelper.CreateModelClassInModelsNamespace(generationConfiguration, root, "parentClass", false);
+        var composedType = new CodeUnionType { Name = "expiresAt" };
+        composedType.AddType(new CodeType { Name = "DateOnly" }, new CodeType { Name = "Guid" }, new CodeType { Name = "string" });
+        parentClass.AddProperty(new CodeProperty
+        {
+            Name = "expiresAt",
+            Kind = CodePropertyKind.Custom,
+            Type = composedType,
+        });
+        TestHelper.AddSerializationPropertiesToModelClass(parentClass);
+        await ILanguageRefiner.RefineAsync(generationConfiguration, root, cancellationToken: TestContext.Current.CancellationToken);
+        var modelsNS = root.FindChildByName<CodeNamespace>(generationConfiguration.ModelsNamespaceName);
+        var codeFile = modelsNS.FindChildByName<CodeFile>("index", false);
+        WriteCode(writer, codeFile);
+
+        var result = tw.ToString();
+        // the composed type is narrowed with "instanceof", which is a value usage, so the imports cannot be erased
+        Assert.Contains("instanceof DateOnly", result);
+        Assert.Contains("instanceof Guid", result);
+        Assert.DoesNotContain("type DateOnly", result);
+        Assert.DoesNotContain("type Guid", result);
+    }
+
 }


### PR DESCRIPTION
Fixes #8177.

A composed type holding one of the runtime primitives generates TypeScript that doesn't compile:

```
error TS1361: 'DateOnly' cannot be used as a value because it was imported using 'import type'.
```

Give a model a union property of `DateOnly | Guid | string` and the barrel comes out like this:

```ts
import { type AdditionalDataHolder, type DateOnly, type Guid, type Parsable, type ParseNode, type SerializationWriter } from '@microsoft/kiota-abstractions';

...

if (parentClass.expiresAt instanceof DateOnly) {
```

`instanceof` reads the symbol at runtime, so an erased import can't work there. #8107 started emitting those checks for `Guid`, `Date`, `DateOnly`, `TimeOnly` and `Duration` inside composed type serializers.

`SetUsingsNotErasable` in `TypeScriptRefiner` is the piece that already forces a value import, and its scope was narrower than the problem. It only looked at properties carrying a default value, because parsing a default used to be the one thing that needed a symbol at runtime. It now also checks the class's own `OriginalComposedType`, the wrapper that holds the usings for the branches, and clears `IsErasable` on any branch the writer narrows with `instanceof`.

The list of those five types was private to `CodeFunctionWriter`, so I moved it to `TypeScriptConventionService.IsInstanceOfPrimitiveType` where the refiner can read the same list the writer uses.

`WritesValueImportForRuntimePrimitiveInComposedTypeAsync` covers it. On main the import still says `type DateOnly`; with the change `DateOnly` and `Guid` both arrive as value imports and the `instanceof` lines are untouched. Kiota.Builder.Tests.Writers.TypeScript 138 passed and Kiota.Builder.Tests.Refiners 230 passed.

I checked this with that test rather than by generating a client from the GitHub description, since `it/config.json` still suppresses typescript for that description.
