### PR TITLE
correctly format golang comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TypeScript: the discriminator switch in a composed type serializer was built from the wire name, but model properties are camel cased by the refiner, so a discriminator such as `pet_type` was emitted as `.pet_type` where the generated interface declares `petType` and the client did not compile. The accessor is now resolved from the model property, which also corrects `@odata.type` from `.OdataType` to `.odataType`. [#7862](https://github.com/microsoft/kiota/issues/7862)
 - TypeScript: the factory generated for a collection of a primitive union was declared returning the collection but its body read a scalar, so `(number | string)[] | undefined` came back from `parseNode?.getNumberValue() ?? parseNode?.getStringValue()` and only the first item of the payload survived. The collection reads are now emitted for that case, matching what the deserializer already does for the same shape. [#8178](https://github.com/microsoft/kiota/issues/8178)
 - Golang: Fix comment format [#8186](https://github.com/microsoft/kiota/pull/8186)
-- Fix deadlock in code generation [#8186](https://github.com/microsoft/kiota/pull/8186)
+- Fixed a deadlock where two parallel workers could each be building a model class whose parent was, transitively, waiting on the other worker's class. The fix detects that cross-thread wait cycle before blocking and falls back to proceeding without waiting, instead of serializing all model construction behind a single lock, which would have undone the concurrency `MaxDegreeOfParallelism` provides for large specifications such as Graph. [#8186](https://github.com/microsoft/kiota/pull/8186)
 
 ## [1.35.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A HEAD operation with no response schema generated an executor returning a `Stream`. The default return type was picked from the response codes alone, so a HEAD declaring only a `200` fell through to binary, while one that happened to list `304` returned void by accident. The request method is now checked first, so a HEAD that falls through to the default returns void. [#4245](https://github.com/microsoft/kiota/issues/4245)
 - TypeScript: the discriminator switch in a composed type serializer was built from the wire name, but model properties are camel cased by the refiner, so a discriminator such as `pet_type` was emitted as `.pet_type` where the generated interface declares `petType` and the client did not compile. The accessor is now resolved from the model property, which also corrects `@odata.type` from `.OdataType` to `.odataType`. [#7862](https://github.com/microsoft/kiota/issues/7862)
 - TypeScript: the factory generated for a collection of a primitive union was declared returning the collection but its body read a scalar, so `(number | string)[] | undefined` came back from `parseNode?.getNumberValue() ?? parseNode?.getStringValue()` and only the first item of the payload survived. The collection reads are now emitted for that case, matching what the deserializer already does for the same shape. [#8178](https://github.com/microsoft/kiota/issues/8178)
+- Golang: Fix comment format [#8186](https://github.com/microsoft/kiota/pull/8186)
+- Fix deadlock in code generation [#8186](https://github.com/microsoft/kiota/pull/8186)
 
 ## [1.35.0] - 2026-09-01
 
@@ -1861,4 +1863,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial GitHub release
-

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2329,19 +2329,17 @@ public partial class KiotaBuilder
         return currentNamespace;
     }
     private ConcurrentDictionary<string, ModelClassBuildLifecycle> classLifecycles = new(StringComparer.OrdinalIgnoreCase);
-    private readonly object modelDeclarationLock = new();
+    // Tracks, for each class currently building its properties, which thread owns it, and for each
+    // thread currently blocked waiting on a parent's properties, which lifecycle it is waiting on.
+    // Together these form a wait-for graph: a worker about to block checks whether doing so would
+    // close a cycle back to itself (its own class being, transitively, blocked on the class it is
+    // about to wait for) before waiting, so independent models still build fully in parallel and only
+    // the rare cyclic case falls back to proceeding without waiting.
+    private readonly ConcurrentDictionary<ModelClassBuildLifecycle, int> lifecycleOwnerThreadId = new();
+    private readonly ConcurrentDictionary<int, ModelClassBuildLifecycle> threadWaitingOnLifecycle = new();
+    private readonly object waitForGraphLock = new();
     private static readonly ThreadLocal<HashSet<string>> schemasBeingProcessedForDiscriminators = new(() => new(StringComparer.OrdinalIgnoreCase));
     private CodeElement AddModelDeclarationIfDoesntExist(OpenApiUrlTreeNode currentNode, OpenApiOperation? currentOperation, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, CodeClass? inheritsFrom = null)
-    {
-        // Models recursively reference each other through properties, inheritance and discriminators.
-        // Serialize their construction with a reentrant lock so parallel request builders cannot
-        // hold one model's lifecycle lock while waiting for a model owned by another worker.
-        lock (modelDeclarationLock)
-        {
-            return AddModelDeclarationIfDoesntExistCore(currentNode, currentOperation, schema, declarationName, currentNamespace, inheritsFrom);
-        }
-    }
-    private CodeElement AddModelDeclarationIfDoesntExistCore(OpenApiUrlTreeNode currentNode, OpenApiOperation? currentOperation, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, CodeClass? inheritsFrom)
     {
         if (GetExistingDeclaration(currentNamespace, currentNode, declarationName) is not CodeElement existingDeclaration) // we can find it in the components
         {
@@ -2487,21 +2485,24 @@ public partial class KiotaBuilder
         var lifecycle = classLifecycles.GetOrAdd(currentNamespace.Name + "." + declarationName, static n => new());
         if (!lifecycle.IsPropertiesBuilt() && !lifecycle.IsPropertiesBuildingInProgress())
         {
+            var currentThreadId = Environment.CurrentManagedThreadId;
             try
             {
                 lifecycle.StartBuildingProperties();
+                lifecycleOwnerThreadId[lifecycle] = currentThreadId;
                 if (!lifecycle.IsPropertiesBuilt())
                 {
                     if (inheritsFrom != null)
                     {
                         classLifecycles.TryGetValue(inheritsFrom.Parent!.Name + "." + inheritsFrom.Name, out var superClassLifecycle);
-                        superClassLifecycle!.WaitForPropertiesBuilt();
+                        WaitForSuperClassProperties(superClassLifecycle!, currentThreadId, declarationName, currentNamespace.Name);
                     }
                     CreatePropertiesForModelClass(currentNode, schema, currentNamespace, newClass); // order matters since we might be recursively generating ancestors for discriminator mappings and duplicating additional data/backing store properties
                 }
             }
             finally
             {
+                lifecycleOwnerThreadId.TryRemove(lifecycle, out _);
                 lifecycle.PropertiesBuildingDone();
             }
         }
@@ -2537,6 +2538,55 @@ public partial class KiotaBuilder
                 discriminatorVisited.Remove(schemaRefId);
         }
         return newClass;
+    }
+    /// <summary>
+    /// Waits for the superclass' properties to be built before letting the current thread build its own,
+    /// unless doing so would deadlock: two (or more) threads can each be building a class whose parent is,
+    /// transitively through some other in-flight class, waiting on the class the other thread owns. Before
+    /// blocking, this walks the current wait-for graph from <paramref name="superClassLifecycle"/> back through
+    /// each owning thread's own wait, if any; finding our own thread proves waiting would close a cycle, so we
+    /// skip the wait and proceed with whatever properties the superclass currently has, same as the existing
+    /// same-thread circular reference case.
+    /// </summary>
+    private void WaitForSuperClassProperties(ModelClassBuildLifecycle superClassLifecycle, int currentThreadId, string declarationName, string namespaceName)
+    {
+        bool wouldDeadlock;
+        lock (waitForGraphLock)
+        {
+            wouldDeadlock = WouldWaitingCreateCycle(superClassLifecycle, currentThreadId);
+            if (!wouldDeadlock)
+                threadWaitingOnLifecycle[currentThreadId] = superClassLifecycle;
+        }
+        if (wouldDeadlock)
+        {
+            LogCircularInheritanceWait(declarationName, namespaceName);
+            return;
+        }
+        try
+        {
+            superClassLifecycle.WaitForPropertiesBuilt();
+        }
+        finally
+        {
+            lock (waitForGraphLock)
+            {
+                threadWaitingOnLifecycle.TryRemove(currentThreadId, out _);
+            }
+        }
+    }
+    private bool WouldWaitingCreateCycle(ModelClassBuildLifecycle target, int currentThreadId)
+    {
+        var visited = new HashSet<ModelClassBuildLifecycle>();
+        var cursor = target;
+        while (visited.Add(cursor) && lifecycleOwnerThreadId.TryGetValue(cursor, out var ownerThreadId))
+        {
+            if (ownerThreadId == currentThreadId)
+                return true;
+            if (!threadWaitingOnLifecycle.TryGetValue(ownerThreadId, out var next))
+                return false;
+            cursor = next;
+        }
+        return false;
     }
     /// <summary>
     /// Creates a reference to the component so inheritance scenarios get the right class name
@@ -3107,4 +3157,6 @@ public partial class KiotaBuilder
     private partial void LogIgnoringDuplicateParameter(string name);
     [LoggerMessage(Level = LogLevel.Warning, Message = "Circular property reference detected for model {ModelName} in namespace {Namespace}. Skipping property creation to prevent infinite recursion.")]
     private partial void LogCircularPropertyReference(string modelName, string @namespace);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Circular inheritance wait detected for model {ModelName} in namespace {Namespace}. Proceeding without waiting for the parent's properties to avoid a deadlock.")]
+    private partial void LogCircularInheritanceWait(string modelName, string @namespace);
 }

--- a/src/Kiota.Builder/KiotaBuilder.cs
+++ b/src/Kiota.Builder/KiotaBuilder.cs
@@ -2329,8 +2329,19 @@ public partial class KiotaBuilder
         return currentNamespace;
     }
     private ConcurrentDictionary<string, ModelClassBuildLifecycle> classLifecycles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object modelDeclarationLock = new();
     private static readonly ThreadLocal<HashSet<string>> schemasBeingProcessedForDiscriminators = new(() => new(StringComparer.OrdinalIgnoreCase));
     private CodeElement AddModelDeclarationIfDoesntExist(OpenApiUrlTreeNode currentNode, OpenApiOperation? currentOperation, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, CodeClass? inheritsFrom = null)
+    {
+        // Models recursively reference each other through properties, inheritance and discriminators.
+        // Serialize their construction with a reentrant lock so parallel request builders cannot
+        // hold one model's lifecycle lock while waiting for a model owned by another worker.
+        lock (modelDeclarationLock)
+        {
+            return AddModelDeclarationIfDoesntExistCore(currentNode, currentOperation, schema, declarationName, currentNamespace, inheritsFrom);
+        }
+    }
+    private CodeElement AddModelDeclarationIfDoesntExistCore(OpenApiUrlTreeNode currentNode, OpenApiOperation? currentOperation, IOpenApiSchema schema, string declarationName, CodeNamespace currentNamespace, CodeClass? inheritsFrom)
     {
         if (GetExistingDeclaration(currentNamespace, currentNode, declarationName) is not CodeElement existingDeclaration) // we can find it in the components
         {

--- a/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
+++ b/src/Kiota.Builder/Writers/Go/CodeEnumWriter.cs
@@ -49,7 +49,7 @@ public class CodeEnumWriter : BaseElementWriter<CodeEnum, GoConventionService>
             foreach (var item in enumOptions)
             {
                 if (item.Documentation.DescriptionAvailable)
-                    writer.WriteLine($"// {GoConventionService.RemoveInvalidDescriptionCharacters(item.Documentation.DescriptionTemplate)}");
+                    conventions.WriteDescriptionItem(GoConventionService.RemoveInvalidDescriptionCharacters(item.Documentation.DescriptionTemplate), writer);
 
                 if (isMultiValue)
                     writer.WriteLine($"{item.Name.ToUpperInvariant()}_{typeName.ToUpperInvariant()} = {(int)Math.Pow(2, power)}");

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -211,7 +211,8 @@ public class GoConventionService : CommonLanguageConventionService
             _ when string.IsNullOrEmpty(description) => DocCommentPrefix,
             _ => $"{DocCommentPrefix} {description}",
         };
-        writer.WriteLine(comment.Replace("''", "“", StringComparison.Ordinal).TrimEnd(' '));
+        // the replacement of double backticks and double single quotes with quotation marks will be removed in go1.28 (https://github.com/golang/go/issues/76975)
+        writer.WriteLine(comment.Replace("``", "“", StringComparison.Ordinal).Replace("''", "”", StringComparison.Ordinal).TrimEnd(' '));
     }
     public void WriteLinkDescription(CodeDocumentation documentation, LanguageWriter writer)
     {

--- a/src/Kiota.Builder/Writers/Go/GoConventionService.cs
+++ b/src/Kiota.Builder/Writers/Go/GoConventionService.cs
@@ -211,7 +211,7 @@ public class GoConventionService : CommonLanguageConventionService
             _ when string.IsNullOrEmpty(description) => DocCommentPrefix,
             _ => $"{DocCommentPrefix} {description}",
         };
-        writer.WriteLine(comment);
+        writer.WriteLine(comment.Replace("''", "“", StringComparison.Ordinal).TrimEnd(' '));
     }
     public void WriteLinkDescription(CodeDocumentation documentation, LanguageWriter writer)
     {

--- a/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
+++ b/tests/Kiota.Builder.IntegrationTests/GenerateSample.cs
@@ -253,23 +253,31 @@ public sealed class GenerateSample : IDisposable
     [InlineData("GeneratesUritemplateHints.yaml")]
     [InlineData("SwaggerPetStore.json")]
     [Theory]
-    public async Task GeneratedGoCodeIsFormattedAsync(string descriptionFile)
+    public Task GeneratedGoCodeIsFormattedAsync(string descriptionFile) =>
+        AssertGeneratedGoCodeIsFormattedAsync(GetAbsolutePath(descriptionFile), Path.GetFileNameWithoutExtension(descriptionFile));
+
+    [Fact]
+    public Task GeneratedGraphGoCodeIsFormattedAsync() =>
+        AssertGeneratedGoCodeIsFormattedAsync("https://aka.ms/graph/v1.0/openapi.yaml", "GraphV1");
+
+    private async Task AssertGeneratedGoCodeIsFormattedAsync(string descriptionFile, string descriptionName)
     {
         var gofmt = GetGoFmtPath();
         Assert.SkipWhen(string.IsNullOrEmpty(gofmt), "gofmt (the Go toolchain) is not available on this machine.");
 
         var logger = LoggerFactory.Create(static builder => { }).CreateLogger<KiotaBuilder>();
 
-        var descriptionName = Path.GetFileNameWithoutExtension(descriptionFile);
         var outputPath = Path.Combine(Directory.GetCurrentDirectory(), "Generated", "GoFormatting", descriptionName);
         var configuration = new GenerationConfiguration
         {
             Language = GenerationLanguage.Go,
-            OpenAPIFilePath = GetAbsolutePath(descriptionFile),
+            OpenAPIFilePath = descriptionFile,
             OutputPath = outputPath,
             CleanOutput = true,
         };
-        await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(TestContext.Current.CancellationToken);
+        Assert.True(await new KiotaBuilder(logger, configuration, _httpClient).GenerateClientAsync(TestContext.Current.CancellationToken),
+            $"Client generation failed for '{descriptionFile}'.");
+        Assert.NotEmpty(Directory.EnumerateFiles(outputPath, "*.go", SearchOption.AllDirectories));
 
         // "gofmt -l" lists the files whose formatting differs from gofmt's. The generated code is
         // expected to already be formatted, so the command must not report any file.

--- a/tests/Kiota.Builder.Tests/ModelClassBuildDeadlockAvoidanceTests.cs
+++ b/tests/Kiota.Builder.Tests/ModelClassBuildDeadlockAvoidanceTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Kiota.Builder.Configuration;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace Kiota.Builder.Tests;
+
+// Regression coverage for the cross-thread deadlock that can occur when two Parallel.ForEach
+// workers each build a class whose parent is, transitively, waiting on the other worker's class.
+// KiotaBuilder detects that cycle in its wait-for graph instead of blocking forever; these tests
+// exercise that detection directly rather than trying to race real threads into the exact
+// interleaving, which the original bug depended on and which large specs like Graph triggered.
+public sealed class ModelClassBuildDeadlockAvoidanceTests
+{
+    private static KiotaBuilder NewBuilder() =>
+        new(NullLogger<KiotaBuilder>.Instance, new GenerationConfiguration { ClientClassName = "Test", OpenAPIFilePath = "test.yaml" }, new HttpClient());
+
+    private static object GetPrivateField(KiotaBuilder builder, string name) =>
+        typeof(KiotaBuilder).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(builder)!;
+
+    private static bool WouldWaitingCreateCycle(KiotaBuilder builder, ModelClassBuildLifecycle target, int currentThreadId) =>
+        (bool)typeof(KiotaBuilder).GetMethod("WouldWaitingCreateCycle", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(builder, [target, currentThreadId])!;
+
+    private static void WaitForSuperClassProperties(KiotaBuilder builder, ModelClassBuildLifecycle lifecycle, int currentThreadId, string declarationName, string namespaceName) =>
+        typeof(KiotaBuilder).GetMethod("WaitForSuperClassProperties", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(builder, [lifecycle, currentThreadId, declarationName, namespaceName]);
+
+    [Fact]
+    public void DetectsTwoThreadCycle()
+    {
+        var builder = NewBuilder();
+        var owners = (ConcurrentDictionary<ModelClassBuildLifecycle, int>)GetPrivateField(builder, "lifecycleOwnerThreadId");
+        var waiting = (ConcurrentDictionary<int, ModelClassBuildLifecycle>)GetPrivateField(builder, "threadWaitingOnLifecycle");
+
+        using var lifecycleX = new ModelClassBuildLifecycle();
+        using var lifecycleY = new ModelClassBuildLifecycle();
+        // Thread 1 owns X and is already blocked waiting on Y (owned by thread 2).
+        owners[lifecycleX] = 1;
+        owners[lifecycleY] = 2;
+        waiting[1] = lifecycleY;
+
+        // Thread 2 about to wait on X would close the cycle back to itself.
+        Assert.True(WouldWaitingCreateCycle(builder, lifecycleX, 2));
+    }
+
+    [Fact]
+    public void DetectsLongerCycleAcrossMultipleThreads()
+    {
+        var builder = NewBuilder();
+        var owners = (ConcurrentDictionary<ModelClassBuildLifecycle, int>)GetPrivateField(builder, "lifecycleOwnerThreadId");
+        var waiting = (ConcurrentDictionary<int, ModelClassBuildLifecycle>)GetPrivateField(builder, "threadWaitingOnLifecycle");
+
+        using var lifecycleA = new ModelClassBuildLifecycle();
+        using var lifecycleB = new ModelClassBuildLifecycle();
+        using var lifecycleC = new ModelClassBuildLifecycle();
+        // thread 1 owns A, waits on B (owned by thread 2); thread 2 waits on C (owned by thread 3).
+        owners[lifecycleA] = 1;
+        owners[lifecycleB] = 2;
+        owners[lifecycleC] = 3;
+        waiting[1] = lifecycleB;
+        waiting[2] = lifecycleC;
+
+        // thread 3 about to wait on A would close a 3-thread cycle.
+        Assert.True(WouldWaitingCreateCycle(builder, lifecycleA, 3));
+    }
+
+    [Fact]
+    public void DoesNotFlagIndependentModelsAsCyclic()
+    {
+        var builder = NewBuilder();
+        var owners = (ConcurrentDictionary<ModelClassBuildLifecycle, int>)GetPrivateField(builder, "lifecycleOwnerThreadId");
+
+        using var lifecycleX = new ModelClassBuildLifecycle();
+        using var lifecycleY = new ModelClassBuildLifecycle();
+        owners[lifecycleX] = 1;
+        owners[lifecycleY] = 2;
+        // Thread 2 isn't waiting on anything owned by thread 3: no cycle.
+        Assert.False(WouldWaitingCreateCycle(builder, lifecycleY, 3));
+    }
+
+    [Fact]
+    public void DoesNotFlagUnownedOrCompletedLifecycleAsCyclic()
+    {
+        var builder = NewBuilder();
+        using var lifecycleX = new ModelClassBuildLifecycle();
+        // Nobody currently owns lifecycleX (not started, or already finished): always safe to wait.
+        Assert.False(WouldWaitingCreateCycle(builder, lifecycleX, 1));
+    }
+
+    [Fact]
+    public void SkipsWaitingWhenCycleDetectedInsteadOfBlocking()
+    {
+        var builder = NewBuilder();
+        var owners = (ConcurrentDictionary<ModelClassBuildLifecycle, int>)GetPrivateField(builder, "lifecycleOwnerThreadId");
+        var waiting = (ConcurrentDictionary<int, ModelClassBuildLifecycle>)GetPrivateField(builder, "threadWaitingOnLifecycle");
+
+        using var lifecycleX = new ModelClassBuildLifecycle();
+        using var lifecycleY = new ModelClassBuildLifecycle();
+        owners[lifecycleX] = 1;
+        owners[lifecycleY] = 2;
+        waiting[1] = lifecycleY;
+
+        // lifecycleX's properties are never signaled: a real wait would block forever.
+        // Because thread 2 waiting on X closes the cycle, this must return promptly instead.
+        WaitForSuperClassProperties(builder, lifecycleX, 2, "Child", "Ns");
+        Assert.False(lifecycleX.IsPropertiesBuilt());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task StillWaitsForRealParentCompletionWhenNotCyclic()
+    {
+        var builder = NewBuilder();
+        using var lifecycleParent = new ModelClassBuildLifecycle();
+
+        // Monitor.Enter/Exit are thread-affine, so the owner's start and completion must run as a
+        // single synchronous unit on one pool thread rather than straddling an `await`.
+        var ownerTask = Task.Run(() =>
+        {
+            lifecycleParent.StartBuildingProperties();
+            Thread.Sleep(300);
+            lifecycleParent.PropertiesBuildingDone();
+        }, TestContext.Current.CancellationToken);
+
+        var waitTask = Task.Run(() => WaitForSuperClassProperties(builder, lifecycleParent, Environment.CurrentManagedThreadId + 1000, "Child", "Ns"), TestContext.Current.CancellationToken);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+        Assert.False(waitTask.IsCompleted);
+
+        await Task.WhenAll(ownerTask, waitTask);
+        Assert.True(lifecycleParent.IsPropertiesBuilt());
+    }
+}


### PR DESCRIPTION
This is a follow up to https://github.com/microsoft/kiota/pull/6416 to fix the remaining golang styling issues.

1) Comments are now whitespace trimmed at the end as `go fmt` does the same
2) double single quotes now use the utf8 character used by `go fmt` (https://github.com/golang/go/issues/76975) which will go away in go 1.28

Testing instructions:
```
rm -rf ./golangtest/ && cp -r ./it/go golangtest && dotnet build && ./src/kiota/bin/Debug/net10.0/kiota generate --openapi https://aka.ms/graph/v1.0/openapi.yaml --output ./golangtest/client --language go --exclude-backward-compatible --clean-output -n 'integrationtest/client' -i '/groups/getByIds#POST' -i '/devices#GET' -i '/devices/{device-id}#GET' -i '/devices/{device-id}/registeredOwners#GET' -i '/devices/{device-id}/registeredUsers#GET' -i '/devices/{device-id}/memberOf#GET' -i '/devices/{device-id}/memberOf/graph.group#GET' -i '/users#GET' -i '/users/{user-id}#GET' -i '/users/{user-id}/ownedDevices#GET' -i '/users/{user-id}/ownedObjects#GET' -i '/users/{user-id}/registeredDevices#GET' -i '/users/{user-id}/appRoleAssignments#GET' -i '/users/{user-id}/authentication/methods#GET' -i '/identityProtection/riskyUsers#GET' -i '/roleManagement/directory/roleEligibilitySchedules#GET' -i '/roleManagement/directory/roleAssignmentSchedules#GET'
cd golangtest
git init
git add .
go fmt ./...
git diff
```

The diff should show no touched files (the used graph urls all contain those problems)

I also added a unit test to generate the whole graph api client which takes some time. This test is optional and can be run with `dotnet run --project tests/Kiota.Builder.IntegrationTests -- -explicit on -method
  '*GeneratedGraphGoCodeIsFormattedAsync'`

I also encountered a deadlock on code generation when running the tests which might need some more investigation (see rolled back commits)